### PR TITLE
feat: Level Up Wizard for player characters

### DIFF
--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
@@ -38,6 +38,8 @@ import type {
   LevelUpWizardState,
   ASIChoice,
   SubclassSpellGrant,
+  SubclassMigration,
+  MissedSubclassFeature,
   WizardStepConfig,
 } from './LevelUpWizard.types';
 
@@ -181,6 +183,12 @@ export function useLevelUpWizard(character: CharacterState) {
   );
   const [hpRollResult, setHPRollResult] = useState<number | undefined>();
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [migrationSubclass, setMigrationSubclass] = useState<
+    ProcessedSubclass | undefined
+  >();
+  const [migrationAdoptedFeatures, setMigrationAdoptedFeatures] = useState<
+    Set<string>
+  >(new Set());
 
   const targetClass: MulticlassInfo | null =
     targetClassIndex >= 0 ? classes[targetClassIndex] : null;
@@ -216,6 +224,73 @@ export function useLevelUpWizard(character: CharacterState) {
     !targetClass?.subclass &&
     !selectedSubclass;
 
+  // Detect subclass migration: character is past subclass selection level but has no subclass
+  const needsSubclassMigration =
+    !!matchedClass &&
+    !!subclassSelectionLevel &&
+    !!targetClass &&
+    !targetClass.subclass &&
+    !selectedSubclass &&
+    targetClass.level >= subclassSelectionLevel;
+
+  const subclassMigration: SubclassMigration = useMemo(() => {
+    if (!needsSubclassMigration || !matchedClass || !subclassSelectionLevel) {
+      return { needed: false, missedFeatures: [], missedSpellGrants: [] };
+    }
+
+    if (!migrationSubclass) {
+      return {
+        needed: true,
+        missedFeatures: [],
+        missedSpellGrants: [],
+      };
+    }
+
+    const missedFeatures: MissedSubclassFeature[] = [];
+    for (const f of migrationSubclass.features) {
+      if (f.level >= subclassSelectionLevel && f.level <= targetClass!.level) {
+        const key = `${f.name}-${f.level}`;
+        missedFeatures.push({
+          feature: f,
+          level: f.level,
+          adopted: migrationAdoptedFeatures.has(key),
+        });
+      }
+    }
+
+    const missedSpellGrants: SubclassSpellGrant[] = [];
+    if (migrationSubclass.spellList) {
+      for (const entry of migrationSubclass.spellList) {
+        if (
+          entry.level >= subclassSelectionLevel &&
+          entry.level <= targetClass!.level
+        ) {
+          for (const spellName of entry.spells) {
+            missedSpellGrants.push({
+              spellName,
+              grantType: 'prepared',
+              isAlwaysPrepared: true,
+            });
+          }
+        }
+      }
+    }
+
+    return {
+      needed: true,
+      selectedSubclass: migrationSubclass,
+      missedFeatures,
+      missedSpellGrants,
+    };
+  }, [
+    needsSubclassMigration,
+    matchedClass,
+    subclassSelectionLevel,
+    targetClass,
+    migrationSubclass,
+    migrationAdoptedFeatures,
+  ]);
+
   const asiLevels = matchedClass ? getASILevels(matchedClass) : [];
   const requiresASI = asiLevels.includes(newClassLevel);
 
@@ -224,6 +299,7 @@ export function useLevelUpWizard(character: CharacterState) {
     : [];
 
   const activeSubclass: ProcessedSubclass | undefined = useMemo(() => {
+    if (migrationSubclass) return migrationSubclass;
     if (selectedSubclass) return selectedSubclass;
     if (!matchedClass || !targetClass?.subclass) return undefined;
     return matchedClass.subclasses.find(
@@ -231,7 +307,7 @@ export function useLevelUpWizard(character: CharacterState) {
         sc.shortName === targetClass.subclass ||
         sc.name === targetClass.subclass
     );
-  }, [matchedClass, targetClass, selectedSubclass]);
+  }, [matchedClass, targetClass, selectedSubclass, migrationSubclass]);
 
   const subclassFeatures = activeSubclass
     ? getSubclassFeaturesForLevel(activeSubclass, newClassLevel)
@@ -257,11 +333,13 @@ export function useLevelUpWizard(character: CharacterState) {
       isCustomClass,
       needsEditionPicker,
       isMulticlassed: classes.length > 1,
+      needsSubclassMigration: needsSubclassMigration,
       requiresSubclass:
-        requiresSubclass ||
-        (!!matchedClass &&
-          subclassSelectionLevel === newClassLevel &&
-          !targetClass?.subclass),
+        !needsSubclassMigration &&
+        (requiresSubclass ||
+          (!!matchedClass &&
+            subclassSelectionLevel === newClassLevel &&
+            !targetClass?.subclass)),
       hasFeatures: hasFeatures || subclassSpellGrants.length > 0,
       requiresASI,
       needsHPInput,
@@ -270,6 +348,7 @@ export function useLevelUpWizard(character: CharacterState) {
     isCustomClass,
     needsEditionPicker,
     classes.length,
+    needsSubclassMigration,
     requiresSubclass,
     matchedClass,
     subclassSelectionLevel,
@@ -290,6 +369,8 @@ export function useLevelUpWizard(character: CharacterState) {
         return !!selectedEdition;
       case 'class':
         return targetClassIndex >= 0;
+      case 'subclass-migration':
+        return !!migrationSubclass;
       case 'subclass':
         return !!selectedSubclass;
       case 'features': {
@@ -312,6 +393,7 @@ export function useLevelUpWizard(character: CharacterState) {
     currentStep,
     selectedEdition,
     targetClassIndex,
+    migrationSubclass,
     selectedSubclass,
     asiChoice,
     hpRollResult,
@@ -345,11 +427,13 @@ export function useLevelUpWizard(character: CharacterState) {
     const classIdx = targetClassIndex;
 
     const updatedClasses = [...classes];
+    const subclassToSet =
+      selectedSubclass?.shortName || migrationSubclass?.shortName;
     updatedClasses[classIdx] = {
       ...updatedClasses[classIdx],
       level: newClassLevel,
       ...(selectedEdition ? { classSource: selectedEdition } : {}),
-      ...(selectedSubclass ? { subclass: selectedSubclass.shortName } : {}),
+      ...(subclassToSet ? { subclass: subclassToSet } : {}),
     };
 
     const updatedCharacter: CharacterState = {
@@ -378,12 +462,27 @@ export function useLevelUpWizard(character: CharacterState) {
     }
 
     let newSpells = [...(migrated.spells || [])];
+    // Migration: add missed subclass spells
+    if (
+      subclassMigration.needed &&
+      subclassMigration.missedSpellGrants.length > 0 &&
+      migrationSubclass
+    ) {
+      const migSpells = buildSubclassSpells(
+        subclassMigration.missedSpellGrants,
+        allSpells,
+        migrationSubclass.shortName,
+        newSpells
+      );
+      newSpells = [...newSpells, ...migSpells];
+    }
+    // Current level subclass spells
     if (subclassSpellGrants.length > 0 && activeSubclass) {
       const subSpells = buildSubclassSpells(
         subclassSpellGrants,
         allSpells,
         activeSubclass.shortName,
-        migrated.spells || []
+        newSpells
       );
       newSpells = [...newSpells, ...subSpells];
     }
@@ -411,21 +510,44 @@ export function useLevelUpWizard(character: CharacterState) {
       hitPoints: { ...migrated.hitPoints, ...hpUpdates },
     });
 
+    let featureOrder = (migrated.extendedFeatures || []).length;
+
+    // Migration: add adopted missed subclass features
+    if (subclassMigration.needed && migrationSubclass) {
+      const adoptedFeatures = subclassMigration.missedFeatures
+        .filter(mf => mf.adopted)
+        .map(mf => mf.feature);
+      if (adoptedFeatures.length > 0) {
+        const migEntries = buildFeatureEntries(
+          adoptedFeatures,
+          'class',
+          `${migrationSubclass.shortName} (${targetClass.className} - migrated)`,
+          featureOrder
+        );
+        migEntries.forEach(f => addExtendedFeature(f));
+        featureOrder += migEntries.length;
+      }
+    }
+
     const featureSourceDetail = `${targetClass.className} Level ${newClassLevel}`;
     const classFeatureEntries = buildFeatureEntries(
       classFeatures,
       'class',
       featureSourceDetail,
-      (migrated.extendedFeatures || []).length,
+      featureOrder,
       featureChoices
     );
+    featureOrder += classFeatureEntries.length;
+
     const subFeatureEntries = buildFeatureEntries(
       subclassFeatures,
       'class',
       `${activeSubclass?.shortName || targetClass.subclass || ''} (${targetClass.className} ${newClassLevel})`,
-      (migrated.extendedFeatures || []).length + classFeatureEntries.length,
+      featureOrder,
       featureChoices
     );
+    featureOrder += subFeatureEntries.length;
+
     if (asiChoice?.type === 'feat') {
       const featEntry = buildFeatureEntries(
         [
@@ -440,9 +562,7 @@ export function useLevelUpWizard(character: CharacterState) {
         ],
         'feat',
         asiChoice.feat.name,
-        (migrated.extendedFeatures || []).length +
-          classFeatureEntries.length +
-          subFeatureEntries.length
+        featureOrder
       );
       featEntry.forEach(f => addExtendedFeature(f));
     }
@@ -458,6 +578,8 @@ export function useLevelUpWizard(character: CharacterState) {
     selectedSubclass,
     migrated,
     asiChoice,
+    subclassMigration,
+    migrationSubclass,
     subclassSpellGrants,
     activeSubclass,
     allSpells,
@@ -491,6 +613,7 @@ export function useLevelUpWizard(character: CharacterState) {
       hpRollResult,
       steps,
       currentStepIndex,
+      subclassMigration,
     } as LevelUpWizardState,
     editionOptions,
     availableSubclasses: matchedClass
@@ -512,6 +635,8 @@ export function useLevelUpWizard(character: CharacterState) {
     setASIChoice,
     setFeatureChoices,
     setHPRollResult,
+    setMigrationSubclass,
+    setMigrationAdoptedFeatures,
     applyLevelUp,
   };
 }

--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
@@ -117,7 +117,7 @@ function buildFeatureEntries(
     )
     .map((f, i) => ({
       name: f.name,
-      description: f.entries?.join('\n\n') || '',
+      description: f.entries?.map(e => `<p>${e}</p>`).join('') || '',
       maxUses: 0,
       usedUses: 0,
       restType: 'long' as const,

--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
@@ -1,0 +1,473 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import { useCharacterStore } from '@/store/characterStore';
+import { useClassData } from '@/hooks/useClassData';
+import { useSpellsData } from '@/hooks/useSpellsData';
+import type {
+  CharacterState,
+  MulticlassInfo,
+  Spell,
+  ExtendedFeature,
+} from '@/types/character';
+import type {
+  ProcessedClass,
+  ProcessedSubclass,
+  ClassFeature,
+} from '@/types/classes';
+import type { ProcessedSpell } from '@/types/spells';
+import {
+  calculateCharacterSpellSlots,
+  calculateCharacterPactMagic,
+  calculateModifier,
+} from '@/utils/calculations';
+import { calculateHitDicePools, migrateToMulticlass } from '@/utils/multiclass';
+import {
+  matchClassByName,
+  getEditionOptions,
+  getSubclassSelectionLevel,
+  getASILevels,
+  getFeaturesForLevel,
+  getSubclassFeaturesForLevel,
+  getAvailableSubclasses,
+  computeWizardSteps,
+  getSpellsKnownDelta,
+  getCantripsKnownDelta,
+} from './LevelUpWizard.utils';
+import type {
+  LevelUpWizardState,
+  ASIChoice,
+  SubclassSpellGrant,
+  WizardStepConfig,
+} from './LevelUpWizard.types';
+
+function resolveSubclassSpellGrants(
+  subclass: ProcessedSubclass,
+  level: number
+): SubclassSpellGrant[] {
+  if (!subclass.spellList) return [];
+  const grants: SubclassSpellGrant[] = [];
+  for (const entry of subclass.spellList) {
+    if (entry.level !== level) continue;
+    for (const spellName of entry.spells) {
+      grants.push({
+        spellName,
+        grantType: 'prepared',
+        isAlwaysPrepared: true,
+      });
+    }
+  }
+  return grants;
+}
+
+function buildSubclassSpells(
+  grants: SubclassSpellGrant[],
+  allSpells: ProcessedSpell[],
+  subclassName: string,
+  existingSpells: Spell[]
+): Spell[] {
+  const result: Spell[] = [];
+  const existingNames = new Set(existingSpells.map(s => s.name.toLowerCase()));
+
+  for (const grant of grants) {
+    if (grant.grantType === 'expanded') continue;
+    if (existingNames.has(grant.spellName.toLowerCase())) continue;
+
+    const found = allSpells.find(
+      s => s.name.toLowerCase() === grant.spellName.toLowerCase()
+    );
+    if (!found) continue;
+
+    const now = new Date().toISOString();
+    const spell: Spell = {
+      id: `${found.id}-${subclassName.toLowerCase().replace(/\s+/g, '-')}`,
+      name: found.name,
+      level: found.level,
+      school: found.school,
+      castingTime: found.castingTime,
+      range: found.range,
+      duration: found.duration,
+      components: {
+        verbal: found.components.verbal,
+        somatic: found.components.somatic,
+        material: found.components.material,
+        materialDescription: found.components.materialComponent,
+      },
+      description: found.description,
+      isPrepared: grant.isAlwaysPrepared,
+      isAlwaysPrepared: grant.isAlwaysPrepared,
+      castingSource: subclassName,
+      createdAt: now,
+      updatedAt: now,
+    };
+    result.push(spell);
+  }
+  return result;
+}
+
+function buildFeatureEntries(
+  features: ClassFeature[],
+  sourceType: 'class' | 'feat',
+  sourceDetail: string,
+  startOrder: number
+): Omit<ExtendedFeature, 'id' | 'createdAt' | 'updatedAt'>[] {
+  return features
+    .filter(
+      f => f.name !== 'Ability Score Improvement' && f.name !== 'Epic Boon'
+    )
+    .map((f, i) => ({
+      name: f.name,
+      description: f.entries?.join('\n\n') || '',
+      maxUses: 0,
+      usedUses: 0,
+      restType: 'long' as const,
+      sourceType,
+      sourceDetail,
+      displayOrder: startOrder + i,
+      isPassive: true,
+      scaleWithProficiency: false,
+      proficiencyMultiplier: 1,
+    }));
+}
+
+export function useLevelUpWizard(character: CharacterState) {
+  const { classData, loading: classLoading } = useClassData();
+  const { spells: allSpells, loading: spellsLoading } = useSpellsData();
+  const updateCharacter = useCharacterStore(s => s.updateCharacter);
+  const addExtendedFeature = useCharacterStore(s => s.addExtendedFeature);
+
+  const migrated = useMemo(() => migrateToMulticlass(character), [character]);
+  const classes = migrated.classes || [];
+  const totalLevel = migrated.totalLevel || migrated.level || 1;
+
+  const [selectedEdition, setSelectedEdition] = useState<string | undefined>();
+  const [targetClassIndex, setTargetClassIndex] = useState<number>(
+    classes.length === 1 ? 0 : -1
+  );
+  const [selectedSubclass, setSelectedSubclass] = useState<
+    ProcessedSubclass | undefined
+  >();
+  const [asiChoice, setASIChoice] = useState<ASIChoice | undefined>();
+  const [hpRollResult, setHPRollResult] = useState<number | undefined>();
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+
+  const targetClass: MulticlassInfo | null =
+    targetClassIndex >= 0 ? classes[targetClassIndex] : null;
+
+  const editionToUse = selectedEdition || targetClass?.classSource;
+
+  const matchedClass: ProcessedClass | null = useMemo(() => {
+    if (!targetClass || targetClass.isCustom) return null;
+    return matchClassByName(classData, targetClass.className, editionToUse);
+  }, [classData, targetClass, editionToUse]);
+
+  const editionOptions = useMemo(() => {
+    if (!targetClass) return [];
+    return getEditionOptions(classData, targetClass.className);
+  }, [classData, targetClass]);
+
+  const needsEditionPicker =
+    !!targetClass &&
+    !targetClass.isCustom &&
+    !targetClass.classSource &&
+    !selectedEdition &&
+    editionOptions.length > 1;
+
+  const newClassLevel = targetClass ? targetClass.level + 1 : 1;
+  const newTotalLevel = totalLevel + 1;
+
+  const subclassSelectionLevel = matchedClass
+    ? getSubclassSelectionLevel(matchedClass)
+    : null;
+  const requiresSubclass =
+    !!matchedClass &&
+    subclassSelectionLevel === newClassLevel &&
+    !targetClass?.subclass &&
+    !selectedSubclass;
+
+  const asiLevels = matchedClass ? getASILevels(matchedClass) : [];
+  const requiresASI = asiLevels.includes(newClassLevel);
+
+  const classFeatures = matchedClass
+    ? getFeaturesForLevel(matchedClass, newClassLevel)
+    : [];
+
+  const activeSubclass: ProcessedSubclass | undefined = useMemo(() => {
+    if (selectedSubclass) return selectedSubclass;
+    if (!matchedClass || !targetClass?.subclass) return undefined;
+    return matchedClass.subclasses.find(
+      sc =>
+        sc.shortName === targetClass.subclass ||
+        sc.name === targetClass.subclass
+    );
+  }, [matchedClass, targetClass, selectedSubclass]);
+
+  const subclassFeatures = activeSubclass
+    ? getSubclassFeaturesForLevel(activeSubclass, newClassLevel)
+    : [];
+
+  const allFeatures = [...classFeatures, ...subclassFeatures];
+  const hasFeatures =
+    allFeatures.filter(
+      f => f.name !== 'Ability Score Improvement' && f.name !== 'Epic Boon'
+    ).length > 0;
+
+  const subclassSpellGrants: SubclassSpellGrant[] = useMemo(() => {
+    if (!activeSubclass) return [];
+    return resolveSubclassSpellGrants(activeSubclass, newClassLevel);
+  }, [activeSubclass, newClassLevel]);
+
+  const isCustomClass =
+    !!targetClass?.isCustom || (!matchedClass && !!targetClass);
+  const needsHPInput = character.hitPoints.calculationMode === 'manual';
+
+  const steps: WizardStepConfig[] = useMemo(() => {
+    return computeWizardSteps({
+      isCustomClass,
+      needsEditionPicker,
+      isMulticlassed: classes.length > 1,
+      requiresSubclass:
+        requiresSubclass ||
+        (!!matchedClass &&
+          subclassSelectionLevel === newClassLevel &&
+          !targetClass?.subclass),
+      hasFeatures: hasFeatures || subclassSpellGrants.length > 0,
+      requiresASI,
+      needsHPInput,
+    });
+  }, [
+    isCustomClass,
+    needsEditionPicker,
+    classes.length,
+    requiresSubclass,
+    matchedClass,
+    subclassSelectionLevel,
+    newClassLevel,
+    targetClass,
+    hasFeatures,
+    subclassSpellGrants.length,
+    requiresASI,
+    needsHPInput,
+  ]);
+
+  const currentStep = steps[currentStepIndex] || steps[0];
+
+  const canGoNext = useCallback((): boolean => {
+    if (!currentStep) return false;
+    switch (currentStep.id) {
+      case 'edition':
+        return !!selectedEdition;
+      case 'class':
+        return targetClassIndex >= 0;
+      case 'subclass':
+        return !!selectedSubclass;
+      case 'features':
+        return true;
+      case 'asi':
+        return !!asiChoice;
+      case 'hp':
+        return hpRollResult !== undefined && hpRollResult > 0;
+      case 'confirm':
+        return true;
+      default:
+        return true;
+    }
+  }, [
+    currentStep,
+    selectedEdition,
+    targetClassIndex,
+    selectedSubclass,
+    asiChoice,
+    hpRollResult,
+  ]);
+
+  const goNext = useCallback(() => {
+    if (currentStepIndex < steps.length - 1) {
+      setCurrentStepIndex(prev => prev + 1);
+    }
+  }, [currentStepIndex, steps.length]);
+
+  const goBack = useCallback(() => {
+    if (currentStepIndex > 0) {
+      setCurrentStepIndex(prev => prev - 1);
+    }
+  }, [currentStepIndex]);
+
+  const spellsKnownDelta = matchedClass
+    ? getSpellsKnownDelta(matchedClass, newClassLevel - 1, newClassLevel)
+    : 0;
+
+  const cantripsKnownDelta = matchedClass
+    ? getCantripsKnownDelta(matchedClass, newClassLevel - 1, newClassLevel)
+    : 0;
+
+  const applyLevelUp = useCallback(() => {
+    if (!targetClass) return;
+    const classIdx = targetClassIndex;
+
+    const updatedClasses = [...classes];
+    updatedClasses[classIdx] = {
+      ...updatedClasses[classIdx],
+      level: newClassLevel,
+      ...(selectedEdition ? { classSource: selectedEdition } : {}),
+      ...(selectedSubclass ? { subclass: selectedSubclass.shortName } : {}),
+    };
+
+    const updatedCharacter: CharacterState = {
+      ...migrated,
+      classes: updatedClasses,
+      totalLevel: newTotalLevel,
+      level: newTotalLevel,
+    };
+
+    const hitDicePools = calculateHitDicePools(
+      updatedClasses,
+      migrated.hitDicePools
+    );
+    const spellSlots = calculateCharacterSpellSlots(updatedCharacter);
+    const pactMagic = calculateCharacterPactMagic(updatedCharacter);
+
+    let abilities = { ...migrated.abilities };
+    if (asiChoice?.type === 'asi') {
+      for (const inc of asiChoice.increases) {
+        const key = inc.ability as keyof typeof abilities;
+        abilities = {
+          ...abilities,
+          [key]: Math.min(20, abilities[key] + inc.amount),
+        };
+      }
+    }
+
+    let newSpells = [...(migrated.spells || [])];
+    if (subclassSpellGrants.length > 0 && activeSubclass) {
+      const subSpells = buildSubclassSpells(
+        subclassSpellGrants,
+        allSpells,
+        activeSubclass.shortName,
+        migrated.spells || []
+      );
+      newSpells = [...newSpells, ...subSpells];
+    }
+    if (asiChoice?.type === 'feat' && asiChoice.grantedSpells.length > 0) {
+      newSpells = [...newSpells, ...asiChoice.grantedSpells];
+    }
+
+    const hpUpdates: Partial<CharacterState['hitPoints']> = {};
+    if (needsHPInput && hpRollResult !== undefined) {
+      const conMod = calculateModifier(abilities.constitution);
+      hpUpdates.max = (migrated.hitPoints.max || 0) + hpRollResult + conMod;
+      hpUpdates.current =
+        (migrated.hitPoints.current || 0) + hpRollResult + conMod;
+    }
+
+    updateCharacter({
+      classes: updatedClasses,
+      totalLevel: newTotalLevel,
+      level: newTotalLevel,
+      hitDicePools,
+      spellSlots,
+      pactMagic,
+      abilities,
+      spells: newSpells,
+      hitPoints: { ...migrated.hitPoints, ...hpUpdates },
+    });
+
+    const featureSourceDetail = `${targetClass.className} Level ${newClassLevel}`;
+    const classFeatureEntries = buildFeatureEntries(
+      classFeatures,
+      'class',
+      featureSourceDetail,
+      (migrated.extendedFeatures || []).length
+    );
+    const subFeatureEntries = buildFeatureEntries(
+      subclassFeatures,
+      'class',
+      `${activeSubclass?.shortName || targetClass.subclass || ''} (${targetClass.className} ${newClassLevel})`,
+      (migrated.extendedFeatures || []).length + classFeatureEntries.length
+    );
+    if (asiChoice?.type === 'feat') {
+      const featEntry = buildFeatureEntries(
+        [
+          {
+            name: asiChoice.feat.name,
+            level: newClassLevel,
+            source: asiChoice.feat.source,
+            entries: [asiChoice.feat.description],
+            isSubclassFeature: false,
+            original: '',
+          },
+        ],
+        'feat',
+        asiChoice.feat.name,
+        (migrated.extendedFeatures || []).length +
+          classFeatureEntries.length +
+          subFeatureEntries.length
+      );
+      featEntry.forEach(f => addExtendedFeature(f));
+    }
+    classFeatureEntries.forEach(f => addExtendedFeature(f));
+    subFeatureEntries.forEach(f => addExtendedFeature(f));
+  }, [
+    targetClass,
+    targetClassIndex,
+    classes,
+    newClassLevel,
+    newTotalLevel,
+    selectedEdition,
+    selectedSubclass,
+    migrated,
+    asiChoice,
+    subclassSpellGrants,
+    activeSubclass,
+    allSpells,
+    classFeatures,
+    subclassFeatures,
+    needsHPInput,
+    hpRollResult,
+    updateCharacter,
+    addExtendedFeature,
+  ]);
+
+  return {
+    loading: classLoading || spellsLoading,
+    state: {
+      targetClassIndex,
+      targetClass: targetClass as MulticlassInfo,
+      newClassLevel,
+      newTotalLevel,
+      matchedClass,
+      features: classFeatures,
+      subclassFeatures,
+      subclassSpellGrants,
+      requiresSubclass,
+      requiresASI,
+      isCustomClass,
+      selectedEdition,
+      selectedSubclass,
+      asiChoice,
+      hpRollResult,
+      steps,
+      currentStepIndex,
+    } as LevelUpWizardState,
+    editionOptions,
+    availableSubclasses: matchedClass
+      ? getAvailableSubclasses(matchedClass)
+      : [],
+    classes,
+    totalLevel,
+    character: migrated,
+    allSpells,
+    spellsKnownDelta,
+    cantripsKnownDelta,
+    currentStep,
+    canGoNext: canGoNext(),
+    goNext,
+    goBack,
+    setSelectedEdition,
+    setTargetClassIndex,
+    setSelectedSubclass,
+    setASIChoice,
+    setHPRollResult,
+    applyLevelUp,
+  };
+}

--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
@@ -109,13 +109,17 @@ function buildFeatureEntries(
   features: ClassFeature[],
   sourceType: 'class' | 'feat',
   sourceDetail: string,
-  startOrder: number
+  startOrder: number,
+  chosenOptions?: Record<string, string>
 ): Omit<ExtendedFeature, 'id' | 'createdAt' | 'updatedAt'>[] {
-  return features
-    .filter(
-      f => f.name !== 'Ability Score Improvement' && f.name !== 'Epic Boon'
-    )
-    .map((f, i) => ({
+  const result: Omit<ExtendedFeature, 'id' | 'createdAt' | 'updatedAt'>[] = [];
+  let order = startOrder;
+
+  for (const f of features) {
+    if (f.name === 'Ability Score Improvement' || f.name === 'Epic Boon')
+      continue;
+
+    result.push({
       name: f.name,
       description: f.entries?.map(e => `<p>${e}</p>`).join('') || '',
       maxUses: 0,
@@ -123,11 +127,35 @@ function buildFeatureEntries(
       restType: 'long' as const,
       sourceType,
       sourceDetail,
-      displayOrder: startOrder + i,
+      displayOrder: order++,
       isPassive: true,
       scaleWithProficiency: false,
       proficiencyMultiplier: 1,
-    }));
+    });
+
+    if (f.choice && chosenOptions?.[f.name]) {
+      const chosen = f.choice.options.find(
+        o => o.name === chosenOptions[f.name]
+      );
+      if (chosen) {
+        result.push({
+          name: chosen.name,
+          description: chosen.entries.map(e => `<p>${e}</p>`).join(''),
+          maxUses: 0,
+          usedUses: 0,
+          restType: 'long' as const,
+          sourceType,
+          sourceDetail,
+          displayOrder: order++,
+          isPassive: true,
+          scaleWithProficiency: false,
+          proficiencyMultiplier: 1,
+        });
+      }
+    }
+  }
+
+  return result;
 }
 
 export function useLevelUpWizard(character: CharacterState) {
@@ -148,6 +176,9 @@ export function useLevelUpWizard(character: CharacterState) {
     ProcessedSubclass | undefined
   >();
   const [asiChoice, setASIChoice] = useState<ASIChoice | undefined>();
+  const [featureChoices, setFeatureChoices] = useState<Record<string, string>>(
+    {}
+  );
   const [hpRollResult, setHPRollResult] = useState<number | undefined>();
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
 
@@ -261,8 +292,13 @@ export function useLevelUpWizard(character: CharacterState) {
         return targetClassIndex >= 0;
       case 'subclass':
         return !!selectedSubclass;
-      case 'features':
-        return true;
+      case 'features': {
+        const allChoiceFeatures = [
+          ...classFeatures,
+          ...subclassFeatures,
+        ].filter(f => f.choice);
+        return allChoiceFeatures.every(f => featureChoices[f.name]);
+      }
       case 'asi':
         return !!asiChoice;
       case 'hp':
@@ -279,6 +315,9 @@ export function useLevelUpWizard(character: CharacterState) {
     selectedSubclass,
     asiChoice,
     hpRollResult,
+    classFeatures,
+    subclassFeatures,
+    featureChoices,
   ]);
 
   const goNext = useCallback(() => {
@@ -377,13 +416,15 @@ export function useLevelUpWizard(character: CharacterState) {
       classFeatures,
       'class',
       featureSourceDetail,
-      (migrated.extendedFeatures || []).length
+      (migrated.extendedFeatures || []).length,
+      featureChoices
     );
     const subFeatureEntries = buildFeatureEntries(
       subclassFeatures,
       'class',
       `${activeSubclass?.shortName || targetClass.subclass || ''} (${targetClass.className} ${newClassLevel})`,
-      (migrated.extendedFeatures || []).length + classFeatureEntries.length
+      (migrated.extendedFeatures || []).length + classFeatureEntries.length,
+      featureChoices
     );
     if (asiChoice?.type === 'feat') {
       const featEntry = buildFeatureEntries(
@@ -422,6 +463,7 @@ export function useLevelUpWizard(character: CharacterState) {
     allSpells,
     classFeatures,
     subclassFeatures,
+    featureChoices,
     needsHPInput,
     hpRollResult,
     updateCharacter,
@@ -445,6 +487,7 @@ export function useLevelUpWizard(character: CharacterState) {
       selectedEdition,
       selectedSubclass,
       asiChoice,
+      featureChoices,
       hpRollResult,
       steps,
       currentStepIndex,
@@ -467,6 +510,7 @@ export function useLevelUpWizard(character: CharacterState) {
     setTargetClassIndex,
     setSelectedSubclass,
     setASIChoice,
+    setFeatureChoices,
     setHPRollResult,
     applyLevelUp,
   };

--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.types.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.types.ts
@@ -1,0 +1,51 @@
+import type { MulticlassInfo, Spell } from '@/types/character';
+import type {
+  ClassFeature,
+  ProcessedClass,
+  ProcessedSubclass,
+} from '@/types/classes';
+import type { ProcessedFeat } from '@/utils/featDataLoader';
+
+export type WizardStepId =
+  | 'edition'
+  | 'class'
+  | 'subclass'
+  | 'features'
+  | 'asi'
+  | 'hp'
+  | 'confirm';
+
+export interface WizardStepConfig {
+  id: WizardStepId;
+  label: string;
+}
+
+export type ASIChoice =
+  | { type: 'asi'; increases: { ability: string; amount: number }[] }
+  | { type: 'feat'; feat: ProcessedFeat; grantedSpells: Spell[] };
+
+export interface SubclassSpellGrant {
+  spellName: string;
+  grantType: 'prepared' | 'known' | 'expanded';
+  isAlwaysPrepared: boolean;
+}
+
+export interface LevelUpWizardState {
+  targetClassIndex: number;
+  targetClass: MulticlassInfo;
+  newClassLevel: number;
+  newTotalLevel: number;
+  matchedClass: ProcessedClass | null;
+  features: ClassFeature[];
+  subclassFeatures: ClassFeature[];
+  subclassSpellGrants: SubclassSpellGrant[];
+  requiresSubclass: boolean;
+  requiresASI: boolean;
+  isCustomClass: boolean;
+  selectedEdition?: string;
+  selectedSubclass?: ProcessedSubclass;
+  asiChoice?: ASIChoice;
+  hpRollResult?: number;
+  steps: WizardStepConfig[];
+  currentStepIndex: number;
+}

--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.types.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.types.ts
@@ -45,6 +45,7 @@ export interface LevelUpWizardState {
   selectedEdition?: string;
   selectedSubclass?: ProcessedSubclass;
   asiChoice?: ASIChoice;
+  featureChoices: Record<string, string>;
   hpRollResult?: number;
   steps: WizardStepConfig[];
   currentStepIndex: number;

--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.types.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.types.ts
@@ -9,6 +9,7 @@ import type { ProcessedFeat } from '@/utils/featDataLoader';
 export type WizardStepId =
   | 'edition'
   | 'class'
+  | 'subclass-migration'
   | 'subclass'
   | 'features'
   | 'asi'
@@ -30,6 +31,19 @@ export interface SubclassSpellGrant {
   isAlwaysPrepared: boolean;
 }
 
+export interface MissedSubclassFeature {
+  feature: ClassFeature;
+  level: number;
+  adopted: boolean;
+}
+
+export interface SubclassMigration {
+  needed: boolean;
+  selectedSubclass?: ProcessedSubclass;
+  missedFeatures: MissedSubclassFeature[];
+  missedSpellGrants: SubclassSpellGrant[];
+}
+
 export interface LevelUpWizardState {
   targetClassIndex: number;
   targetClass: MulticlassInfo;
@@ -49,4 +63,5 @@ export interface LevelUpWizardState {
   hpRollResult?: number;
   steps: WizardStepConfig[];
   currentStepIndex: number;
+  subclassMigration: SubclassMigration;
 }

--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.utils.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.utils.ts
@@ -1,0 +1,140 @@
+import type {
+  ClassFeature,
+  ProcessedClass,
+  ProcessedSubclass,
+} from '@/types/classes';
+import type { WizardStepConfig } from './LevelUpWizard.types';
+
+export function getSubclassSelectionLevel(
+  processedClass: ProcessedClass
+): number | null {
+  const first = processedClass.features.find(f => f.isSubclassFeature);
+  return first ? first.level : null;
+}
+
+export function getASILevels(processedClass: ProcessedClass): number[] {
+  return processedClass.features
+    .filter(
+      f => f.name === 'Ability Score Improvement' || f.name === 'Epic Boon'
+    )
+    .map(f => f.level);
+}
+
+export function getFeaturesForLevel(
+  processedClass: ProcessedClass,
+  level: number
+): ClassFeature[] {
+  return processedClass.features.filter(
+    f => f.level === level && !f.isSubclassFeature
+  );
+}
+
+export function getSubclassFeaturesForLevel(
+  subclass: ProcessedSubclass,
+  level: number
+): ClassFeature[] {
+  return subclass.features.filter(f => f.level === level);
+}
+
+export function matchClassByName(
+  classes: ProcessedClass[],
+  className: string,
+  classSource?: string
+): ProcessedClass | null {
+  const nameLower = className.toLowerCase();
+  const matches = classes.filter(c => c.name.toLowerCase() === nameLower);
+  if (matches.length === 0) return null;
+  if (matches.length === 1) return matches[0];
+  if (classSource) {
+    const sourceMatch = matches.find(c => {
+      const src = c.source.toUpperCase();
+      return (
+        src === classSource.toUpperCase() ||
+        (classSource === 'XPHB' && src === 'PHB2024') ||
+        (classSource === 'PHB' && src === 'PHB')
+      );
+    });
+    if (sourceMatch) return sourceMatch;
+  }
+  return matches[0];
+}
+
+export function getEditionOptions(
+  classes: ProcessedClass[],
+  className: string
+): ProcessedClass[] {
+  const nameLower = className.toLowerCase();
+  return classes.filter(c => c.name.toLowerCase() === nameLower);
+}
+
+export function getAvailableSubclasses(
+  matchedClass: ProcessedClass
+): ProcessedSubclass[] {
+  return matchedClass.subclasses;
+}
+
+export function computeWizardSteps(params: {
+  isCustomClass: boolean;
+  needsEditionPicker: boolean;
+  isMulticlassed: boolean;
+  requiresSubclass: boolean;
+  hasFeatures: boolean;
+  requiresASI: boolean;
+  needsHPInput: boolean;
+}): WizardStepConfig[] {
+  const steps: WizardStepConfig[] = [];
+
+  if (params.isCustomClass) {
+    if (params.needsHPInput) {
+      steps.push({ id: 'hp', label: 'Hit Points' });
+    }
+    steps.push({ id: 'confirm', label: 'Confirm' });
+    return steps;
+  }
+
+  if (params.needsEditionPicker) {
+    steps.push({ id: 'edition', label: 'Edition' });
+  }
+  if (params.isMulticlassed) {
+    steps.push({ id: 'class', label: 'Class' });
+  }
+  if (params.requiresSubclass) {
+    steps.push({ id: 'subclass', label: 'Subclass' });
+  }
+  if (params.hasFeatures) {
+    steps.push({ id: 'features', label: 'Features' });
+  }
+  if (params.requiresASI) {
+    steps.push({ id: 'asi', label: 'Ability Score' });
+  }
+  if (params.needsHPInput) {
+    steps.push({ id: 'hp', label: 'Hit Points' });
+  }
+  steps.push({ id: 'confirm', label: 'Confirm' });
+
+  return steps;
+}
+
+export function getSpellsKnownDelta(
+  processedClass: ProcessedClass,
+  oldLevel: number,
+  newLevel: number
+): number {
+  const prog = processedClass.spellcasting.spellsKnownProgression;
+  if (!prog) return 0;
+  const oldCount = prog[oldLevel - 1] ?? 0;
+  const newCount = prog[newLevel - 1] ?? 0;
+  return newCount - oldCount;
+}
+
+export function getCantripsKnownDelta(
+  processedClass: ProcessedClass,
+  oldLevel: number,
+  newLevel: number
+): number {
+  const prog = processedClass.spellcasting.cantripProgression;
+  if (!prog) return 0;
+  const oldCount = prog[oldLevel - 1] ?? 0;
+  const newCount = prog[newLevel - 1] ?? 0;
+  return newCount - oldCount;
+}

--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.utils.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.utils.ts
@@ -73,10 +73,25 @@ export function getAvailableSubclasses(
   return matchedClass.subclasses;
 }
 
+export function getMissedSubclassFeatureLevels(
+  subclass: ProcessedSubclass,
+  fromLevel: number,
+  toLevel: number
+): number[] {
+  const levels = new Set<number>();
+  for (const f of subclass.features) {
+    if (f.level >= fromLevel && f.level <= toLevel) {
+      levels.add(f.level);
+    }
+  }
+  return Array.from(levels).sort((a, b) => a - b);
+}
+
 export function computeWizardSteps(params: {
   isCustomClass: boolean;
   needsEditionPicker: boolean;
   isMulticlassed: boolean;
+  needsSubclassMigration: boolean;
   requiresSubclass: boolean;
   hasFeatures: boolean;
   requiresASI: boolean;
@@ -97,6 +112,9 @@ export function computeWizardSteps(params: {
   }
   if (params.isMulticlassed) {
     steps.push({ id: 'class', label: 'Class' });
+  }
+  if (params.needsSubclassMigration) {
+    steps.push({ id: 'subclass-migration', label: 'Subclass' });
   }
   if (params.requiresSubclass) {
     steps.push({ id: 'subclass', label: 'Subclass' });

--- a/src/components/ui/character/LevelUpWizard/index.tsx
+++ b/src/components/ui/character/LevelUpWizard/index.tsx
@@ -155,6 +155,7 @@ export default function LevelUpWizard({ isOpen, onClose }: LevelUpWizardProps) {
               onChoiceChange={wizard.setASIChoice}
               allSpells={wizard.allSpells}
               spellsLoading={false}
+              newTotalLevel={state.newTotalLevel}
             />
           )}
 

--- a/src/components/ui/character/LevelUpWizard/index.tsx
+++ b/src/components/ui/character/LevelUpWizard/index.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useCallback } from 'react';
+import { ArrowLeft, ArrowRight, Check, Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+} from '@/components/ui/feedback/dialog';
+import { Button } from '@/components/ui/forms/button';
+import { cn } from '@/utils/cn';
+import { calculateModifier } from '@/utils/calculations';
+import { useCharacterStore } from '@/store/characterStore';
+import { useLevelUpWizard } from './LevelUpWizard.hooks';
+import EditionPickerStep from './steps/EditionPickerStep';
+import ClassPickerStep from './steps/ClassPickerStep';
+import SubclassSelectionStep from './steps/SubclassSelectionStep';
+import FeaturesSummaryStep from './steps/FeaturesSummaryStep';
+import ASIFeatStep from './steps/ASIFeatStep';
+import HPStep from './steps/HPStep';
+import ConfirmationStep from './steps/ConfirmationStep';
+
+interface LevelUpWizardProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function LevelUpWizard({ isOpen, onClose }: LevelUpWizardProps) {
+  const character = useCharacterStore(s => s.character);
+  const wizard = useLevelUpWizard(character);
+
+  const handleApply = useCallback(() => {
+    wizard.applyLevelUp();
+    onClose();
+  }, [wizard, onClose]);
+
+  if (wizard.loading) {
+    return (
+      <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
+        <DialogContent size="md">
+          <div className="flex items-center justify-center py-16">
+            <Loader2 size={24} className="text-muted animate-spin" />
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  const { state, currentStep } = wizard;
+  const isLastStep = state.currentStepIndex === state.steps.length - 1;
+  const isFirstStep = state.currentStepIndex === 0;
+
+  const activeSubclassName =
+    state.selectedSubclass?.shortName ||
+    state.targetClass?.subclass ||
+    undefined;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>
+            Level Up — {state.targetClass?.className || 'Character'}{' '}
+            {state.targetClass &&
+              `${state.targetClass.level} → ${state.newClassLevel}`}
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Step indicators */}
+        {state.steps.length > 1 && (
+          <div className="border-divider flex items-center gap-1 border-b px-6 pb-3">
+            {state.steps.map((step, i) => (
+              <div key={step.id} className="flex items-center gap-1">
+                <div
+                  className={cn(
+                    'flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium',
+                    i < state.currentStepIndex
+                      ? 'bg-accent-emerald-bg text-accent-emerald-text'
+                      : i === state.currentStepIndex
+                        ? 'bg-accent-blue-bg text-accent-blue-text'
+                        : 'bg-surface-secondary text-muted'
+                  )}
+                >
+                  {i < state.currentStepIndex ? <Check size={12} /> : i + 1}
+                </div>
+                <span
+                  className={cn(
+                    'hidden text-xs sm:inline',
+                    i === state.currentStepIndex
+                      ? 'text-heading font-medium'
+                      : 'text-muted'
+                  )}
+                >
+                  {step.label}
+                </span>
+                {i < state.steps.length - 1 && (
+                  <div className="bg-surface-secondary mx-1 h-px w-4" />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <DialogBody className="min-h-[300px]">
+          {currentStep?.id === 'edition' && (
+            <EditionPickerStep
+              editionOptions={wizard.editionOptions}
+              selectedEdition={state.selectedEdition}
+              onSelect={wizard.setSelectedEdition}
+            />
+          )}
+
+          {currentStep?.id === 'class' && (
+            <ClassPickerStep
+              classes={wizard.classes}
+              selectedIndex={state.targetClassIndex}
+              onSelect={wizard.setTargetClassIndex}
+            />
+          )}
+
+          {currentStep?.id === 'subclass' && state.matchedClass && (
+            <SubclassSelectionStep
+              className={state.targetClass?.className || ''}
+              subclasses={wizard.availableSubclasses}
+              selectedSubclass={state.selectedSubclass}
+              onSelect={wizard.setSelectedSubclass}
+            />
+          )}
+
+          {currentStep?.id === 'features' && (
+            <FeaturesSummaryStep
+              className={state.targetClass?.className || ''}
+              newLevel={state.newClassLevel}
+              features={state.features}
+              subclassFeatures={state.subclassFeatures}
+              subclassName={activeSubclassName}
+              subclassSpellGrants={state.subclassSpellGrants}
+            />
+          )}
+
+          {currentStep?.id === 'asi' && (
+            <ASIFeatStep
+              abilities={character.abilities}
+              asiChoice={state.asiChoice}
+              onChoiceChange={wizard.setASIChoice}
+              allSpells={wizard.allSpells}
+              spellsLoading={false}
+            />
+          )}
+
+          {currentStep?.id === 'hp' && state.targetClass && (
+            <HPStep
+              hitDie={state.targetClass.hitDie}
+              constitutionScore={character.abilities.constitution}
+              hpRollResult={state.hpRollResult}
+              onRollResultChange={wizard.setHPRollResult}
+            />
+          )}
+
+          {currentStep?.id === 'confirm' && state.targetClass && (
+            <ConfirmationStep
+              className={state.targetClass.className}
+              oldClassLevel={state.targetClass.level}
+              newClassLevel={state.newClassLevel}
+              oldTotalLevel={wizard.totalLevel}
+              newTotalLevel={state.newTotalLevel}
+              selectedSubclass={state.selectedSubclass?.shortName}
+              features={state.features}
+              subclassFeatures={state.subclassFeatures}
+              subclassSpellGrants={state.subclassSpellGrants}
+              asiChoice={state.asiChoice}
+              abilities={character.abilities}
+              hpRollResult={state.hpRollResult}
+              hitDie={state.targetClass.hitDie}
+              conModifier={calculateModifier(character.abilities.constitution)}
+              isCustomClass={state.isCustomClass}
+              spellsKnownDelta={wizard.spellsKnownDelta}
+              cantripsKnownDelta={wizard.cantripsKnownDelta}
+            />
+          )}
+        </DialogBody>
+
+        <DialogFooter>
+          <div className="flex w-full items-center justify-between">
+            <div>
+              {!isFirstStep && (
+                <Button variant="ghost" onClick={wizard.goBack}>
+                  <ArrowLeft size={14} className="mr-1" />
+                  Back
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              {isLastStep ? (
+                <Button variant="primary" onClick={handleApply}>
+                  <Check size={14} className="mr-1" />
+                  Apply Level Up
+                </Button>
+              ) : (
+                <Button
+                  variant="primary"
+                  onClick={wizard.goNext}
+                  disabled={!wizard.canGoNext}
+                >
+                  Next
+                  <ArrowRight size={14} className="ml-1" />
+                </Button>
+              )}
+            </div>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/character/LevelUpWizard/index.tsx
+++ b/src/components/ui/character/LevelUpWizard/index.tsx
@@ -138,6 +138,13 @@ export default function LevelUpWizard({ isOpen, onClose }: LevelUpWizardProps) {
               subclassFeatures={state.subclassFeatures}
               subclassName={activeSubclassName}
               subclassSpellGrants={state.subclassSpellGrants}
+              featureChoices={state.featureChoices}
+              onFeatureChoiceChange={(featureName, optionName) =>
+                wizard.setFeatureChoices(prev => ({
+                  ...prev,
+                  [featureName]: optionName,
+                }))
+              }
             />
           )}
 

--- a/src/components/ui/character/LevelUpWizard/index.tsx
+++ b/src/components/ui/character/LevelUpWizard/index.tsx
@@ -18,6 +18,7 @@ import { useLevelUpWizard } from './LevelUpWizard.hooks';
 import EditionPickerStep from './steps/EditionPickerStep';
 import ClassPickerStep from './steps/ClassPickerStep';
 import SubclassSelectionStep from './steps/SubclassSelectionStep';
+import SubclassMigrationStep from './steps/SubclassMigrationStep';
 import FeaturesSummaryStep from './steps/FeaturesSummaryStep';
 import ASIFeatStep from './steps/ASIFeatStep';
 import HPStep from './steps/HPStep';
@@ -54,6 +55,7 @@ export default function LevelUpWizard({ isOpen, onClose }: LevelUpWizardProps) {
   const isFirstStep = state.currentStepIndex === 0;
 
   const activeSubclassName =
+    state.subclassMigration?.selectedSubclass?.shortName ||
     state.selectedSubclass?.shortName ||
     state.targetClass?.subclass ||
     undefined;
@@ -121,6 +123,29 @@ export default function LevelUpWizard({ isOpen, onClose }: LevelUpWizardProps) {
             />
           )}
 
+          {currentStep?.id === 'subclass-migration' && (
+            <SubclassMigrationStep
+              className={state.targetClass?.className || ''}
+              currentLevel={state.targetClass?.level || 0}
+              subclasses={wizard.availableSubclasses}
+              selectedSubclass={state.subclassMigration.selectedSubclass}
+              onSelectSubclass={wizard.setMigrationSubclass}
+              missedFeatures={state.subclassMigration.missedFeatures}
+              missedSpellGrants={state.subclassMigration.missedSpellGrants}
+              onToggleFeature={key => {
+                wizard.setMigrationAdoptedFeatures(prev => {
+                  const next = new Set(prev);
+                  if (next.has(key)) {
+                    next.delete(key);
+                  } else {
+                    next.add(key);
+                  }
+                  return next;
+                });
+              }}
+            />
+          )}
+
           {currentStep?.id === 'subclass' && state.matchedClass && (
             <SubclassSelectionStep
               className={state.targetClass?.className || ''}
@@ -175,7 +200,10 @@ export default function LevelUpWizard({ isOpen, onClose }: LevelUpWizardProps) {
               newClassLevel={state.newClassLevel}
               oldTotalLevel={wizard.totalLevel}
               newTotalLevel={state.newTotalLevel}
-              selectedSubclass={state.selectedSubclass?.shortName}
+              selectedSubclass={
+                state.subclassMigration?.selectedSubclass?.shortName ||
+                state.selectedSubclass?.shortName
+              }
               features={state.features}
               subclassFeatures={state.subclassFeatures}
               subclassSpellGrants={state.subclassSpellGrants}

--- a/src/components/ui/character/LevelUpWizard/steps/ASIFeatStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/ASIFeatStep.tsx
@@ -18,6 +18,7 @@ interface ASIFeatStepProps {
   onChoiceChange: (choice: ASIChoice) => void;
   allSpells: ProcessedSpell[];
   spellsLoading: boolean;
+  newTotalLevel: number;
 }
 
 const ABILITY_NAMES: { key: keyof CharacterAbilities; label: string }[] = [
@@ -129,11 +130,13 @@ function FeatPanel({
   onChoiceChange,
   allSpells,
   spellsLoading,
+  newTotalLevel,
 }: {
   asiChoice: ASIChoice | undefined;
   onChoiceChange: (choice: ASIChoice) => void;
   allSpells: ProcessedSpell[];
   spellsLoading: boolean;
+  newTotalLevel: number;
 }) {
   const { feats, loading: featsLoading } = useFeatsData();
   const [search, setSearch] = useState('');
@@ -144,9 +147,13 @@ function FeatPanel({
 
   const selectedFeat = asiChoice?.type === 'feat' ? asiChoice.feat : null;
 
+  const eligible = feats.filter(
+    f => !f.levelRequirement || f.levelRequirement <= newTotalLevel
+  );
+
   const filtered = search.trim()
-    ? feats.filter(f => f.name.toLowerCase().includes(search.toLowerCase()))
-    : feats;
+    ? eligible.filter(f => f.name.toLowerCase().includes(search.toLowerCase()))
+    : eligible;
 
   const handleSelectFeat = useCallback(
     (feat: ProcessedFeat) => {
@@ -288,6 +295,7 @@ export default function ASIFeatStep({
   onChoiceChange,
   allSpells,
   spellsLoading,
+  newTotalLevel,
 }: ASIFeatStepProps) {
   const [mode, setMode] = useState<'asi' | 'feat'>(asiChoice?.type || 'asi');
 
@@ -346,6 +354,7 @@ export default function ASIFeatStep({
           onChoiceChange={onChoiceChange}
           allSpells={allSpells}
           spellsLoading={spellsLoading}
+          newTotalLevel={newTotalLevel}
         />
       )}
     </div>

--- a/src/components/ui/character/LevelUpWizard/steps/ASIFeatStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/ASIFeatStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { Plus, Minus, Search } from 'lucide-react';
+import { Plus, Minus, Search, ChevronDown, ChevronUp } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { Input } from '@/components/ui/forms/input';
 import { useFeatsData } from '@/hooks/useFeatsData';
@@ -137,6 +137,7 @@ function FeatPanel({
 }) {
   const { feats, loading: featsLoading } = useFeatsData();
   const [search, setSearch] = useState('');
+  const [expandedFeatId, setExpandedFeatId] = useState<string | null>(null);
   const [spellPickerFeat, setSpellPickerFeat] = useState<ProcessedFeat | null>(
     null
   );
@@ -200,31 +201,68 @@ function FeatPanel({
       <div className="max-h-60 space-y-1 overflow-y-auto">
         {filtered.slice(0, 50).map(feat => {
           const isSelected = selectedFeat?.id === feat.id;
+          const isExpanded = expandedFeatId === feat.id;
           return (
-            <button
+            <div
               key={feat.id}
-              onClick={() => handleSelectFeat(feat)}
               className={cn(
-                'flex w-full flex-col rounded-lg border px-3 py-2 text-left transition-all',
+                'rounded-lg border transition-all',
                 isSelected
                   ? 'border-accent-purple-border bg-accent-purple-bg'
-                  : 'border-divider bg-surface-raised hover:bg-surface-secondary'
+                  : 'border-divider bg-surface-raised'
               )}
             >
-              <span
-                className={cn(
-                  'text-sm font-medium',
-                  isSelected ? 'text-accent-purple-text' : 'text-heading'
-                )}
-              >
-                {feat.name}
-              </span>
-              {feat.prerequisites.length > 0 && (
-                <span className="text-faint text-xs">
-                  Requires: {feat.prerequisites.join(', ')}
-                </span>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => handleSelectFeat(feat)}
+                  className={cn(
+                    'flex min-w-0 flex-1 flex-col px-3 py-2 text-left',
+                    !isSelected && 'hover:bg-surface-secondary'
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'text-sm font-medium',
+                      isSelected ? 'text-accent-purple-text' : 'text-heading'
+                    )}
+                  >
+                    {feat.name}
+                  </span>
+                  {feat.prerequisites.length > 0 && (
+                    <span className="text-faint text-xs">
+                      Requires: {feat.prerequisites.join(', ')}
+                    </span>
+                  )}
+                </button>
+                <button
+                  onClick={e => {
+                    e.stopPropagation();
+                    setExpandedFeatId(isExpanded ? null : feat.id);
+                  }}
+                  className="text-muted hover:text-heading flex-shrink-0 px-2 py-2"
+                  title={isExpanded ? 'Hide details' : 'Show details'}
+                >
+                  {isExpanded ? (
+                    <ChevronUp size={14} />
+                  ) : (
+                    <ChevronDown size={14} />
+                  )}
+                </button>
+              </div>
+              {isExpanded && (
+                <div className="border-divider border-t px-3 py-2">
+                  <div
+                    className="text-body text-xs leading-relaxed"
+                    dangerouslySetInnerHTML={{ __html: feat.description }}
+                  />
+                  {feat.abilityIncreases && (
+                    <p className="text-accent-blue-text mt-1 text-xs">
+                      {feat.abilityIncreases}
+                    </p>
+                  )}
+                </div>
               )}
-            </button>
+            </div>
           );
         })}
       </div>

--- a/src/components/ui/character/LevelUpWizard/steps/ASIFeatStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/ASIFeatStep.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Plus, Minus, Search } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { Input } from '@/components/ui/forms/input';
+import { useFeatsData } from '@/hooks/useFeatsData';
+import { parseAdditionalSpells } from '@/utils/additionalSpellsParser';
+import GrantedSpellPicker from '@/components/ui/character/ExtendedFeatures/GrantedSpellPicker';
+import type { CharacterAbilities, Spell } from '@/types/character';
+import type { ProcessedSpell } from '@/types/spells';
+import type { ASIChoice } from '../LevelUpWizard.types';
+import type { ProcessedFeat } from '@/utils/featDataLoader';
+
+interface ASIFeatStepProps {
+  abilities: CharacterAbilities;
+  asiChoice: ASIChoice | undefined;
+  onChoiceChange: (choice: ASIChoice) => void;
+  allSpells: ProcessedSpell[];
+  spellsLoading: boolean;
+}
+
+const ABILITY_NAMES: { key: keyof CharacterAbilities; label: string }[] = [
+  { key: 'strength', label: 'STR' },
+  { key: 'dexterity', label: 'DEX' },
+  { key: 'constitution', label: 'CON' },
+  { key: 'intelligence', label: 'INT' },
+  { key: 'wisdom', label: 'WIS' },
+  { key: 'charisma', label: 'CHA' },
+];
+
+function ASIPanel({
+  abilities,
+  asiChoice,
+  onChoiceChange,
+}: {
+  abilities: CharacterAbilities;
+  asiChoice: ASIChoice | undefined;
+  onChoiceChange: (choice: ASIChoice) => void;
+}) {
+  const increases = asiChoice?.type === 'asi' ? asiChoice.increases : [];
+  const totalPoints = increases.reduce((sum, inc) => sum + inc.amount, 0);
+  const remaining = 2 - totalPoints;
+
+  const handleIncrement = (ability: string) => {
+    if (remaining <= 0) return;
+    const current = abilities[ability as keyof CharacterAbilities];
+    const currentIncrease =
+      increases.find(i => i.ability === ability)?.amount || 0;
+    if (current + currentIncrease >= 20) return;
+    if (currentIncrease >= 2) return;
+
+    const updated = increases.filter(i => i.ability !== ability);
+    updated.push({ ability, amount: currentIncrease + 1 });
+    onChoiceChange({ type: 'asi', increases: updated });
+  };
+
+  const handleDecrement = (ability: string) => {
+    const currentIncrease =
+      increases.find(i => i.ability === ability)?.amount || 0;
+    if (currentIncrease <= 0) return;
+
+    const updated = increases.filter(i => i.ability !== ability);
+    if (currentIncrease > 1) {
+      updated.push({ ability, amount: currentIncrease - 1 });
+    }
+    onChoiceChange({ type: 'asi', increases: updated });
+  };
+
+  return (
+    <div className="space-y-3">
+      <p className="text-muted text-center text-xs">
+        Distribute 2 points (+2 to one, or +1 to two). Max 20 per ability.
+      </p>
+      <p className="text-accent-blue-text text-center text-sm font-semibold">
+        {remaining} point{remaining !== 1 ? 's' : ''} remaining
+      </p>
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        {ABILITY_NAMES.map(({ key, label }) => {
+          const base = abilities[key];
+          const inc = increases.find(i => i.ability === key)?.amount || 0;
+          const newVal = base + inc;
+          const atMax = newVal >= 20;
+
+          return (
+            <div
+              key={key}
+              className={cn(
+                'border-divider bg-surface-raised flex items-center justify-between rounded-lg border px-3 py-2',
+                inc > 0 && 'border-accent-blue-border bg-accent-blue-bg'
+              )}
+            >
+              <div>
+                <span className="text-heading text-xs font-bold">{label}</span>
+                <span className="text-muted ml-1 text-xs">
+                  {base}
+                  {inc > 0 && (
+                    <span className="text-accent-blue-text"> → {newVal}</span>
+                  )}
+                </span>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => handleDecrement(key)}
+                  disabled={inc === 0}
+                  className="text-muted hover:text-heading disabled:opacity-30"
+                >
+                  <Minus size={14} />
+                </button>
+                <button
+                  onClick={() => handleIncrement(key)}
+                  disabled={remaining <= 0 || atMax || inc >= 2}
+                  className="text-muted hover:text-heading disabled:opacity-30"
+                >
+                  <Plus size={14} />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FeatPanel({
+  asiChoice,
+  onChoiceChange,
+  allSpells,
+  spellsLoading,
+}: {
+  asiChoice: ASIChoice | undefined;
+  onChoiceChange: (choice: ASIChoice) => void;
+  allSpells: ProcessedSpell[];
+  spellsLoading: boolean;
+}) {
+  const { feats, loading: featsLoading } = useFeatsData();
+  const [search, setSearch] = useState('');
+  const [spellPickerFeat, setSpellPickerFeat] = useState<ProcessedFeat | null>(
+    null
+  );
+
+  const selectedFeat = asiChoice?.type === 'feat' ? asiChoice.feat : null;
+
+  const filtered = search.trim()
+    ? feats.filter(f => f.name.toLowerCase().includes(search.toLowerCase()))
+    : feats;
+
+  const handleSelectFeat = useCallback(
+    (feat: ProcessedFeat) => {
+      if (feat.grantsSpells && feat.additionalSpells) {
+        setSpellPickerFeat(feat);
+      } else {
+        onChoiceChange({ type: 'feat', feat, grantedSpells: [] });
+      }
+    },
+    [onChoiceChange]
+  );
+
+  const handleSpellsConfirmed = useCallback(
+    (spells: Spell[]) => {
+      if (spellPickerFeat) {
+        onChoiceChange({
+          type: 'feat',
+          feat: spellPickerFeat,
+          grantedSpells: spells,
+        });
+        setSpellPickerFeat(null);
+      }
+    },
+    [spellPickerFeat, onChoiceChange]
+  );
+
+  if (featsLoading) {
+    return (
+      <p className="text-muted py-4 text-center text-sm">Loading feats...</p>
+    );
+  }
+
+  const parsedSpells = spellPickerFeat?.additionalSpells
+    ? parseAdditionalSpells(spellPickerFeat.additionalSpells)
+    : null;
+
+  return (
+    <div className="space-y-3">
+      <div className="relative">
+        <Search
+          size={14}
+          className="text-muted absolute top-1/2 left-3 -translate-y-1/2"
+        />
+        <Input
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Search feats..."
+          className="pl-8"
+        />
+      </div>
+
+      <div className="max-h-60 space-y-1 overflow-y-auto">
+        {filtered.slice(0, 50).map(feat => {
+          const isSelected = selectedFeat?.id === feat.id;
+          return (
+            <button
+              key={feat.id}
+              onClick={() => handleSelectFeat(feat)}
+              className={cn(
+                'flex w-full flex-col rounded-lg border px-3 py-2 text-left transition-all',
+                isSelected
+                  ? 'border-accent-purple-border bg-accent-purple-bg'
+                  : 'border-divider bg-surface-raised hover:bg-surface-secondary'
+              )}
+            >
+              <span
+                className={cn(
+                  'text-sm font-medium',
+                  isSelected ? 'text-accent-purple-text' : 'text-heading'
+                )}
+              >
+                {feat.name}
+              </span>
+              {feat.prerequisites.length > 0 && (
+                <span className="text-faint text-xs">
+                  Requires: {feat.prerequisites.join(', ')}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {spellPickerFeat && parsedSpells && (
+        <GrantedSpellPicker
+          isOpen={true}
+          onClose={() => setSpellPickerFeat(null)}
+          onConfirm={handleSpellsConfirmed}
+          featName={spellPickerFeat.name}
+          parsed={parsedSpells}
+          allSpells={allSpells}
+          spellsLoading={spellsLoading}
+        />
+      )}
+    </div>
+  );
+}
+
+export default function ASIFeatStep({
+  abilities,
+  asiChoice,
+  onChoiceChange,
+  allSpells,
+  spellsLoading,
+}: ASIFeatStepProps) {
+  const [mode, setMode] = useState<'asi' | 'feat'>(asiChoice?.type || 'asi');
+
+  const handleModeChange = (newMode: 'asi' | 'feat') => {
+    setMode(newMode);
+    if (newMode === 'asi' && asiChoice?.type !== 'asi') {
+      onChoiceChange({ type: 'asi', increases: [] });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <h3 className="text-heading text-lg font-semibold">
+          Ability Score Improvement
+        </h3>
+        <p className="text-muted mt-1 text-sm">
+          Increase your ability scores or take a feat.
+        </p>
+      </div>
+
+      <div className="border-divider flex overflow-hidden rounded-lg border">
+        <button
+          onClick={() => handleModeChange('asi')}
+          className={cn(
+            'flex-1 px-4 py-2 text-sm font-medium transition-colors',
+            mode === 'asi'
+              ? 'bg-accent-blue-bg text-accent-blue-text'
+              : 'bg-surface-raised text-muted hover:text-heading'
+          )}
+        >
+          Ability Scores
+        </button>
+        <button
+          onClick={() => handleModeChange('feat')}
+          className={cn(
+            'border-divider flex-1 border-l px-4 py-2 text-sm font-medium transition-colors',
+            mode === 'feat'
+              ? 'bg-accent-purple-bg text-accent-purple-text'
+              : 'bg-surface-raised text-muted hover:text-heading'
+          )}
+        >
+          Take a Feat
+        </button>
+      </div>
+
+      {mode === 'asi' ? (
+        <ASIPanel
+          abilities={abilities}
+          asiChoice={asiChoice}
+          onChoiceChange={onChoiceChange}
+        />
+      ) : (
+        <FeatPanel
+          asiChoice={asiChoice}
+          onChoiceChange={onChoiceChange}
+          allSpells={allSpells}
+          spellsLoading={spellsLoading}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/character/LevelUpWizard/steps/ASIFeatStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/ASIFeatStep.tsx
@@ -227,14 +227,17 @@ function FeatPanel({
                     !isSelected && 'hover:bg-surface-secondary'
                   )}
                 >
-                  <span
-                    className={cn(
-                      'text-sm font-medium',
-                      isSelected ? 'text-accent-purple-text' : 'text-heading'
-                    )}
-                  >
-                    {feat.name}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        'text-sm font-medium',
+                        isSelected ? 'text-accent-purple-text' : 'text-heading'
+                      )}
+                    >
+                      {feat.name}
+                    </span>
+                    <span className="text-faint text-xs">{feat.source}</span>
+                  </div>
                   {feat.prerequisites.length > 0 && (
                     <span className="text-faint text-xs">
                       Requires: {feat.prerequisites.join(', ')}

--- a/src/components/ui/character/LevelUpWizard/steps/ClassPickerStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/ClassPickerStep.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Shield } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import type { MulticlassInfo } from '@/types/character';
+
+interface ClassPickerStepProps {
+  classes: MulticlassInfo[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+}
+
+export default function ClassPickerStep({
+  classes,
+  selectedIndex,
+  onSelect,
+}: ClassPickerStepProps) {
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <h3 className="text-heading text-lg font-semibold">
+          Which class gains a level?
+        </h3>
+        <p className="text-muted mt-1 text-sm">
+          Select the class you want to advance.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {classes.map((cls, index) => {
+          const isSelected = selectedIndex === index;
+          return (
+            <button
+              key={cls.className + index}
+              onClick={() => onSelect(index)}
+              className={cn(
+                'flex w-full items-center gap-3 rounded-lg border p-4 text-left transition-all',
+                isSelected
+                  ? 'border-accent-blue-border bg-accent-blue-bg'
+                  : 'border-divider bg-surface-raised hover:bg-surface-secondary'
+              )}
+            >
+              <Shield
+                size={20}
+                className={cn(
+                  'flex-shrink-0',
+                  isSelected ? 'text-accent-blue-text' : 'text-muted'
+                )}
+              />
+              <div className="flex-1">
+                <span
+                  className={cn(
+                    'font-semibold',
+                    isSelected ? 'text-accent-blue-text' : 'text-heading'
+                  )}
+                >
+                  {cls.className}
+                </span>
+                {cls.subclass && (
+                  <span className="text-muted ml-1 text-sm">
+                    ({cls.subclass})
+                  </span>
+                )}
+              </div>
+              <div className="text-muted text-sm">
+                Level {cls.level} → {cls.level + 1}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/character/LevelUpWizard/steps/ConfirmationStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/ConfirmationStep.tsx
@@ -155,17 +155,25 @@ export default function ConfirmationStep({
                   </ul>
                 </>
               ) : (
-                <span className="text-heading text-sm">
-                  Feat:{' '}
-                  <span className="font-medium">{asiChoice.feat.name}</span>
-                  {asiChoice.grantedSpells.length > 0 && (
-                    <span className="text-muted">
-                      {' '}
-                      (+{asiChoice.grantedSpells.length} spell
-                      {asiChoice.grantedSpells.length > 1 ? 's' : ''})
-                    </span>
-                  )}
-                </span>
+                <div>
+                  <span className="text-heading text-sm">
+                    Feat:{' '}
+                    <span className="font-medium">{asiChoice.feat.name}</span>
+                    {asiChoice.grantedSpells.length > 0 && (
+                      <span className="text-muted">
+                        {' '}
+                        (+{asiChoice.grantedSpells.length} spell
+                        {asiChoice.grantedSpells.length > 1 ? 's' : ''})
+                      </span>
+                    )}
+                  </span>
+                  <div
+                    className="text-muted mt-1 text-xs leading-relaxed"
+                    dangerouslySetInnerHTML={{
+                      __html: asiChoice.feat.description,
+                    }}
+                  />
+                </div>
               )}
             </div>
           </div>

--- a/src/components/ui/character/LevelUpWizard/steps/ConfirmationStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/ConfirmationStep.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { Check, ArrowUp, Sparkles, BookOpen, Heart, Sword } from 'lucide-react';
+import type { ClassFeature } from '@/types/classes';
+import type { CharacterAbilities } from '@/types/character';
+import type { ASIChoice, SubclassSpellGrant } from '../LevelUpWizard.types';
+
+interface ConfirmationStepProps {
+  className: string;
+  oldClassLevel: number;
+  newClassLevel: number;
+  oldTotalLevel: number;
+  newTotalLevel: number;
+  selectedSubclass?: string;
+  features: ClassFeature[];
+  subclassFeatures: ClassFeature[];
+  subclassSpellGrants: SubclassSpellGrant[];
+  asiChoice?: ASIChoice;
+  abilities: CharacterAbilities;
+  hpRollResult?: number;
+  hitDie: number;
+  conModifier: number;
+  isCustomClass: boolean;
+  spellsKnownDelta: number;
+  cantripsKnownDelta: number;
+}
+
+export default function ConfirmationStep({
+  className,
+  oldClassLevel,
+  newClassLevel,
+  oldTotalLevel,
+  newTotalLevel,
+  selectedSubclass,
+  features,
+  subclassFeatures,
+  subclassSpellGrants,
+  asiChoice,
+  abilities,
+  hpRollResult,
+  hitDie,
+  conModifier,
+  isCustomClass,
+  spellsKnownDelta,
+  cantripsKnownDelta,
+}: ConfirmationStepProps) {
+  const displayFeatures = [...features, ...subclassFeatures].filter(
+    f => f.name !== 'Ability Score Improvement' && f.name !== 'Epic Boon'
+  );
+
+  const autoGrantedSpells = subclassSpellGrants.filter(
+    g => g.grantType !== 'expanded'
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <h3 className="text-heading text-lg font-semibold">Level Up Summary</h3>
+        <p className="text-muted mt-1 text-sm">
+          Review your changes before applying.
+        </p>
+      </div>
+
+      <div className="border-divider bg-surface-raised space-y-3 rounded-lg border p-4">
+        {/* Level */}
+        <div className="flex items-center gap-2">
+          <ArrowUp size={14} className="text-accent-emerald-text" />
+          <span className="text-heading text-sm font-medium">
+            {className} {oldClassLevel} → {newClassLevel}
+          </span>
+          {oldTotalLevel !== oldClassLevel && (
+            <span className="text-muted text-xs">(Total: {newTotalLevel})</span>
+          )}
+        </div>
+
+        {/* Subclass */}
+        {selectedSubclass && (
+          <div className="flex items-center gap-2">
+            <Sparkles size={14} className="text-accent-purple-text" />
+            <span className="text-heading text-sm">
+              Subclass: <span className="font-medium">{selectedSubclass}</span>
+            </span>
+          </div>
+        )}
+
+        {/* Features */}
+        {displayFeatures.length > 0 && (
+          <div className="flex items-start gap-2">
+            <BookOpen size={14} className="text-accent-amber-text mt-0.5" />
+            <div>
+              <span className="text-heading text-sm font-medium">
+                Features:
+              </span>
+              <ul className="text-body mt-1 space-y-0.5 text-sm">
+                {displayFeatures.map((f, i) => (
+                  <li key={i} className="flex items-center gap-1">
+                    <Check
+                      size={12}
+                      className="text-accent-emerald-text flex-shrink-0"
+                    />
+                    {f.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+
+        {/* Subclass spells */}
+        {autoGrantedSpells.length > 0 && (
+          <div className="flex items-start gap-2">
+            <Sparkles size={14} className="text-accent-purple-text mt-0.5" />
+            <div>
+              <span className="text-heading text-sm font-medium">
+                Subclass Spells:
+              </span>
+              <ul className="text-body mt-1 space-y-0.5 text-sm">
+                {autoGrantedSpells.map((g, i) => (
+                  <li key={i} className="flex items-center gap-1">
+                    <Check
+                      size={12}
+                      className="text-accent-emerald-text flex-shrink-0"
+                    />
+                    {g.spellName} (always prepared)
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+
+        {/* ASI / Feat */}
+        {asiChoice && (
+          <div className="flex items-start gap-2">
+            <Sword size={14} className="text-accent-blue-text mt-0.5" />
+            <div>
+              {asiChoice.type === 'asi' ? (
+                <>
+                  <span className="text-heading text-sm font-medium">
+                    Ability Scores:
+                  </span>
+                  <ul className="text-body mt-1 space-y-0.5 text-sm">
+                    {asiChoice.increases.map((inc, i) => (
+                      <li key={i}>
+                        {inc.ability.charAt(0).toUpperCase() +
+                          inc.ability.slice(1)}
+                        : {abilities[inc.ability as keyof CharacterAbilities]} →{' '}
+                        {Math.min(
+                          20,
+                          abilities[inc.ability as keyof CharacterAbilities] +
+                            inc.amount
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              ) : (
+                <span className="text-heading text-sm">
+                  Feat:{' '}
+                  <span className="font-medium">{asiChoice.feat.name}</span>
+                  {asiChoice.grantedSpells.length > 0 && (
+                    <span className="text-muted">
+                      {' '}
+                      (+{asiChoice.grantedSpells.length} spell
+                      {asiChoice.grantedSpells.length > 1 ? 's' : ''})
+                    </span>
+                  )}
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* HP */}
+        {hpRollResult !== undefined && (
+          <div className="flex items-center gap-2">
+            <Heart size={14} className="text-accent-red-text" />
+            <span className="text-heading text-sm">
+              HP: +{Math.max(1, hpRollResult + conModifier)} (d{hitDie}:{' '}
+              {hpRollResult} + CON: {conModifier >= 0 ? '+' : ''}
+              {conModifier})
+            </span>
+          </div>
+        )}
+
+        {/* Custom class note */}
+        {isCustomClass && (
+          <p className="text-muted text-xs italic">
+            Custom class — update features and abilities manually.
+          </p>
+        )}
+
+        {/* Spell notes */}
+        {(spellsKnownDelta > 0 || cantripsKnownDelta > 0) && (
+          <div className="border-divider mt-2 border-t pt-2">
+            <p className="text-muted text-xs">
+              {cantripsKnownDelta > 0 &&
+                `You can learn ${cantripsKnownDelta} new cantrip${cantripsKnownDelta > 1 ? 's' : ''}. `}
+              {spellsKnownDelta > 0 &&
+                `You can learn ${spellsKnownDelta} new spell${spellsKnownDelta > 1 ? 's' : ''}. `}
+              Visit the Spells tab to choose.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/character/LevelUpWizard/steps/EditionPickerStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/EditionPickerStep.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { BookOpen } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import type { ProcessedClass } from '@/types/classes';
+
+interface EditionPickerStepProps {
+  editionOptions: ProcessedClass[];
+  selectedEdition: string | undefined;
+  onSelect: (source: string) => void;
+}
+
+const EDITION_INFO: Record<string, { label: string; description: string }> = {
+  PHB: {
+    label: '2014 Rules (PHB)',
+    description: "Original Player's Handbook — classic 5th Edition rules",
+  },
+  PHB2024: {
+    label: '2024 Rules (PHB 2024)',
+    description: "Revised Player's Handbook — updated 5.5e rules",
+  },
+};
+
+function getEditionKey(source: string): string {
+  const upper = source.toUpperCase();
+  if (upper === 'PHB2024' || upper === 'XPHB') return 'PHB2024';
+  return 'PHB';
+}
+
+function getSourceValue(source: string): string {
+  const upper = source.toUpperCase();
+  if (upper === 'PHB2024') return 'XPHB';
+  return upper;
+}
+
+export default function EditionPickerStep({
+  editionOptions,
+  selectedEdition,
+  onSelect,
+}: EditionPickerStepProps) {
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <h3 className="text-heading text-lg font-semibold">
+          Which edition are you playing?
+        </h3>
+        <p className="text-muted mt-1 text-sm">
+          This determines which class features and subclasses are available.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {editionOptions.map(option => {
+          const key = getEditionKey(option.source);
+          const info = EDITION_INFO[key] || {
+            label: option.source,
+            description: '',
+          };
+          const sourceValue = getSourceValue(option.source);
+          const isSelected = selectedEdition === sourceValue;
+
+          return (
+            <button
+              key={option.id}
+              onClick={() => onSelect(sourceValue)}
+              className={cn(
+                'rounded-lg border p-4 text-left transition-all',
+                isSelected
+                  ? 'border-accent-blue-border bg-accent-blue-bg'
+                  : 'border-divider bg-surface-raised hover:bg-surface-secondary'
+              )}
+            >
+              <div className="flex items-start gap-3">
+                <BookOpen
+                  size={20}
+                  className={cn(
+                    'mt-0.5 flex-shrink-0',
+                    isSelected ? 'text-accent-blue-text' : 'text-muted'
+                  )}
+                />
+                <div>
+                  <p
+                    className={cn(
+                      'font-semibold',
+                      isSelected ? 'text-accent-blue-text' : 'text-heading'
+                    )}
+                  >
+                    {info.label}
+                  </p>
+                  <p className="text-muted mt-1 text-xs">{info.description}</p>
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/character/LevelUpWizard/steps/FeaturesSummaryStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/FeaturesSummaryStep.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState } from 'react';
+import { BookOpen, ChevronDown, ChevronUp, Sparkles } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import type { ClassFeature } from '@/types/classes';
+import type { SubclassSpellGrant } from '../LevelUpWizard.types';
+
+interface FeaturesSummaryStepProps {
+  className: string;
+  newLevel: number;
+  features: ClassFeature[];
+  subclassFeatures: ClassFeature[];
+  subclassName?: string;
+  subclassSpellGrants: SubclassSpellGrant[];
+}
+
+function FeatureCard({ feature }: { feature: ClassFeature }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDescription = feature.entries && feature.entries.length > 0;
+
+  return (
+    <div className="border-divider bg-surface-raised rounded-lg border">
+      <button
+        onClick={() => hasDescription && setExpanded(!expanded)}
+        className={cn(
+          'flex w-full items-center justify-between p-3 text-left',
+          hasDescription && 'hover:bg-surface-secondary cursor-pointer'
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <BookOpen
+            size={14}
+            className="text-accent-amber-text flex-shrink-0"
+          />
+          <span className="text-heading text-sm font-medium">
+            {feature.name}
+          </span>
+        </div>
+        {hasDescription &&
+          (expanded ? (
+            <ChevronUp size={14} className="text-muted" />
+          ) : (
+            <ChevronDown size={14} className="text-muted" />
+          ))}
+      </button>
+      {expanded && hasDescription && (
+        <div className="border-divider text-body border-t px-3 py-2 text-sm leading-relaxed">
+          {feature.entries!.map((entry, i) => (
+            <p key={i} className="mb-2 last:mb-0">
+              {entry}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function FeaturesSummaryStep({
+  className,
+  newLevel,
+  features,
+  subclassFeatures,
+  subclassName,
+  subclassSpellGrants,
+}: FeaturesSummaryStepProps) {
+  const displayFeatures = features.filter(
+    f => f.name !== 'Ability Score Improvement' && f.name !== 'Epic Boon'
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <h3 className="text-heading text-lg font-semibold">
+          New Features at Level {newLevel}
+        </h3>
+        <p className="text-muted mt-1 text-sm">
+          Here&apos;s what your {className} gains.
+        </p>
+      </div>
+
+      {displayFeatures.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-heading text-sm font-semibold">Class Features</h4>
+          {displayFeatures.map((f, i) => (
+            <FeatureCard key={`class-${i}`} feature={f} />
+          ))}
+        </div>
+      )}
+
+      {subclassFeatures.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-heading text-sm font-semibold">
+            {subclassName || 'Subclass'} Features
+          </h4>
+          {subclassFeatures.map((f, i) => (
+            <FeatureCard key={`sub-${i}`} feature={f} />
+          ))}
+        </div>
+      )}
+
+      {subclassSpellGrants.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-heading flex items-center gap-2 text-sm font-semibold">
+            <Sparkles size={14} className="text-accent-purple-text" />
+            {subclassName || 'Subclass'} Spells
+          </h4>
+          <div className="border-divider bg-surface-raised space-y-1 rounded-lg border p-3">
+            {subclassSpellGrants.map((grant, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between text-sm"
+              >
+                <span className="text-heading">{grant.spellName}</span>
+                <span
+                  className={cn(
+                    'rounded-full px-2 py-0.5 text-xs font-medium',
+                    grant.grantType === 'expanded'
+                      ? 'bg-surface-secondary text-muted'
+                      : 'bg-accent-emerald-bg text-accent-emerald-text'
+                  )}
+                >
+                  {grant.grantType === 'expanded'
+                    ? 'Available'
+                    : 'Always Prepared'}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/character/LevelUpWizard/steps/FeaturesSummaryStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/FeaturesSummaryStep.tsx
@@ -47,9 +47,11 @@ function FeatureCard({ feature }: { feature: ClassFeature }) {
       {expanded && hasDescription && (
         <div className="border-divider text-body border-t px-3 py-2 text-sm leading-relaxed">
           {feature.entries!.map((entry, i) => (
-            <p key={i} className="mb-2 last:mb-0">
-              {entry}
-            </p>
+            <p
+              key={i}
+              className="mb-2 last:mb-0"
+              dangerouslySetInnerHTML={{ __html: entry }}
+            />
           ))}
         </div>
       )}

--- a/src/components/ui/character/LevelUpWizard/steps/FeaturesSummaryStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/FeaturesSummaryStep.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import { BookOpen, ChevronDown, ChevronUp, Sparkles } from 'lucide-react';
+import {
+  BookOpen,
+  ChevronDown,
+  ChevronUp,
+  Sparkles,
+  Check,
+} from 'lucide-react';
 import { cn } from '@/utils/cn';
 import type { ClassFeature } from '@/types/classes';
 import type { SubclassSpellGrant } from '../LevelUpWizard.types';
@@ -13,19 +19,31 @@ interface FeaturesSummaryStepProps {
   subclassFeatures: ClassFeature[];
   subclassName?: string;
   subclassSpellGrants: SubclassSpellGrant[];
+  featureChoices: Record<string, string>;
+  onFeatureChoiceChange: (featureName: string, optionName: string) => void;
 }
 
-function FeatureCard({ feature }: { feature: ClassFeature }) {
-  const [expanded, setExpanded] = useState(false);
+function FeatureCard({
+  feature,
+  selectedOption,
+  onOptionSelect,
+}: {
+  feature: ClassFeature;
+  selectedOption?: string;
+  onOptionSelect?: (optionName: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(!!feature.choice);
   const hasDescription = feature.entries && feature.entries.length > 0;
+  const hasChoice = !!feature.choice;
 
   return (
     <div className="border-divider bg-surface-raised rounded-lg border">
       <button
-        onClick={() => hasDescription && setExpanded(!expanded)}
+        onClick={() => (hasDescription || hasChoice) && setExpanded(!expanded)}
         className={cn(
           'flex w-full items-center justify-between p-3 text-left',
-          hasDescription && 'hover:bg-surface-secondary cursor-pointer'
+          (hasDescription || hasChoice) &&
+            'hover:bg-surface-secondary cursor-pointer'
         )}
       >
         <div className="flex items-center gap-2">
@@ -36,23 +54,98 @@ function FeatureCard({ feature }: { feature: ClassFeature }) {
           <span className="text-heading text-sm font-medium">
             {feature.name}
           </span>
+          {hasChoice && !selectedOption && (
+            <span className="bg-accent-amber-bg text-accent-amber-text rounded-full px-2 py-0.5 text-xs font-medium">
+              Choose one
+            </span>
+          )}
+          {hasChoice && selectedOption && (
+            <span className="bg-accent-emerald-bg text-accent-emerald-text rounded-full px-2 py-0.5 text-xs font-medium">
+              {selectedOption}
+            </span>
+          )}
         </div>
-        {hasDescription &&
+        {(hasDescription || hasChoice) &&
           (expanded ? (
             <ChevronUp size={14} className="text-muted" />
           ) : (
             <ChevronDown size={14} className="text-muted" />
           ))}
       </button>
-      {expanded && hasDescription && (
-        <div className="border-divider text-body border-t px-3 py-2 text-sm leading-relaxed">
-          {feature.entries!.map((entry, i) => (
-            <p
-              key={i}
-              className="mb-2 last:mb-0"
-              dangerouslySetInnerHTML={{ __html: entry }}
-            />
-          ))}
+      {expanded && (
+        <div className="border-divider border-t px-3 py-2">
+          {hasDescription && (
+            <div className="text-body text-sm leading-relaxed">
+              {feature.entries!.map((entry, i) => (
+                <p
+                  key={i}
+                  className="mb-2 last:mb-0"
+                  dangerouslySetInnerHTML={{ __html: entry }}
+                />
+              ))}
+            </div>
+          )}
+          {hasChoice && (
+            <div className="mt-2 space-y-2">
+              {feature.choice!.options.map(option => {
+                const isSelected = selectedOption === option.name;
+                return (
+                  <button
+                    key={option.name}
+                    onClick={e => {
+                      e.stopPropagation();
+                      onOptionSelect?.(option.name);
+                    }}
+                    className={cn(
+                      'w-full rounded-lg border p-3 text-left transition-all',
+                      isSelected
+                        ? 'border-accent-emerald-border bg-accent-emerald-bg'
+                        : 'border-divider bg-surface hover:bg-surface-secondary'
+                    )}
+                  >
+                    <div className="flex items-center gap-2">
+                      <div
+                        className={cn(
+                          'flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border',
+                          isSelected
+                            ? 'border-accent-emerald-border bg-accent-emerald-bg'
+                            : 'border-divider'
+                        )}
+                      >
+                        {isSelected && (
+                          <Check
+                            size={12}
+                            className="text-accent-emerald-text"
+                          />
+                        )}
+                      </div>
+                      <span
+                        className={cn(
+                          'text-sm font-medium',
+                          isSelected
+                            ? 'text-accent-emerald-text'
+                            : 'text-heading'
+                        )}
+                      >
+                        {option.name}
+                      </span>
+                    </div>
+                    {option.entries.length > 0 && (
+                      <div className="text-muted mt-1 pl-7 text-xs leading-relaxed">
+                        {option.entries.map((entry, i) => (
+                          <p
+                            key={i}
+                            className="mb-1 last:mb-0"
+                            dangerouslySetInnerHTML={{ __html: entry }}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -66,6 +159,8 @@ export default function FeaturesSummaryStep({
   subclassFeatures,
   subclassName,
   subclassSpellGrants,
+  featureChoices,
+  onFeatureChoiceChange,
 }: FeaturesSummaryStepProps) {
   const displayFeatures = features.filter(
     f => f.name !== 'Ability Score Improvement' && f.name !== 'Epic Boon'
@@ -86,7 +181,12 @@ export default function FeaturesSummaryStep({
         <div className="space-y-2">
           <h4 className="text-heading text-sm font-semibold">Class Features</h4>
           {displayFeatures.map((f, i) => (
-            <FeatureCard key={`class-${i}`} feature={f} />
+            <FeatureCard
+              key={`class-${i}`}
+              feature={f}
+              selectedOption={featureChoices[f.name]}
+              onOptionSelect={name => onFeatureChoiceChange(f.name, name)}
+            />
           ))}
         </div>
       )}
@@ -97,7 +197,12 @@ export default function FeaturesSummaryStep({
             {subclassName || 'Subclass'} Features
           </h4>
           {subclassFeatures.map((f, i) => (
-            <FeatureCard key={`sub-${i}`} feature={f} />
+            <FeatureCard
+              key={`sub-${i}`}
+              feature={f}
+              selectedOption={featureChoices[f.name]}
+              onOptionSelect={name => onFeatureChoiceChange(f.name, name)}
+            />
           ))}
         </div>
       )}

--- a/src/components/ui/character/LevelUpWizard/steps/HPStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/HPStep.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Heart } from 'lucide-react';
+import { Input } from '@/components/ui/forms/input';
+import { calculateModifier } from '@/utils/calculations';
+
+interface HPStepProps {
+  hitDie: number;
+  constitutionScore: number;
+  hpRollResult: number | undefined;
+  onRollResultChange: (result: number | undefined) => void;
+}
+
+export default function HPStep({
+  hitDie,
+  constitutionScore,
+  hpRollResult,
+  onRollResultChange,
+}: HPStepProps) {
+  const conMod = calculateModifier(constitutionScore);
+  const average = Math.ceil(hitDie / 2) + 1;
+  const totalGain = hpRollResult !== undefined ? hpRollResult + conMod : null;
+
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <h3 className="text-heading text-lg font-semibold">Hit Points</h3>
+        <p className="text-muted mt-1 text-sm">
+          Roll your d{hitDie} or take the average ({average}).
+        </p>
+      </div>
+
+      <div className="border-divider bg-surface-raised mx-auto max-w-xs rounded-lg border p-4">
+        <div className="flex items-center justify-center gap-2">
+          <Heart size={18} className="text-accent-red-text" />
+          <label className="text-heading text-sm font-medium">
+            Hit Die Roll (d{hitDie})
+          </label>
+        </div>
+
+        <div className="mt-3 flex items-center justify-center gap-3">
+          <Input
+            type="number"
+            min={1}
+            max={hitDie}
+            value={hpRollResult ?? ''}
+            onChange={e => {
+              const val = e.target.value;
+              onRollResultChange(val ? parseInt(val, 10) : undefined);
+            }}
+            placeholder={`1-${hitDie}`}
+            className="w-24 text-center"
+          />
+        </div>
+
+        {totalGain !== null && (
+          <div className="text-muted mt-3 space-y-1 text-center text-xs">
+            <p>
+              Roll: {hpRollResult} + CON modifier: {conMod >= 0 ? '+' : ''}
+              {conMod}
+            </p>
+            <p className="text-accent-emerald-text text-sm font-semibold">
+              Total HP gained: +{Math.max(1, totalGain)}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/character/LevelUpWizard/steps/SubclassMigrationStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/SubclassMigrationStep.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { Sparkles, BookOpen, Check, AlertTriangle } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import type { ProcessedSubclass } from '@/types/classes';
+import type {
+  MissedSubclassFeature,
+  SubclassSpellGrant,
+} from '../LevelUpWizard.types';
+
+interface SubclassMigrationStepProps {
+  className: string;
+  currentLevel: number;
+  subclasses: ProcessedSubclass[];
+  selectedSubclass: ProcessedSubclass | undefined;
+  onSelectSubclass: (subclass: ProcessedSubclass) => void;
+  missedFeatures: MissedSubclassFeature[];
+  missedSpellGrants: SubclassSpellGrant[];
+  onToggleFeature: (featureKey: string) => void;
+}
+
+export default function SubclassMigrationStep({
+  className,
+  currentLevel,
+  subclasses,
+  selectedSubclass,
+  onSelectSubclass,
+  missedFeatures,
+  missedSpellGrants,
+  onToggleFeature,
+}: SubclassMigrationStepProps) {
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <div className="bg-accent-amber-bg text-accent-amber-text mx-auto mb-2 flex w-fit items-center gap-2 rounded-full px-3 py-1 text-xs font-medium">
+          <AlertTriangle size={12} />
+          Subclass not set
+        </div>
+        <h3 className="text-heading text-lg font-semibold">
+          Choose your {className} subclass
+        </h3>
+        <p className="text-muted mt-1 text-sm">
+          Your character is level {currentLevel} but has no subclass. Select one
+          now to continue.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {subclasses.map(sc => {
+          const isSelected = selectedSubclass?.id === sc.id;
+          return (
+            <button
+              key={sc.id}
+              onClick={() => onSelectSubclass(sc)}
+              className={cn(
+                'rounded-lg border p-3 text-left transition-all',
+                isSelected
+                  ? 'border-accent-purple-border bg-accent-purple-bg'
+                  : 'border-divider bg-surface-raised hover:bg-surface-secondary'
+              )}
+            >
+              <div className="flex items-start gap-2">
+                <Sparkles
+                  size={16}
+                  className={cn(
+                    'mt-0.5 flex-shrink-0',
+                    isSelected ? 'text-accent-purple-text' : 'text-muted'
+                  )}
+                />
+                <div className="min-w-0">
+                  <p
+                    className={cn(
+                      'text-sm font-semibold',
+                      isSelected ? 'text-accent-purple-text' : 'text-heading'
+                    )}
+                  >
+                    {sc.name}
+                  </p>
+                  <p className="text-faint mt-0.5 text-xs">{sc.source}</p>
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {selectedSubclass && missedFeatures.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-heading text-sm font-semibold">
+            Missed subclass features
+          </h4>
+          <p className="text-muted text-xs">
+            These features were available at earlier levels. Toggle on any you
+            haven&apos;t already added manually.
+          </p>
+          <div className="space-y-1">
+            {missedFeatures.map(mf => {
+              const key = `${mf.feature.name}-${mf.level}`;
+              return (
+                <button
+                  key={key}
+                  onClick={() => onToggleFeature(key)}
+                  className={cn(
+                    'flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition-all',
+                    mf.adopted
+                      ? 'border-accent-emerald-border bg-accent-emerald-bg'
+                      : 'border-divider bg-surface-raised hover:bg-surface-secondary'
+                  )}
+                >
+                  <div
+                    className={cn(
+                      'flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border',
+                      mf.adopted
+                        ? 'border-accent-emerald-border bg-accent-emerald-bg'
+                        : 'border-divider'
+                    )}
+                  >
+                    {mf.adopted && (
+                      <Check size={12} className="text-accent-emerald-text" />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <BookOpen
+                        size={12}
+                        className="text-accent-amber-text flex-shrink-0"
+                      />
+                      <span
+                        className={cn(
+                          'text-sm font-medium',
+                          mf.adopted
+                            ? 'text-accent-emerald-text'
+                            : 'text-heading'
+                        )}
+                      >
+                        {mf.feature.name}
+                      </span>
+                      <span className="text-faint text-xs">Lv {mf.level}</span>
+                    </div>
+                    {mf.feature.entries && mf.feature.entries.length > 0 && (
+                      <p
+                        className="text-muted mt-0.5 line-clamp-2 text-xs"
+                        dangerouslySetInnerHTML={{
+                          __html: mf.feature.entries[0],
+                        }}
+                      />
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {selectedSubclass && missedSpellGrants.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-heading flex items-center gap-2 text-sm font-semibold">
+            <Sparkles size={14} className="text-accent-purple-text" />
+            Missed subclass spells
+          </h4>
+          <p className="text-muted text-xs">
+            These spells will be added automatically.
+          </p>
+          <div className="border-divider bg-surface-raised space-y-1 rounded-lg border p-3">
+            {missedSpellGrants.map((grant, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between text-sm"
+              >
+                <span className="text-heading">{grant.spellName}</span>
+                <span className="bg-accent-emerald-bg text-accent-emerald-text rounded-full px-2 py-0.5 text-xs font-medium">
+                  Always Prepared
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/character/LevelUpWizard/steps/SubclassSelectionStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/SubclassSelectionStep.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import type { ProcessedSubclass } from '@/types/classes';
+
+interface SubclassSelectionStepProps {
+  className: string;
+  subclasses: ProcessedSubclass[];
+  selectedSubclass: ProcessedSubclass | undefined;
+  onSelect: (subclass: ProcessedSubclass) => void;
+}
+
+export default function SubclassSelectionStep({
+  className,
+  subclasses,
+  selectedSubclass,
+  onSelect,
+}: SubclassSelectionStepProps) {
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <h3 className="text-heading text-lg font-semibold">
+          Choose your {className} subclass
+        </h3>
+        <p className="text-muted mt-1 text-sm">
+          This choice shapes your character for the rest of the game.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {subclasses.map(sc => {
+          const isSelected = selectedSubclass?.id === sc.id;
+          return (
+            <button
+              key={sc.id}
+              onClick={() => onSelect(sc)}
+              className={cn(
+                'rounded-lg border p-4 text-left transition-all',
+                isSelected
+                  ? 'border-accent-purple-border bg-accent-purple-bg'
+                  : 'border-divider bg-surface-raised hover:bg-surface-secondary'
+              )}
+            >
+              <div className="flex items-start gap-3">
+                <Sparkles
+                  size={18}
+                  className={cn(
+                    'mt-0.5 flex-shrink-0',
+                    isSelected ? 'text-accent-purple-text' : 'text-muted'
+                  )}
+                />
+                <div className="min-w-0">
+                  <p
+                    className={cn(
+                      'font-semibold',
+                      isSelected ? 'text-accent-purple-text' : 'text-heading'
+                    )}
+                  >
+                    {sc.name}
+                  </p>
+                  <p className="text-faint mt-0.5 text-xs">{sc.source}</p>
+                  {sc.description && (
+                    <p className="text-muted mt-2 line-clamp-3 text-xs">
+                      {sc.description}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/character/tabbedSheetConfig.tsx
+++ b/src/components/ui/character/tabbedSheetConfig.tsx
@@ -63,19 +63,8 @@ import {
 
 function WizardHatIcon({ size = 14 }: { size?: number }) {
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M12 2L6 18h12L12 2z" />
-      <path d="M4 22c0-2 3.5-4 8-4s8 2 8 4" />
-      <circle cx="10" cy="10" r="1" fill="currentColor" stroke="none" />
+    <svg width={size} height={size} viewBox="0 0 512 512" fill="currentColor">
+      <path d="M496 448H16c-8.84 0-16 7.16-16 16v32c0 8.84 7.16 16 16 16h480c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zm-304-64l-64-32 64-32 32-64 32 64 64 32-64 32-16 32h208l-86.41-201.63a63.955 63.955 0 0 1-1.89-45.45L416 0 228.42 107.19a127.989 127.989 0 0 0-53.46 59.15L64 416h144l-16-32zm64-224l16-32 16 32 32 16-32 16-16 32-16-32-32-16 32-16z" />
     </svg>
   );
 }

--- a/src/components/ui/character/tabbedSheetConfig.tsx
+++ b/src/components/ui/character/tabbedSheetConfig.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Angry, Zap, ChevronDown, ChevronRight, ArrowUp } from 'lucide-react';
+import { Angry, Zap, ChevronDown, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import LevelUpWizard from '@/components/ui/character/LevelUpWizard';
 import ErrorBoundary from '@/components/ui/feedback/ErrorBoundary';
@@ -61,12 +61,31 @@ import {
   InventoryItem,
 } from '@/types/character';
 
+function WizardHatIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 2L6 18h12L12 2z" />
+      <path d="M4 22c0-2 3.5-4 8-4s8 2 8 4" />
+      <circle cx="10" cy="10" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
 function LevelUpButton() {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <>
       <Button variant="primary" size="sm" onClick={() => setIsOpen(true)}>
-        <ArrowUp size={14} className="mr-1" />
+        <WizardHatIcon size={14} />
         Level Up
       </Button>
       {isOpen && (

--- a/src/components/ui/character/tabbedSheetConfig.tsx
+++ b/src/components/ui/character/tabbedSheetConfig.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { Angry, Zap, ChevronDown, ChevronRight } from 'lucide-react';
+import { Angry, Zap, ChevronDown, ChevronRight, ArrowUp } from 'lucide-react';
+import { Button } from '@/components/ui/forms/button';
+import LevelUpWizard from '@/components/ui/character/LevelUpWizard';
 import ErrorBoundary from '@/components/ui/feedback/ErrorBoundary';
 import { PlayerCalendarView } from '@/components/ui/calendar/PlayerCalendarView';
 import PlayerLocationView from '@/components/ui/campaign/location-map/PlayerLocationView';
@@ -58,6 +60,21 @@ import {
   Spell,
   InventoryItem,
 } from '@/types/character';
+
+function LevelUpButton() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Button variant="primary" size="sm" onClick={() => setIsOpen(true)}>
+        <ArrowUp size={14} className="mr-1" />
+        Level Up
+      </Button>
+      {isOpen && (
+        <LevelUpWizard isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      )}
+    </>
+  );
+}
 
 export interface TabbedSheetConfigParams {
   character: CharacterState;
@@ -392,9 +409,12 @@ export function createTabbedSheetConfig(
                 onRollSavingThrow={params.rollSavingThrow}
               />
               <div className="border-accent-amber-border bg-surface-raised rounded-lg border p-6 shadow-lg">
-                <h2 className="border-divider text-heading mb-4 border-b pb-2 text-lg font-bold">
-                  Experience Points
-                </h2>
+                <div className="border-divider mb-4 flex items-center justify-between border-b pb-2">
+                  <h2 className="text-heading text-lg font-bold">
+                    Experience Points
+                  </h2>
+                  {totalLevel < 20 && <LevelUpButton />}
+                </div>
                 <XPTracker
                   currentXP={character.experience}
                   currentLevel={totalLevel}

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -308,6 +308,7 @@ export interface MulticlassInfo {
   spellcaster?: 'full' | 'half' | 'third' | 'warlock' | 'none';
   hitDie: number; // d6, d8, d10, d12 - the size of the hit die for this class
   subclass?: string; // Optional subclass name
+  classSource?: string; // PHB or XPHB
 }
 
 // Multiclass validation result
@@ -935,6 +936,7 @@ export interface MulticlassInfo {
   spellcaster?: 'full' | 'half' | 'third' | 'warlock' | 'none';
   hitDie: number;
   subclass?: string;
+  classSource?: string; // PHB or XPHB
 }
 
 export interface HitDicePools {

--- a/src/types/classes.ts
+++ b/src/types/classes.ts
@@ -87,6 +87,16 @@ export interface RawSubclassData {
   };
 }
 
+export interface FeatureOption {
+  name: string;
+  entries: string[];
+}
+
+export interface FeatureChoice {
+  count: number;
+  options: FeatureOption[];
+}
+
 // Class feature with description
 export interface ClassFeature {
   name: string;
@@ -98,6 +108,7 @@ export interface ClassFeature {
   subclassShortName?: string;
   original: string; // Original feature reference
   is2024Rules?: boolean;
+  choice?: FeatureChoice;
 }
 
 // Processed class data for our application

--- a/src/utils/classDataLoader.ts
+++ b/src/utils/classDataLoader.ts
@@ -9,6 +9,8 @@ import {
   ProcessedClass,
   ProcessedSubclass,
   ClassFeature,
+  FeatureChoice,
+  FeatureOption,
   SubclassSpellList,
   SpellcastingType,
 } from '@/types/classes';
@@ -229,8 +231,14 @@ function processClassFeatures(
     );
 
     let entries: string[] = [];
+    let choice: FeatureChoice | undefined;
     if (featureDesc?.entries && Array.isArray(featureDesc.entries)) {
-      entries = processFeatureEntries(featureDesc.entries);
+      const processed = processFeatureEntries(
+        featureDesc.entries,
+        classFeatureDescriptions
+      );
+      entries = processed.html;
+      choice = processed.choice;
     }
 
     return {
@@ -242,6 +250,7 @@ function processClassFeatures(
       isSubclassFeature,
       original,
       is2024Rules: Boolean(featureDesc?.basicRules2024),
+      ...(choice ? { choice } : {}),
     };
   });
 
@@ -280,8 +289,14 @@ function processSubclassFeatures(
   const features = relevantFeatures.map(featureDesc => {
     const feature = featureDesc as Record<string, unknown>;
     let entries: string[] = [];
+    let choice: FeatureChoice | undefined;
     if (feature.entries && Array.isArray(feature.entries)) {
-      entries = processFeatureEntries(feature.entries);
+      const processed = processFeatureEntries(
+        feature.entries,
+        subclassFeatureDescriptions
+      );
+      entries = processed.html;
+      choice = processed.choice;
     }
 
     // Force 2024 D&D compliance: all subclass features start at level 3 minimum
@@ -298,6 +313,7 @@ function processSubclassFeatures(
       subclassShortName,
       original: `${feature.name}|${className}||${subclassShortName}||${feature.level}`,
       is2024Rules: Boolean(feature.basicRules2024),
+      ...(choice ? { choice } : {}),
     };
   });
 
@@ -308,30 +324,68 @@ function processSubclassFeatures(
 /**
  * Process feature entries and flatten nested structures
  */
-function processFeatureEntries(entries: unknown[]): string[] {
+function processFeatureEntries(
+  entries: unknown[],
+  featureDescriptions?: Record<string, unknown>[]
+): { html: string[]; choice?: FeatureChoice } {
   const result: string[] = [];
+  let choice: FeatureChoice | undefined;
 
   for (const entry of entries) {
     if (typeof entry === 'string') {
       result.push(parseReferences(entry).html);
     } else if (entry && typeof entry === 'object') {
       const entryObj = entry as Record<string, unknown>;
-      if (entryObj.type === 'entries' && Array.isArray(entryObj.entries)) {
-        // Nested entries
+      if (entryObj.type === 'options' && Array.isArray(entryObj.entries)) {
+        const count = (entryObj.count as number) || 1;
+        const options: FeatureOption[] = [];
+        for (const optEntry of entryObj.entries) {
+          if (optEntry && typeof optEntry === 'object') {
+            const opt = optEntry as Record<string, unknown>;
+            if (
+              opt.type === 'refClassFeature' &&
+              typeof opt.classFeature === 'string'
+            ) {
+              const resolved = resolveRefClassFeature(
+                opt.classFeature,
+                featureDescriptions
+              );
+              if (resolved) options.push(resolved);
+            } else if (opt.name) {
+              const nested = processFeatureEntries(
+                Array.isArray(opt.entries) ? opt.entries : [],
+                featureDescriptions
+              );
+              options.push({ name: String(opt.name), entries: nested.html });
+            }
+          }
+        }
+        if (options.length > 0) {
+          choice = { count, options };
+        }
+      } else if (
+        entryObj.type === 'entries' &&
+        Array.isArray(entryObj.entries)
+      ) {
         if (entryObj.name) {
           result.push(`<strong>${entryObj.name}</strong>`);
         }
-        result.push(...processFeatureEntries(entryObj.entries));
+        const nested = processFeatureEntries(
+          entryObj.entries,
+          featureDescriptions
+        );
+        result.push(...nested.html);
+        if (nested.choice) choice = nested.choice;
       } else if (entryObj.type === 'inset' && Array.isArray(entryObj.entries)) {
-        // Inset boxes
         if (entryObj.name) {
           result.push(
             `<div class="inset"><strong>${entryObj.name}</strong></div>`
           );
         }
-        result.push(...processFeatureEntries(entryObj.entries));
+        result.push(
+          ...processFeatureEntries(entryObj.entries, featureDescriptions).html
+        );
       } else if (entryObj.type === 'list' && Array.isArray(entryObj.items)) {
-        // Lists
         result.push('<ul>');
         for (const item of entryObj.items) {
           if (typeof item === 'string') {
@@ -340,13 +394,38 @@ function processFeatureEntries(entries: unknown[]): string[] {
         }
         result.push('</ul>');
       } else if (Array.isArray(entryObj.entries)) {
-        // Generic nested entries
-        result.push(...processFeatureEntries(entryObj.entries));
+        const nested = processFeatureEntries(
+          entryObj.entries,
+          featureDescriptions
+        );
+        result.push(...nested.html);
+        if (nested.choice) choice = nested.choice;
       }
     }
   }
 
-  return result;
+  return { html: result, choice };
+}
+
+function resolveRefClassFeature(
+  ref: string,
+  featureDescriptions?: Record<string, unknown>[]
+): FeatureOption | null {
+  if (!featureDescriptions) return null;
+  const parts = ref.split('|');
+  const name = parts[0];
+  const className = parts[1];
+  const level = parseInt(parts[parts.length - 1]);
+
+  const desc = featureDescriptions.find(
+    d => d.name === name && d.className === className && d.level === level
+  );
+  if (!desc) return null;
+
+  const entries = Array.isArray(desc.entries)
+    ? processFeatureEntries(desc.entries, featureDescriptions).html
+    : [];
+  return { name, entries };
 }
 
 /**
@@ -828,10 +907,10 @@ export async function loadAllClasses(): Promise<ProcessedClass[]> {
       // First, prioritize 2024 versions
       const aIs2024 = a.source === 'PHB2024';
       const bIs2024 = b.source === 'PHB2024';
-      
+
       if (aIs2024 && !bIs2024) return -1;
       if (!aIs2024 && bIs2024) return 1;
-      
+
       // Then sort alphabetically by name
       return a.name.localeCompare(b.name);
     });

--- a/src/utils/featDataLoader.ts
+++ b/src/utils/featDataLoader.ts
@@ -5,6 +5,7 @@
  */
 
 import featsData from '../../json/feats.json';
+import { processAndFormatDndText } from './textFormatting';
 
 // Raw feat data from JSON
 interface RawFeatData {
@@ -48,6 +49,7 @@ export interface ProcessedFeat {
   page?: number;
   description: string; // Parsed and formatted description
   prerequisites: string[]; // Human-readable prerequisites
+  levelRequirement?: number; // Minimum character level required
   abilityIncreases: string; // Description of ability score increases
   category?: string;
   repeatable: boolean;
@@ -236,10 +238,25 @@ function grantsSpells(feat: RawFeatData): boolean {
 /**
  * Process raw feat data into our application format
  */
+function extractLevelRequirement(
+  prerequisite?: RawFeatData['prerequisite']
+): number | undefined {
+  if (!prerequisite) return undefined;
+  for (const prereq of prerequisite) {
+    if (prereq.level) return prereq.level;
+  }
+  return undefined;
+}
+
 function processFeat(rawFeat: RawFeatData): ProcessedFeat {
   const id = generateFeatId(rawFeat.name, rawFeat.source);
-  const description = parseFeatEntries(rawFeat.entries);
+  const rawDescription = parseFeatEntries(rawFeat.entries);
+  const description = processAndFormatDndText(rawDescription).replace(
+    /\n\n/g,
+    '<br/>'
+  );
   const prerequisites = parsePrerequisites(rawFeat.prerequisite);
+  const levelRequirement = extractLevelRequirement(rawFeat.prerequisite);
   const abilityIncreases = parseAbilityIncreases(rawFeat.ability);
 
   return {
@@ -249,6 +266,7 @@ function processFeat(rawFeat: RawFeatData): ProcessedFeat {
     page: rawFeat.page,
     description,
     prerequisites,
+    levelRequirement,
     abilityIncreases,
     category: rawFeat.category,
     repeatable: rawFeat.repeatable || false,

--- a/src/utils/textFormatting.ts
+++ b/src/utils/textFormatting.ts
@@ -13,45 +13,15 @@ export function processDndText(text: string): string {
   // Handle {@dc XX} notation - convert to "DC XX"
   processedText = processedText.replace(/\{@dc\s+(\d+)\}/g, 'DC $1');
 
-  // Handle {@variantrule Name|Source} notation - extract just the name
-  processedText = processedText.replace(
-    /\{@variantrule\s+([^|}\s]+)(\|[^}]*)?\}/g,
-    '$1'
-  );
-
-  // Handle {@action Name|Source} notation - extract just the name
-  processedText = processedText.replace(
-    /\{@action\s+([^|}\s]+)(\|[^}]*)?\}/g,
-    '$1'
-  );
-
-  // Handle {@condition Name|Source} notation - extract just the name
-  processedText = processedText.replace(
-    /\{@condition\s+([^|}\s]+)(\|[^}]*)?\}/g,
-    '$1'
-  );
-
-  // Handle {@spell Name|Source} notation - extract just the name
-  processedText = processedText.replace(
-    /\{@spell\s+([^|}\s]+)(\|[^}]*)?\}/g,
-    '$1'
-  );
-
-  // Handle {@status Name|Source} notation - extract just the name
-  processedText = processedText.replace(
-    /\{@status\s+([^|}\s]+)(\|[^}]*)?\}/g,
-    '$1'
-  );
-
   // Handle {@damage XdY} notation - keep as is but remove braces
   processedText = processedText.replace(/\{@damage\s+([^}]+)\}/g, '$1');
 
   // Handle {@dice XdY} notation - keep as is but remove braces
   processedText = processedText.replace(/\{@dice\s+([^}]+)\}/g, '$1');
 
-  // Handle any remaining {@...} notation by extracting the first word after @
+  // Handle all {@tag Name|Source} notations - extract the display name (before first pipe)
   processedText = processedText.replace(
-    /\{@\w+\s+([^|}\s]+)(\|[^}]*)?\}/g,
+    /\{@\w+\s+([^|}]+?)(?:\|[^}]*)?\}/g,
     '$1'
   );
 


### PR DESCRIPTION
## Summary

- Multi-step modal wizard that guides players through D&D 5e level-up choices
- Conditional steps: edition picker (PHB vs XPHB), class picker (multiclass), subclass selection, features summary with selectable options, ASI/feat choice with expandable descriptions, HP roll (manual mode), and confirmation
- Subclass migration: detects characters past subclass selection level with no subclass set and offers a migration step with optional retroactive feature adoption
- Parses class feature options (e.g., Druid's Elemental Fury) from JSON data into selectable choices
- Formats `{@spell}`, `{@filter}`, etc. tags in feat/feature descriptions
- Filters feats by level requirement (hides Epic Boons from low-level characters)
- Shows book source next to each feat
- Custom wizard hat icon on the Level Up button
- All changes applied atomically via single `updateCharacter()` call

### New files
- `LevelUpWizard/` — index, hooks, types, utils, and 8 step components
- `SubclassMigrationStep` — handles legacy characters missing subclass data

### Modified files
- `character.ts` — `classSource` field on `MulticlassInfo`
- `classes.ts` — `FeatureChoice`/`FeatureOption` types, `choice` field on `ClassFeature`
- `classDataLoader.ts` — parse `type:"options"` and `refClassFeature` entries
- `featDataLoader.ts` — format descriptions, add `levelRequirement`
- `textFormatting.ts` — fix multi-word name regex for D&D tags
- `tabbedSheetConfig.tsx` — Level Up button in Stats tab XP section

## Test plan
- [x] Open a character sheet, go to Stats tab → Experience Points section, verify wizard hat Level Up button appears (hidden at level 20)
- [x] Click Level Up on a single-class character without edition set → edition picker should appear
- [x] Level up a Druid to level 7 → verify "Elemental Fury" shows selectable options (Potent Spellcasting / Primal Strike)
- [x] Level up to an ASI level (4, 8, 12, 16, 19) → verify ability score +/- controls and feat picker with expandable descriptions
- [x] Search feats, verify `{@spell}` tags are rendered as plain text, book source shown
- [x] Verify Epic Boons don't appear for characters below level 19
- [x] Test subclass migration: open a level 5+ character with no subclass → should get migration step before normal level-up
- [x] Toggle missed features on/off in migration step, verify they appear in Features tab after applying
- [x] Verify confirmation page shows feat description when a feat is selected
- [x] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)