### PR TITLE
Player combat experience, DM combat controls & data-loss protection

### DIFF
--- a/src/app/api/campaign/[code]/party-hp/__tests__/route.test.ts
+++ b/src/app/api/campaign/[code]/party-hp/__tests__/route.test.ts
@@ -221,7 +221,9 @@ describe('GET /api/campaign/[code]/party-hp', () => {
     expect(data.members[0].hitPoints).not.toBeNull();
   });
 
-  it('applies temp AC when isTempACActive is true', async () => {
+  it('stacks temp AC on base AC when isTempACActive is true', async () => {
+    // Matches the canonical calculateCharacterArmorClass / character-sheet
+    // behavior: temp AC is additive (base 14 + temp 20 = 34), not a replacement.
     seedRedis('campaign:ABC123', createMockCampaignData());
     seedRedisSet('campaign:ABC123:players', ['player-1']);
     seedRedis(
@@ -246,7 +248,7 @@ describe('GET /api/campaign/[code]/party-hp', () => {
     const data = await res.json();
 
     expect(res.status).toBe(200);
-    expect(data.members[0].armorClass).toBe(20);
+    expect(data.members[0].armorClass).toBe(34);
   });
 
   it('adds shield bonus to AC when isWearingShield is true', async () => {
@@ -262,6 +264,51 @@ describe('GET /api/campaign/[code]/party-hp', () => {
           tempArmorClass: 0,
           isWearingShield: true,
           shieldBonus: 2,
+        },
+      })
+    );
+
+    const req = createNextRequest('/api/campaign/ABC123/party-hp');
+    const res = await GET(
+      req as NextRequest,
+      createRouteParams({ code: 'ABC123' })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.members[0].armorClass).toBe(18);
+  });
+
+  it('includes active AC buffs (e.g. Haste +2) in the reported AC', async () => {
+    seedRedis('campaign:ABC123', createMockCampaignData());
+    seedRedisSet('campaign:ABC123:players', ['player-1']);
+    seedRedis(
+      'campaign:ABC123:player:player-1',
+      createMockPlayerData({
+        characterData: {
+          ...createMockPlayerData().characterData,
+          armorClass: 16,
+          isTempACActive: false,
+          tempArmorClass: 0,
+          isWearingShield: false,
+          shieldBonus: 2,
+          temporaryBuffs: [
+            {
+              id: 'buff-haste',
+              name: 'Haste',
+              effects: [
+                {
+                  id: 'eff-1',
+                  targetStat: 'ac',
+                  mode: 'add',
+                  value: 2,
+                },
+              ],
+              isActive: true,
+              createdAt: '2025-01-01T00:00:00.000Z',
+              updatedAt: '2025-01-01T00:00:00.000Z',
+            },
+          ],
         },
       })
     );

--- a/src/app/api/campaign/[code]/party-hp/route.ts
+++ b/src/app/api/campaign/[code]/party-hp/route.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/redis';
 import { CampaignPlayerData } from '@/types/campaign';
 import { DeathSavingThrows } from '@/types/character';
+import { calculateCharacterArmorClass } from '@/utils/calculations';
 
 export interface PartyMemberHP {
   characterId: string;
@@ -66,13 +67,10 @@ export async function GET(
 
           const primaryClass = char.classes?.[0];
 
-          let ac = char.armorClass ?? 10;
-          if (char.isTempACActive && char.tempArmorClass) {
-            ac = char.tempArmorClass;
-          }
-          if (char.isWearingShield) {
-            ac += char.shieldBonus ?? 2;
-          }
+          // Use the shared AC calculation so the party tracker matches the
+          // character sheet, including active temporary buffs (Shield, Mage
+          // Armor, Barkskin, Haste, etc.).
+          const ac = calculateCharacterArmorClass(char);
 
           members.push({
             characterId: parsed.characterId,

--- a/src/app/api/campaign/[code]/shared/__tests__/route.test.ts
+++ b/src/app/api/campaign/[code]/shared/__tests__/route.test.ts
@@ -253,6 +253,37 @@ describe('GET /api/campaign/[code]/shared', () => {
     expect(data.dmEffects).toEqual([]);
     expect(data.transfers).toEqual([]);
   });
+
+  it('returns the stored initiative state', async () => {
+    seedRedis(campaignSharedKey('ABC123', 'initiative'), {
+      encounterId: 'enc-1',
+      isActive: true,
+      round: 3,
+      currentEntityId: 'a',
+      turnOrder: [{ entityId: 'a', displayName: 'Aragorn', type: 'player' }],
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const req = new NextRequest(
+      'http://localhost/api/campaign/ABC123/shared?role=player&playerId=char-a'
+    );
+    const res = await GET(req, createRouteParams({ code: 'ABC123' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.initiative).not.toBeNull();
+    expect(data.initiative.round).toBe(3);
+    expect(data.initiative.currentEntityId).toBe('a');
+  });
+
+  it('returns null initiative when none is stored', async () => {
+    const req = new NextRequest(
+      'http://localhost/api/campaign/ABC123/shared?role=player&playerId=char-a'
+    );
+    const res = await GET(req, createRouteParams({ code: 'ABC123' }));
+    const data = await res.json();
+    expect(data.initiative).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/app/api/campaign/[code]/shared/route.ts
+++ b/src/app/api/campaign/[code]/shared/route.ts
@@ -19,6 +19,7 @@ import type {
   SharedCampaignState,
   SharedCustomCounter,
   ItemTransfer,
+  SharedInitiativeState,
 } from '@/types/sharedState';
 
 export async function GET(
@@ -34,6 +35,16 @@ export async function GET(
     const calendarRaw = await redis.get<string>(
       campaignSharedKey(code, 'calendar')
     );
+    const initiativeRaw = await redis.get<string>(
+      campaignSharedKey(code, 'initiative')
+    );
+    let initiative: SharedInitiativeState | null = null;
+    if (initiativeRaw) {
+      initiative =
+        typeof initiativeRaw === 'string'
+          ? JSON.parse(initiativeRaw)
+          : initiativeRaw;
+    }
 
     let calendar: SharedCalendarPlayer | null = null;
 
@@ -105,6 +116,7 @@ export async function GET(
       dmEffects,
       customCounter,
       transfers,
+      initiative,
     };
     return NextResponse.json(state);
   } catch (error) {

--- a/src/app/api/campaign/[code]/turn-request/__tests__/route.test.ts
+++ b/src/app/api/campaign/[code]/turn-request/__tests__/route.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockRedis, resetRedis, seedRedis } from '@/test/mocks/redis';
+import {
+  createNextRequest,
+  createRouteParams,
+  createMockCampaignData,
+} from '@/test/helpers';
+import { POST, GET, DELETE } from '../route';
+import { NextRequest } from 'next/server';
+
+vi.mock('@upstash/redis', () => ({ Redis: vi.fn(() => mockRedis) }));
+
+const reqBody = {
+  encounterId: 'enc-1',
+  round: 2,
+  entityId: 'a',
+  playerId: 'char-a',
+  requestedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('turn-request route', () => {
+  beforeEach(() => resetRedis());
+
+  it('stores a turn-end request via POST', async () => {
+    seedRedis('campaign:ABC123', createMockCampaignData());
+    const req = createNextRequest('/api/campaign/ABC123/turn-request', {
+      method: 'POST',
+      body: reqBody,
+    });
+    const res = await POST(
+      req as NextRequest,
+      createRouteParams({ code: 'ABC123' })
+    );
+    expect(res.status).toBe(200);
+
+    const getReq = createNextRequest('/api/campaign/ABC123/turn-request');
+    const getRes = await GET(
+      getReq as NextRequest,
+      createRouteParams({ code: 'ABC123' })
+    );
+    const data = await getRes.json();
+    expect(data.request.entityId).toBe('a');
+    expect(data.request.round).toBe(2);
+  });
+
+  it('returns null request when none stored', async () => {
+    seedRedis('campaign:ABC123', createMockCampaignData());
+    const getReq = createNextRequest('/api/campaign/ABC123/turn-request');
+    const getRes = await GET(
+      getReq as NextRequest,
+      createRouteParams({ code: 'ABC123' })
+    );
+    const data = await getRes.json();
+    expect(data.request).toBeNull();
+  });
+
+  it('clears the request via DELETE', async () => {
+    seedRedis('campaign:ABC123', createMockCampaignData());
+    seedRedis('campaign:ABC123:shared:turnRequest', reqBody);
+
+    const delReq = createNextRequest('/api/campaign/ABC123/turn-request', {
+      method: 'DELETE',
+    });
+    const delRes = await DELETE(
+      delReq as NextRequest,
+      createRouteParams({ code: 'ABC123' })
+    );
+    expect(delRes.status).toBe(200);
+
+    const getReq = createNextRequest('/api/campaign/ABC123/turn-request');
+    const getRes = await GET(
+      getReq as NextRequest,
+      createRouteParams({ code: 'ABC123' })
+    );
+    const data = await getRes.json();
+    expect(data.request).toBeNull();
+  });
+});

--- a/src/app/api/campaign/[code]/turn-request/route.ts
+++ b/src/app/api/campaign/[code]/turn-request/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getRedis,
+  campaignSharedKey,
+  refreshCampaignTTL,
+  SLIDING_TTL_SECONDS,
+} from '@/lib/redis';
+import type { TurnEndRequest } from '@/types/sharedState';
+
+const KEY_FEATURE = 'turnRequest';
+
+// Player submits a request to end their turn.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ code: string }> }
+) {
+  try {
+    const { code } = await params;
+    const body = (await request.json()) as TurnEndRequest;
+    if (!body.encounterId || !body.entityId || !body.playerId) {
+      return NextResponse.json(
+        { error: 'encounterId, entityId and playerId are required' },
+        { status: 400 }
+      );
+    }
+    const redis = getRedis();
+    await redis.set(
+      campaignSharedKey(code, KEY_FEATURE),
+      JSON.stringify(body),
+      {
+        ex: SLIDING_TTL_SECONDS,
+      }
+    );
+    await refreshCampaignTTL(redis, code);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error storing turn request:', error);
+    return NextResponse.json(
+      { error: 'Failed to store turn request' },
+      { status: 500 }
+    );
+  }
+}
+
+// DM reads the pending request (if any).
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ code: string }> }
+) {
+  try {
+    const { code } = await params;
+    const redis = getRedis();
+    const raw = await redis.get<string>(campaignSharedKey(code, KEY_FEATURE));
+    const requestData: TurnEndRequest | null = raw
+      ? typeof raw === 'string'
+        ? JSON.parse(raw)
+        : raw
+      : null;
+    return NextResponse.json({ request: requestData });
+  } catch (error) {
+    console.error('Error reading turn request:', error);
+    return NextResponse.json(
+      { error: 'Failed to read turn request' },
+      { status: 500 }
+    );
+  }
+}
+
+// DM clears the request after applying or rejecting it.
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ code: string }> }
+) {
+  try {
+    const { code } = await params;
+    const redis = getRedis();
+    await redis.del(campaignSharedKey(code, KEY_FEATURE));
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error clearing turn request:', error);
+    return NextResponse.json(
+      { error: 'Failed to clear turn request' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -25,6 +25,7 @@ import { ToastContainer, useToast } from '@/components/ui/feedback/Toast';
 import { ConfirmationModal } from '@/components/ui/feedback/ConfirmationModal';
 import { YouDiedOverlay } from '@/components/ui/feedback/YouDiedOverlay';
 import { LevelUpOverlay } from '@/components/ui/feedback/LevelUpOverlay';
+import { CombatStartBanner } from '@/components/ui/feedback/CombatStartBanner';
 
 import CharacterSheetHeader from '@/components/ui/character/CharacterSheetHeader';
 import { useHydration } from '@/hooks/useHydration';
@@ -70,6 +71,8 @@ export default function CharacterSheet() {
 
   const { getCharacterById, updateCharacterData } = usePlayerStore();
   const playerCharacter = getCharacterById(characterId);
+  const playerSettings = usePlayerStore(s => s.settings);
+  const [showCombatBanner, setShowCombatBanner] = useState(false);
 
   const hasHydrated = useHydration();
 
@@ -561,6 +564,30 @@ export default function CharacterSheet() {
 
   const onSendItem = playerSync.campaignCode ? handleSendItem : undefined;
 
+  // "Combat begins" banner: fire once per encounter when combat reaches round 1.
+  // Reset when combat ends so a later encounter can show it again. round !== 1 is
+  // ignored so loading into an in-progress fight doesn't trigger it.
+  const enableCombatStartBanner = playerSettings.enableCombatStartBanner;
+  const combatBannerShownForRef = useRef<string | null>(null);
+  const initiativeActive = sharedState?.initiative?.isActive ?? false;
+  const initiativeRound = sharedState?.initiative?.round ?? 0;
+  const initiativeEncounterId = sharedState?.initiative?.encounterId ?? null;
+  useEffect(() => {
+    if (!initiativeActive) {
+      combatBannerShownForRef.current = null;
+      return;
+    }
+    if (initiativeRound !== 1) return;
+    if (combatBannerShownForRef.current === initiativeEncounterId) return;
+    combatBannerShownForRef.current = initiativeEncounterId;
+    if (enableCombatStartBanner) setShowCombatBanner(true);
+  }, [
+    initiativeActive,
+    initiativeRound,
+    initiativeEncounterId,
+    enableCombatStartBanner,
+  ]);
+
   if (!hasHydrated) {
     return <NotHydrated />;
   }
@@ -823,6 +850,12 @@ export default function CharacterSheet() {
             state={sharedState?.initiative ?? null}
             characterId={characterId}
             onEndTurn={handleEndTurn}
+          />
+
+          {/* "Combat begins" flourish when a fight starts */}
+          <CombatStartBanner
+            isVisible={showCombatBanner}
+            onDone={() => setShowCombatBanner(false)}
           />
 
           {/* Header */}

--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -26,6 +26,7 @@ import { ConfirmationModal } from '@/components/ui/feedback/ConfirmationModal';
 import { YouDiedOverlay } from '@/components/ui/feedback/YouDiedOverlay';
 import { LevelUpOverlay } from '@/components/ui/feedback/LevelUpOverlay';
 import { CombatStartBanner } from '@/components/ui/feedback/CombatStartBanner';
+import { useStorageQuotaListener } from '@/hooks/useStorageQuotaListener';
 
 import CharacterSheetHeader from '@/components/ui/character/CharacterSheetHeader';
 import { useHydration } from '@/hooks/useHydration';
@@ -96,6 +97,19 @@ export default function CharacterSheet() {
     showLongRest,
     addToast,
   } = useToast();
+
+  // Warn if a save fails because localStorage is full (auto-save writes here).
+  useStorageQuotaListener(
+    useCallback(() => {
+      addToast({
+        type: 'error',
+        title: 'Save failed — storage full',
+        message:
+          'This change could not be saved. Export a backup from the character list now to avoid losing data.',
+        duration: 12000,
+      });
+    }, [addToast])
+  );
 
   const {
     character,

--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -52,6 +52,7 @@ import { usePartySync } from '@/hooks/usePartySync';
 import { RollSummary } from '@/types/dice';
 import NotHydrated from '@/components/ui/feedback/NotHydrated';
 import CharacterHUD from '@/components/ui/character/CharacterHUD';
+import { InitiativePanel } from '@/components/ui/campaign/InitiativePanel';
 import RestDialog from '@/components/ui/character/RestDialog';
 import { useCalendarStore } from '@/store/calendarStore';
 import { useSharedCampaignState } from '@/hooks/useSharedCampaignState';
@@ -526,6 +527,38 @@ export default function CharacterSheet() {
     ]
   );
 
+  const handleEndTurn = useCallback(
+    async (entityId: string) => {
+      const init = sharedState?.initiative;
+      if (!playerSync.campaignCode || !init) return;
+      try {
+        const res = await fetch(
+          `/api/campaign/${playerSync.campaignCode}/turn-request`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              encounterId: init.encounterId,
+              round: init.round,
+              entityId,
+              playerId: characterId,
+              requestedAt: new Date().toISOString(),
+            }),
+          }
+        );
+        if (!res.ok) {
+          console.warn(
+            'End-turn request was rejected by the server:',
+            res.status
+          );
+        }
+      } catch (err) {
+        console.error('Failed to send end-turn request:', err);
+      }
+    },
+    [playerSync.campaignCode, sharedState?.initiative, characterId]
+  );
+
   const onSendItem = playerSync.campaignCode ? handleSendItem : undefined;
 
   if (!hasHydrated) {
@@ -783,6 +816,13 @@ export default function CharacterSheet() {
           <PartyHPSidebar
             campaignCode={playerSync.campaignCode ?? null}
             currentCharacterId={characterId}
+          />
+
+          {/* Shared initiative panel — shown during active combat */}
+          <InitiativePanel
+            state={sharedState?.initiative ?? null}
+            characterId={characterId}
+            onEndTurn={handleEndTurn}
           />
 
           {/* Header */}

--- a/src/app/player/page.tsx
+++ b/src/app/player/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
 import {
   Plus,
@@ -28,6 +28,12 @@ import { AvatarUpload } from '@/components/ui/character/AvatarUpload';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { JoinCampaignDialog } from '@/components/ui/campaign/JoinCampaignDialog';
 import { ToastContainer, useToast } from '@/components/ui/feedback/Toast';
+import { DataSafetyBanner } from '@/components/ui/feedback/DataSafetyBanner';
+import { useStorageQuotaListener } from '@/hooks/useStorageQuotaListener';
+import {
+  exportAllCharactersToFile,
+  isCharacterBackup,
+} from '@/utils/fileOperations';
 
 export default function PlayerDashboardPage() {
   const {
@@ -53,6 +59,32 @@ export default function PlayerDashboardPage() {
   const activeCharacters = getActiveCharacters();
   const archivedCharacters = getArchivedCharacters();
   const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleExportAll = useCallback(() => {
+    if (characters.length === 0) return;
+    exportAllCharactersToFile(characters);
+    addToast({
+      type: 'success',
+      title: 'Backup exported',
+      message: `Saved a backup of ${characters.length} character${
+        characters.length === 1 ? '' : 's'
+      }. Keep it somewhere safe.`,
+      duration: 5000,
+    });
+  }, [characters, addToast]);
+
+  // Surface a clear warning if a localStorage save ever fails (quota full).
+  useStorageQuotaListener(
+    useCallback(() => {
+      addToast({
+        type: 'error',
+        title: 'Save failed — storage full',
+        message:
+          'Your latest change could not be saved. Export a backup now to avoid losing data.',
+        duration: 12000,
+      });
+    }, [addToast])
+  );
 
   // Check for migration on component mount
   useEffect(() => {
@@ -106,6 +138,20 @@ export default function PlayerDashboardPage() {
       try {
         const fileText = await file.text();
         const characterData = JSON.parse(fileText);
+
+        // Full-roster backup bundle → restore every character in it.
+        if (isCharacterBackup(characterData)) {
+          const count = characterData.characters.length;
+          characterData.characters.forEach(c => importCharacter(c));
+          addToast({
+            type: 'success',
+            title: 'Backup restored',
+            message: `Imported ${count} character${count === 1 ? '' : 's'} from the backup.`,
+            duration: 5000,
+          });
+          event.target.value = '';
+          return;
+        }
 
         let characterName = 'Imported Character';
         if (characterData.name) {
@@ -397,6 +443,15 @@ export default function PlayerDashboardPage() {
             >
               Import
             </Button>
+            {characters.length > 0 && (
+              <Button
+                variant="outline"
+                leftIcon={<Download size={18} />}
+                onClick={handleExportAll}
+              >
+                Export All
+              </Button>
+            )}
             <input
               ref={fileInputRef}
               type="file"
@@ -411,6 +466,11 @@ export default function PlayerDashboardPage() {
             </Link>
           </div>
         </div>
+
+        {/* Local-storage safety reminder */}
+        {characters.length > 0 && (
+          <DataSafetyBanner onExport={handleExportAll} />
+        )}
 
         {/* Stats Cards */}
         <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">

--- a/src/app/player/page.tsx
+++ b/src/app/player/page.tsx
@@ -19,6 +19,7 @@ import {
   ChevronUp,
   TrendingUp,
   Link2,
+  Swords,
 } from 'lucide-react';
 import { usePlayerStore, PlayerCharacter } from '@/store/playerStore';
 import { Button } from '@/components/ui/forms';
@@ -622,6 +623,37 @@ export default function PlayerDashboardPage() {
                       onChange={e =>
                         updateSettings({
                           enableLevelUpAnimation: e.target.checked,
+                        })
+                      }
+                      className="peer sr-only"
+                    />
+                    <div className="peer bg-divider-strong after:border-divider-strong dark:after:bg-surface-raised h-6 w-11 rounded-full peer-checked:bg-amber-500 peer-focus:ring-2 peer-focus:ring-amber-300 peer-focus:outline-none after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:border after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full peer-checked:after:border-white"></div>
+                  </label>
+                </div>
+
+                {/* Combat Start Banner Toggle */}
+                <div className="border-divider bg-surface-secondary flex items-center justify-between rounded-lg border p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="bg-accent-red-bg flex h-10 w-10 items-center justify-center rounded-lg">
+                      <Swords className="text-accent-red-text-muted h-5 w-5" />
+                    </div>
+                    <div>
+                      <h4 className="text-heading font-medium">
+                        Combat Start Banner
+                      </h4>
+                      <p className="text-muted text-sm">
+                        A &quot;Combat Begins&quot; flourish when the DM starts
+                        a fight
+                      </p>
+                    </div>
+                  </div>
+                  <label className="relative inline-flex cursor-pointer items-center">
+                    <input
+                      type="checkbox"
+                      checked={settings?.enableCombatStartBanner}
+                      onChange={e =>
+                        updateSettings({
+                          enableCombatStartBanner: e.target.checked,
                         })
                       }
                       className="peer sr-only"

--- a/src/components/ui/campaign/InitiativePanel.tsx
+++ b/src/components/ui/campaign/InitiativePanel.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Swords, User, Skull } from 'lucide-react';
+import { Button } from '@/components/ui/forms/button';
+import { useDraggableY } from '@/hooks/useDraggableY';
+import { getHpBarColor } from '@/utils/hpColor';
+import type { SharedInitiativeState } from '@/types/sharedState';
+
+const OPEN_KEY = 'rollkeeper-initiative-panel-open';
+const POS_KEY = 'rollkeeper-initiative-panel-y';
+const DEFAULT_TOP = 120;
+
+interface InitiativePanelProps {
+  state: SharedInitiativeState | null;
+  characterId: string; // the open character (its playerCharacterId)
+  onEndTurn: (entityId: string) => void;
+}
+
+/** The entity whose turn comes after `fromId` in the turn order (wraps). */
+function nextEntityId(
+  turnOrder: SharedInitiativeState['turnOrder'],
+  fromId: string
+): string {
+  if (turnOrder.length === 0) return fromId;
+  const idx = turnOrder.findIndex(t => t.entityId === fromId);
+  if (idx === -1) return fromId;
+  return turnOrder[(idx + 1) % turnOrder.length].entityId;
+}
+
+/**
+ * Player-facing combat panel. Renders only while combat is active, as a thin,
+ * collapsible sidebar pinned to the right edge (mirrors PartyHPSidebar). The
+ * header doubles as a vertical drag handle so it can be moved up/down out of the
+ * way; open state and vertical position persist to localStorage.
+ */
+export function InitiativePanel({
+  state,
+  characterId,
+  onEndTurn,
+}: InitiativePanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  // Optimistic end-turn: the entity whose turn we locally advanced past while
+  // waiting for the DM's synced state to catch up.
+  const [pendingFrom, setPendingFrom] = useState<string | null>(null);
+  const { topPx, containerRef, startDrag } = useDraggableY(POS_KEY);
+
+  // Load persisted open state (default open).
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(OPEN_KEY) !== 'false') setIsOpen(true);
+    } catch {
+      // Ignore localStorage errors
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(OPEN_KEY, String(isOpen));
+    } catch {
+      // Ignore localStorage errors
+    }
+  }, [isOpen]);
+
+  // Reconcile: once the synced state moves off the turn we ended (or combat
+  // ends), drop the optimistic override and follow the source of truth.
+  const syncedCurrentId = state?.currentEntityId ?? null;
+  useEffect(() => {
+    if (pendingFrom !== null && syncedCurrentId !== pendingFrom) {
+      setPendingFrom(null);
+    }
+  }, [syncedCurrentId, pendingFrom]);
+
+  if (!state || !state.isActive) return null;
+
+  // While an end-turn is in flight, highlight the next combatant locally so the
+  // player gets instant feedback instead of waiting for the next poll.
+  const isOptimistic =
+    pendingFrom !== null && state.currentEntityId === pendingFrom;
+  const effectiveCurrentId = isOptimistic
+    ? nextEntityId(state.turnOrder, pendingFrom)
+    : state.currentEntityId;
+
+  const activeEntry = state.turnOrder.find(
+    t => t.entityId === effectiveCurrentId
+  );
+  const isMyTurn =
+    !!activeEntry && activeEntry.playerCharacterId === characterId;
+
+  const handleEndTurnClick = () => {
+    if (!activeEntry) return;
+    onEndTurn(activeEntry.entityId);
+    setPendingFrom(state.currentEntityId);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed right-0 z-[55] flex"
+      style={{ top: topPx ?? DEFAULT_TOP }}
+    >
+      {/* Toggle tab — sticks out to the left of the panel */}
+      <button
+        onClick={() => setIsOpen(o => !o)}
+        aria-label={isOpen ? 'Hide initiative' : 'Show initiative'}
+        title={isOpen ? 'Hide initiative' : 'Show initiative'}
+        className={`relative self-start rounded-l-lg border-y-2 border-l-2 px-1.5 py-3 shadow-md transition-colors ${
+          isMyTurn
+            ? 'border-accent-amber-border bg-accent-amber-bg text-accent-amber-text animate-pulse'
+            : isOpen
+              ? 'border-accent-red-border bg-accent-red-bg text-accent-red-text'
+              : 'border-divider bg-surface-raised text-muted hover:text-body hover:bg-surface-secondary'
+        }`}
+      >
+        <Swords size={16} />
+        {!isOpen && (
+          <span className="bg-accent-red-bg text-accent-red-text border-accent-red-border absolute -top-1 -left-1 flex h-4 min-w-4 items-center justify-center rounded-full border px-1 text-[10px] font-bold">
+            {state.round}
+          </span>
+        )}
+      </button>
+
+      {/* Panel wrapper — collapses width when closed */}
+      <div
+        className="overflow-hidden transition-[width] duration-300 ease-in-out"
+        style={{ width: isOpen ? '240px' : '0px' }}
+      >
+        <div className="border-divider bg-surface-raised flex max-h-[70vh] w-[240px] flex-col overflow-hidden rounded-l-xl border-y-2 border-l-2 shadow-lg">
+          {/* Header — also the vertical drag handle */}
+          <div
+            onPointerDown={startDrag}
+            className="border-divider flex flex-shrink-0 cursor-grab touch-none items-center gap-2 border-b px-3 py-2.5 select-none active:cursor-grabbing"
+          >
+            <Swords size={14} className="text-accent-red-text" />
+            <span className="text-heading text-sm font-semibold">
+              Combat · Round {state.round}
+            </span>
+          </div>
+
+          {/* Turn order */}
+          <ul className="flex-1 overflow-y-auto py-1">
+            {state.turnOrder.map(entry => {
+              const isCurrent = entry.entityId === effectiveCurrentId;
+              const isYou = entry.playerCharacterId === characterId;
+              const isPlayer = entry.type === 'player';
+              const hp = entry.currentHp;
+              const maxHp = entry.maxHp;
+              const hasHp = hp !== undefined && maxHp !== undefined;
+              return (
+                <li
+                  key={entry.entityId}
+                  className={`flex flex-col gap-1 px-3 py-1.5 ${
+                    isCurrent
+                      ? 'bg-accent-amber-bg border-accent-amber-border border-l-2'
+                      : 'border-l-2 border-transparent'
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    {isPlayer ? (
+                      <User
+                        size={13}
+                        className="text-accent-blue-text shrink-0"
+                      />
+                    ) : (
+                      <Skull size={13} className="text-faint shrink-0" />
+                    )}
+                    {isCurrent && (
+                      <span aria-hidden className="text-accent-amber-text">
+                        ▶
+                      </span>
+                    )}
+                    <span
+                      className={`truncate text-sm ${
+                        isCurrent
+                          ? 'text-accent-amber-text font-semibold'
+                          : isPlayer
+                            ? 'text-heading font-medium'
+                            : 'text-muted'
+                      }`}
+                    >
+                      {entry.displayName}
+                      {isYou && (
+                        <span className="text-muted ml-1 font-normal">
+                          (you)
+                        </span>
+                      )}
+                    </span>
+                    {hasHp && (
+                      <span className="text-faint ml-auto text-xs whitespace-nowrap">
+                        {hp}/{maxHp}
+                      </span>
+                    )}
+                  </div>
+                  {isPlayer && hasHp && (
+                    <div className="bg-surface-secondary ml-[21px] h-1.5 overflow-hidden rounded-full">
+                      <div
+                        className={`h-full rounded-full transition-all ${getHpBarColor(hp, maxHp)}`}
+                        style={{
+                          width: `${maxHp > 0 ? Math.min(100, (hp / maxHp) * 100) : 0}%`,
+                        }}
+                      />
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+
+          {/* End my turn — only on the open character's turn */}
+          {isMyTurn && (
+            <div className="border-divider flex-shrink-0 border-t p-2">
+              <Button
+                variant="primary"
+                className="w-full"
+                onClick={handleEndTurnClick}
+              >
+                End my turn
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/InitiativePanel.tsx
+++ b/src/components/ui/campaign/InitiativePanel.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Swords, User, Skull } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { useDraggableY } from '@/hooks/useDraggableY';
-import { getHpBarColor } from '@/utils/hpColor';
+import { getHpBarColor, getHpTierTextColor } from '@/utils/hpColor';
 import type { SharedInitiativeState } from '@/types/sharedState';
 
 const OPEN_KEY = 'rollkeeper-initiative-panel-open';
@@ -151,39 +151,58 @@ export function InitiativePanel({
               const isCurrent = entry.entityId === effectiveCurrentId;
               const isYou = entry.playerCharacterId === characterId;
               const isPlayer = entry.type === 'player';
+              const isDead = entry.isDead === true;
               const hp = entry.currentHp;
               const maxHp = entry.maxHp;
               const hasHp = hp !== undefined && maxHp !== undefined;
-              // Right-aligned HP summary (players + enemy 'exact'/'percent'/'label')
-              const hpText = hasHp
-                ? `${hp}/${maxHp}`
-                : entry.hpPercent !== undefined &&
-                    state.enemyHpMode === 'percent'
-                  ? `${entry.hpPercent}%`
-                  : entry.hpState
-                    ? entry.hpState
+              // Right-aligned HP summary. Dead overrides everything.
+              const hpText = isDead
+                ? isPlayer
+                  ? 'Down'
+                  : 'Defeated'
+                : hasHp
+                  ? `${hp}/${maxHp}`
+                  : entry.hpPercent !== undefined &&
+                      state.enemyHpMode === 'percent'
+                    ? `${entry.hpPercent}%`
+                    : (entry.hpState ?? null);
+              // Colour: dead = red; players use neutral (they have a bar);
+              // enemies use their coarse health tier.
+              const hpTextColor = isDead
+                ? 'text-accent-red-text font-medium'
+                : isPlayer
+                  ? 'text-faint'
+                  : entry.hpTier
+                    ? getHpTierTextColor(entry.hpTier)
+                    : 'text-faint';
+              // Bar for players (real HP) and enemy 'bar' mode (%). Hidden when dead.
+              const barPercent = isDead
+                ? null
+                : hasHp
+                  ? maxHp > 0
+                    ? Math.min(100, (hp / maxHp) * 100)
+                    : 0
+                  : !isPlayer &&
+                      state.enemyHpMode === 'bar' &&
+                      entry.hpPercent !== undefined
+                    ? entry.hpPercent
                     : null;
-              // Bar for players (from real HP) and for enemy 'bar' mode (from %)
-              const barPercent = hasHp
-                ? maxHp > 0
-                  ? Math.min(100, (hp / maxHp) * 100)
-                  : 0
-                : !isPlayer &&
-                    state.enemyHpMode === 'bar' &&
-                    entry.hpPercent !== undefined
-                  ? entry.hpPercent
-                  : null;
               return (
                 <li
                   key={entry.entityId}
                   className={`flex flex-col gap-1 px-3 py-1.5 ${
-                    isCurrent
+                    isCurrent && !isDead
                       ? 'bg-accent-amber-bg border-accent-amber-border border-l-2'
                       : 'border-l-2 border-transparent'
                   }`}
                 >
                   <div className="flex items-center gap-2">
-                    {isPlayer ? (
+                    {isDead ? (
+                      <Skull
+                        size={13}
+                        className="text-accent-red-text shrink-0"
+                      />
+                    ) : isPlayer ? (
                       <User
                         size={13}
                         className="text-accent-blue-text shrink-0"
@@ -191,18 +210,20 @@ export function InitiativePanel({
                     ) : (
                       <Skull size={13} className="text-faint shrink-0" />
                     )}
-                    {isCurrent && (
+                    {isCurrent && !isDead && (
                       <span aria-hidden className="text-accent-amber-text">
                         ▶
                       </span>
                     )}
                     <span
                       className={`truncate text-sm ${
-                        isCurrent
-                          ? 'text-accent-amber-text font-semibold'
-                          : isPlayer
-                            ? 'text-heading font-medium'
-                            : 'text-muted'
+                        isDead
+                          ? 'text-faint line-through'
+                          : isCurrent
+                            ? 'text-accent-amber-text font-semibold'
+                            : isPlayer
+                              ? 'text-heading font-medium'
+                              : 'text-muted'
                       }`}
                     >
                       {entry.displayName}
@@ -213,7 +234,9 @@ export function InitiativePanel({
                       )}
                     </span>
                     {hpText && (
-                      <span className="text-faint ml-auto text-xs whitespace-nowrap">
+                      <span
+                        className={`ml-auto text-xs whitespace-nowrap ${hpTextColor}`}
+                      >
                         {hpText}
                       </span>
                     )}

--- a/src/components/ui/campaign/InitiativePanel.tsx
+++ b/src/components/ui/campaign/InitiativePanel.tsx
@@ -223,7 +223,7 @@ export function InitiativePanel({
                             ? 'text-accent-amber-text font-semibold'
                             : isPlayer
                               ? 'text-heading font-medium'
-                              : 'text-muted'
+                              : 'text-accent-red-text-muted'
                       }`}
                     >
                       {entry.displayName}

--- a/src/components/ui/campaign/InitiativePanel.tsx
+++ b/src/components/ui/campaign/InitiativePanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Swords, User, Skull } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { useDraggableY } from '@/hooks/useDraggableY';
@@ -61,6 +61,14 @@ export function InitiativePanel({
       // Ignore localStorage errors
     }
   }, [isOpen]);
+
+  // Auto-open the panel when combat starts so players don't miss it.
+  const isActive = !!state?.isActive;
+  const prevActiveRef = useRef(false);
+  useEffect(() => {
+    if (isActive && !prevActiveRef.current) setIsOpen(true);
+    prevActiveRef.current = isActive;
+  }, [isActive]);
 
   // Reconcile: once the synced state moves off the turn we ended (or combat
   // ends), drop the optimistic override and follow the source of truth.

--- a/src/components/ui/campaign/InitiativePanel.tsx
+++ b/src/components/ui/campaign/InitiativePanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { Swords, User, Skull } from 'lucide-react';
+import { Swords, User, Skull, Shield, CircleDot } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { useDraggableY } from '@/hooks/useDraggableY';
 import { getHpBarColor, getHpTierTextColor } from '@/utils/hpColor';
@@ -152,6 +152,14 @@ export function InitiativePanel({
               const isYou = entry.playerCharacterId === characterId;
               const isPlayer = entry.type === 'player';
               const isDead = entry.isDead === true;
+              // Player-facing allegiance (disguise): colour + icon by side.
+              const disposition = entry.disposition ?? 'enemy';
+              const dispoColor =
+                disposition === 'ally'
+                  ? 'text-accent-emerald-text'
+                  : disposition === 'neutral'
+                    ? 'text-muted'
+                    : 'text-accent-red-text-muted';
               const hp = entry.currentHp;
               const maxHp = entry.maxHp;
               const hasHp = hp !== undefined && maxHp !== undefined;
@@ -207,8 +215,15 @@ export function InitiativePanel({
                         size={13}
                         className="text-accent-blue-text shrink-0"
                       />
+                    ) : disposition === 'ally' ? (
+                      <Shield size={13} className={`shrink-0 ${dispoColor}`} />
+                    ) : disposition === 'neutral' ? (
+                      <CircleDot
+                        size={13}
+                        className={`shrink-0 ${dispoColor}`}
+                      />
                     ) : (
-                      <Skull size={13} className="text-faint shrink-0" />
+                      <Skull size={13} className={`shrink-0 ${dispoColor}`} />
                     )}
                     {isCurrent && !isDead && (
                       <span aria-hidden className="text-accent-amber-text">
@@ -223,7 +238,7 @@ export function InitiativePanel({
                             ? 'text-accent-amber-text font-semibold'
                             : isPlayer
                               ? 'text-heading font-medium'
-                              : 'text-accent-red-text-muted'
+                              : dispoColor
                       }`}
                     >
                       {entry.displayName}

--- a/src/components/ui/campaign/InitiativePanel.tsx
+++ b/src/components/ui/campaign/InitiativePanel.tsx
@@ -146,6 +146,25 @@ export function InitiativePanel({
               const hp = entry.currentHp;
               const maxHp = entry.maxHp;
               const hasHp = hp !== undefined && maxHp !== undefined;
+              // Right-aligned HP summary (players + enemy 'exact'/'percent'/'label')
+              const hpText = hasHp
+                ? `${hp}/${maxHp}`
+                : entry.hpPercent !== undefined &&
+                    state.enemyHpMode === 'percent'
+                  ? `${entry.hpPercent}%`
+                  : entry.hpState
+                    ? entry.hpState
+                    : null;
+              // Bar for players (from real HP) and for enemy 'bar' mode (from %)
+              const barPercent = hasHp
+                ? maxHp > 0
+                  ? Math.min(100, (hp / maxHp) * 100)
+                  : 0
+                : !isPlayer &&
+                    state.enemyHpMode === 'bar' &&
+                    entry.hpPercent !== undefined
+                  ? entry.hpPercent
+                  : null;
               return (
                 <li
                   key={entry.entityId}
@@ -185,19 +204,17 @@ export function InitiativePanel({
                         </span>
                       )}
                     </span>
-                    {hasHp && (
+                    {hpText && (
                       <span className="text-faint ml-auto text-xs whitespace-nowrap">
-                        {hp}/{maxHp}
+                        {hpText}
                       </span>
                     )}
                   </div>
-                  {isPlayer && hasHp && (
+                  {barPercent !== null && (
                     <div className="bg-surface-secondary ml-[21px] h-1.5 overflow-hidden rounded-full">
                       <div
-                        className={`h-full rounded-full transition-all ${getHpBarColor(hp, maxHp)}`}
-                        style={{
-                          width: `${maxHp > 0 ? Math.min(100, (hp / maxHp) * 100) : 0}%`,
-                        }}
+                        className={`h-full rounded-full transition-all ${getHpBarColor(barPercent, 100)}`}
+                        style={{ width: `${barPercent}%` }}
                       />
                     </div>
                   )}

--- a/src/components/ui/campaign/InitiativePanel.tsx
+++ b/src/components/ui/campaign/InitiativePanel.tsx
@@ -104,7 +104,7 @@ export function InitiativePanel({
         onClick={() => setIsOpen(o => !o)}
         aria-label={isOpen ? 'Hide initiative' : 'Show initiative'}
         title={isOpen ? 'Hide initiative' : 'Show initiative'}
-        className={`relative self-start rounded-l-lg border-y-2 border-l-2 px-1.5 py-3 shadow-md transition-colors ${
+        className={`relative self-center rounded-l-lg border-y-2 border-l-2 px-2.5 py-5 shadow-md transition-colors ${
           isMyTurn
             ? 'border-accent-amber-border bg-accent-amber-bg text-accent-amber-text animate-pulse'
             : isOpen
@@ -112,7 +112,7 @@ export function InitiativePanel({
               : 'border-divider bg-surface-raised text-muted hover:text-body hover:bg-surface-secondary'
         }`}
       >
-        <Swords size={16} />
+        <Swords size={20} />
         {!isOpen && (
           <span className="bg-accent-red-bg text-accent-red-text border-accent-red-border absolute -top-1 -left-1 flex h-4 min-w-4 items-center justify-center rounded-full border px-1 text-[10px] font-bold">
             {state.round}

--- a/src/components/ui/campaign/PartyHPSidebar.tsx
+++ b/src/components/ui/campaign/PartyHPSidebar.tsx
@@ -1,21 +1,16 @@
 'use client';
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import { Users, User, Heart, Skull, EyeOff, Shield } from 'lucide-react';
 import { usePartySync } from '@/hooks/usePartySync';
+import { useDraggableY } from '@/hooks/useDraggableY';
+import { getHpBarColor } from '@/utils/hpColor';
 import { PartyMemberHP } from '@/app/api/campaign/[code]/party-hp/route';
 import { Badge } from '@/components/ui/layout/badge';
 
 const STORAGE_KEY = 'rollkeeper-party-hp-sidebar';
-
-function getHpBarColor(current: number, max: number): string {
-  if (max === 0) return 'bg-surface-secondary';
-  const pct = current / max;
-  if (pct > 0.5) return 'bg-green-600 dark:bg-green-500';
-  if (pct > 0.25) return 'bg-amber-500 dark:bg-amber-400';
-  return 'bg-red-600 dark:bg-red-500';
-}
+const POS_KEY = 'rollkeeper-party-hp-sidebar-y';
 
 function DeathSavesDisplay({
   deathSaves,
@@ -155,7 +150,7 @@ export function PartyHPSidebar({
   currentCharacterId,
 }: PartyHPSidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const sidebarRef = useRef<HTMLDivElement>(null);
+  const { topPx, containerRef: sidebarRef, startDrag } = useDraggableY(POS_KEY);
   const { partyMembers, loading } = usePartySync({
     campaignCode,
     currentCharacterId,
@@ -181,11 +176,17 @@ export function PartyHPSidebar({
   }, [isOpen]);
 
   // Close on outside click
-  const handleOutsideClick = useCallback((e: MouseEvent) => {
-    if (sidebarRef.current && !sidebarRef.current.contains(e.target as Node)) {
-      setIsOpen(false);
-    }
-  }, []);
+  const handleOutsideClick = useCallback(
+    (e: MouseEvent) => {
+      if (
+        sidebarRef.current &&
+        !sidebarRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    },
+    [sidebarRef]
+  );
 
   useEffect(() => {
     if (isOpen) {
@@ -201,7 +202,10 @@ export function PartyHPSidebar({
   return (
     <div
       ref={sidebarRef}
-      className="fixed top-1/2 left-0 z-[55] hidden -translate-y-1/2 lg:flex"
+      className={`fixed left-0 z-[55] hidden lg:flex ${
+        topPx === null ? 'top-1/2 -translate-y-1/2' : ''
+      }`}
+      style={topPx !== null ? { top: topPx } : undefined}
     >
       {/* Panel Wrapper — collapses width when closed */}
       <div
@@ -209,8 +213,11 @@ export function PartyHPSidebar({
         style={{ width: isOpen ? '240px' : '0px' }}
       >
         <div className="border-divider bg-surface-raised max-h-[70vh] w-[240px] overflow-hidden rounded-r-xl border-y-2 border-r-2 shadow-lg">
-          {/* Header */}
-          <div className="border-divider border-b px-3 py-2.5">
+          {/* Header — also the vertical drag handle */}
+          <div
+            onPointerDown={startDrag}
+            className="border-divider cursor-grab touch-none border-b px-3 py-2.5 select-none active:cursor-grabbing"
+          >
             <div className="text-heading flex items-center gap-2 text-sm font-semibold">
               <Users size={14} className="text-accent-blue-text" />
               Party HP

--- a/src/components/ui/campaign/PartyHPSidebar.tsx
+++ b/src/components/ui/campaign/PartyHPSidebar.tsx
@@ -255,14 +255,14 @@ export function PartyHPSidebar({
       {/* Toggle Button */}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className={`relative self-center rounded-r-lg border-y-2 border-r-2 px-1.5 py-3 shadow-md transition-colors ${
+        className={`relative self-center rounded-r-lg border-y-2 border-r-2 px-2.5 py-5 shadow-md transition-colors ${
           isOpen
             ? 'border-accent-blue-border bg-accent-blue-bg text-accent-blue-text'
             : 'border-divider bg-surface-raised text-muted hover:text-body hover:bg-surface-secondary'
         }`}
         title={isOpen ? 'Hide party HP' : 'Show party HP'}
       >
-        <Users size={16} />
+        <Users size={20} />
         {!isOpen && partyMembers.length > 0 && (
           <div className="bg-accent-blue-bg text-accent-blue-text border-accent-blue-border absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full border text-xs font-bold">
             {partyMembers.length}

--- a/src/components/ui/campaign/__tests__/InitiativePanel.test.tsx
+++ b/src/components/ui/campaign/__tests__/InitiativePanel.test.tsx
@@ -8,6 +8,7 @@ const base: SharedInitiativeState = {
   isActive: true,
   round: 3,
   currentEntityId: 'a',
+  enemyHpMode: 'off',
   turnOrder: [
     {
       entityId: 'a',

--- a/src/components/ui/campaign/__tests__/InitiativePanel.test.tsx
+++ b/src/components/ui/campaign/__tests__/InitiativePanel.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { InitiativePanel } from '../InitiativePanel';
+import type { SharedInitiativeState } from '@/types/sharedState';
+
+const base: SharedInitiativeState = {
+  encounterId: 'enc-1',
+  isActive: true,
+  round: 3,
+  currentEntityId: 'a',
+  turnOrder: [
+    {
+      entityId: 'a',
+      displayName: 'Aragorn',
+      type: 'player',
+      playerCharacterId: 'char-a',
+      currentHp: 24,
+      maxHp: 30,
+    },
+    { entityId: 'm', displayName: 'Enemy', type: 'monster' },
+  ],
+  updatedAt: '',
+};
+
+const noop = () => {};
+
+describe('InitiativePanel', () => {
+  afterEach(() => cleanup());
+
+  it('renders nothing when there is no active initiative', () => {
+    const { container } = render(
+      <InitiativePanel state={null} characterId="char-a" onEndTurn={noop} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the round and ordered combatants when active', () => {
+    render(
+      <InitiativePanel state={base} characterId="char-a" onEndTurn={noop} />
+    );
+    expect(screen.getByText(/Round 3/i)).toBeInTheDocument();
+    expect(screen.getByText('Aragorn')).toBeInTheDocument();
+    expect(screen.getByText('Enemy')).toBeInTheDocument();
+  });
+
+  it("shows the End my turn button only when it is the open character's turn", () => {
+    const { rerender } = render(
+      <InitiativePanel state={base} characterId="char-a" onEndTurn={noop} />
+    );
+    expect(
+      screen.getByRole('button', { name: /end my turn/i })
+    ).toBeInTheDocument();
+
+    // Different character open → no button
+    rerender(
+      <InitiativePanel state={base} characterId="char-b" onEndTurn={noop} />
+    );
+    expect(
+      screen.queryByRole('button', { name: /end my turn/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onEndTurn with the active entity when the button is clicked', async () => {
+    const onEndTurn = vi.fn();
+    const { default: userEvent } = await import('@testing-library/user-event');
+    render(
+      <InitiativePanel
+        state={base}
+        characterId="char-a"
+        onEndTurn={onEndTurn}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /end my turn/i }));
+    expect(onEndTurn).toHaveBeenCalledWith('a');
+  });
+
+  it('optimistically advances the highlight and hides the button after ending turn', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    // Same synced state throughout (props do not change) — the panel should
+    // still reflect the ended turn locally.
+    render(
+      <InitiativePanel state={base} characterId="char-a" onEndTurn={noop} />
+    );
+    expect(
+      screen.getByRole('button', { name: /end my turn/i })
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /end my turn/i }));
+
+    // It is no longer the open character's turn locally, so the button is gone
+    // even though the synced `state` prop has not changed yet.
+    expect(
+      screen.queryByRole('button', { name: /end my turn/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when initiative is present but combat is not active', () => {
+    const { container } = render(
+      <InitiativePanel
+        state={{ ...base, isActive: false }}
+        characterId="char-a"
+        onEndTurn={noop}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/ui/encounter/AddEntityDialog.tsx
+++ b/src/components/ui/encounter/AddEntityDialog.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/feedback/dialog';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
+import { Checkbox } from '@/components/ui/forms/checkbox';
 import { EncounterEntity, CampaignNPC } from '@/types/encounter';
 import { ProcessedMonster } from '@/types/bestiary';
 import type { Spell } from '@/types/character';
@@ -132,6 +133,8 @@ export function AddEntityDialog({
     useState<ProcessedMonster | null>(null);
   const [customizeHp, setCustomizeHp] = useState('');
   const [customizeAc, setCustomizeAc] = useState('');
+  const [monsterHideFromPlayers, setMonsterHideFromPlayers] = useState(false);
+  const [monsterPlayerAlias, setMonsterPlayerAlias] = useState('');
 
   // NPC creation form
   const [creatingNpc, setCreatingNpc] = useState(false);
@@ -154,6 +157,12 @@ export function AddEntityDialog({
   const [customHp, setCustomHp] = useState('10');
   const [customAc, setCustomAc] = useState('10');
   const [customInitMod, setCustomInitMod] = useState('0');
+  const [customHideFromPlayers, setCustomHideFromPlayers] = useState(false);
+  const [customPlayerAlias, setCustomPlayerAlias] = useState('');
+
+  // NPC add-to-encounter form (per-NPC hide/alias when clicking "Add" on an existing NPC)
+  const [npcHideFromPlayers, setNpcHideFromPlayers] = useState(false);
+  const [npcPlayerAlias, setNpcPlayerAlias] = useState('');
 
   const searchMonsters = useCallback(async (query: string) => {
     if (query.length < 2) {
@@ -181,6 +190,19 @@ export function AddEntityDialog({
     return () => clearTimeout(timeout);
   }, [monsterSearch, searchMonsters]);
 
+  // Reset hide/alias fields when the dialog closes so a previous, unsubmitted
+  // choice doesn't leak into the next time it's opened.
+  useEffect(() => {
+    if (!open) {
+      setMonsterHideFromPlayers(false);
+      setMonsterPlayerAlias('');
+      setNpcHideFromPlayers(false);
+      setNpcPlayerAlias('');
+      setCustomHideFromPlayers(false);
+      setCustomPlayerAlias('');
+    }
+  }, [open]);
+
   const handleSelectMonster = (monster: ProcessedMonster) => {
     setSelectedMonster(monster);
     setCustomizeHp(monster.hpAverage.toString());
@@ -192,6 +214,7 @@ export function AddEntityDialog({
     const color = GROUP_COLORS[selectedMonsterColorIdx % GROUP_COLORS.length];
     const hpOverride = parseInt(customizeHp) || undefined;
     const acOverride = parseInt(customizeAc) || undefined;
+    const aliasValue = monsterPlayerAlias.trim() || undefined;
 
     for (let i = 0; i < monsterCount; i++) {
       const suffix = monsterCount > 1 ? ` ${String.fromCharCode(65 + i)}` : '';
@@ -203,12 +226,18 @@ export function AddEntityDialog({
         acOverride:
           acOverride !== selectedMonster.acValue ? acOverride : undefined,
       });
-      onAddEntity(entity);
+      onAddEntity({
+        ...entity,
+        isHidden: monsterHideFromPlayers,
+        playerAlias: aliasValue,
+      });
     }
 
     setSelectedMonsterColorIdx(prev => prev + 1);
     setMonsterCount(1);
     setSelectedMonster(null);
+    setMonsterHideFromPlayers(false);
+    setMonsterPlayerAlias('');
   };
 
   const handleAddPlayer = (player: (typeof campaignPlayers)[number]) => {
@@ -251,7 +280,8 @@ export function AddEntityDialog({
       tempHp: 0,
       armorClass: npc.armorClass,
       conditions: [],
-      isHidden: false,
+      isHidden: npcHideFromPlayers,
+      playerAlias: npcPlayerAlias.trim() || undefined,
       monsterStatBlock: npc.monsterStatBlock,
       abilities,
       hitDice: npc.hitDice ? { ...npc.hitDice } : undefined,
@@ -299,6 +329,8 @@ export function AddEntityDialog({
           })()
         : undefined,
     });
+    setNpcHideFromPlayers(false);
+    setNpcPlayerAlias('');
   };
 
   const handleCreateNpc = () => {
@@ -330,12 +362,15 @@ export function AddEntityDialog({
       tempHp: 0,
       armorClass: parseInt(customAc) || 10,
       conditions: [],
-      isHidden: false,
+      isHidden: customHideFromPlayers,
+      playerAlias: customPlayerAlias.trim() || undefined,
     });
     setCustomName('');
     setCustomHp('10');
     setCustomAc('10');
     setCustomInitMod('0');
+    setCustomHideFromPlayers(false);
+    setCustomPlayerAlias('');
   };
 
   return (
@@ -371,7 +406,11 @@ export function AddEntityDialog({
                   /* Monster customization step */
                   <div className="space-y-3">
                     <button
-                      onClick={() => setSelectedMonster(null)}
+                      onClick={() => {
+                        setSelectedMonster(null);
+                        setMonsterHideFromPlayers(false);
+                        setMonsterPlayerAlias('');
+                      }}
                       className="text-muted hover:text-body flex items-center gap-1 text-sm transition-colors"
                     >
                       <ArrowLeft size={14} />
@@ -459,6 +498,24 @@ export function AddEntityDialog({
                           selectedMonster.legendaryActions.length > 0 &&
                           ' · Legendary'}
                       </p>
+                    </div>
+
+                    {/* Hide / alias controls for monster */}
+                    <div className="space-y-2">
+                      <Checkbox
+                        size="sm"
+                        checked={monsterHideFromPlayers}
+                        onCheckedChange={setMonsterHideFromPlayers}
+                        label="Hide name from players"
+                      />
+                      {(monsterHideFromPlayers || monsterPlayerAlias) && (
+                        <Input
+                          value={monsterPlayerAlias}
+                          onChange={e => setMonsterPlayerAlias(e.target.value)}
+                          placeholder="Name players see (optional)"
+                          label="Player alias"
+                        />
+                      )}
                     </div>
 
                     <Button
@@ -633,6 +690,26 @@ export function AddEntityDialog({
                   </Button>
                 )}
 
+                {/* Hide / alias options applied when adding any NPC below */}
+                {!creatingNpc && (
+                  <div className="border-divider space-y-2 rounded-lg border p-2">
+                    <Checkbox
+                      size="sm"
+                      checked={npcHideFromPlayers}
+                      onCheckedChange={setNpcHideFromPlayers}
+                      label="Hide name from players"
+                    />
+                    {(npcHideFromPlayers || npcPlayerAlias) && (
+                      <Input
+                        value={npcPlayerAlias}
+                        onChange={e => setNpcPlayerAlias(e.target.value)}
+                        placeholder="Name players see (optional)"
+                        label="Player alias"
+                      />
+                    )}
+                  </div>
+                )}
+
                 {allNpcs.length === 0 && !creatingNpc ? (
                   <p className="text-muted py-8 text-center text-sm">
                     No NPCs yet. Create one to reuse across encounters.
@@ -742,6 +819,23 @@ export function AddEntityDialog({
                     label="Init Mod"
                     type="number"
                   />
+                </div>
+                {/* Hide / alias controls for custom entity */}
+                <div className="space-y-2">
+                  <Checkbox
+                    size="sm"
+                    checked={customHideFromPlayers}
+                    onCheckedChange={setCustomHideFromPlayers}
+                    label="Hide name from players"
+                  />
+                  {(customHideFromPlayers || customPlayerAlias) && (
+                    <Input
+                      value={customPlayerAlias}
+                      onChange={e => setCustomPlayerAlias(e.target.value)}
+                      placeholder="Name players see (optional)"
+                      label="Player alias"
+                    />
+                  )}
                 </div>
                 <Button
                   variant="primary"

--- a/src/components/ui/encounter/AddEntityDialog.tsx
+++ b/src/components/ui/encounter/AddEntityDialog.tsx
@@ -21,7 +21,11 @@ import {
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
 import { Checkbox } from '@/components/ui/forms/checkbox';
-import { EncounterEntity, CampaignNPC } from '@/types/encounter';
+import {
+  EncounterEntity,
+  CampaignNPC,
+  PlayerDisposition,
+} from '@/types/encounter';
 import { ProcessedMonster } from '@/types/bestiary';
 import type { Spell } from '@/types/character';
 import { useNPCStore } from '@/store/npcStore';
@@ -112,6 +116,63 @@ const GROUP_COLORS = [
   '#f97316', // orange
 ];
 
+const DISPOSITION_OPTIONS: Array<{
+  value: PlayerDisposition;
+  label: string;
+  title: string;
+  activeClass: string;
+}> = [
+  {
+    value: 'ally',
+    label: 'Ally',
+    title: 'Players see this as an ally',
+    activeClass: 'bg-surface-raised text-accent-emerald-text shadow-sm',
+  },
+  {
+    value: 'enemy',
+    label: 'Enemy',
+    title: 'Players see this as an enemy',
+    activeClass: 'bg-surface-raised text-accent-red-text shadow-sm',
+  },
+  {
+    value: 'neutral',
+    label: 'Neutral',
+    title: 'Players see this as neutral',
+    activeClass: 'bg-surface-raised text-muted shadow-sm',
+  },
+];
+
+function DispositionToggle({
+  value,
+  onChange,
+}: {
+  value: PlayerDisposition;
+  onChange: (v: PlayerDisposition) => void;
+}) {
+  return (
+    <div>
+      <label className="text-body mb-1 block text-sm">Player sees as</label>
+      <div className="bg-surface-secondary inline-flex rounded-lg p-0.5">
+        {DISPOSITION_OPTIONS.map(opt => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+              value === opt.value
+                ? opt.activeClass
+                : 'text-muted hover:text-body'
+            }`}
+            title={opt.title}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function AddEntityDialog({
   open,
   onOpenChange,
@@ -163,6 +224,12 @@ export function AddEntityDialog({
   // NPC add-to-encounter form (per-NPC hide/alias when clicking "Add" on an existing NPC)
   const [npcHideFromPlayers, setNpcHideFromPlayers] = useState(false);
   const [npcPlayerAlias, setNpcPlayerAlias] = useState('');
+  const [npcDisposition, setNpcDisposition] =
+    useState<PlayerDisposition>('enemy');
+  const [monsterDisposition, setMonsterDisposition] =
+    useState<PlayerDisposition>('enemy');
+  const [customDisposition, setCustomDisposition] =
+    useState<PlayerDisposition>('enemy');
 
   const searchMonsters = useCallback(async (query: string) => {
     if (query.length < 2) {
@@ -196,10 +263,13 @@ export function AddEntityDialog({
     if (!open) {
       setMonsterHideFromPlayers(false);
       setMonsterPlayerAlias('');
+      setMonsterDisposition('enemy');
       setNpcHideFromPlayers(false);
       setNpcPlayerAlias('');
+      setNpcDisposition('enemy');
       setCustomHideFromPlayers(false);
       setCustomPlayerAlias('');
+      setCustomDisposition('enemy');
     }
   }, [open]);
 
@@ -230,6 +300,7 @@ export function AddEntityDialog({
         ...entity,
         isHidden: monsterHideFromPlayers,
         playerAlias: aliasValue,
+        playerDisposition: monsterDisposition,
       });
     }
 
@@ -238,6 +309,7 @@ export function AddEntityDialog({
     setSelectedMonster(null);
     setMonsterHideFromPlayers(false);
     setMonsterPlayerAlias('');
+    setMonsterDisposition('enemy');
   };
 
   const handleAddPlayer = (player: (typeof campaignPlayers)[number]) => {
@@ -282,6 +354,7 @@ export function AddEntityDialog({
       conditions: [],
       isHidden: npcHideFromPlayers,
       playerAlias: npcPlayerAlias.trim() || undefined,
+      playerDisposition: npcDisposition,
       monsterStatBlock: npc.monsterStatBlock,
       abilities,
       hitDice: npc.hitDice ? { ...npc.hitDice } : undefined,
@@ -331,6 +404,7 @@ export function AddEntityDialog({
     });
     setNpcHideFromPlayers(false);
     setNpcPlayerAlias('');
+    setNpcDisposition('enemy');
   };
 
   const handleCreateNpc = () => {
@@ -364,6 +438,7 @@ export function AddEntityDialog({
       conditions: [],
       isHidden: customHideFromPlayers,
       playerAlias: customPlayerAlias.trim() || undefined,
+      playerDisposition: customDisposition,
     });
     setCustomName('');
     setCustomHp('10');
@@ -371,6 +446,7 @@ export function AddEntityDialog({
     setCustomInitMod('0');
     setCustomHideFromPlayers(false);
     setCustomPlayerAlias('');
+    setCustomDisposition('enemy');
   };
 
   return (
@@ -500,7 +576,7 @@ export function AddEntityDialog({
                       </p>
                     </div>
 
-                    {/* Hide / alias controls for monster */}
+                    {/* Hide / alias / disposition controls for monster */}
                     <div className="space-y-2">
                       <Checkbox
                         size="sm"
@@ -516,6 +592,10 @@ export function AddEntityDialog({
                           label="Player alias"
                         />
                       )}
+                      <DispositionToggle
+                        value={monsterDisposition}
+                        onChange={setMonsterDisposition}
+                      />
                     </div>
 
                     <Button
@@ -690,7 +770,7 @@ export function AddEntityDialog({
                   </Button>
                 )}
 
-                {/* Hide / alias options applied when adding any NPC below */}
+                {/* Hide / alias / disposition options applied when adding any NPC below */}
                 {!creatingNpc && (
                   <div className="border-divider space-y-2 rounded-lg border p-2">
                     <Checkbox
@@ -707,6 +787,10 @@ export function AddEntityDialog({
                         label="Player alias"
                       />
                     )}
+                    <DispositionToggle
+                      value={npcDisposition}
+                      onChange={setNpcDisposition}
+                    />
                   </div>
                 )}
 
@@ -820,7 +904,7 @@ export function AddEntityDialog({
                     type="number"
                   />
                 </div>
-                {/* Hide / alias controls for custom entity */}
+                {/* Hide / alias / disposition controls for custom entity */}
                 <div className="space-y-2">
                   <Checkbox
                     size="sm"
@@ -836,6 +920,10 @@ export function AddEntityDialog({
                       label="Player alias"
                     />
                   )}
+                  <DispositionToggle
+                    value={customDisposition}
+                    onChange={setCustomDisposition}
+                  />
                 </div>
                 <Button
                   variant="primary"

--- a/src/components/ui/encounter/CombatConfigDialog.tsx
+++ b/src/components/ui/encounter/CombatConfigDialog.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { Trash2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogBody,
+  DialogFooter,
+} from '@/components/ui/feedback/dialog';
+import { Button } from '@/components/ui/forms/button';
+import { Input } from '@/components/ui/forms/input';
+import {
+  RadioGroupField,
+  RadioGroupItem,
+} from '@/components/ui/forms/radio-group';
+import { useEncounterStore } from '@/store/encounterStore';
+import {
+  type EnemyHpDisplay,
+  type HpStateBand,
+  DEFAULT_HP_STATE_BANDS,
+} from '@/types/encounter';
+
+interface HpDisplayOption {
+  value: EnemyHpDisplay;
+  label: string;
+  description: string;
+}
+
+const HP_DISPLAY_OPTIONS: HpDisplayOption[] = [
+  {
+    value: 'off',
+    label: 'Off',
+    description: 'Players see nothing — enemy HP is fully hidden.',
+  },
+  {
+    value: 'label',
+    label: 'State label',
+    description: 'Players see a word like "Bloodied" or "Injured".',
+  },
+  {
+    value: 'bar',
+    label: 'HP bar',
+    description: 'Players see a coloured HP bar without numbers.',
+  },
+  {
+    value: 'percent',
+    label: 'Percentage',
+    description: 'Players see a number like "45%".',
+  },
+  {
+    value: 'exact',
+    label: 'Exact numbers',
+    description: 'Players see the full value, e.g. "54 / 120".',
+  },
+];
+
+interface CombatConfigDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CombatConfigDialog({
+  open,
+  onOpenChange,
+}: CombatConfigDialogProps) {
+  const combatConfig = useEncounterStore(s => s.combatConfig);
+  const setCombatConfig = useEncounterStore(s => s.setCombatConfig);
+
+  const [hpDisplay, setHpDisplay] = useState<EnemyHpDisplay>(
+    combatConfig.enemyHpDisplay
+  );
+  const [bands, setBands] = useState<HpStateBand[]>(combatConfig.hpStateBands);
+
+  // Re-sync local state when dialog opens or store changes
+  useEffect(() => {
+    if (open) {
+      setHpDisplay(combatConfig.enemyHpDisplay);
+      setBands(combatConfig.hpStateBands);
+    }
+  }, [open, combatConfig]);
+
+  const handleAddBand = () => {
+    setBands(prev => [...prev, { minPercent: 0, label: '' }]);
+  };
+
+  const handleRemoveBand = (index: number) => {
+    setBands(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const handleBandChange = (
+    index: number,
+    field: keyof HpStateBand,
+    value: string
+  ) => {
+    setBands(prev =>
+      prev.map((band, i) => {
+        if (i !== index) return band;
+        if (field === 'minPercent') {
+          const parsed = parseInt(value, 10);
+          const clamped = isNaN(parsed)
+            ? 0
+            : Math.max(0, Math.min(100, parsed));
+          return { ...band, minPercent: clamped };
+        }
+        return { ...band, label: value };
+      })
+    );
+  };
+
+  const handleResetBands = () => {
+    setBands([...DEFAULT_HP_STATE_BANDS]);
+  };
+
+  const handleSave = () => {
+    const cleaned = bands
+      .filter(b => b.label.trim() !== '')
+      .sort((a, b) => b.minPercent - a.minPercent);
+
+    setCombatConfig({ enemyHpDisplay: hpDisplay, hpStateBands: cleaned });
+    onOpenChange(false);
+  };
+
+  const handleCancel = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Combat Configuration</DialogTitle>
+          <DialogDescription>
+            Controls what players see for enemy HP during combat.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogBody className="space-y-6">
+          {/* Enemy HP display picker */}
+          <RadioGroupField
+            label="Enemy HP display"
+            value={hpDisplay}
+            onValueChange={v => setHpDisplay(v as EnemyHpDisplay)}
+          >
+            <div className="space-y-2">
+              {HP_DISPLAY_OPTIONS.map(opt => (
+                <RadioGroupItem
+                  key={opt.value}
+                  value={opt.value}
+                  label={opt.label}
+                  description={opt.description}
+                  variant="card"
+                  size="sm"
+                />
+              ))}
+            </div>
+          </RadioGroupField>
+
+          {/* HP state bands editor — only shown when display === 'label' */}
+          {hpDisplay === 'label' && (
+            <div className="space-y-3">
+              <div className="border-divider flex items-center justify-between border-b pb-2">
+                <span className="text-heading text-sm font-medium">
+                  HP state labels
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleResetBands}
+                  type="button"
+                >
+                  Reset to defaults
+                </Button>
+              </div>
+
+              <p className="text-muted text-xs">
+                Each band covers HP from its threshold up to the next band. Rows
+                with empty labels are dropped on save.
+              </p>
+
+              <div className="space-y-2">
+                {bands.map((band, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <Input
+                      type="number"
+                      value={band.minPercent.toString()}
+                      onChange={e =>
+                        handleBandChange(index, 'minPercent', e.target.value)
+                      }
+                      min={0}
+                      max={100}
+                      wrapperClassName="w-24 shrink-0"
+                      aria-label="Minimum percent"
+                    />
+                    <span className="text-muted shrink-0 text-sm">%</span>
+                    <Input
+                      type="text"
+                      value={band.label}
+                      onChange={e =>
+                        handleBandChange(index, 'label', e.target.value)
+                      }
+                      placeholder="Label..."
+                      wrapperClassName="flex-1"
+                      aria-label="Band label"
+                    />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleRemoveBand(index)}
+                      type="button"
+                      aria-label="Remove band"
+                    >
+                      <Trash2 size={14} className="text-muted" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleAddBand}
+                type="button"
+              >
+                + Add band
+              </Button>
+            </div>
+          )}
+        </DialogBody>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            size="md"
+            onClick={handleCancel}
+            type="button"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            onClick={handleSave}
+            type="button"
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/encounter/EncounterList.tsx
+++ b/src/components/ui/encounter/EncounterList.tsx
@@ -11,12 +11,14 @@ import {
   Play,
   Square,
   Map as MapIcon,
+  Settings,
 } from 'lucide-react';
 import { useEncounterStore } from '@/store/encounterStore';
 import { useBattleMapStore } from '@/store/battleMapStore';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
 import { Badge } from '@/components/ui/layout/badge';
+import { CombatConfigDialog } from '@/components/ui/encounter/CombatConfigDialog';
 import { Encounter } from '@/types/encounter';
 import type { BattleMap } from '@/types/battlemap';
 
@@ -38,6 +40,7 @@ export function EncounterList({ campaignCode }: EncounterListProps) {
   }, [battleMaps]);
   const [newName, setNewName] = useState('');
   const [isCreating, setIsCreating] = useState(false);
+  const [configOpen, setConfigOpen] = useState(false);
 
   const handleCreate = () => {
     if (!newName.trim()) return;
@@ -54,45 +57,59 @@ export function EncounterList({ campaignCode }: EncounterListProps) {
 
   return (
     <div className="space-y-6">
-      {/* Create button / form */}
-      {isCreating ? (
-        <div className="bg-surface-raised border-divider flex items-center gap-3 rounded-lg border p-4">
-          <Input
-            value={newName}
-            onChange={e => setNewName(e.target.value)}
-            placeholder="Encounter name..."
-            onKeyDown={e => {
-              if (e.key === 'Enter') handleCreate();
-              if (e.key === 'Escape') setIsCreating(false);
-            }}
-            autoFocus
-            className="flex-1"
-          />
+      {/* Header row: Create button / form + gear button */}
+      <div className="flex items-center gap-2">
+        {isCreating ? (
+          <div className="bg-surface-raised border-divider flex flex-1 items-center gap-3 rounded-lg border p-4">
+            <Input
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              placeholder="Encounter name..."
+              onKeyDown={e => {
+                if (e.key === 'Enter') handleCreate();
+                if (e.key === 'Escape') setIsCreating(false);
+              }}
+              autoFocus
+              className="flex-1"
+            />
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleCreate}
+              disabled={!newName.trim()}
+            >
+              Create
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsCreating(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        ) : (
           <Button
             variant="primary"
-            size="sm"
-            onClick={handleCreate}
-            disabled={!newName.trim()}
+            onClick={() => setIsCreating(true)}
+            leftIcon={<Plus size={18} />}
           >
-            Create
+            New Encounter
           </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setIsCreating(false)}
-          >
-            Cancel
-          </Button>
-        </div>
-      ) : (
+        )}
+
         <Button
-          variant="primary"
-          onClick={() => setIsCreating(true)}
-          leftIcon={<Plus size={18} />}
+          variant="ghost"
+          size="sm"
+          onClick={() => setConfigOpen(true)}
+          title="Combat configuration"
+          aria-label="Open combat configuration"
         >
-          New Encounter
+          <Settings size={16} className="text-muted" />
         </Button>
-      )}
+      </div>
+
+      <CombatConfigDialog open={configOpen} onOpenChange={setConfigOpen} />
 
       {/* Encounter list */}
       {sorted.length === 0 ? (

--- a/src/components/ui/encounter/EncounterList.tsx
+++ b/src/components/ui/encounter/EncounterList.tsx
@@ -148,8 +148,8 @@ function EncounterCard({
   const npcCount = encounter.entities.filter(e => e.type === 'npc').length;
 
   return (
-    <div className="border-divider bg-surface-raised hover:bg-surface-secondary rounded-lg border shadow-sm transition-all hover:shadow-md">
-      <div className="p-4">
+    <div className="border-divider bg-surface-raised hover:bg-surface-secondary flex h-full flex-col rounded-lg border shadow-sm transition-all hover:shadow-md">
+      <div className="flex flex-1 flex-col p-4">
         <div className="mb-3 flex items-start justify-between">
           <h3 className="text-heading truncate text-lg font-semibold">
             {encounter.name}
@@ -212,7 +212,7 @@ function EncounterCard({
           </Link>
         )}
 
-        <div className="flex items-center gap-2">
+        <div className="mt-auto flex items-center gap-2 pt-1">
           <Link
             href={`/dm/campaign/${campaignCode}/encounters/${encounter.id}`}
             className="flex-1"

--- a/src/components/ui/encounter/EncounterView.tsx
+++ b/src/components/ui/encounter/EncounterView.tsx
@@ -14,6 +14,9 @@ import {
 } from '@/utils/encounterSync';
 import { useDmEffectsSync } from '@/hooks/useDmEffectsSync';
 import { useDmCounterSync } from '@/hooks/useDmCounterSync';
+import { useDmInitiativeSync } from '@/hooks/useDmInitiativeSync';
+import { useTurnRequestSync } from '@/hooks/useTurnRequestSync';
+import { buildSharedInitiative } from '@/utils/buildSharedInitiative';
 import { Button } from '@/components/ui/forms/button';
 import { InitiativeTracker } from './InitiativeTracker';
 import { AddEntityDialog } from './AddEntityDialog';
@@ -78,6 +81,29 @@ export function EncounterView({
 
   const { syncPlayerEffects } = useDmEffectsSync({ campaignCode, dmId });
   useDmCounterSync(campaignCode, dmId);
+
+  const { pushInitiative } = useDmInitiativeSync({ campaignCode, dmId });
+
+  useTurnRequestSync({
+    campaignCode,
+    encounterId: encounter?.id,
+    isActive: !!encounter?.isActive,
+    // No onApplied: EncounterView has no toast mechanism.
+  });
+
+  // Push initiative state to Redis whenever turn/round/entities change.
+  // Only fires for campaign-linked encounters; safe when encounter is undefined.
+  useEffect(() => {
+    if (!encounter || !encounter.campaignCode) return;
+    pushInitiative(buildSharedInitiative(encounter));
+  }, [
+    encounter,
+    encounter?.isActive,
+    encounter?.round,
+    encounter?.currentTurn,
+    encounter?.entities,
+    pushInitiative,
+  ]);
 
   const { players: campaignPlayers } = useCampaignSync({
     code: campaignCode,

--- a/src/components/ui/encounter/EncounterView.tsx
+++ b/src/components/ui/encounter/EncounterView.tsx
@@ -82,6 +82,8 @@ export function EncounterView({
   const { syncPlayerEffects } = useDmEffectsSync({ campaignCode, dmId });
   useDmCounterSync(campaignCode, dmId);
 
+  const combatConfig = useEncounterStore(state => state.combatConfig);
+
   const { pushInitiative } = useDmInitiativeSync({ campaignCode, dmId });
 
   useTurnRequestSync({
@@ -95,13 +97,14 @@ export function EncounterView({
   // Only fires for campaign-linked encounters; safe when encounter is undefined.
   useEffect(() => {
     if (!encounter || !encounter.campaignCode) return;
-    pushInitiative(buildSharedInitiative(encounter));
+    pushInitiative(buildSharedInitiative(encounter, combatConfig));
   }, [
     encounter,
     encounter?.isActive,
     encounter?.round,
     encounter?.currentTurn,
     encounter?.entities,
+    combatConfig,
     pushInitiative,
   ]);
 

--- a/src/components/ui/encounter/EntityCard.tsx
+++ b/src/components/ui/encounter/EntityCard.tsx
@@ -25,7 +25,11 @@ import {
   ClockAlert,
 } from 'lucide-react';
 import { Input } from '@/components/ui/forms/input';
-import { EncounterEntity, ChessPiece } from '@/types/encounter';
+import {
+  EncounterEntity,
+  ChessPiece,
+  PlayerDisposition,
+} from '@/types/encounter';
 import { HPBar } from '@/components/shared/combat/HPBar';
 import { ConditionBadge } from '@/components/shared/combat/ConditionBadge';
 import { EntityCardExpanded } from './EntityCardExpanded';
@@ -611,6 +615,47 @@ export function EntityCard({
                     <Pencil size={13} />
                   </button>
                 )}
+                {/* Disposition segmented toggle */}
+                <div
+                  className="bg-surface-secondary ml-1 flex shrink-0 items-center rounded-md p-0.5"
+                  title="Player-facing allegiance"
+                >
+                  {(
+                    [
+                      { value: 'ally', label: 'A', title: 'Ally' },
+                      { value: 'enemy', label: 'E', title: 'Enemy' },
+                      { value: 'neutral', label: 'N', title: 'Neutral' },
+                    ] as Array<{
+                      value: PlayerDisposition;
+                      label: string;
+                      title: string;
+                    }>
+                  ).map(opt => {
+                    const active =
+                      (entity.playerDisposition ?? 'enemy') === opt.value;
+                    const activeClass =
+                      opt.value === 'ally'
+                        ? 'bg-surface-raised text-accent-emerald-text shadow-sm'
+                        : opt.value === 'enemy'
+                          ? 'bg-surface-raised text-accent-red-text shadow-sm'
+                          : 'bg-surface-raised text-muted shadow-sm';
+                    return (
+                      <button
+                        key={opt.value}
+                        onClick={e => {
+                          e.stopPropagation();
+                          onUpdate({ playerDisposition: opt.value });
+                        }}
+                        className={`rounded px-1.5 py-0.5 text-[10px] font-semibold transition-colors ${
+                          active ? activeClass : 'text-faint hover:text-muted'
+                        }`}
+                        title={opt.title}
+                      >
+                        {opt.label}
+                      </button>
+                    );
+                  })}
+                </div>
               </>
             )}
             {(entity.type === 'player' || entity.summonOwnerId) && (

--- a/src/components/ui/encounter/EntityCard.tsx
+++ b/src/components/ui/encounter/EntityCard.tsx
@@ -6,6 +6,8 @@ import {
   ChevronUp,
   Shield,
   Eye,
+  EyeOff,
+  Pencil,
   Sparkles,
   Angry,
   Minus,
@@ -22,6 +24,7 @@ import {
   Brain,
   ClockAlert,
 } from 'lucide-react';
+import { Input } from '@/components/ui/forms/input';
 import { EncounterEntity, ChessPiece } from '@/types/encounter';
 import { HPBar } from '@/components/shared/combat/HPBar';
 import { ConditionBadge } from '@/components/shared/combat/ConditionBadge';
@@ -405,6 +408,8 @@ export function EntityCard({
   const [initInput, setInitInput] = useState('');
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState('');
+  const [isEditingAlias, setIsEditingAlias] = useState(false);
+  const [aliasInput, setAliasInput] = useState('');
   const style = entity.summonOwnerId
     ? TYPE_STYLES.player
     : (TYPE_STYLES[entity.type] ?? TYPE_STYLES.monster);
@@ -539,6 +544,75 @@ export function EntityCard({
                   ? 'NPC'
                   : entity.type.charAt(0).toUpperCase() + entity.type.slice(1)}
             </span>
+            {/* DM-only: eye toggle + alias edit for non-player entities */}
+            {entity.type !== 'player' && (
+              <>
+                <button
+                  onClick={e => {
+                    e.stopPropagation();
+                    onUpdate({ isHidden: !entity.isHidden });
+                  }}
+                  className={`shrink-0 rounded p-0.5 transition-colors ${
+                    entity.isHidden
+                      ? 'text-accent-amber-text hover:text-accent-amber-text hover:bg-accent-amber-bg'
+                      : 'text-faint hover:text-muted hover:bg-surface-raised'
+                  }`}
+                  title={
+                    entity.isHidden
+                      ? 'Name hidden from players — click to reveal'
+                      : 'Name visible to players — click to hide'
+                  }
+                >
+                  {entity.isHidden ? <EyeOff size={13} /> : <Eye size={13} />}
+                </button>
+                {isEditingAlias ? (
+                  <Input
+                    value={aliasInput}
+                    onChange={e => setAliasInput(e.target.value)}
+                    onBlur={() => {
+                      onUpdate({
+                        playerAlias: aliasInput.trim() || undefined,
+                      });
+                      setIsEditingAlias(false);
+                    }}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') {
+                        onUpdate({
+                          playerAlias: aliasInput.trim() || undefined,
+                        });
+                        setIsEditingAlias(false);
+                      }
+                      if (e.key === 'Escape') {
+                        setIsEditingAlias(false);
+                      }
+                    }}
+                    placeholder="Alias…"
+                    className="h-5 w-24 shrink-0 px-1 py-0 text-xs"
+                    autoFocus
+                  />
+                ) : (
+                  <button
+                    onClick={e => {
+                      e.stopPropagation();
+                      setAliasInput(entity.playerAlias ?? '');
+                      setIsEditingAlias(true);
+                    }}
+                    className={`shrink-0 rounded p-0.5 transition-colors ${
+                      entity.playerAlias
+                        ? 'text-accent-blue-text hover:bg-accent-blue-bg'
+                        : 'text-faint hover:text-muted hover:bg-surface-raised'
+                    }`}
+                    title={
+                      entity.playerAlias
+                        ? `Players see: "${entity.playerAlias}" — click to edit`
+                        : 'Set alias players see — click to edit'
+                    }
+                  >
+                    <Pencil size={13} />
+                  </button>
+                )}
+              </>
+            )}
             {(entity.type === 'player' || entity.summonOwnerId) && (
               <SyncIndicator lastSynced={lastSynced} />
             )}
@@ -588,6 +662,18 @@ export function EntityCard({
                 size="sm"
               />
             ))}
+
+          {/* DM hint: what players see when name is hidden or aliased */}
+          {entity.type !== 'player' &&
+            (entity.isHidden || entity.playerAlias) && (
+              <div className="text-faint mt-0.5 text-[10px]">
+                Players see:{' '}
+                <span className="font-medium">
+                  {entity.playerAlias?.trim() ||
+                    (entity.isHidden ? 'Enemy' : entity.name)}
+                </span>
+              </div>
+            )}
 
           {/* Death Saving Throws (players & NPCs at 0 HP) */}
           {(entity.type === 'player' || entity.type === 'npc') &&

--- a/src/components/ui/feedback/CombatStartBanner.tsx
+++ b/src/components/ui/feedback/CombatStartBanner.tsx
@@ -41,55 +41,86 @@ export function CombatStartBanner({
   if (!render) return null;
 
   const banner = (
-    <div
-      className="pointer-events-none fixed inset-0 z-[9999] flex items-center justify-center"
-      aria-live="polite"
-    >
+    <>
+      {/* Background blur — sits below the sidebars (z-55) so they stay sharp */}
       <div
-        className={`border-accent-red-border bg-surface-raised text-accent-red-text flex items-center gap-3 rounded-xl border-2 px-8 py-4 shadow-2xl ${
-          phase === 'enter' ? 'combat-banner-enter' : 'combat-banner-exit'
+        className={`pointer-events-none fixed inset-0 z-[50] backdrop-blur-sm ${
+          phase === 'enter' ? 'combat-blur-enter' : 'combat-blur-exit'
         }`}
-        style={{ fontFamily: 'var(--font-cinzel-decorative), serif' }}
+      />
+      <div
+        className="pointer-events-none fixed inset-0 z-[9999] flex items-center justify-center"
+        aria-live="polite"
       >
-        <Swords size={28} />
-        <span className="text-2xl font-bold tracking-widest uppercase sm:text-3xl">
-          Combat Begins
-        </span>
-        <Swords size={28} className="-scale-x-100" />
-      </div>
+        <div
+          className={`border-accent-red-border bg-surface-raised text-accent-red-text flex items-center gap-3 rounded-xl border-2 px-8 py-4 shadow-2xl ${
+            phase === 'enter' ? 'combat-banner-enter' : 'combat-banner-exit'
+          }`}
+          style={{ fontFamily: 'var(--font-cinzel-decorative), serif' }}
+        >
+          <Swords size={28} />
+          <span className="text-2xl font-bold tracking-widest uppercase sm:text-3xl">
+            Combat Begins
+          </span>
+          <Swords size={28} className="-scale-x-100" />
+        </div>
 
-      <style jsx>{`
-        .combat-banner-enter {
-          animation: combatBannerIn 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
-        }
-        .combat-banner-exit {
-          animation: combatBannerOut 0.7s ease-in forwards;
-        }
-        @keyframes combatBannerIn {
-          0% {
-            opacity: 0;
-            transform: translateY(-32px) scale(0.92);
+        <style jsx>{`
+          .combat-banner-enter {
+            animation: combatBannerIn 0.6s cubic-bezier(0.2, 0.8, 0.2, 1)
+              forwards;
           }
-          60% {
-            transform: translateY(4px) scale(1.02);
+          .combat-banner-exit {
+            animation: combatBannerOut 0.7s ease-in forwards;
           }
-          100% {
-            opacity: 1;
-            transform: translateY(0) scale(1);
+          .combat-blur-enter {
+            animation: combatBlurIn 0.5s ease-out forwards;
           }
-        }
-        @keyframes combatBannerOut {
-          0% {
-            opacity: 1;
-            transform: scale(1);
+          .combat-blur-exit {
+            animation: combatBlurOut 0.7s ease-in forwards;
           }
-          100% {
-            opacity: 0;
-            transform: scale(1.06);
+          @keyframes combatBlurIn {
+            0% {
+              opacity: 0;
+            }
+            100% {
+              opacity: 1;
+            }
           }
-        }
-      `}</style>
-    </div>
+          @keyframes combatBlurOut {
+            0% {
+              opacity: 1;
+            }
+            100% {
+              opacity: 0;
+            }
+          }
+          @keyframes combatBannerIn {
+            0% {
+              opacity: 0;
+              transform: translateY(-32px) scale(0.92);
+            }
+            60% {
+              transform: translateY(4px) scale(1.02);
+            }
+            100% {
+              opacity: 1;
+              transform: translateY(0) scale(1);
+            }
+          }
+          @keyframes combatBannerOut {
+            0% {
+              opacity: 1;
+              transform: scale(1);
+            }
+            100% {
+              opacity: 0;
+              transform: scale(1.06);
+            }
+          }
+        `}</style>
+      </div>
+    </>
   );
 
   if (typeof window === 'undefined') return null;

--- a/src/components/ui/feedback/CombatStartBanner.tsx
+++ b/src/components/ui/feedback/CombatStartBanner.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Swords } from 'lucide-react';
+
+interface CombatStartBannerProps {
+  isVisible: boolean;
+  onDone?: () => void;
+  durationMs?: number;
+}
+
+/**
+ * A non-blocking "Combat Begins" banner that sweeps into the center of the
+ * screen, holds, then fades. `pointer-events-none` so it never blocks the sheet.
+ * Rendered via portal at document.body. Self-dismisses after `durationMs`.
+ */
+export function CombatStartBanner({
+  isVisible,
+  onDone,
+  durationMs = 2600,
+}: CombatStartBannerProps) {
+  const [render, setRender] = useState(false);
+  const [phase, setPhase] = useState<'enter' | 'exit'>('enter');
+
+  useEffect(() => {
+    if (!isVisible) return;
+    setRender(true);
+    setPhase('enter');
+    const exitTimer = setTimeout(() => setPhase('exit'), durationMs - 700);
+    const doneTimer = setTimeout(() => {
+      setRender(false);
+      onDone?.();
+    }, durationMs);
+    return () => {
+      clearTimeout(exitTimer);
+      clearTimeout(doneTimer);
+    };
+  }, [isVisible, durationMs, onDone]);
+
+  if (!render) return null;
+
+  const banner = (
+    <div
+      className="pointer-events-none fixed inset-0 z-[9999] flex items-center justify-center"
+      aria-live="polite"
+    >
+      <div
+        className={`border-accent-red-border bg-surface-raised text-accent-red-text flex items-center gap-3 rounded-xl border-2 px-8 py-4 shadow-2xl ${
+          phase === 'enter' ? 'combat-banner-enter' : 'combat-banner-exit'
+        }`}
+        style={{ fontFamily: 'var(--font-cinzel-decorative), serif' }}
+      >
+        <Swords size={28} />
+        <span className="text-2xl font-bold tracking-widest uppercase sm:text-3xl">
+          Combat Begins
+        </span>
+        <Swords size={28} className="-scale-x-100" />
+      </div>
+
+      <style jsx>{`
+        .combat-banner-enter {
+          animation: combatBannerIn 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+        }
+        .combat-banner-exit {
+          animation: combatBannerOut 0.7s ease-in forwards;
+        }
+        @keyframes combatBannerIn {
+          0% {
+            opacity: 0;
+            transform: translateY(-32px) scale(0.92);
+          }
+          60% {
+            transform: translateY(4px) scale(1.02);
+          }
+          100% {
+            opacity: 1;
+            transform: translateY(0) scale(1);
+          }
+        }
+        @keyframes combatBannerOut {
+          0% {
+            opacity: 1;
+            transform: scale(1);
+          }
+          100% {
+            opacity: 0;
+            transform: scale(1.06);
+          }
+        }
+      `}</style>
+    </div>
+  );
+
+  if (typeof window === 'undefined') return null;
+  return createPortal(banner, document.body);
+}
+
+export default CombatStartBanner;

--- a/src/components/ui/feedback/DataSafetyBanner.tsx
+++ b/src/components/ui/feedback/DataSafetyBanner.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { AlertTriangle, X, Download } from 'lucide-react';
+import { Button } from '@/components/ui/forms/button';
+
+const DISMISS_KEY = 'rollkeeper-data-warning-dismissed';
+
+interface DataSafetyBannerProps {
+  onExport: () => void;
+}
+
+/**
+ * One-time, dismissible reminder that character data lives only in this browser,
+ * nudging the user to keep an exported backup. Dismissal persists.
+ */
+export function DataSafetyBanner({ onExport }: DataSafetyBannerProps) {
+  // Hidden on first paint until we know the persisted choice (avoids a flash).
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    try {
+      setDismissed(localStorage.getItem(DISMISS_KEY) === 'true');
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, 'true');
+    } catch {
+      // Ignore localStorage errors
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <div className="border-accent-amber-border bg-accent-amber-bg mb-6 flex items-start gap-3 rounded-lg border p-4">
+      <AlertTriangle className="text-accent-amber-text mt-0.5 h-5 w-5 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <p className="text-heading text-sm font-medium">
+          Your characters are saved only in this browser
+        </p>
+        <p className="text-muted text-sm">
+          Clearing browser data or switching devices will lose them. Export a
+          backup to stay safe.
+        </p>
+      </div>
+      <Button
+        variant="warning"
+        size="sm"
+        leftIcon={<Download size={16} />}
+        onClick={onExport}
+      >
+        Export All
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleDismiss}
+        aria-label="Dismiss"
+      >
+        <X size={16} />
+      </Button>
+    </div>
+  );
+}

--- a/src/hooks/__tests__/useDmInitiativeSync.test.ts
+++ b/src/hooks/__tests__/useDmInitiativeSync.test.ts
@@ -8,6 +8,7 @@ const state: SharedInitiativeState = {
   isActive: true,
   round: 1,
   currentEntityId: 'a',
+  enemyHpMode: 'off',
   turnOrder: [],
   updatedAt: '',
 };

--- a/src/hooks/__tests__/useDmInitiativeSync.test.ts
+++ b/src/hooks/__tests__/useDmInitiativeSync.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDmInitiativeSync } from '../useDmInitiativeSync';
+import type { SharedInitiativeState } from '@/types/sharedState';
+
+const state: SharedInitiativeState = {
+  encounterId: 'enc-1',
+  isActive: true,
+  round: 1,
+  currentEntityId: 'a',
+  turnOrder: [],
+  updatedAt: '',
+};
+
+describe('useDmInitiativeSync', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true }))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('POSTs the initiative feature with the dmId', async () => {
+    const { result } = renderHook(() =>
+      useDmInitiativeSync({ campaignCode: 'ABC123', dmId: 'dm-1' })
+    );
+    await result.current.pushInitiative(state);
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/campaign/ABC123/shared',
+      expect.objectContaining({ method: 'POST' })
+    );
+    const body = JSON.parse(
+      (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body
+    );
+    expect(body.feature).toBe('initiative');
+    expect(body.dmId).toBe('dm-1');
+    expect(body.data.encounterId).toBe('enc-1');
+  });
+});

--- a/src/hooks/__tests__/useDraggableY.test.ts
+++ b/src/hooks/__tests__/useDraggableY.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { clampTop } from '../useDraggableY';
+
+describe('clampTop', () => {
+  it('returns the moved position when within bounds', () => {
+    expect(clampTop(100, 50, 800)).toBe(150);
+    expect(clampTop(200, -50, 800)).toBe(150);
+  });
+
+  it('clamps to the top margin when dragged above the viewport', () => {
+    expect(clampTop(100, -500, 800)).toBe(8);
+  });
+
+  it('clamps to (innerHeight - bottomMargin) when dragged below the viewport', () => {
+    // 800 - 120 = 680
+    expect(clampTop(100, 5000, 800)).toBe(680);
+  });
+});

--- a/src/hooks/__tests__/useSharedCampaignState.test.ts
+++ b/src/hooks/__tests__/useSharedCampaignState.test.ts
@@ -16,6 +16,7 @@ const makeSharedState = (
   dmEffects: [],
   customCounter: null,
   transfers: [],
+  initiative: null,
   ...overrides,
 });
 

--- a/src/hooks/useDmInitiativeSync.ts
+++ b/src/hooks/useDmInitiativeSync.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+import type { SharedInitiativeState } from '@/types/sharedState';
+
+interface UseDmInitiativeSyncOptions {
+  campaignCode: string;
+  dmId: string;
+}
+
+export function useDmInitiativeSync({
+  campaignCode,
+  dmId,
+}: UseDmInitiativeSyncOptions) {
+  const pushInitiative = useCallback(
+    async (state: SharedInitiativeState) => {
+      try {
+        await fetch(`/api/campaign/${campaignCode}/shared`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ feature: 'initiative', data: state, dmId }),
+        });
+      } catch (err) {
+        console.warn('Failed to sync initiative state:', err);
+      }
+    },
+    [campaignCode, dmId]
+  );
+
+  return { pushInitiative };
+}

--- a/src/hooks/useDraggableY.ts
+++ b/src/hooks/useDraggableY.ts
@@ -1,0 +1,97 @@
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+
+/**
+ * Clamp a dragged vertical position so the element stays on screen.
+ * Pure — exported for unit testing.
+ */
+export function clampTop(
+  startTop: number,
+  dy: number,
+  innerHeight: number,
+  bottomMargin = 120,
+  topMargin = 8
+): number {
+  return Math.max(
+    topMargin,
+    Math.min(startTop + dy, innerHeight - bottomMargin)
+  );
+}
+
+interface DraggableY<T extends HTMLElement> {
+  topPx: number | null; // null => not yet positioned (use the component's default)
+  containerRef: React.RefObject<T | null>;
+  startDrag: (e: ReactPointerEvent) => void;
+}
+
+/**
+ * Vertical-only drag positioning for a fixed-position panel, persisted to
+ * localStorage. Returns `topPx: null` until a stored value loads or the user
+ * drags, so the consumer can keep its own default placement (e.g. centered)
+ * until then. Attach `containerRef` to the panel and `startDrag` to its handle.
+ */
+export function useDraggableY<T extends HTMLElement = HTMLDivElement>(
+  storageKey: string
+): DraggableY<T> {
+  const [topPx, setTopPx] = useState<number | null>(null);
+  const containerRef = useRef<T | null>(null);
+  const dragRef = useRef<{ startY: number; startTop: number } | null>(null);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (stored !== null) setTopPx(Number(stored));
+    } catch {
+      // Ignore localStorage errors
+    }
+  }, [storageKey]);
+
+  const handlePointerMove = useCallback((e: PointerEvent) => {
+    if (!dragRef.current) return;
+    const dy = e.clientY - dragRef.current.startY;
+    setTopPx(clampTop(dragRef.current.startTop, dy, window.innerHeight));
+  }, []);
+
+  const handlePointerUp = useCallback(() => {
+    dragRef.current = null;
+    document.removeEventListener('pointermove', handlePointerMove);
+    document.removeEventListener('pointerup', handlePointerUp);
+    setTopPx(t => {
+      if (t !== null) {
+        try {
+          localStorage.setItem(storageKey, String(t));
+        } catch {
+          // Ignore localStorage errors
+        }
+      }
+      return t;
+    });
+  }, [handlePointerMove, storageKey]);
+
+  const startDrag = useCallback(
+    (e: ReactPointerEvent) => {
+      const startTop =
+        topPx ?? containerRef.current?.getBoundingClientRect().top ?? 0;
+      dragRef.current = { startY: e.clientY, startTop };
+      document.addEventListener('pointermove', handlePointerMove);
+      document.addEventListener('pointerup', handlePointerUp);
+    },
+    [topPx, handlePointerMove, handlePointerUp]
+  );
+
+  // Clean up listeners if unmounted mid-drag.
+  useEffect(
+    () => () => {
+      document.removeEventListener('pointermove', handlePointerMove);
+      document.removeEventListener('pointerup', handlePointerUp);
+    },
+    [handlePointerMove, handlePointerUp]
+  );
+
+  return { topPx, containerRef, startDrag };
+}

--- a/src/hooks/useSharedCampaignState.ts
+++ b/src/hooks/useSharedCampaignState.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { SharedCampaignState, ItemTransfer } from '@/types/sharedState';
 
-const POLL_INTERVAL_MS = 15000; // 15 seconds
+const POLL_INTERVAL_MS = 15000; // 15 seconds (idle / out of combat)
+const COMBAT_POLL_INTERVAL_MS = 5000; // 5 seconds while combat is active
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const ACTIVITY_EVENTS = [
   'mousemove',
@@ -37,6 +38,16 @@ export function useSharedCampaignState(
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const idleTimerRef = useRef<NodeJS.Timeout | null>(null);
   const isPausedRef = useRef(false);
+  const currentIntervalRef = useRef(POLL_INTERVAL_MS);
+  // Stable ref so fetchSharedState can call startPolling without a circular dep.
+  const startPollingRef = useRef<() => void>(() => {});
+
+  const stopPolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
 
   const fetchSharedState = useCallback(async () => {
     if (!campaignCode) return;
@@ -51,6 +62,14 @@ export function useSharedCampaignState(
       setSharedState(data);
       setError(null);
       setLastFetched(new Date());
+      // Adaptive poll: 5s while combat is active, 15s otherwise.
+      const desired = data.initiative?.isActive
+        ? COMBAT_POLL_INTERVAL_MS
+        : POLL_INTERVAL_MS;
+      if (desired !== currentIntervalRef.current && !isPausedRef.current) {
+        currentIntervalRef.current = desired;
+        startPollingRef.current();
+      }
       if (data.transfers && data.transfers.length > 0) {
         setPendingTransfers(prev => {
           const existingIds = new Set(prev.map(t => t.id));
@@ -69,17 +88,16 @@ export function useSharedCampaignState(
     }
   }, [campaignCode, playerId]);
 
-  const stopPolling = useCallback(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-  }, []);
-
   const startPolling = useCallback(() => {
     stopPolling();
-    intervalRef.current = setInterval(fetchSharedState, POLL_INTERVAL_MS);
+    intervalRef.current = setInterval(
+      fetchSharedState,
+      currentIntervalRef.current
+    );
   }, [fetchSharedState, stopPolling]);
+
+  // Keep the ref in sync with the latest startPolling callback.
+  startPollingRef.current = startPolling;
 
   const pausePolling = useCallback(() => {
     if (isPausedRef.current) return;

--- a/src/hooks/useStorageQuotaListener.ts
+++ b/src/hooks/useStorageQuotaListener.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { STORAGE_QUOTA_EVENT } from '@/lib/safeStorage';
+
+/**
+ * Calls `onQuota` whenever a localStorage write fails due to a full quota
+ * (fired by the safe-storage wrapper). Pages use this to warn the user that a
+ * save did not persist and they should export a backup.
+ */
+export function useStorageQuotaListener(onQuota: () => void): void {
+  useEffect(() => {
+    const handler = () => onQuota();
+    window.addEventListener(STORAGE_QUOTA_EVENT, handler);
+    return () => window.removeEventListener(STORAGE_QUOTA_EVENT, handler);
+  }, [onQuota]);
+}

--- a/src/hooks/useTurnRequestSync.ts
+++ b/src/hooks/useTurnRequestSync.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from 'react';
+import { useEncounterStore } from '@/store/encounterStore';
+import { shouldApplyTurnRequest } from '@/utils/turnRequest';
+import type { TurnEndRequest } from '@/types/sharedState';
+
+const POLL_MS = 4000;
+
+interface Options {
+  campaignCode: string;
+  encounterId: string | undefined;
+  isActive: boolean;
+  onApplied?: (req: TurnEndRequest) => void;
+}
+
+/**
+ * While combat is active, polls the turn-request key. When a request validates
+ * against the live encounter, advances the turn (DM stays authoritative) and
+ * clears the request. Stale/invalid requests are cleared without advancing.
+ */
+export function useTurnRequestSync({
+  campaignCode,
+  encounterId,
+  isActive,
+  onApplied,
+}: Options) {
+  const onAppliedRef = useRef(onApplied);
+  onAppliedRef.current = onApplied;
+
+  useEffect(() => {
+    if (!campaignCode || !encounterId || !isActive) return;
+
+    let cancelled = false;
+
+    const clearRequest = () =>
+      fetch(`/api/campaign/${campaignCode}/turn-request`, {
+        method: 'DELETE',
+      }).catch(() => {});
+
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/campaign/${campaignCode}/turn-request`);
+        if (!res.ok) return;
+        const { request } = (await res.json()) as {
+          request: TurnEndRequest | null;
+        };
+        if (!request || cancelled) return;
+
+        // Re-read the freshest encounter at apply time.
+        const encounter = useEncounterStore
+          .getState()
+          .getEncounter(encounterId);
+        if (encounter && shouldApplyTurnRequest(encounter, request)) {
+          useEncounterStore.getState().nextTurn(encounterId);
+          onAppliedRef.current?.(request);
+        }
+        // Whether applied or stale, consume the request.
+        await clearRequest();
+      } catch {
+        // best-effort; next tick retries
+      }
+    };
+
+    const id = setInterval(poll, POLL_MS);
+    poll();
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [campaignCode, encounterId, isActive]);
+}

--- a/src/lib/__tests__/safeStorage.test.ts
+++ b/src/lib/__tests__/safeStorage.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createSafeStorage,
+  isQuotaExceeded,
+  STORAGE_QUOTA_EVENT,
+} from '../safeStorage';
+
+function mockBacking(setItemImpl?: (k: string, v: string) => void): Storage {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: setItemImpl ?? ((k: string, v: string) => map.set(k, v)),
+    removeItem: (k: string) => map.delete(k),
+    clear: () => map.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+}
+
+function quotaError(): DOMException {
+  return new DOMException('quota', 'QuotaExceededError');
+}
+
+describe('isQuotaExceeded', () => {
+  it('recognises a QuotaExceededError DOMException', () => {
+    expect(isQuotaExceeded(quotaError())).toBe(true);
+  });
+  it('rejects unrelated errors', () => {
+    expect(isQuotaExceeded(new Error('nope'))).toBe(false);
+  });
+});
+
+describe('createSafeStorage', () => {
+  it('delegates get/set/remove to the backing storage', () => {
+    const storage = createSafeStorage(mockBacking());
+    storage.setItem('k', 'v');
+    expect(storage.getItem('k')).toBe('v');
+    storage.removeItem('k');
+    expect(storage.getItem('k')).toBeNull();
+  });
+
+  it('on quota error: fires the quota event and does NOT throw', () => {
+    const storage = createSafeStorage(
+      mockBacking(() => {
+        throw quotaError();
+      })
+    );
+    const listener = vi.fn();
+    window.addEventListener(STORAGE_QUOTA_EVENT, listener);
+    expect(() => storage.setItem('big', 'x')).not.toThrow();
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener(STORAGE_QUOTA_EVENT, listener);
+  });
+
+  it('rethrows non-quota errors', () => {
+    const storage = createSafeStorage(
+      mockBacking(() => {
+        throw new Error('boom');
+      })
+    );
+    expect(() => storage.setItem('k', 'v')).toThrow('boom');
+  });
+});

--- a/src/lib/safeStorage.ts
+++ b/src/lib/safeStorage.ts
@@ -1,0 +1,54 @@
+import type { StateStorage } from 'zustand/middleware';
+
+/** Window event fired when a localStorage write fails because the quota is full. */
+export const STORAGE_QUOTA_EVENT = 'rollkeeper:storage-quota-exceeded';
+
+/** True for the various browser representations of a storage-quota error. */
+export function isQuotaExceeded(e: unknown): boolean {
+  if (!(e instanceof DOMException)) return false;
+  return (
+    e.name === 'QuotaExceededError' ||
+    e.name === 'NS_ERROR_DOM_QUOTA_REACHED' || // Firefox
+    e.code === 22 ||
+    e.code === 1014
+  );
+}
+
+/**
+ * A localStorage-backed Zustand storage that fails loudly, not silently. When a
+ * write exceeds the quota it dispatches `STORAGE_QUOTA_EVENT` (so the UI can warn
+ * the user to export) instead of throwing — the app keeps running. Non-quota
+ * errors still propagate. Pass a backing store for tests; defaults to
+ * `localStorage` on the client.
+ */
+export function createSafeStorage(backing?: Storage): StateStorage {
+  const store =
+    backing ?? (typeof localStorage !== 'undefined' ? localStorage : undefined);
+
+  return {
+    getItem: key => (store ? store.getItem(key) : null),
+    setItem: (key, value) => {
+      if (!store) return;
+      try {
+        store.setItem(key, value);
+      } catch (e) {
+        if (isQuotaExceeded(e)) {
+          console.error(
+            `localStorage quota exceeded while saving "${key}". Data was not persisted.`,
+            e
+          );
+          if (typeof window !== 'undefined') {
+            window.dispatchEvent(
+              new CustomEvent(STORAGE_QUOTA_EVENT, { detail: { key } })
+            );
+          }
+        } else {
+          throw e;
+        }
+      }
+    },
+    removeItem: key => {
+      if (store) store.removeItem(key);
+    },
+  };
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware } from './middleware';
+
+describe('middleware dev-route gating', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns 404 for a dev-only route in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const res = middleware(new NextRequest('http://localhost/dice-test'));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for a nested dev-only path in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const res = middleware(
+      new NextRequest('http://localhost/design-system/buttons')
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('allows dev-only routes outside production', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const res = middleware(new NextRequest('http://localhost/dice-test'));
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Dev/demo routes that should never be reachable in production. They exist as
+ * internal tooling (design-system showcase, dice playgrounds, error-boundary
+ * test) and stay available during local development.
+ */
+const DEV_ONLY_PREFIXES = [
+  '/dice-test',
+  '/dice-components-demo',
+  '/design-system',
+  '/test-error',
+];
+
+export function middleware(request: NextRequest): NextResponse {
+  if (process.env.NODE_ENV === 'production') {
+    const { pathname } = request.nextUrl;
+    const isDevOnly = DEV_ONLY_PREFIXES.some(
+      prefix => pathname === prefix || pathname.startsWith(`${prefix}/`)
+    );
+    if (isDevOnly) {
+      return new NextResponse('Not Found', { status: 404 });
+    }
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/dice-test/:path*',
+    '/dice-components-demo/:path*',
+    '/design-system/:path*',
+    '/test-error/:path*',
+  ],
+};

--- a/src/store/__tests__/characterStore-class.test.ts
+++ b/src/store/__tests__/characterStore-class.test.ts
@@ -16,7 +16,11 @@ function resetStore(overrides: Record<string, unknown> = {}) {
   usePlayerStore.setState({
     characters: [],
     activeCharacterId: null,
-    settings: { enableDeathAnimation: false, enableLevelUpAnimation: false },
+    settings: {
+      enableDeathAnimation: false,
+      enableLevelUpAnimation: false,
+      enableCombatStartBanner: false,
+    },
     lastSelectedCharacterId: null,
   });
 }

--- a/src/store/__tests__/characterStore-conditions.test.ts
+++ b/src/store/__tests__/characterStore-conditions.test.ts
@@ -16,7 +16,11 @@ function resetStore(overrides = {}) {
   usePlayerStore.setState({
     characters: [],
     activeCharacterId: null,
-    settings: { enableDeathAnimation: false, enableLevelUpAnimation: false },
+    settings: {
+      enableDeathAnimation: false,
+      enableLevelUpAnimation: false,
+      enableCombatStartBanner: false,
+    },
     lastSelectedCharacterId: null,
   });
 }
@@ -884,12 +888,10 @@ describe('characterStore — tool proficiencies', () => {
     });
 
     it('stores proficiency level correctly', () => {
-      useCharacterStore
-        .getState()
-        .addToolProficiency({
-          name: "Smith's Tools",
-          proficiencyLevel: 'expertise',
-        });
+      useCharacterStore.getState().addToolProficiency({
+        name: "Smith's Tools",
+        proficiencyLevel: 'expertise',
+      });
       expect(
         useCharacterStore.getState().character.toolProficiencies[0]
           .proficiencyLevel
@@ -918,12 +920,10 @@ describe('characterStore — tool proficiencies', () => {
 
     it('does not affect other tools', () => {
       useCharacterStore.getState().addToolProficiency(baseTool);
-      useCharacterStore
-        .getState()
-        .addToolProficiency({
-          name: "Smith's Tools",
-          proficiencyLevel: 'none',
-        });
+      useCharacterStore.getState().addToolProficiency({
+        name: "Smith's Tools",
+        proficiencyLevel: 'none',
+      });
       const firstId =
         useCharacterStore.getState().character.toolProficiencies[0].id;
 
@@ -950,12 +950,10 @@ describe('characterStore — tool proficiencies', () => {
 
     it('does not remove other tools', () => {
       useCharacterStore.getState().addToolProficiency(baseTool);
-      useCharacterStore
-        .getState()
-        .addToolProficiency({
-          name: "Smith's Tools",
-          proficiencyLevel: 'none',
-        });
+      useCharacterStore.getState().addToolProficiency({
+        name: "Smith's Tools",
+        proficiencyLevel: 'none',
+      });
       const firstId =
         useCharacterStore.getState().character.toolProficiencies[0].id;
 

--- a/src/store/__tests__/characterStore-features.test.ts
+++ b/src/store/__tests__/characterStore-features.test.ts
@@ -16,7 +16,11 @@ function resetStore(overrides = {}) {
   usePlayerStore.setState({
     characters: [],
     activeCharacterId: null,
-    settings: { enableDeathAnimation: false, enableLevelUpAnimation: false },
+    settings: {
+      enableDeathAnimation: false,
+      enableLevelUpAnimation: false,
+      enableCombatStartBanner: false,
+    },
     lastSelectedCharacterId: null,
   });
 }
@@ -196,27 +200,21 @@ describe('characterStore — extended features', () => {
   });
 
   it('reorderExtendedFeatures (with sourceType) reorders within source type only', () => {
-    useCharacterStore
-      .getState()
-      .addExtendedFeature({
-        ...baseFeature,
-        name: 'Class A',
-        sourceType: 'class' as const,
-      });
-    useCharacterStore
-      .getState()
-      .addExtendedFeature({
-        ...baseFeature,
-        name: 'Class B',
-        sourceType: 'class' as const,
-      });
-    useCharacterStore
-      .getState()
-      .addExtendedFeature({
-        ...baseFeature,
-        name: 'Feat A',
-        sourceType: 'feat' as const,
-      });
+    useCharacterStore.getState().addExtendedFeature({
+      ...baseFeature,
+      name: 'Class A',
+      sourceType: 'class' as const,
+    });
+    useCharacterStore.getState().addExtendedFeature({
+      ...baseFeature,
+      name: 'Class B',
+      sourceType: 'class' as const,
+    });
+    useCharacterStore.getState().addExtendedFeature({
+      ...baseFeature,
+      name: 'Feat A',
+      sourceType: 'feat' as const,
+    });
     useCharacterStore.getState().reorderExtendedFeatures(0, 1, 'class');
     const { extendedFeatures } = useCharacterStore.getState().character;
     const classFeatures = extendedFeatures.filter(
@@ -450,12 +448,10 @@ describe('characterStore — traits (rich text)', () => {
   it('updateTrait modifies the trait by id', () => {
     useCharacterStore.getState().addTrait(traitEntry);
     const id = useCharacterStore.getState().character.traits[0].id;
-    useCharacterStore
-      .getState()
-      .updateTrait(id, {
-        title: 'Fearless',
-        content: '<p>Immune to fear.</p>',
-      });
+    useCharacterStore.getState().updateTrait(id, {
+      title: 'Fearless',
+      content: '<p>Immune to fear.</p>',
+    });
     const { traits } = useCharacterStore.getState().character;
     expect(traits[0].title).toBe('Fearless');
     expect(traits[0].content).toBe('<p>Immune to fear.</p>');
@@ -512,12 +508,10 @@ describe('characterStore — notes', () => {
   it('updateNote modifies the note by id', () => {
     useCharacterStore.getState().addNote(noteEntry);
     const id = useCharacterStore.getState().character.notes[0].id;
-    useCharacterStore
-      .getState()
-      .updateNote(id, {
-        title: 'Session 1 - Updated',
-        content: '<p>Met the innkeeper. Got a quest.</p>',
-      });
+    useCharacterStore.getState().updateNote(id, {
+      title: 'Session 1 - Updated',
+      content: '<p>Met the innkeeper. Got a quest.</p>',
+    });
     const { notes } = useCharacterStore.getState().character;
     expect(notes[0].title).toBe('Session 1 - Updated');
     expect(notes[0].content).toBe('<p>Met the innkeeper. Got a quest.</p>');
@@ -611,11 +605,9 @@ describe('characterStore — background', () => {
   });
 
   it('updateCharacterBackground updates backstory', () => {
-    useCharacterStore
-      .getState()
-      .updateCharacterBackground({
-        backstory: '<p>A long and storied past.</p>',
-      });
+    useCharacterStore.getState().updateCharacterBackground({
+      backstory: '<p>A long and storied past.</p>',
+    });
     expect(
       useCharacterStore.getState().character.characterBackground.backstory
     ).toBe('<p>A long and storied past.</p>');

--- a/src/store/__tests__/characterStore-hp.test.ts
+++ b/src/store/__tests__/characterStore-hp.test.ts
@@ -16,7 +16,11 @@ function resetStore(overrides = {}) {
   usePlayerStore.setState({
     characters: [],
     activeCharacterId: null,
-    settings: { enableDeathAnimation: false, enableLevelUpAnimation: false },
+    settings: {
+      enableDeathAnimation: false,
+      enableLevelUpAnimation: false,
+      enableCombatStartBanner: false,
+    },
     lastSelectedCharacterId: null,
   });
 }

--- a/src/store/__tests__/characterStore-inventory.test.ts
+++ b/src/store/__tests__/characterStore-inventory.test.ts
@@ -16,7 +16,11 @@ function resetStore(overrides = {}) {
   usePlayerStore.setState({
     characters: [],
     activeCharacterId: null,
-    settings: { enableDeathAnimation: false, enableLevelUpAnimation: false },
+    settings: {
+      enableDeathAnimation: false,
+      enableLevelUpAnimation: false,
+      enableCombatStartBanner: false,
+    },
     lastSelectedCharacterId: null,
   });
 }

--- a/src/store/__tests__/characterStore-persistence.test.ts
+++ b/src/store/__tests__/characterStore-persistence.test.ts
@@ -16,7 +16,11 @@ function resetStore(overrides = {}) {
   usePlayerStore.setState({
     characters: [],
     activeCharacterId: null,
-    settings: { enableDeathAnimation: false, enableLevelUpAnimation: false },
+    settings: {
+      enableDeathAnimation: false,
+      enableLevelUpAnimation: false,
+      enableCombatStartBanner: false,
+    },
     lastSelectedCharacterId: null,
   });
 }

--- a/src/store/__tests__/characterStore-rest.test.ts
+++ b/src/store/__tests__/characterStore-rest.test.ts
@@ -111,7 +111,11 @@ function resetStoreWithUsedResources() {
   usePlayerStore.setState({
     characters: [],
     activeCharacterId: null,
-    settings: { enableDeathAnimation: false, enableLevelUpAnimation: false },
+    settings: {
+      enableDeathAnimation: false,
+      enableLevelUpAnimation: false,
+      enableCombatStartBanner: false,
+    },
     lastSelectedCharacterId: null,
   });
 }

--- a/src/store/__tests__/characterStore-spells.test.ts
+++ b/src/store/__tests__/characterStore-spells.test.ts
@@ -22,7 +22,11 @@ function resetStore(overrides = {}) {
   usePlayerStore.setState({
     characters: [],
     activeCharacterId: null,
-    settings: { enableDeathAnimation: false, enableLevelUpAnimation: false },
+    settings: {
+      enableDeathAnimation: false,
+      enableLevelUpAnimation: false,
+      enableCombatStartBanner: false,
+    },
     lastSelectedCharacterId: null,
   });
 }

--- a/src/store/__tests__/characterStore-summons.test.ts
+++ b/src/store/__tests__/characterStore-summons.test.ts
@@ -19,7 +19,11 @@ function resetStore(overrides = {}) {
   usePlayerStore.setState({
     characters: [],
     activeCharacterId: null,
-    settings: { enableDeathAnimation: false, enableLevelUpAnimation: false },
+    settings: {
+      enableDeathAnimation: false,
+      enableLevelUpAnimation: false,
+      enableCombatStartBanner: false,
+    },
     lastSelectedCharacterId: null,
   });
 }

--- a/src/store/__tests__/playerStore.test.ts
+++ b/src/store/__tests__/playerStore.test.ts
@@ -5,7 +5,11 @@ function resetStore() {
   usePlayerStore.setState({
     characters: [],
     activeCharacterId: null,
-    settings: { enableDeathAnimation: false, enableLevelUpAnimation: false },
+    settings: {
+      enableDeathAnimation: false,
+      enableLevelUpAnimation: false,
+      enableCombatStartBanner: false,
+    },
     lastSelectedCharacterId: null,
   });
 }
@@ -375,6 +379,7 @@ describe('playerStore', () => {
       expect(usePlayerStore.getState().settings).toEqual({
         enableDeathAnimation: false,
         enableLevelUpAnimation: false,
+        enableCombatStartBanner: true,
       });
     });
   });
@@ -392,6 +397,7 @@ describe('playerStore', () => {
       expect(state.settings).toEqual({
         enableDeathAnimation: false,
         enableLevelUpAnimation: false,
+        enableCombatStartBanner: true,
       });
     });
   });

--- a/src/store/battleMapStore.ts
+++ b/src/store/battleMapStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { createSafeStorage } from '@/lib/safeStorage';
 import type { BattleMap } from '@/types/battlemap';
 
 const BATTLEMAP_STORAGE_KEY = 'rollkeeper-battlemap-data';
@@ -197,7 +198,7 @@ export const useBattleMapStore = create<BattleMapStoreState>()(
     }),
     {
       name: BATTLEMAP_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => createSafeStorage()),
     }
   )
 );

--- a/src/store/calendarStore.ts
+++ b/src/store/calendarStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { createSafeStorage } from '@/lib/safeStorage';
 import type {
   CalendarConfig,
   CalendarEvent,
@@ -177,7 +178,7 @@ export const useCalendarStore = create<CalendarStoreState>()(
     }),
     {
       name: CALENDAR_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => createSafeStorage()),
       version: 3,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as CalendarStoreState;

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { createSafeStorage } from '@/lib/safeStorage';
 import {
   CharacterState,
   SaveStatus,
@@ -5136,7 +5137,7 @@ export const useCharacterStore = create<CharacterStore>()(
     }),
     {
       name: STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => createSafeStorage()),
       // Only persist the character data and save metadata
       partialize: state => ({
         character: state.character,

--- a/src/store/combatLogStore.ts
+++ b/src/store/combatLogStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { createSafeStorage } from '@/lib/safeStorage';
 import {
   CombatLogEvent,
   CombatLogFilters,
@@ -236,7 +237,7 @@ export const useCombatLogStore = create<CombatLogStoreState>()(
     }),
     {
       name: COMBAT_LOG_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => createSafeStorage()),
       version: 1,
     }
   )

--- a/src/store/dmStore.ts
+++ b/src/store/dmStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { createSafeStorage } from '@/lib/safeStorage';
 import { CampaignInfo } from '@/types/campaign';
 
 const DM_STORAGE_KEY = 'rollkeeper-dm-data';
@@ -147,7 +148,7 @@ export const useDmStore = create<DmStoreState>()(
     }),
     {
       name: DM_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => createSafeStorage()),
       version: 1,
     }
   )

--- a/src/store/encounterStore.test.ts
+++ b/src/store/encounterStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getSortedEntities } from './encounterStore';
+import useEncounterStore, { getSortedEntities } from './encounterStore';
 import { EncounterEntity } from '@/types/encounter';
 
 /** Helper to create a minimal EncounterEntity with overrides */
@@ -464,5 +464,49 @@ describe('getSortedEntities', () => {
         'cat', // 10, summon of p3
       ]);
     });
+  });
+});
+
+describe('prevTurn', () => {
+  const store = useEncounterStore.getState();
+
+  function entityData(name: string, initiative: number) {
+    return {
+      type: 'monster' as const,
+      name,
+      initiative,
+      initiativeModifier: 0,
+      currentHp: 10,
+      maxHp: 10,
+      tempHp: 0,
+      armorClass: 10,
+      conditions: [],
+      isHidden: false,
+    };
+  }
+
+  function getEntity(encId: string, entityId: string) {
+    return useEncounterStore
+      .getState()
+      .getEncounter(encId)
+      ?.entities.find(e => e.id === entityId);
+  }
+
+  it('resets the incoming entity reaction when stepping backwards', () => {
+    const encId = store.createEncounter('Prev Turn Test');
+    const aId = store.addEntity(encId, entityData('A', 20));
+    store.addEntity(encId, entityData('B', 10));
+
+    store.startCombat(encId); // currentTurn 0 = A (init 20)
+    store.nextTurn(encId); // currentTurn 1 = B
+
+    // A used its reaction during B's turn
+    store.updateEntity(encId, aId, { hasUsedReaction: true });
+    expect(getEntity(encId, aId)?.hasUsedReaction).toBe(true);
+
+    // Stepping back into A's turn should make A's reaction available again,
+    // mirroring nextTurn resetting the incoming entity's reaction.
+    store.prevTurn(encId);
+    expect(getEntity(encId, aId)?.hasUsedReaction).toBe(false);
   });
 });

--- a/src/store/encounterStore.ts
+++ b/src/store/encounterStore.ts
@@ -407,11 +407,24 @@ export const useEncounterStore = create<EncounterStoreState>()(
             enc => {
               if (!enc.isActive || enc.entities.length === 0) return enc;
               const isFirstTurn = enc.currentTurn === 0;
+              const incomingTurn = isFirstTurn
+                ? enc.entities.length - 1
+                : enc.currentTurn - 1;
+
+              // Reset reaction for the entity whose turn is starting, mirroring
+              // nextTurn so backing up the tracker keeps reaction state correct.
+              let entities = enc.entities;
+              const incomingEntity = entities[incomingTurn];
+              if (incomingEntity?.hasUsedReaction) {
+                entities = entities.map((e, i) =>
+                  i === incomingTurn ? { ...e, hasUsedReaction: false } : e
+                );
+              }
+
               return {
                 ...enc,
-                currentTurn: isFirstTurn
-                  ? enc.entities.length - 1
-                  : enc.currentTurn - 1,
+                entities,
+                currentTurn: incomingTurn,
                 round: isFirstTurn ? Math.max(1, enc.round - 1) : enc.round,
                 updatedAt: new Date().toISOString(),
               };

--- a/src/store/encounterStore.ts
+++ b/src/store/encounterStore.ts
@@ -4,6 +4,8 @@ import {
   Encounter,
   EncounterEntity,
   EncounterCondition,
+  CombatConfig,
+  DEFAULT_COMBAT_CONFIG,
 } from '@/types/encounter';
 import { useNPCStore } from './npcStore';
 
@@ -42,6 +44,10 @@ function syncNPCEntityToStore(
 interface EncounterStoreState {
   encounters: Encounter[];
   activeEncounterId: string | null;
+
+  // Global combat settings (shared across encounters)
+  combatConfig: CombatConfig;
+  setCombatConfig: (updates: Partial<CombatConfig>) => void;
 
   // Encounter CRUD
   createEncounter: (name: string, campaignCode?: string) => string;
@@ -223,6 +229,13 @@ export const useEncounterStore = create<EncounterStoreState>()(
     (set, get) => ({
       encounters: [],
       activeEncounterId: null,
+      combatConfig: DEFAULT_COMBAT_CONFIG,
+
+      setCombatConfig: updates => {
+        set(state => ({
+          combatConfig: { ...state.combatConfig, ...updates },
+        }));
+      },
 
       createEncounter: (name, campaignCode) => {
         const id = generateId();

--- a/src/store/encounterStore.ts
+++ b/src/store/encounterStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { createSafeStorage } from '@/lib/safeStorage';
 import {
   Encounter,
   EncounterEntity,
@@ -911,7 +912,7 @@ export const useEncounterStore = create<EncounterStoreState>()(
     }),
     {
       name: ENCOUNTER_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => createSafeStorage()),
       version: 1,
     }
   )

--- a/src/store/locationStore.ts
+++ b/src/store/locationStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { createSafeStorage } from '@/lib/safeStorage';
 import type { LocationMap } from '@/types/location';
 
 const LOCATION_STORAGE_KEY = 'rollkeeper-location-data';
@@ -162,7 +163,7 @@ export const useLocationStore = create<LocationStoreState>()(
     }),
     {
       name: LOCATION_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => createSafeStorage()),
     }
   )
 );

--- a/src/store/npcStore.ts
+++ b/src/store/npcStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { createSafeStorage } from '@/lib/safeStorage';
 import { CampaignNPC } from '@/types/encounter';
 import { Spell } from '@/types/character';
 import {
@@ -361,7 +362,7 @@ export const useNPCStore = create<NPCStoreState>()(
     }),
     {
       name: NPC_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => createSafeStorage()),
       version: 2,
       migrate: (persisted: unknown, version: number) => {
         if (version < 2) {

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { createSafeStorage } from '@/lib/safeStorage';
 import { CharacterState, CharacterExport } from '@/types/character';
 import { DEFAULT_CHARACTER_STATE, STORAGE_KEY } from '@/utils/constants';
 
@@ -82,7 +83,7 @@ interface PlayerStoreState {
   migrateFromOldStorage: () => boolean;
   exportCharacter: (characterId: string) => PlayerCharacter | null;
   importCharacter: (
-    data: CharacterState | CharacterExport,
+    data: CharacterState | CharacterExport | PlayerCharacter,
     name?: string
   ) => string;
 
@@ -454,7 +455,7 @@ export const usePlayerStore = create<PlayerStoreState>()(
     }),
     {
       name: PLAYER_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => createSafeStorage()),
       version: 1,
       merge: (persistedState, currentState) => ({
         ...currentState,

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -30,11 +30,13 @@ export interface PlayerCharacter {
 export interface PlayerSettings {
   enableDeathAnimation: boolean;
   enableLevelUpAnimation: boolean;
+  enableCombatStartBanner: boolean;
 }
 
 const DEFAULT_PLAYER_SETTINGS: PlayerSettings = {
   enableDeathAnimation: false,
   enableLevelUpAnimation: false,
+  enableCombatStartBanner: true,
 };
 
 // Store state interface

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -186,6 +186,36 @@ export interface Encounter {
   updatedAt: string;
 }
 
+// How much of an enemy's (non-player) HP players may see during combat.
+export type EnemyHpDisplay = 'off' | 'label' | 'bar' | 'percent' | 'exact';
+
+// A named HP band shown to players when enemyHpDisplay is 'label'. `minPercent`
+// is the lowest HP percentage (inclusive) at which this label applies.
+export interface HpStateBand {
+  minPercent: number;
+  label: string;
+}
+
+// Global, DM-controlled combat settings (shared across all encounters).
+export interface CombatConfig {
+  enemyHpDisplay: EnemyHpDisplay;
+  hpStateBands: HpStateBand[];
+}
+
+export const DEFAULT_HP_STATE_BANDS: HpStateBand[] = [
+  { minPercent: 100, label: 'Unharmed' },
+  { minPercent: 75, label: 'Healthy' },
+  { minPercent: 50, label: 'Injured' },
+  { minPercent: 25, label: 'Bloodied' },
+  { minPercent: 1, label: 'Near Death' },
+  { minPercent: 0, label: 'Down' },
+];
+
+export const DEFAULT_COMBAT_CONFIG: CombatConfig = {
+  enemyHpDisplay: 'off',
+  hpStateBands: DEFAULT_HP_STATE_BANDS,
+};
+
 export interface NPCInventoryItem {
   id: string;
   name: string;

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -155,7 +155,8 @@ export interface EncounterEntity {
 
   // Visual
   color?: string; // For grouping same monsters
-  isHidden?: boolean; // DM can hide from players
+  isHidden?: boolean; // DM can hide the real name from players (they see a generic label)
+  playerAlias?: string; // Optional name players see instead (DM-controlled entities); takes precedence over the hidden generic label
   chessPiece?: ChessPiece; // Chess piece icon for map correlation
 
   // Player sync reference

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -100,6 +100,10 @@ export type ChessPiece =
   | 'knight'
   | 'pawn';
 
+// Player-facing allegiance for a DM-controlled combatant (lets a villain be
+// disguised as an ally until the DM reveals the twist).
+export type PlayerDisposition = 'ally' | 'enemy' | 'neutral';
+
 export interface EncounterEntity {
   id: string;
   type: EntityType;
@@ -157,6 +161,7 @@ export interface EncounterEntity {
   color?: string; // For grouping same monsters
   isHidden?: boolean; // DM can hide the real name from players (they see a generic label)
   playerAlias?: string; // Optional name players see instead (DM-controlled entities); takes precedence over the hidden generic label
+  playerDisposition?: PlayerDisposition; // Allegiance players see (disguise); defaults to enemy for non-players
   chessPiece?: ChessPiece; // Chess piece icon for map correlation
 
   // Player sync reference

--- a/src/types/sharedState.ts
+++ b/src/types/sharedState.ts
@@ -1,5 +1,6 @@
 import type { CalendarConfig, WeatherType } from './calendar';
 import type { InventoryItem } from './character';
+import type { EnemyHpDisplay } from './encounter';
 
 // Stored in Redis — DM's calendar data (events stay local, not synced)
 export interface SharedCalendar {
@@ -60,8 +61,10 @@ export interface SharedTurnEntry {
   displayName: string; // real name, or "Enemy" when hidden && non-player
   type: 'player' | 'monster' | 'npc' | 'lair';
   playerCharacterId?: string; // player entities only — marks "you" + identity
-  currentHp?: number; // player entities only — never set for monsters/npcs/lairs
-  maxHp?: number; // player entities only
+  currentHp?: number; // players always; non-players only when enemyHpMode is 'exact'
+  maxHp?: number; // players always; non-players only when enemyHpMode is 'exact'
+  hpState?: string; // non-players when enemyHpMode is 'label' (e.g. "Bloodied")
+  hpPercent?: number; // non-players when enemyHpMode is 'bar' | 'percent' (0-100)
 }
 
 // Initiative/turn state pushed by the DM, read by players
@@ -71,6 +74,9 @@ export interface SharedInitiativeState {
   round: number;
   currentEntityId: string | null;
   turnOrder: SharedTurnEntry[];
+  // How non-player HP is presented to players; tells the panel how to render
+  // hpState / hpPercent / currentHp on enemy rows. Defaults to 'off'.
+  enemyHpMode: EnemyHpDisplay;
   updatedAt: string; // ISO timestamp
 }
 

--- a/src/types/sharedState.ts
+++ b/src/types/sharedState.ts
@@ -54,6 +54,35 @@ export interface SharedCustomCounter {
   updatedAt: string; // ISO timestamp
 }
 
+// A single combatant row shown to players during combat
+export interface SharedTurnEntry {
+  entityId: string;
+  displayName: string; // real name, or "Enemy" when hidden && non-player
+  type: 'player' | 'monster' | 'npc' | 'lair';
+  playerCharacterId?: string; // player entities only — marks "you" + identity
+  currentHp?: number; // player entities only — never set for monsters/npcs/lairs
+  maxHp?: number; // player entities only
+}
+
+// Initiative/turn state pushed by the DM, read by players
+export interface SharedInitiativeState {
+  encounterId: string;
+  isActive: boolean;
+  round: number;
+  currentEntityId: string | null;
+  turnOrder: SharedTurnEntry[];
+  updatedAt: string; // ISO timestamp
+}
+
+// Player → DM request to advance past their own turn
+export interface TurnEndRequest {
+  encounterId: string;
+  round: number;
+  entityId: string;
+  playerId: string;
+  requestedAt: string; // ISO timestamp
+}
+
 // Full shared state envelope returned by GET
 export interface SharedCampaignState {
   calendar: SharedCalendarPlayer | null;
@@ -61,6 +90,7 @@ export interface SharedCampaignState {
   dmEffects: DmEffect[];
   customCounter: { label: string; value: number } | null;
   transfers: ItemTransfer[];
+  initiative: SharedInitiativeState | null;
 }
 
 // POST body for DM pushing shared state

--- a/src/types/sharedState.ts
+++ b/src/types/sharedState.ts
@@ -65,6 +65,11 @@ export interface SharedTurnEntry {
   maxHp?: number; // players always; non-players only when enemyHpMode is 'exact'
   hpState?: string; // non-players when enemyHpMode is 'label' (e.g. "Bloodied")
   hpPercent?: number; // non-players when enemyHpMode is 'bar' | 'percent' (0-100)
+  // Coarse health tier for colour-coding any shown enemy HP indicator. Set for
+  // non-players whenever enemyHpMode !== 'off' (kept coarse so 'label' mode does
+  // not leak an exact percentage).
+  hpTier?: 'high' | 'mid' | 'low' | 'critical';
+  isDead?: boolean; // current HP <= 0 (players always; enemies when HP is shared)
 }
 
 // Initiative/turn state pushed by the DM, read by players

--- a/src/types/sharedState.ts
+++ b/src/types/sharedState.ts
@@ -70,6 +70,7 @@ export interface SharedTurnEntry {
   // not leak an exact percentage).
   hpTier?: 'high' | 'mid' | 'low' | 'critical';
   isDead?: boolean; // current HP <= 0 (players always; enemies when HP is shared)
+  disposition?: 'ally' | 'enemy' | 'neutral'; // player-facing allegiance (non-players)
 }
 
 // Initiative/turn state pushed by the DM, read by players

--- a/src/utils/__tests__/buildSharedInitiative.test.ts
+++ b/src/utils/__tests__/buildSharedInitiative.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { buildSharedInitiative } from '../buildSharedInitiative';
+import type { Encounter, EncounterEntity } from '@/types/encounter';
+
+function entity(o: Partial<EncounterEntity> & { id: string }): EncounterEntity {
+  return {
+    type: 'monster',
+    name: 'E',
+    initiative: 10,
+    initiativeModifier: 0,
+    currentHp: 10,
+    maxHp: 10,
+    tempHp: 0,
+    armorClass: 10,
+    conditions: [],
+    isHidden: false,
+    ...o,
+  };
+}
+
+function encounter(
+  entities: EncounterEntity[],
+  o: Partial<Encounter> = {}
+): Encounter {
+  return {
+    id: 'enc-1',
+    name: 'Fight',
+    campaignCode: 'ABC123',
+    entities,
+    currentTurn: 0,
+    round: 2,
+    isActive: true,
+    sortOrder: 'initiative',
+    createdAt: '',
+    updatedAt: '',
+    ...o,
+  };
+}
+
+describe('buildSharedInitiative', () => {
+  it('orders entries by initiative (desc) and sets currentEntityId from currentTurn', () => {
+    const enc = encounter(
+      [
+        entity({
+          id: 'a',
+          name: 'Aragorn',
+          type: 'player',
+          initiative: 20,
+          playerCharacterId: 'char-a',
+        }),
+        entity({ id: 'b', name: 'Goblin', initiative: 5 }),
+      ],
+      { currentTurn: 1 }
+    );
+    const result = buildSharedInitiative(enc);
+    expect(result.turnOrder.map(t => t.entityId)).toEqual(['a', 'b']);
+    expect(result.currentEntityId).toBe('b');
+    expect(result.round).toBe(2);
+    expect(result.isActive).toBe(true);
+    expect(result.encounterId).toBe('enc-1');
+  });
+
+  it('relabels hidden non-player entities to "Enemy" and omits their identity', () => {
+    const enc = encounter([
+      entity({
+        id: 'm',
+        name: 'Adult Red Dragon',
+        initiative: 18,
+        isHidden: true,
+      }),
+    ]);
+    expect(enc).toBeDefined();
+    const result = buildSharedInitiative(enc);
+    expect(result.turnOrder[0].displayName).toBe('Enemy');
+  });
+
+  it('keeps hidden PLAYER names (only non-players are masked)', () => {
+    const enc = encounter([
+      entity({
+        id: 'p',
+        name: 'Aragorn',
+        type: 'player',
+        initiative: 18,
+        isHidden: true,
+        playerCharacterId: 'char-a',
+      }),
+    ]);
+    expect(buildSharedInitiative(enc).turnOrder[0].displayName).toBe('Aragorn');
+  });
+
+  it('uses playerAlias as the player-facing name for non-player entities', () => {
+    const enc = encounter([
+      entity({
+        id: 'm',
+        name: 'Vecna the Archlich',
+        initiative: 18,
+        playerAlias: 'Hooded Figure',
+      }),
+    ]);
+    expect(buildSharedInitiative(enc).turnOrder[0].displayName).toBe(
+      'Hooded Figure'
+    );
+  });
+
+  it('lets playerAlias take precedence over the hidden "Enemy" label', () => {
+    const enc = encounter([
+      entity({
+        id: 'm',
+        name: 'Goblin Boss',
+        initiative: 18,
+        isHidden: true,
+        playerAlias: 'Hooded Figure',
+      }),
+    ]);
+    expect(buildSharedInitiative(enc).turnOrder[0].displayName).toBe(
+      'Hooded Figure'
+    );
+  });
+
+  it('ignores a blank/whitespace playerAlias and falls back to name or "Enemy"', () => {
+    const enc = encounter([
+      entity({ id: 'm1', name: 'Goblin', initiative: 10, playerAlias: '   ' }),
+      entity({
+        id: 'm2',
+        name: 'Orc',
+        initiative: 8,
+        isHidden: true,
+        playerAlias: '',
+      }),
+    ]);
+    const rows = buildSharedInitiative(enc).turnOrder;
+    expect(rows.find(r => r.entityId === 'm1')!.displayName).toBe('Goblin');
+    expect(rows.find(r => r.entityId === 'm2')!.displayName).toBe('Enemy');
+  });
+
+  it('ignores playerAlias for player entities (players are never masked)', () => {
+    const enc = encounter([
+      entity({
+        id: 'p',
+        name: 'Aragorn',
+        type: 'player',
+        initiative: 18,
+        playerAlias: 'Fake',
+        playerCharacterId: 'char-a',
+      }),
+    ]);
+    expect(buildSharedInitiative(enc).turnOrder[0].displayName).toBe('Aragorn');
+  });
+
+  it('includes HP for player entities only', () => {
+    const enc = encounter([
+      entity({
+        id: 'p',
+        name: 'Aragorn',
+        type: 'player',
+        initiative: 18,
+        currentHp: 24,
+        maxHp: 30,
+        playerCharacterId: 'char-a',
+      }),
+      entity({
+        id: 'm',
+        name: 'Goblin',
+        initiative: 5,
+        currentHp: 7,
+        maxHp: 7,
+      }),
+    ]);
+    const rows = buildSharedInitiative(enc).turnOrder;
+    const player = rows.find(r => r.entityId === 'p')!;
+    const monster = rows.find(r => r.entityId === 'm')!;
+    expect(player.currentHp).toBe(24);
+    expect(player.maxHp).toBe(30);
+    expect(player.playerCharacterId).toBe('char-a');
+    expect(monster.currentHp).toBeUndefined();
+    expect(monster.maxHp).toBeUndefined();
+    expect(monster.playerCharacterId).toBeUndefined();
+  });
+});

--- a/src/utils/__tests__/buildSharedInitiative.test.ts
+++ b/src/utils/__tests__/buildSharedInitiative.test.ts
@@ -133,6 +133,53 @@ describe('buildSharedInitiative', () => {
     expect(rows.find(r => r.entityId === 'm2')!.displayName).toBe('Enemy');
   });
 
+  it('hidden generic label follows the disguise disposition', () => {
+    const enc = encounter([
+      entity({
+        id: 'a',
+        name: 'Strahd',
+        initiative: 20,
+        isHidden: true,
+        playerDisposition: 'ally',
+      }),
+      entity({
+        id: 'n',
+        name: 'Spy',
+        initiative: 15,
+        isHidden: true,
+        playerDisposition: 'neutral',
+      }),
+      entity({ id: 'e', name: 'Orc', initiative: 10, isHidden: true }),
+    ]);
+    const rows = buildSharedInitiative(enc).turnOrder;
+    expect(rows.find(r => r.entityId === 'a')!.displayName).toBe('Ally');
+    expect(rows.find(r => r.entityId === 'n')!.displayName).toBe('Stranger');
+    expect(rows.find(r => r.entityId === 'e')!.displayName).toBe('Enemy');
+  });
+
+  it('sends disposition for non-players (default enemy), not for players', () => {
+    const enc = encounter([
+      entity({
+        id: 'a',
+        name: 'Noble',
+        initiative: 20,
+        playerDisposition: 'ally',
+      }),
+      entity({ id: 'e', name: 'Goblin', initiative: 10 }),
+      entity({
+        id: 'p',
+        name: 'Aragorn',
+        type: 'player',
+        initiative: 15,
+        playerCharacterId: 'char-a',
+      }),
+    ]);
+    const rows = buildSharedInitiative(enc).turnOrder;
+    expect(rows.find(r => r.entityId === 'a')!.disposition).toBe('ally');
+    expect(rows.find(r => r.entityId === 'e')!.disposition).toBe('enemy');
+    expect(rows.find(r => r.entityId === 'p')!.disposition).toBeUndefined();
+  });
+
   it('ignores playerAlias for player entities (players are never masked)', () => {
     const enc = encounter([
       entity({

--- a/src/utils/__tests__/buildSharedInitiative.test.ts
+++ b/src/utils/__tests__/buildSharedInitiative.test.ts
@@ -249,4 +249,61 @@ describe('buildSharedInitiative — enemy HP config', () => {
     expect(monster.currentHp).toBe(5);
     expect(monster.maxHp).toBe(20);
   });
+
+  it('sets a coarse hpTier for a living enemy when HP is shown', () => {
+    const result = buildSharedInitiative(enc(), {
+      enemyHpDisplay: 'label',
+      hpStateBands: bands,
+    });
+    // 5/20 = 25% -> 'critical'
+    expect(result.turnOrder.find(r => r.entityId === 'm')!.hpTier).toBe(
+      'critical'
+    );
+  });
+
+  it('marks a dead enemy isDead (no tier) when HP is shown', () => {
+    const e = encounter([
+      entity({
+        id: 'm',
+        name: 'Goblin',
+        initiative: 5,
+        currentHp: 0,
+        maxHp: 20,
+      }),
+    ]);
+    const monster = buildSharedInitiative(e, {
+      enemyHpDisplay: 'label',
+      hpStateBands: bands,
+    }).turnOrder[0];
+    expect(monster.isDead).toBe(true);
+    expect(monster.hpTier).toBeUndefined();
+  });
+
+  it('never marks enemy death when HP display is off', () => {
+    const e = encounter([
+      entity({
+        id: 'm',
+        name: 'Goblin',
+        initiative: 5,
+        currentHp: 0,
+        maxHp: 20,
+      }),
+    ]);
+    expect(buildSharedInitiative(e).turnOrder[0].isDead).toBeUndefined();
+  });
+
+  it('marks a downed player isDead', () => {
+    const e = encounter([
+      entity({
+        id: 'p',
+        name: 'Aragorn',
+        type: 'player',
+        initiative: 20,
+        currentHp: 0,
+        maxHp: 30,
+        playerCharacterId: 'char-a',
+      }),
+    ]);
+    expect(buildSharedInitiative(e).turnOrder[0].isDead).toBe(true);
+  });
 });

--- a/src/utils/__tests__/buildSharedInitiative.test.ts
+++ b/src/utils/__tests__/buildSharedInitiative.test.ts
@@ -177,3 +177,76 @@ describe('buildSharedInitiative', () => {
     expect(monster.playerCharacterId).toBeUndefined();
   });
 });
+
+describe('buildSharedInitiative — enemy HP config', () => {
+  const enc = () =>
+    encounter([
+      entity({
+        id: 'p',
+        name: 'Aragorn',
+        type: 'player',
+        initiative: 20,
+        currentHp: 24,
+        maxHp: 30,
+        playerCharacterId: 'char-a',
+      }),
+      entity({
+        id: 'm',
+        name: 'Goblin',
+        initiative: 5,
+        currentHp: 5,
+        maxHp: 20,
+      }),
+    ]);
+
+  const bands = [
+    { minPercent: 50, label: 'Healthy' },
+    { minPercent: 0, label: 'Bloodied' },
+  ];
+
+  it('defaults to off — non-players expose no HP and mode is "off"', () => {
+    const result = buildSharedInitiative(enc());
+    expect(result.enemyHpMode).toBe('off');
+    const monster = result.turnOrder.find(r => r.entityId === 'm')!;
+    expect(monster.hpState).toBeUndefined();
+    expect(monster.hpPercent).toBeUndefined();
+    expect(monster.currentHp).toBeUndefined();
+  });
+
+  it('label mode sets hpState for non-players (not players)', () => {
+    const result = buildSharedInitiative(enc(), {
+      enemyHpDisplay: 'label',
+      hpStateBands: bands,
+    });
+    expect(result.enemyHpMode).toBe('label');
+    expect(result.turnOrder.find(r => r.entityId === 'm')!.hpState).toBe(
+      'Bloodied' // 5/20 = 25% -> below 50 band
+    );
+    expect(
+      result.turnOrder.find(r => r.entityId === 'p')!.hpState
+    ).toBeUndefined();
+  });
+
+  it('percent and bar modes set hpPercent (no raw HP) for non-players', () => {
+    for (const mode of ['percent', 'bar'] as const) {
+      const result = buildSharedInitiative(enc(), {
+        enemyHpDisplay: mode,
+        hpStateBands: bands,
+      });
+      const monster = result.turnOrder.find(r => r.entityId === 'm')!;
+      expect(monster.hpPercent).toBe(25);
+      expect(monster.currentHp).toBeUndefined();
+      expect(monster.maxHp).toBeUndefined();
+    }
+  });
+
+  it('exact mode exposes raw HP for non-players', () => {
+    const result = buildSharedInitiative(enc(), {
+      enemyHpDisplay: 'exact',
+      hpStateBands: bands,
+    });
+    const monster = result.turnOrder.find(r => r.entityId === 'm')!;
+    expect(monster.currentHp).toBe(5);
+    expect(monster.maxHp).toBe(20);
+  });
+});

--- a/src/utils/__tests__/hpColor.test.ts
+++ b/src/utils/__tests__/hpColor.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { getHpBarColor } from '../hpColor';
+
+describe('getHpBarColor', () => {
+  it('is green above 50%', () => {
+    expect(getHpBarColor(30, 50)).toContain('green');
+  });
+
+  it('is amber between 25% and 50%', () => {
+    expect(getHpBarColor(20, 50)).toContain('amber');
+  });
+
+  it('is red at or below 25%', () => {
+    expect(getHpBarColor(10, 50)).toContain('red');
+  });
+
+  it('falls back to a neutral token when max is 0', () => {
+    expect(getHpBarColor(0, 0)).toBe('bg-surface-secondary');
+  });
+});

--- a/src/utils/__tests__/hpState.test.ts
+++ b/src/utils/__tests__/hpState.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { hpPercent, hpStateLabel } from '../hpState';
+import { DEFAULT_HP_STATE_BANDS } from '@/types/encounter';
+
+describe('hpPercent', () => {
+  it('computes a clamped 0-100 percentage', () => {
+    expect(hpPercent(60, 120)).toBe(50);
+    expect(hpPercent(120, 120)).toBe(100);
+    expect(hpPercent(-5, 120)).toBe(0);
+    expect(hpPercent(10, 0)).toBe(0); // guard divide-by-zero
+  });
+});
+
+describe('hpStateLabel', () => {
+  const bands = DEFAULT_HP_STATE_BANDS;
+
+  it('returns the full-health label at 100%', () => {
+    expect(hpStateLabel(120, 120, bands)).toBe('Unharmed');
+  });
+
+  it('returns the down label at 0 HP', () => {
+    expect(hpStateLabel(0, 120, bands)).toBe('Down');
+  });
+
+  it('picks the band for the current percentage', () => {
+    expect(hpStateLabel(100, 120, bands)).toBe('Healthy'); // ~83%
+    expect(hpStateLabel(60, 120, bands)).toBe('Injured'); // 50%
+    expect(hpStateLabel(40, 120, bands)).toBe('Bloodied'); // ~33%
+    expect(hpStateLabel(6, 120, bands)).toBe('Near Death'); // 5%
+  });
+
+  it('is order-independent (sorts bands internally)', () => {
+    const shuffled = [
+      { minPercent: 0, label: 'Down' },
+      { minPercent: 50, label: 'Half' },
+      { minPercent: 100, label: 'Full' },
+    ];
+    expect(hpStateLabel(120, 120, shuffled)).toBe('Full');
+    expect(hpStateLabel(30, 120, shuffled)).toBe('Down'); // 25% -> below 50 band
+    expect(hpStateLabel(72, 120, shuffled)).toBe('Half'); // 60%
+  });
+
+  it('returns empty string when no bands are configured', () => {
+    expect(hpStateLabel(50, 120, [])).toBe('');
+  });
+});

--- a/src/utils/__tests__/turnRequest.test.ts
+++ b/src/utils/__tests__/turnRequest.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { shouldApplyTurnRequest } from '../turnRequest';
+import type { Encounter } from '@/types/encounter';
+import type { TurnEndRequest } from '@/types/sharedState';
+
+function enc(o: Partial<Encounter> = {}): Encounter {
+  return {
+    id: 'enc-1',
+    name: 'Fight',
+    entities: [
+      {
+        id: 'a',
+        type: 'player',
+        name: 'Aragorn',
+        initiative: 20,
+        initiativeModifier: 0,
+        currentHp: 10,
+        maxHp: 10,
+        tempHp: 0,
+        armorClass: 10,
+        conditions: [],
+      },
+    ],
+    currentTurn: 0,
+    round: 2,
+    isActive: true,
+    sortOrder: 'initiative',
+    createdAt: '',
+    updatedAt: '',
+    ...o,
+  };
+}
+
+const req = (o: Partial<TurnEndRequest> = {}): TurnEndRequest => ({
+  encounterId: 'enc-1',
+  round: 2,
+  entityId: 'a',
+  playerId: 'char-a',
+  requestedAt: '',
+  ...o,
+});
+
+describe('shouldApplyTurnRequest', () => {
+  it('applies when encounter, round and current entity all match', () => {
+    expect(shouldApplyTurnRequest(enc(), req())).toBe(true);
+  });
+  it('rejects when the round no longer matches (stale)', () => {
+    expect(shouldApplyTurnRequest(enc({ round: 3 }), req({ round: 2 }))).toBe(
+      false
+    );
+  });
+  it("rejects when it is not that entity's turn", () => {
+    expect(
+      shouldApplyTurnRequest(
+        enc({ currentTurn: 0 }),
+        req({ entityId: 'someone-else' })
+      )
+    ).toBe(false);
+  });
+  it('rejects when the encounter id differs', () => {
+    expect(
+      shouldApplyTurnRequest(
+        enc({ id: 'enc-2' }),
+        req({ encounterId: 'enc-1' })
+      )
+    ).toBe(false);
+  });
+  it('rejects when combat is not active', () => {
+    expect(shouldApplyTurnRequest(enc({ isActive: false }), req())).toBe(false);
+  });
+});

--- a/src/utils/buildSharedInitiative.ts
+++ b/src/utils/buildSharedInitiative.ts
@@ -11,14 +11,23 @@ import type {
   SharedTurnEntry,
 } from '@/types/sharedState';
 
+const HIDDEN_LABEL: Record<
+  NonNullable<EncounterEntity['playerDisposition']>,
+  string
+> = {
+  ally: 'Ally',
+  neutral: 'Stranger',
+  enemy: 'Enemy',
+};
+
 function playerFacingName(entity: EncounterEntity): string {
   // Players are never masked.
   if (entity.type === 'player') return entity.name;
   // A custom alias wins over everything else.
   const alias = entity.playerAlias?.trim();
   if (alias) return alias;
-  // Otherwise a hidden entity shows a generic label.
-  if (entity.isHidden) return 'Enemy';
+  // Otherwise a hidden entity shows a generic label matching its disguise.
+  if (entity.isHidden) return HIDDEN_LABEL[entity.playerDisposition ?? 'enemy'];
   return entity.name;
 }
 
@@ -43,6 +52,9 @@ function toEntry(
     entry.isDead = entity.currentHp <= 0;
     return entry;
   }
+
+  // Player-facing allegiance (disguise). Defaults to enemy for non-players.
+  entry.disposition = entity.playerDisposition ?? 'enemy';
 
   // Non-players (enemies/NPCs) expose only what the DM's combat config allows.
   if (config.enemyHpDisplay === 'off') return entry;

--- a/src/utils/buildSharedInitiative.ts
+++ b/src/utils/buildSharedInitiative.ts
@@ -1,5 +1,11 @@
 import { getSortedEntities } from '@/store/encounterStore';
-import type { Encounter, EncounterEntity } from '@/types/encounter';
+import {
+  DEFAULT_COMBAT_CONFIG,
+  type CombatConfig,
+  type Encounter,
+  type EncounterEntity,
+} from '@/types/encounter';
+import { hpPercent, hpStateLabel } from '@/utils/hpState';
 import type {
   SharedInitiativeState,
   SharedTurnEntry,
@@ -16,7 +22,10 @@ function playerFacingName(entity: EncounterEntity): string {
   return entity.name;
 }
 
-function toEntry(entity: EncounterEntity): SharedTurnEntry {
+function toEntry(
+  entity: EncounterEntity,
+  config: CombatConfig
+): SharedTurnEntry {
   const isPlayer = entity.type === 'player';
   const displayName = playerFacingName(entity);
 
@@ -26,11 +35,34 @@ function toEntry(entity: EncounterEntity): SharedTurnEntry {
     type: entity.type as SharedTurnEntry['type'],
   };
 
-  // HP + identity are exposed for player entities only.
+  // Players always expose identity + exact HP (their own sheet is authoritative).
   if (isPlayer) {
     entry.playerCharacterId = entity.playerCharacterId;
     entry.currentHp = entity.currentHp;
     entry.maxHp = entity.maxHp;
+    return entry;
+  }
+
+  // Non-players (enemies/NPCs) expose only what the DM's combat config allows.
+  switch (config.enemyHpDisplay) {
+    case 'label':
+      entry.hpState = hpStateLabel(
+        entity.currentHp,
+        entity.maxHp,
+        config.hpStateBands
+      );
+      break;
+    case 'bar':
+    case 'percent':
+      entry.hpPercent = Math.round(hpPercent(entity.currentHp, entity.maxHp));
+      break;
+    case 'exact':
+      entry.currentHp = entity.currentHp;
+      entry.maxHp = entity.maxHp;
+      break;
+    case 'off':
+    default:
+      break;
   }
 
   return entry;
@@ -41,7 +73,8 @@ function toEntry(entity: EncounterEntity): SharedTurnEntry {
  * Pure — safe to unit test and to call on every turn change.
  */
 export function buildSharedInitiative(
-  encounter: Encounter
+  encounter: Encounter,
+  config: CombatConfig = DEFAULT_COMBAT_CONFIG
 ): SharedInitiativeState {
   const sorted = getSortedEntities(encounter.entities);
   const current = sorted[encounter.currentTurn];
@@ -51,7 +84,8 @@ export function buildSharedInitiative(
     isActive: encounter.isActive,
     round: encounter.round,
     currentEntityId: current ? current.id : null,
-    turnOrder: sorted.map(toEntry),
+    turnOrder: sorted.map(e => toEntry(e, config)),
+    enemyHpMode: config.enemyHpDisplay,
     updatedAt: new Date().toISOString(),
   };
 }

--- a/src/utils/buildSharedInitiative.ts
+++ b/src/utils/buildSharedInitiative.ts
@@ -5,7 +5,7 @@ import {
   type Encounter,
   type EncounterEntity,
 } from '@/types/encounter';
-import { hpPercent, hpStateLabel } from '@/utils/hpState';
+import { hpPercent, hpStateLabel, hpTier } from '@/utils/hpState';
 import type {
   SharedInitiativeState,
   SharedTurnEntry,
@@ -40,10 +40,17 @@ function toEntry(
     entry.playerCharacterId = entity.playerCharacterId;
     entry.currentHp = entity.currentHp;
     entry.maxHp = entity.maxHp;
+    entry.isDead = entity.currentHp <= 0;
     return entry;
   }
 
   // Non-players (enemies/NPCs) expose only what the DM's combat config allows.
+  if (config.enemyHpDisplay === 'off') return entry;
+
+  const pct = hpPercent(entity.currentHp, entity.maxHp);
+  entry.isDead = entity.currentHp <= 0;
+  if (!entry.isDead) entry.hpTier = hpTier(pct);
+
   switch (config.enemyHpDisplay) {
     case 'label':
       entry.hpState = hpStateLabel(
@@ -54,14 +61,11 @@ function toEntry(
       break;
     case 'bar':
     case 'percent':
-      entry.hpPercent = Math.round(hpPercent(entity.currentHp, entity.maxHp));
+      entry.hpPercent = Math.round(pct);
       break;
     case 'exact':
       entry.currentHp = entity.currentHp;
       entry.maxHp = entity.maxHp;
-      break;
-    case 'off':
-    default:
       break;
   }
 

--- a/src/utils/buildSharedInitiative.ts
+++ b/src/utils/buildSharedInitiative.ts
@@ -1,0 +1,57 @@
+import { getSortedEntities } from '@/store/encounterStore';
+import type { Encounter, EncounterEntity } from '@/types/encounter';
+import type {
+  SharedInitiativeState,
+  SharedTurnEntry,
+} from '@/types/sharedState';
+
+function playerFacingName(entity: EncounterEntity): string {
+  // Players are never masked.
+  if (entity.type === 'player') return entity.name;
+  // A custom alias wins over everything else.
+  const alias = entity.playerAlias?.trim();
+  if (alias) return alias;
+  // Otherwise a hidden entity shows a generic label.
+  if (entity.isHidden) return 'Enemy';
+  return entity.name;
+}
+
+function toEntry(entity: EncounterEntity): SharedTurnEntry {
+  const isPlayer = entity.type === 'player';
+  const displayName = playerFacingName(entity);
+
+  const entry: SharedTurnEntry = {
+    entityId: entity.id,
+    displayName,
+    type: entity.type as SharedTurnEntry['type'],
+  };
+
+  // HP + identity are exposed for player entities only.
+  if (isPlayer) {
+    entry.playerCharacterId = entity.playerCharacterId;
+    entry.currentHp = entity.currentHp;
+    entry.maxHp = entity.maxHp;
+  }
+
+  return entry;
+}
+
+/**
+ * Derive the player-facing initiative payload from a DM encounter.
+ * Pure — safe to unit test and to call on every turn change.
+ */
+export function buildSharedInitiative(
+  encounter: Encounter
+): SharedInitiativeState {
+  const sorted = getSortedEntities(encounter.entities);
+  const current = sorted[encounter.currentTurn];
+
+  return {
+    encounterId: encounter.id,
+    isActive: encounter.isActive,
+    round: encounter.round,
+    currentEntityId: current ? current.id : null,
+    turnOrder: sorted.map(toEntry),
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/src/utils/fileOperations.ts
+++ b/src/utils/fileOperations.ts
@@ -1,4 +1,53 @@
 import { CharacterExport } from '@/types/character';
+import type { PlayerCharacter } from '@/store/playerStore';
+
+/** A full-roster backup bundle (every character in one file). */
+export interface CharacterBackup {
+  type: 'rollkeeper-backup';
+  version: number;
+  exportedAt: string;
+  characters: PlayerCharacter[];
+}
+
+function downloadJson(data: unknown, filename: string): void {
+  const dataStr = JSON.stringify(data, null, 2);
+  const dataUri =
+    'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
+  const linkElement = document.createElement('a');
+  linkElement.setAttribute('href', dataUri);
+  linkElement.setAttribute('download', filename);
+  linkElement.style.display = 'none';
+  document.body.appendChild(linkElement);
+  linkElement.click();
+  document.body.removeChild(linkElement);
+}
+
+/**
+ * Export every character as a single backup file the user can re-import. This is
+ * the primary safeguard against the localStorage-only data model.
+ */
+export const exportAllCharactersToFile = (
+  characters: PlayerCharacter[]
+): void => {
+  const timestamp = new Date().toISOString().split('T')[0];
+  const backup: CharacterBackup = {
+    type: 'rollkeeper-backup',
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    characters,
+  };
+  downloadJson(backup, `rollkeeper_backup_${timestamp}.json`);
+};
+
+/** True if a parsed JSON file is a full-roster backup bundle. */
+export const isCharacterBackup = (data: unknown): data is CharacterBackup => {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as CharacterBackup).type === 'rollkeeper-backup' &&
+    Array.isArray((data as CharacterBackup).characters)
+  );
+};
 
 /**
  * Export character data as a JSON file download

--- a/src/utils/hpColor.ts
+++ b/src/utils/hpColor.ts
@@ -1,3 +1,5 @@
+import type { HpTier } from './hpState';
+
 /**
  * Tailwind background class for an HP bar, by current/max ratio.
  * Green > 50%, amber > 25%, red at/below 25%. Shared by the party HP sidebar
@@ -9,4 +11,18 @@ export function getHpBarColor(current: number, max: number): string {
   if (pct > 0.5) return 'bg-green-600 dark:bg-green-500';
   if (pct > 0.25) return 'bg-amber-500 dark:bg-amber-400';
   return 'bg-red-600 dark:bg-red-500';
+}
+
+/** Semantic text-colour token for a coarse health tier (enemy status labels). */
+export function getHpTierTextColor(tier: HpTier): string {
+  switch (tier) {
+    case 'high':
+      return 'text-accent-emerald-text';
+    case 'mid':
+      return 'text-accent-amber-text';
+    case 'low':
+      return 'text-accent-orange-text';
+    case 'critical':
+      return 'text-accent-red-text';
+  }
 }

--- a/src/utils/hpColor.ts
+++ b/src/utils/hpColor.ts
@@ -1,0 +1,12 @@
+/**
+ * Tailwind background class for an HP bar, by current/max ratio.
+ * Green > 50%, amber > 25%, red at/below 25%. Shared by the party HP sidebar
+ * and the initiative panel so player HP reads consistently across the app.
+ */
+export function getHpBarColor(current: number, max: number): string {
+  if (max <= 0) return 'bg-surface-secondary';
+  const pct = current / max;
+  if (pct > 0.5) return 'bg-green-600 dark:bg-green-500';
+  if (pct > 0.25) return 'bg-amber-500 dark:bg-amber-400';
+  return 'bg-red-600 dark:bg-red-500';
+}

--- a/src/utils/hpState.ts
+++ b/src/utils/hpState.ts
@@ -6,6 +6,16 @@ export function hpPercent(current: number, max: number): number {
   return Math.max(0, Math.min(100, (current / max) * 100));
 }
 
+export type HpTier = 'high' | 'mid' | 'low' | 'critical';
+
+/** Coarse health tier from a 0-100 percentage, for colour-coding. */
+export function hpTier(percent: number): HpTier {
+  if (percent > 75) return 'high';
+  if (percent > 50) return 'mid';
+  if (percent > 25) return 'low';
+  return 'critical';
+}
+
 /**
  * The player-facing HP-state label for the given HP, using the configured
  * bands. A band applies when the current percentage is at or above its

--- a/src/utils/hpState.ts
+++ b/src/utils/hpState.ts
@@ -1,0 +1,26 @@
+import type { HpStateBand } from '@/types/encounter';
+
+/** Current HP as a clamped 0-100 percentage of max. */
+export function hpPercent(current: number, max: number): number {
+  if (max <= 0) return 0;
+  return Math.max(0, Math.min(100, (current / max) * 100));
+}
+
+/**
+ * The player-facing HP-state label for the given HP, using the configured
+ * bands. A band applies when the current percentage is at or above its
+ * `minPercent`; the highest matching band wins. Returns '' when no bands exist.
+ */
+export function hpStateLabel(
+  current: number,
+  max: number,
+  bands: HpStateBand[]
+): string {
+  if (bands.length === 0) return '';
+  const pct = hpPercent(current, max);
+  // Highest minPercent first; pick the first band the percentage reaches.
+  const sorted = [...bands].sort((a, b) => b.minPercent - a.minPercent);
+  const match = sorted.find(b => pct >= b.minPercent);
+  // Fall back to the lowest band if somehow nothing matched.
+  return (match ?? sorted[sorted.length - 1]).label;
+}

--- a/src/utils/turnRequest.ts
+++ b/src/utils/turnRequest.ts
@@ -1,0 +1,19 @@
+import { getSortedEntities } from '@/store/encounterStore';
+import type { Encounter } from '@/types/encounter';
+import type { TurnEndRequest } from '@/types/sharedState';
+
+/**
+ * A player's end-turn request is only honored when it still refers to the live
+ * state: same encounter, same round, and it is genuinely that entity's turn.
+ * This prevents double-advances from polling lag or stale taps.
+ */
+export function shouldApplyTurnRequest(
+  encounter: Encounter,
+  request: TurnEndRequest
+): boolean {
+  if (!encounter.isActive) return false;
+  if (encounter.id !== request.encounterId) return false;
+  if (encounter.round !== request.round) return false;
+  const current = getSortedEntities(encounter.entities)[encounter.currentTurn];
+  return !!current && current.id === request.entityId;
+}


### PR DESCRIPTION
## Summary

Combat-bug fixes plus a big round of **in-person-table** features centered on a player-facing combat experience, and **data-loss protection** for the localStorage-only data model.

Verified end-to-end by running the app (Redis + dev server) and driving the player UI in a real browser — screenshots in the verification notes.

## Bug fixes
- **Party-tracker AC** now reuses `calculateCharacterArmorClass()` so the DM dashboard matches the character sheet (it previously ignored temp AC + active buffs).
- **`prevTurn()`** resets the incoming entity's reaction, mirroring `nextTurn()`.
- **Dev-only routes** (`/dice-test`, `/design-system`, `/dice-components-demo`, `/test-error`) are 404'd in production via middleware.

## Shared initiative for players
- Live turn order, current turn, and round on player phones — synced through the existing campaign shared state (5s poll during combat).
- **End my turn** with optimistic local advance + a guarded turn-request the DM validates against the live encounter.
- Thin, collapsible, vertically-draggable initiative panel (shared `useDraggableY`); Party HP sidebar made draggable too.

## DM control over what players see
- **Hide name / alias**: hide a combatant's real name (players see a generic label) or show a custom alias.
- **Allegiance disguise**: per-combatant ally / enemy / neutral — players see colour + icon (green shield / red skull / gray circle); the hidden generic label follows it (Ally / Stranger / Enemy).
- **Enemy HP visibility** (global combat config, gear on the encounters page): off / state-label / bar / percentage / exact, with editable HP-state label bands. Tier-coloured statuses; dead combatants clearly marked.

## At-the-table polish
- Auto-open the panel + a "Combat Begins" banner (background blur, sidebar stays sharp) on combat start; player setting (default on).
- Colour-coded player HP; clear party-vs-enemy distinction.
- Equal-height encounter cards with bottom-aligned actions.

## Data-loss protection
- `createSafeStorage` wraps all 9 persisted stores: a quota-exceeded write no longer fails silently — it surfaces a "storage full, export now" toast.
- **Export All** bundles every character into one restorable backup; import detects and restores the bundle.
- Dismissible data-safety banner explaining local-only storage.

## Testing
- `type-check` clean, `lint` clean (pre-existing warnings only), **2289 unit tests passing**. New logic (builders, routes, hooks, storage wrapper, panel) is unit-tested; the two large UI pieces went through spec + quality review.

## Notes / out of scope
- Campaign API auth, weak campaign codes, and the SSR-unsafe `migrateFromOldStorage` are pre-existing and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
