### PR TITLE
fix: SSR localStorage crash, empty-body shared route, relay env loading

### DIFF
--- a/relay/package.json
+++ b/relay/package.json
@@ -7,9 +7,9 @@
     "node": ">=20"
   },
   "scripts": {
-    "dev": "tsx watch src/server.ts",
+    "dev": "tsx watch --env-file-if-exists=.env src/server.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/server.js",
+    "start": "node --env-file-if-exists=.env dist/server.js",
     "test": "vitest run",
     "type-check": "tsc --noEmit -p tsconfig.json"
   },

--- a/src/app/api/campaign/[code]/shared/route.ts
+++ b/src/app/api/campaign/[code]/shared/route.ts
@@ -146,7 +146,15 @@ export async function POST(
 ) {
   try {
     const { code } = await params;
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body !== 'object') {
+      return NextResponse.json(
+        { error: 'Invalid or empty request body' },
+        { status: 400 }
+      );
+    }
+
     const { feature, data, dmId } = body;
 
     if (!feature || !data) {
@@ -297,7 +305,15 @@ export async function DELETE(
 ) {
   try {
     const { code } = await params;
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
+
+    if (!body || typeof body !== 'object') {
+      return NextResponse.json(
+        { error: 'Invalid or empty request body' },
+        { status: 400 }
+      );
+    }
+
     const { playerId, type } = body;
 
     if (!playerId) {

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -131,6 +131,9 @@ const createPlayerCharacter = (
 
 // Migration function
 const migrateOldCharacterData = (): PlayerCharacter | null => {
+  // localStorage is unavailable during SSR; migration only runs in the browser.
+  if (typeof window === 'undefined') return null;
+
   try {
     // Check for old character data
     const oldCharacterData = localStorage.getItem(STORAGE_KEY);


### PR DESCRIPTION
## Summary

Three small, independent fixes surfaced while running the new combat/encounter screen and the relay locally:

- **SSR `localStorage` crash** — `migrateOldCharacterData` in `playerStore` touched the raw `localStorage` global with no SSR guard. The new `/dm/campaign/[code]/encounters/[id]` route pulls the player-store chain into server rendering, so Zustand's `onRehydrateStorage` ran the migration on the server and threw `ReferenceError: localStorage is not defined`. Added a `typeof window === 'undefined'` early return.
- **Empty-body `shared` route 500s** — the campaign `shared` route's `POST`/`DELETE` handlers called `await request.json()` unguarded, so any request arriving with an empty body threw a `SyntaxError` that got logged as a 500 (frequent during Turbopack HMR on the DM screen). They now safely parse and return a clean `400` instead.
- **Relay env not loaded** — `relay` scripts didn't load `.env`, so `npm run dev`/`start` failed with `BATTLEMAP_RELAY_SECRET is required`. Added Node's `--env-file-if-exists=.env`, which loads the file locally but is a no-op on Railway (no committed `.env`), so platform env vars are unaffected.

## Test plan

- [x] `vitest run` on the shared route tests (36 passing)
- [x] `relay` starts past the secret check with `.env` present (only fails on Redis DNS in the sandbox)
- [ ] Confirm Railway deploy still boots (env vars come from the dashboard, `.env` absent → `--env-file-if-exists` skips silently)

Made with [Cursor](https://cursor.com)