### PR TITLE
feat(spells): AoE template metadata — detection, form fields, lazy migrations

### DIFF
--- a/src/components/__tests__/spells-smoke.test.tsx
+++ b/src/components/__tests__/spells-smoke.test.tsx
@@ -48,6 +48,7 @@ const mockFormData: SpellFormData = {
   castingSource: '',
   freeCastMode: 'normal',
   freeCastMax: 1,
+  aoe: null,
 };
 
 const mockSpell: Spell = {

--- a/src/components/shared/spells/SpellFormFields.hooks.ts
+++ b/src/components/shared/spells/SpellFormFields.hooks.ts
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+import { detectSpellAoe, aoeEquals } from '@/utils/spellAoeDetection';
+
+import type { SpellFormData } from '@/utils/spellConversion';
+import type { SpellAoe } from '@/types/spellAoe';
+
+/**
+ * Silent-until-touched AoE auto-fill.
+ * While the user hasn't manually edited the AoE fields, description/range
+ * changes re-run detection and keep the fields in sync. The first manual
+ * edit locks them for the rest of the form session.
+ */
+export function useSpellAoeAutofill(
+  formData: SpellFormData,
+  onChange: (data: SpellFormData) => void
+) {
+  // Edit-clobber guard: if the stored AoE differs from what detection would
+  // produce for the current text, the user set it deliberately — start locked.
+  const [aoeTouched, setAoeTouched] = useState(
+    () =>
+      !aoeEquals(
+        formData.aoe,
+        detectSpellAoe(formData.description, formData.range)
+      )
+  );
+
+  const setDescription = (description: string) => {
+    const next = { ...formData, description };
+    if (!aoeTouched) next.aoe = detectSpellAoe(description, formData.range);
+    onChange(next);
+  };
+
+  const setRange = (range: string) => {
+    const next = { ...formData, range };
+    if (!aoeTouched) next.aoe = detectSpellAoe(formData.description, range);
+    onChange(next);
+  };
+
+  const setAoe = (aoe: SpellAoe | null) => {
+    setAoeTouched(true);
+    onChange({ ...formData, aoe });
+  };
+
+  return { setDescription, setRange, setAoe };
+}

--- a/src/components/shared/spells/SpellFormFields.tsx
+++ b/src/components/shared/spells/SpellFormFields.tsx
@@ -15,8 +15,17 @@ import {
   SAVING_THROWS,
   DAMAGE_TYPES,
 } from '@/utils/spellConstants';
+import { useSpellAoeAutofill } from './SpellFormFields.hooks';
 import type { SpellFormData, FreeCastMode } from '@/utils/spellConversion';
 import type { SpellActionType } from '@/types/character';
+import type { AoeShape } from '@/types/spellAoe';
+
+const AOE_SIZE_LABEL: Record<AoeShape, string> = {
+  circle: 'Radius (ft)',
+  cone: 'Length (ft)',
+  line: 'Length (ft)',
+  square: 'Side (ft)',
+};
 
 export interface SpellFormFieldsProps {
   formData: SpellFormData;
@@ -41,6 +50,11 @@ export function SpellFormFields({
 }: SpellFormFieldsProps) {
   const set = (patch: Partial<SpellFormData>) =>
     onChange({ ...formData, ...patch });
+
+  const { setDescription, setRange, setAoe } = useSpellAoeAutofill(
+    formData,
+    onChange
+  );
 
   return (
     <div className="space-y-6">
@@ -126,7 +140,7 @@ export function SpellFormFields({
             </label>
             <SelectField
               value={formData.range}
-              onValueChange={value => set({ range: value })}
+              onValueChange={value => setRange(value)}
             >
               {RANGES.map(range => (
                 <SelectItem key={range} value={range}>
@@ -350,7 +364,7 @@ export function SpellFormFields({
           </label>
           <RichTextEditor
             content={formData.description}
-            onChange={content => set({ description: content })}
+            onChange={setDescription}
             placeholder="Describe what the spell does..."
             minHeight="150px"
           />
@@ -449,6 +463,67 @@ export function SpellFormFields({
                 ))}
               </SelectField>
             </div>
+          )}
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div>
+            <label className="text-body mb-2 block text-sm font-medium">
+              AoE Template
+            </label>
+            <SelectField
+              value={formData.aoe?.shape ?? 'none'}
+              onValueChange={value => {
+                if (value === 'none') {
+                  setAoe(null);
+                  return;
+                }
+                const shape = value as AoeShape;
+                setAoe({
+                  shape,
+                  sizeFeet: formData.aoe?.sizeFeet ?? 0,
+                  widthFeet:
+                    shape === 'line'
+                      ? (formData.aoe?.widthFeet ?? 5)
+                      : undefined,
+                });
+              }}
+            >
+              <SelectItem value="none">None</SelectItem>
+              <SelectItem value="circle">Circle (radius)</SelectItem>
+              <SelectItem value="cone">Cone</SelectItem>
+              <SelectItem value="line">Line</SelectItem>
+              <SelectItem value="square">Square (cube)</SelectItem>
+            </SelectField>
+          </div>
+          {formData.aoe && (
+            <Input
+              label={AOE_SIZE_LABEL[formData.aoe.shape]}
+              type="number"
+              min={0}
+              value={formData.aoe.sizeFeet || ''}
+              onChange={e =>
+                setAoe({
+                  ...formData.aoe!,
+                  sizeFeet: Number(e.target.value) || 0,
+                })
+              }
+            />
+          )}
+          {formData.aoe?.shape === 'line' && (
+            <Input
+              label="Width (ft)"
+              type="number"
+              min={0}
+              placeholder="5"
+              value={formData.aoe.widthFeet ?? ''}
+              onChange={e =>
+                setAoe({
+                  ...formData.aoe!,
+                  widthFeet:
+                    e.target.value === '' ? undefined : Number(e.target.value),
+                })
+              }
+            />
           )}
         </div>
       </div>

--- a/src/components/shared/spells/__tests__/SpellFormFields.hooks.test.ts
+++ b/src/components/shared/spells/__tests__/SpellFormFields.hooks.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSpellAoeAutofill } from '@/components/shared/spells/SpellFormFields.hooks';
+import { createInitialSpellFormData } from '@/utils/spellConversion';
+import type { SpellFormData } from '@/utils/spellConversion';
+
+const FIREBALL_DESC =
+  'Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw.';
+
+function setup(initial: SpellFormData) {
+  let formData = initial;
+  const onChange = (d: SpellFormData) => {
+    formData = d;
+  };
+  const view = renderHook(({ fd }) => useSpellAoeAutofill(fd, onChange), {
+    initialProps: { fd: initial },
+  });
+  return {
+    get formData() {
+      return formData;
+    },
+    result: view.result,
+    sync: () => view.rerender({ fd: formData }),
+  };
+}
+
+describe('useSpellAoeAutofill', () => {
+  it('auto-fills aoe from description while untouched', () => {
+    const h = setup(createInitialSpellFormData());
+    act(() => h.result.current.setDescription(FIREBALL_DESC));
+    expect(h.formData.aoe).toEqual({ shape: 'circle', sizeFeet: 20 });
+    expect(h.formData.description).toBe(FIREBALL_DESC);
+  });
+
+  it('clears aoe when the description no longer matches (still untouched)', () => {
+    const h = setup(createInitialSpellFormData());
+    act(() => h.result.current.setDescription(FIREBALL_DESC));
+    h.sync();
+    act(() =>
+      h.result.current.setDescription('A dart of force strikes one target.')
+    );
+    expect(h.formData.aoe).toBeNull();
+  });
+
+  it('locks after a manual AoE edit — description changes stop overwriting', () => {
+    const h = setup(createInitialSpellFormData());
+    act(() => h.result.current.setAoe({ shape: 'cone', sizeFeet: 30 }));
+    h.sync();
+    act(() => h.result.current.setDescription(FIREBALL_DESC));
+    expect(h.formData.aoe).toEqual({ shape: 'cone', sizeFeet: 30 });
+  });
+
+  it('locks after manually clearing to None', () => {
+    const h = setup(createInitialSpellFormData());
+    act(() => h.result.current.setAoe(null));
+    h.sync();
+    act(() => h.result.current.setDescription(FIREBALL_DESC));
+    expect(h.formData.aoe).toBeNull();
+  });
+
+  it('edit-clobber guard: starts locked when stored aoe differs from detection', () => {
+    const edited: SpellFormData = {
+      ...createInitialSpellFormData(),
+      description: FIREBALL_DESC,
+      aoe: { shape: 'square', sizeFeet: 10 }, // user overrode detection earlier
+    };
+    const h = setup(edited);
+    act(() =>
+      h.result.current.setDescription(
+        FIREBALL_DESC + ' The fire spreads around corners.'
+      )
+    );
+    expect(h.formData.aoe).toEqual({ shape: 'square', sizeFeet: 10 });
+  });
+
+  it('edit-clobber guard: starts unlocked when stored aoe matches detection', () => {
+    const detected: SpellFormData = {
+      ...createInitialSpellFormData(),
+      description: FIREBALL_DESC,
+      aoe: { shape: 'circle', sizeFeet: 20 },
+    };
+    const h = setup(detected);
+    act(() =>
+      h.result.current.setDescription(
+        'Each creature in a 30-foot cone must save.'
+      )
+    );
+    expect(h.formData.aoe).toEqual({ shape: 'cone', sizeFeet: 30 });
+  });
+});

--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
@@ -22,6 +22,7 @@ import {
   calculateModifier,
 } from '@/utils/calculations';
 import { calculateHitDicePools, migrateToMulticlass } from '@/utils/multiclass';
+import { detectSpellAoe } from '@/utils/spellAoeDetection';
 import {
   matchClassByName,
   getEditionOptions,
@@ -96,6 +97,7 @@ function buildSubclassSpells(
         materialDescription: found.components.materialComponent,
       },
       description: found.description,
+      aoe: detectSpellAoe(found.description, found.range),
       isPrepared: grant.isAlwaysPrepared,
       isAlwaysPrepared: grant.isAlwaysPrepared,
       castingSource: subclassName,

--- a/src/store/__tests__/characterStore-aoeMigration.test.ts
+++ b/src/store/__tests__/characterStore-aoeMigration.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { useCharacterStore } from '@/store/characterStore';
+import type { CharacterState, Spell } from '@/types/character';
+
+const FIREBALL_DESC =
+  'Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw.';
+const CURE_WOUNDS_DESC =
+  'A creature you touch regains a number of hit points equal to 1d8 + your spellcasting ability modifier.';
+
+function makeSpell(overrides: Partial<Spell>): Spell {
+  return {
+    id: `spell-${overrides.name}`,
+    name: 'Unnamed',
+    level: 1,
+    school: 'Evocation',
+    castingTime: '1 action',
+    range: '150 feet',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Instantaneous',
+    description: '',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** Build a legacy blob: current default character + spells, JSON round-tripped
+ *  so undefined keys drop exactly like localStorage persistence. */
+function makeLegacyCharacter(spells: Spell[]): CharacterState {
+  const base = useCharacterStore.getState().character;
+  return JSON.parse(JSON.stringify({ ...base, spells }));
+}
+
+describe('characterStore AoE lazy migration', () => {
+  it('back-fills aoe on legacy spells during loadCharacterState', () => {
+    const legacy = makeLegacyCharacter([
+      makeSpell({ name: 'Fireball', level: 3, description: FIREBALL_DESC }),
+      makeSpell({
+        name: 'Cure Wounds',
+        range: 'Touch',
+        description: CURE_WOUNDS_DESC,
+      }),
+    ]);
+    // sanity: legacy spells have no aoe key at all
+    expect('aoe' in legacy.spells[0]).toBe(false);
+
+    useCharacterStore.getState().loadCharacterState(legacy);
+    const spells = useCharacterStore.getState().character.spells;
+
+    expect(spells.find(s => s.name === 'Fireball')?.aoe).toEqual({
+      shape: 'circle',
+      sizeFeet: 20,
+    });
+    expect(spells.find(s => s.name === 'Cure Wounds')?.aoe).toBeNull();
+  });
+
+  it('never overwrites an explicit null (user cleared a detectable spell)', () => {
+    const legacy = makeLegacyCharacter([
+      makeSpell({
+        name: 'Fireball',
+        level: 3,
+        description: FIREBALL_DESC,
+        aoe: null,
+      }),
+    ]);
+    useCharacterStore.getState().loadCharacterState(legacy);
+    expect(
+      useCharacterStore
+        .getState()
+        .character.spells.find(s => s.name === 'Fireball')?.aoe
+    ).toBeNull();
+  });
+
+  it('never overwrites a user-set value', () => {
+    const legacy = makeLegacyCharacter([
+      makeSpell({
+        name: 'Fireball',
+        level: 3,
+        description: FIREBALL_DESC,
+        aoe: { shape: 'square', sizeFeet: 40 },
+      }),
+    ]);
+    useCharacterStore.getState().loadCharacterState(legacy);
+    expect(
+      useCharacterStore
+        .getState()
+        .character.spells.find(s => s.name === 'Fireball')?.aoe
+    ).toEqual({ shape: 'square', sizeFeet: 40 });
+  });
+});

--- a/src/store/__tests__/npcStore.test.ts
+++ b/src/store/__tests__/npcStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useNPCStore } from '@/store/npcStore';
+import { useNPCStore, migrateNpcPersistedState } from '@/store/npcStore';
 
 const CAMPAIGN = 'test-campaign';
 
@@ -530,5 +530,130 @@ describe('npcStore — longRestNPC', () => {
 
     const npc2 = useNPCStore.getState().getNPC(CAMPAIGN, id2);
     expect(npc2?.currentHp).toBe(10);
+  });
+});
+
+describe('migrateNpcPersistedState v2 → v3 (AoE back-fill)', () => {
+  const FIREBALL_DESC =
+    'Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw.';
+
+  const makeV2State = () =>
+    JSON.parse(
+      JSON.stringify({
+        npcsByCampaign: {
+          'camp-1': [
+            {
+              id: 'npc-1',
+              campaignCode: 'camp-1',
+              name: 'Cult Mage',
+              armorClass: 12,
+              maxHp: 22,
+              speed: '30 ft.',
+              createdAt: '2025-01-01T00:00:00.000Z',
+              updatedAt: '2025-01-01T00:00:00.000Z',
+              spellcasting: {
+                casterLevel: 5,
+                ability: 'intelligence',
+                slotsUsed: {},
+                spells: [
+                  {
+                    id: 'spell-fb',
+                    name: 'Fireball',
+                    level: 3,
+                    school: 'Evocation',
+                    castingTime: '1 action',
+                    range: '150 feet',
+                    components: {
+                      verbal: true,
+                      somatic: true,
+                      material: false,
+                    },
+                    duration: 'Instantaneous',
+                    description: FIREBALL_DESC,
+                    createdAt: '2025-01-01T00:00:00.000Z',
+                    updatedAt: '2025-01-01T00:00:00.000Z',
+                  },
+                  {
+                    id: 'spell-user',
+                    name: 'Custom Blast',
+                    level: 1,
+                    school: 'Evocation',
+                    castingTime: '1 action',
+                    range: '60 feet',
+                    components: {
+                      verbal: true,
+                      somatic: false,
+                      material: false,
+                    },
+                    duration: 'Instantaneous',
+                    description: FIREBALL_DESC,
+                    aoe: null, // DM explicitly cleared it
+                    createdAt: '2025-01-01T00:00:00.000Z',
+                    updatedAt: '2025-01-01T00:00:00.000Z',
+                  },
+                ],
+              },
+            },
+            {
+              id: 'npc-2',
+              campaignCode: 'camp-1',
+              name: 'Guard',
+              armorClass: 16,
+              maxHp: 11,
+              speed: '30 ft.',
+              createdAt: '2025-01-01T00:00:00.000Z',
+              updatedAt: '2025-01-01T00:00:00.000Z',
+              // no spellcasting — must not crash
+            },
+          ],
+        },
+      })
+    );
+
+  it('back-fills aoe on NPC spells when migrating from v2', () => {
+    const migrated = migrateNpcPersistedState(makeV2State(), 2) as {
+      npcsByCampaign: Record<
+        string,
+        { spellcasting?: { spells: { name: string; aoe?: unknown }[] } }[]
+      >;
+    };
+    const spells = migrated.npcsByCampaign['camp-1'][0].spellcasting!.spells;
+    expect(spells.find(s => s.name === 'Fireball')?.aoe).toEqual({
+      shape: 'circle',
+      sizeFeet: 20,
+    });
+  });
+
+  it('preserves explicit null and tolerates NPCs without spellcasting', () => {
+    const migrated = migrateNpcPersistedState(makeV2State(), 2) as {
+      npcsByCampaign: Record<
+        string,
+        { spellcasting?: { spells: { name: string; aoe?: unknown }[] } }[]
+      >;
+    };
+    const spells = migrated.npcsByCampaign['camp-1'][0].spellcasting!.spells;
+    expect(spells.find(s => s.name === 'Custom Blast')?.aoe).toBeNull();
+    expect(migrated.npcsByCampaign['camp-1'][1]).toBeDefined(); // Guard survived
+  });
+
+  it('still handles the legacy v1 flat-array shape', () => {
+    const v1 = {
+      npcs: [
+        {
+          id: 'npc-old',
+          name: 'Old Timer',
+          armorClass: 10,
+          maxHp: 5,
+          speed: '30 ft.',
+          campaignCode: 'camp-x',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+    const migrated = migrateNpcPersistedState(v1, 1) as {
+      npcsByCampaign: Record<string, { name: string }[]>;
+    };
+    expect(migrated.npcsByCampaign['camp-x']).toHaveLength(1);
   });
 });

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -58,6 +58,7 @@ import {
   getClassHitDie,
   isDead,
 } from '@/utils/hpCalculations';
+import { detectSpellAoe } from '@/utils/spellAoeDetection';
 import { usePlayerStore } from '@/store/playerStore';
 
 // Function to migrate weapon damage from old format to new array format
@@ -147,6 +148,14 @@ function migrateCharacterData(character: unknown): CharacterState {
     // Ensure spells array exists
     if (!Array.isArray(result.spells)) {
       result.spells = DEFAULT_CHARACTER_STATE.spells;
+    }
+    // Back-fill AoE template metadata for spells saved before the aoe field
+    // existed. undefined = never detected → run detection once; null or a
+    // value = already decided (by detection or the user) → never touch.
+    for (const spell of result.spells) {
+      if (spell.aoe === undefined) {
+        spell.aoe = detectSpellAoe(spell.description, spell.range);
+      }
     }
     // Ensure spellcasting stats exist
     if (

--- a/src/store/npcStore.ts
+++ b/src/store/npcStore.ts
@@ -7,6 +7,7 @@ import {
   getNPCSpellSlots,
   resetNPCSpellcasting,
 } from '@/utils/npcSpellcasting';
+import { detectSpellAoe } from '@/utils/spellAoeDetection';
 
 const NPC_STORAGE_KEY = 'rollkeeper-npc-data';
 
@@ -74,6 +75,51 @@ interface NPCStoreState {
     spellId: string
   ) => void;
   longRestNPC: (campaignCode: string, npcId: string) => void;
+}
+
+export function migrateNpcPersistedState(
+  persisted: unknown,
+  version: number
+): NPCStoreState {
+  let state: { npcsByCampaign: Record<string, CampaignNPC[]> };
+
+  if (version < 2) {
+    const old = persisted as { npcs?: CampaignNPC[] } | null;
+    const legacyNpcs = old?.npcs ?? [];
+    const npcsByCampaign: Record<string, CampaignNPC[]> = {};
+
+    for (const npc of legacyNpcs) {
+      const code =
+        (npc as CampaignNPC & { campaignCode?: string }).campaignCode ??
+        '_legacy';
+      if (!npcsByCampaign[code]) npcsByCampaign[code] = [];
+      npcsByCampaign[code].push({ ...npc, campaignCode: code });
+    }
+
+    state = { npcsByCampaign };
+  } else {
+    // Harden against a null persisted value (the old code blind-cast it)
+    state = (persisted ?? { npcsByCampaign: {} }) as {
+      npcsByCampaign: Record<string, CampaignNPC[]>;
+    };
+  }
+
+  if (version < 3) {
+    // Back-fill AoE template metadata for NPC spells saved before the aoe
+    // field existed (same undefined/null contract as character spells).
+    for (const npcs of Object.values(state.npcsByCampaign ?? {})) {
+      for (const npc of npcs) {
+        if (!npc.spellcasting) continue;
+        for (const spell of npc.spellcasting.spells) {
+          if (spell.aoe === undefined) {
+            spell.aoe = detectSpellAoe(spell.description, spell.range);
+          }
+        }
+      }
+    }
+  }
+
+  return state as NPCStoreState;
 }
 
 export const useNPCStore = create<NPCStoreState>()(
@@ -363,25 +409,8 @@ export const useNPCStore = create<NPCStoreState>()(
     {
       name: NPC_STORAGE_KEY,
       storage: createJSONStorage(() => createSafeStorage()),
-      version: 2,
-      migrate: (persisted: unknown, version: number) => {
-        if (version < 2) {
-          const old = persisted as { npcs?: CampaignNPC[] } | null;
-          const legacyNpcs = old?.npcs ?? [];
-          const npcsByCampaign: Record<string, CampaignNPC[]> = {};
-
-          for (const npc of legacyNpcs) {
-            const code =
-              (npc as CampaignNPC & { campaignCode?: string }).campaignCode ??
-              '_legacy';
-            if (!npcsByCampaign[code]) npcsByCampaign[code] = [];
-            npcsByCampaign[code].push({ ...npc, campaignCode: code });
-          }
-
-          return { npcsByCampaign };
-        }
-        return persisted as NPCStoreState;
-      },
+      version: 3,
+      migrate: migrateNpcPersistedState,
     }
   )
 );

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -28,6 +28,7 @@ export type SkillName =
 
 import type { SpellbookState } from './spells';
 import type { Summon } from './summon';
+import type { SpellAoe } from './spellAoe';
 
 // Character abilities with scores
 export interface CharacterAbilities {
@@ -280,6 +281,7 @@ export interface Spell {
   freeCastMax?: number; // 0 = at will (unlimited), 1+ = X free casts per long rest
   freeCastsUsed?: number; // how many free casts used since last long rest
   tags?: string[];
+  aoe?: SpellAoe | null; // undefined = never detected; null = no AoE (detected-none or user-cleared)
   createdAt: string;
   updatedAt: string;
 }

--- a/src/types/spellAoe.ts
+++ b/src/types/spellAoe.ts
@@ -1,0 +1,25 @@
+/**
+ * AoE template geometry for spells — the shapes the battle-map canvas renders.
+ *
+ * Mapping from 5e rules text:
+ *   sphere / radius / cylinder / hemisphere / emanation → 'circle' (sizeFeet = radius)
+ *   diameter → 'circle' (sizeFeet = diameter / 2)
+ *   cone → 'cone' (sizeFeet = length)
+ *   line → 'line' (sizeFeet = length, widthFeet defaults to 5)
+ *   wall ("up to X feet long") → 'line'
+ *   cube / square → 'square' (sizeFeet = side)
+ *
+ * NOTE — future canvas SDK shapes: when the canvas gains true cylinder
+ * (circle + height), hemisphere/dome, wall (segmented polyline with
+ * thickness), or token-attached emanation rendering, extend AoeShape and
+ * revisit this mapping. Adding enum values is backward-compatible.
+ */
+export type AoeShape = 'circle' | 'cone' | 'line' | 'square';
+
+export interface SpellAoe {
+  shape: AoeShape;
+  /** radius (circle) / length (cone, line) / side (square), in feet */
+  sizeFeet: number;
+  /** line only; defaults to 5 */
+  widthFeet?: number;
+}

--- a/src/utils/__tests__/spellAoeDetection.test.ts
+++ b/src/utils/__tests__/spellAoeDetection.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import { detectSpellAoe, aoeEquals } from '@/utils/spellAoeDetection';
+
+// Real spell prose (PHB / XPHB wordings) — these are the spec's fixture set.
+const FIREBALL =
+  'A bright streak flashes from your pointing finger to a point you choose within range and then blossoms with a low roar into an explosion of flame. Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw.';
+const LIGHTNING_BOLT =
+  'A stroke of lightning forming a line 100 feet long and 5 feet wide blasts out from you in a direction you choose.';
+const BURNING_HANDS =
+  'A thin sheet of flames shoots forth from your outstretched fingertips. Each creature in a 15-foot cone must make a Dexterity saving throw.';
+const CONE_OF_COLD =
+  'A blast of cold air erupts from your hands. Each creature in a 60-foot cone must make a Constitution saving throw.';
+const THUNDERWAVE =
+  'A wave of thunderous force sweeps out from you. Each creature in a 15-foot cube originating from you must make a Constitution saving throw.';
+const WEB =
+  'You conjure a mass of thick, sticky webbing at a point of your choice within range. The webs fill a 20-foot cube from that point for the duration.';
+const MOONBEAM =
+  'A silvery beam of pale light shines down in a 5-foot-radius, 40-foot-high cylinder centered on a point within range.';
+const SPIRIT_GUARDIANS_2014 =
+  'You call forth spirits to protect you. They flit around you to a distance of 15 feet for the duration.';
+const SPIRIT_GUARDIANS_2024 =
+  'Protective spirits flit around you in a 15-foot Emanation for the duration.';
+const WALL_OF_FIRE =
+  'You create a wall of fire on a solid surface within range. You can make the wall up to 60 feet long, 20 feet high, and 1 foot thick.';
+const SLEEP_2014 =
+  'Creatures within 20 feet of a point you choose within range are affected in ascending order of their current hit points.';
+const DARKNESS =
+  'Magical darkness spreads from a point you choose within range to fill a 15-foot-radius sphere for the duration.';
+const MAGIC_MISSILE =
+  'You create three glowing darts of magical force. Each dart hits a creature of your choice that you can see within range.';
+const CURE_WOUNDS =
+  'A creature you touch regains a number of hit points equal to 1d8 + your spellcasting ability modifier.';
+const SHIELD =
+  'An invisible barrier of magical force appears and protects you. Until the start of your next turn, you have a +5 bonus to AC.';
+
+describe('detectSpellAoe', () => {
+  it('detects radius spheres as circles (Fireball)', () => {
+    expect(detectSpellAoe(FIREBALL, '150 feet')).toEqual({
+      shape: 'circle',
+      sizeFeet: 20,
+    });
+  });
+
+  it('detects lines with explicit length and width (Lightning Bolt)', () => {
+    expect(detectSpellAoe(LIGHTNING_BOLT, 'Self')).toEqual({
+      shape: 'line',
+      sizeFeet: 100,
+      widthFeet: 5,
+    });
+  });
+
+  it('detects cones (Burning Hands, Cone of Cold)', () => {
+    expect(detectSpellAoe(BURNING_HANDS)).toEqual({
+      shape: 'cone',
+      sizeFeet: 15,
+    });
+    expect(detectSpellAoe(CONE_OF_COLD)).toEqual({
+      shape: 'cone',
+      sizeFeet: 60,
+    });
+  });
+
+  it('detects cubes as squares (Thunderwave, Web)', () => {
+    expect(detectSpellAoe(THUNDERWAVE)).toEqual({
+      shape: 'square',
+      sizeFeet: 15,
+    });
+    expect(detectSpellAoe(WEB)).toEqual({ shape: 'square', sizeFeet: 20 });
+  });
+
+  it('detects cylinders as circles by radius (Moonbeam)', () => {
+    expect(detectSpellAoe(MOONBEAM)).toEqual({ shape: 'circle', sizeFeet: 5 });
+  });
+
+  it('detects self-emanations in both 2014 and 2024 wordings (Spirit Guardians)', () => {
+    expect(detectSpellAoe(SPIRIT_GUARDIANS_2014)).toEqual({
+      shape: 'circle',
+      sizeFeet: 15,
+    });
+    expect(detectSpellAoe(SPIRIT_GUARDIANS_2024)).toEqual({
+      shape: 'circle',
+      sizeFeet: 15,
+    });
+  });
+
+  it('detects walls as lines (Wall of Fire)', () => {
+    expect(detectSpellAoe(WALL_OF_FIRE)).toEqual({
+      shape: 'line',
+      sizeFeet: 60,
+      widthFeet: 5,
+    });
+  });
+
+  it('detects point-bursts phrased as "within X feet of a point" (Sleep)', () => {
+    expect(detectSpellAoe(SLEEP_2014)).toEqual({
+      shape: 'circle',
+      sizeFeet: 20,
+    });
+  });
+
+  it('detects utility AoEs (Darkness)', () => {
+    expect(detectSpellAoe(DARKNESS)).toEqual({ shape: 'circle', sizeFeet: 15 });
+  });
+
+  it('detects bare lines with default 5 ft width', () => {
+    expect(detectSpellAoe('The spell creates a 30-foot line of acid.')).toEqual(
+      {
+        shape: 'line',
+        sizeFeet: 30,
+        widthFeet: 5,
+      }
+    );
+  });
+
+  it('halves diameters', () => {
+    expect(detectSpellAoe('fills a 40-foot-diameter sphere')).toEqual({
+      shape: 'circle',
+      sizeFeet: 20,
+    });
+  });
+
+  it('detects "each creature within X feet of you"', () => {
+    expect(
+      detectSpellAoe(
+        'Each creature within 10 feet of you takes thunder damage.'
+      )
+    ).toEqual({ shape: 'circle', sizeFeet: 10 });
+  });
+
+  it('returns null for non-AoE spells', () => {
+    expect(detectSpellAoe(MAGIC_MISSILE, '120 feet')).toBeNull();
+    expect(detectSpellAoe(CURE_WOUNDS, 'Touch')).toBeNull();
+    expect(detectSpellAoe(SHIELD, 'Self')).toBeNull();
+  });
+
+  it('strips TipTap HTML before matching', () => {
+    const html =
+      '<p>Each creature in a <strong>20-foot-radius</strong> sphere centered on that point must make a <em>Dexterity</em> saving throw.</p>';
+    expect(detectSpellAoe(html)).toEqual({ shape: 'circle', sizeFeet: 20 });
+  });
+
+  it('strips 5eTools {@...} tags before matching', () => {
+    const tagged =
+      'A creature takes {@damage 8d6} fire damage. Each creature in a 20-foot-radius sphere must save.';
+    expect(detectSpellAoe(tagged)).toEqual({ shape: 'circle', sizeFeet: 20 });
+  });
+
+  it('tolerates non-string input defensively', () => {
+    expect(detectSpellAoe(undefined)).toBeNull();
+    expect(detectSpellAoe(null, 42)).toBeNull();
+    expect(detectSpellAoe(123 as unknown)).toBeNull();
+  });
+
+  it('prefers line over circle when both appear (order of specificity)', () => {
+    const both =
+      'forming a line 100 feet long and 5 feet wide. Creatures in a 10-foot-radius glow.';
+    expect(detectSpellAoe(both)).toEqual({
+      shape: 'line',
+      sizeFeet: 100,
+      widthFeet: 5,
+    });
+  });
+});
+
+describe('aoeEquals', () => {
+  it('treats null and undefined as equal (both "no AoE")', () => {
+    expect(aoeEquals(null, null)).toBe(true);
+    expect(aoeEquals(null, undefined)).toBe(true);
+    expect(aoeEquals(undefined, undefined)).toBe(true);
+  });
+
+  it('null differs from a value', () => {
+    expect(aoeEquals(null, { shape: 'circle', sizeFeet: 20 })).toBe(false);
+    expect(aoeEquals({ shape: 'circle', sizeFeet: 20 }, null)).toBe(false);
+  });
+
+  it('compares shape and size', () => {
+    expect(
+      aoeEquals(
+        { shape: 'circle', sizeFeet: 20 },
+        { shape: 'circle', sizeFeet: 20 }
+      )
+    ).toBe(true);
+    expect(
+      aoeEquals(
+        { shape: 'circle', sizeFeet: 20 },
+        { shape: 'cone', sizeFeet: 20 }
+      )
+    ).toBe(false);
+    expect(
+      aoeEquals(
+        { shape: 'circle', sizeFeet: 20 },
+        { shape: 'circle', sizeFeet: 30 }
+      )
+    ).toBe(false);
+  });
+
+  it('treats missing widthFeet as the default 5', () => {
+    expect(
+      aoeEquals(
+        { shape: 'line', sizeFeet: 30 },
+        { shape: 'line', sizeFeet: 30, widthFeet: 5 }
+      )
+    ).toBe(true);
+    expect(
+      aoeEquals(
+        { shape: 'line', sizeFeet: 30, widthFeet: 10 },
+        { shape: 'line', sizeFeet: 30 }
+      )
+    ).toBe(false);
+  });
+});

--- a/src/utils/__tests__/spellConversion.test.ts
+++ b/src/utils/__tests__/spellConversion.test.ts
@@ -239,6 +239,7 @@ describe('convertFormDataToSpell', () => {
     castingSource: '',
     freeCastMode: 'normal',
     freeCastMax: 1,
+    aoe: null,
   };
 
   it('creates a Spell with an id', () => {
@@ -490,5 +491,83 @@ describe('spellToFormData', () => {
     const spell = makeSpell({ freeCastMax: undefined });
     const result = spellToFormData(spell);
     expect(result.freeCastMode).toBe('normal');
+  });
+});
+
+// =============================================
+// AoE metadata through the conversion pipeline
+// =============================================
+describe('AoE metadata through the conversion pipeline', () => {
+  const fireballProcessed = {
+    id: 'fireball-phb',
+    name: 'Fireball',
+    level: 3,
+    school: 'V',
+    schoolName: 'Evocation',
+    castingTime: '1 action',
+    range: '150 feet',
+    components: {
+      verbal: true,
+      somatic: true,
+      material: true,
+      materialComponent: 'bat guano',
+    },
+    duration: 'Instantaneous',
+    description:
+      'Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw. A target takes {@damage 8d6} fire damage on a failed save.',
+    concentration: false,
+    isRitual: false,
+    source: 'PHB',
+    saves: ['dexterity'],
+    damage: ['fire'],
+  } as unknown as ProcessedSpell;
+
+  it('convertProcessedSpellToFormData detects AoE from the compendium description', () => {
+    const formData = convertProcessedSpellToFormData(fireballProcessed);
+    expect(formData.aoe).toEqual({ shape: 'circle', sizeFeet: 20 });
+  });
+
+  it('createInitialSpellFormData starts with aoe null', () => {
+    expect(createInitialSpellFormData().aoe).toBeNull();
+  });
+
+  it('convertFormDataToSpell carries aoe (value and explicit null)', () => {
+    const base = createInitialSpellFormData();
+    const withAoe = convertFormDataToSpell({
+      ...base,
+      name: 'Homebrew Burst',
+      aoe: { shape: 'cone', sizeFeet: 30 },
+    });
+    expect(withAoe.aoe).toEqual({ shape: 'cone', sizeFeet: 30 });
+
+    const withoutAoe = convertFormDataToSpell({ ...base, name: 'Plain Spell' });
+    expect(withoutAoe.aoe).toBeNull(); // explicit null, never undefined
+  });
+
+  it('spellToFormData maps stored undefined to null for the form', () => {
+    const legacySpell = {
+      id: 's1',
+      name: 'Old Spell',
+      level: 1,
+      school: 'Evocation',
+      castingTime: '1 action',
+      range: 'Touch',
+      components: { verbal: true, somatic: false, material: false },
+      duration: 'Instantaneous',
+      description: 'A creature you touch regains hit points.',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    } as Spell;
+    expect(spellToFormData(legacySpell).aoe).toBeNull();
+
+    const withAoe = {
+      ...legacySpell,
+      aoe: { shape: 'line', sizeFeet: 60, widthFeet: 10 },
+    } as Spell;
+    expect(spellToFormData(withAoe).aoe).toEqual({
+      shape: 'line',
+      sizeFeet: 60,
+      widthFeet: 10,
+    });
   });
 });

--- a/src/utils/__tests__/spellConversion.test.ts
+++ b/src/utils/__tests__/spellConversion.test.ts
@@ -6,7 +6,6 @@ import {
   createInitialSpellFormData,
   spellToFormData,
   type SpellFormData,
-  type FreeCastMode,
 } from '@/utils/spellConversion';
 import type { ProcessedSpell } from '@/types/spells';
 import type { Spell } from '@/types/character';

--- a/src/utils/spellAoeDetection.ts
+++ b/src/utils/spellAoeDetection.ts
@@ -1,0 +1,94 @@
+/**
+ * Single source of AoE template detection for spells.
+ * Called from: compendium→form conversion (spellConversion.ts), live
+ * auto-fill in SpellFormFields, and the lazy migrations in characterStore
+ * and npcStore. Pure and synchronous — safe to run per keystroke and in bulk.
+ */
+import type { SpellAoe } from '@/types/spellAoe';
+
+/** Strip TipTap HTML and 5eTools {@tag value|meta} markup, collapse whitespace. */
+function normalize(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\{@\w+ ([^|}]+)(?:\|[^}]*)?\}/g, '$1')
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+export function detectSpellAoe(
+  description: unknown,
+  range?: unknown
+): SpellAoe | null {
+  const desc = typeof description === 'string' ? description : '';
+  const rng = typeof range === 'string' ? range : '';
+  if (!desc && !rng) return null;
+  const t = normalize(`${desc} ${rng}`);
+
+  // Ordered most-specific-first: line dims → wall → cone → cube → radius forms.
+  let m =
+    t.match(/line (?:that is )?(\d+) feet long and (\d+) feet wide/) ||
+    t.match(/(\d+) feet long and (\d+) feet wide/);
+  if (m) return { shape: 'line', sizeFeet: +m[1], widthFeet: +m[2] };
+
+  m = t.match(/(\d+)-foot[- ]long,? (\d+)-foot[- ]wide line/);
+  if (m) return { shape: 'line', sizeFeet: +m[1], widthFeet: +m[2] };
+
+  m = t.match(/(\d+)-foot[- ]wide,? (\d+)-foot[- ]long line/);
+  if (m) return { shape: 'line', sizeFeet: +m[2], widthFeet: +m[1] };
+
+  m = t.match(/(\d+)-foot line/);
+  if (m) return { shape: 'line', sizeFeet: +m[1], widthFeet: 5 };
+
+  m = t.match(/wall[^.]{0,80}?up to (\d+) feet long/);
+  if (m) return { shape: 'line', sizeFeet: +m[1], widthFeet: 5 };
+
+  m = t.match(/(\d+)[- ]foot cone/);
+  if (m) return { shape: 'cone', sizeFeet: +m[1] };
+
+  m = t.match(/(\d+)[- ]foot cube/);
+  if (m) return { shape: 'square', sizeFeet: +m[1] };
+
+  m = t.match(/(\d+)[- ]foot square/);
+  if (m) return { shape: 'square', sizeFeet: +m[1] };
+
+  m = t.match(/(\d+)[- ]foot[- ]radius/);
+  if (m) return { shape: 'circle', sizeFeet: +m[1] };
+
+  m = t.match(/(\d+)[- ]foot emanation/);
+  if (m) return { shape: 'circle', sizeFeet: +m[1] };
+
+  m = t.match(/(\d+)[- ]foot[- ]diameter/);
+  if (m) return { shape: 'circle', sizeFeet: Math.round(+m[1] / 2) };
+
+  m = t.match(/radius of (\d+) feet/);
+  if (m) return { shape: 'circle', sizeFeet: +m[1] };
+
+  m = t.match(
+    /(?:each|every|all) creatures? (?:of your choice )?within (\d+) feet of you/
+  );
+  if (m) return { shape: 'circle', sizeFeet: +m[1] };
+
+  m = t.match(/within (\d+) feet of (?:that|a|the) point/);
+  if (m) return { shape: 'circle', sizeFeet: +m[1] };
+
+  m = t.match(/around you to a distance of (\d+) feet/);
+  if (m) return { shape: 'circle', sizeFeet: +m[1] };
+
+  return null;
+}
+
+/**
+ * Semantic equality for AoE values. null and undefined both mean "no AoE".
+ * Missing widthFeet is treated as the default 5.
+ */
+export function aoeEquals(
+  a: SpellAoe | null | undefined,
+  b: SpellAoe | null | undefined
+): boolean {
+  if (!a || !b) return !a && !b;
+  return (
+    a.shape === b.shape &&
+    a.sizeFeet === b.sizeFeet &&
+    (a.widthFeet ?? 5) === (b.widthFeet ?? 5)
+  );
+}

--- a/src/utils/spellConversion.ts
+++ b/src/utils/spellConversion.ts
@@ -5,6 +5,8 @@
 
 import { ProcessedSpell } from '@/types/spells';
 import { Spell, SpellActionType } from '@/types/character';
+import type { SpellAoe } from '@/types/spellAoe';
+import { detectSpellAoe } from './spellAoeDetection';
 import { formatSpellDescriptionForEditor } from './referenceParser';
 
 /**
@@ -39,6 +41,8 @@ export interface SpellFormData {
   castingSource: string;
   freeCastMode: FreeCastMode;
   freeCastMax: number;
+  /** AoE template geometry. Always a value or explicit null in the form — never undefined. */
+  aoe: SpellAoe | null;
 }
 
 /**
@@ -193,6 +197,7 @@ export function convertProcessedSpellToFormData(
     castingSource: '',
     freeCastMode: 'normal',
     freeCastMax: 1,
+    aoe: detectSpellAoe(spell.description, spell.range),
   };
 }
 
@@ -240,6 +245,7 @@ export function convertFormDataToSpell(
           ? formData.freeCastMax
           : undefined,
     freeCastsUsed: formData.freeCastMode !== 'normal' ? 0 : undefined,
+    aoe: formData.aoe,
     createdAt: now,
     updatedAt: now,
   };
@@ -322,6 +328,7 @@ export function createInitialSpellFormData(): SpellFormData {
     castingSource: '',
     freeCastMode: 'normal',
     freeCastMax: 1,
+    aoe: null,
   };
 }
 
@@ -369,5 +376,6 @@ export function spellToFormData(spell: Spell): SpellFormData {
     castingSource: spell.castingSource || '',
     freeCastMode,
     freeCastMax,
+    aoe: spell.aoe ?? null,
   };
 }


### PR DESCRIPTION
## Summary

Adds structured AoE template geometry (`shape` + `sizeFeet` + optional `widthFeet`) to spells, so the upcoming player VTT can arm the template tool when an AoE spell is cast (Fireball → 20 ft radius circle, Lightning Bolt → 100×5 ft line, …).

- **`SpellAoe` type + `detectSpellAoe()` parser** — one pure regex parser detects shape/size from spell prose (strips TipTap HTML and 5eTools `{@...}` tags first). Validated against all 938 spells in `json/spells/`: 89% of officially AoE-tagged spells detected, all headline spells correct.
- **`Spell.aoe?: SpellAoe | null` contract** — `undefined` = never detected (migration may fill), `null` = no AoE / user-cleared (never touched again). Survives localStorage round-trips since `JSON.stringify` drops `undefined` but keeps `null`.
- **Form fields with silent auto-fill** — shape/size/width inputs in the shared `SpellFormFields`; detection auto-fills from description/range until the user manually edits the fields (edit-clobber guard via lazy `aoeTouched` initializer). Both the player spell dialog and NPC spell tab inherit it.
- **Sneaky migrations** — existing character spells back-fill lazily in `migrateCharacterData()` on load; NPC spells via `npcStore` persist v2→3 (migrate extracted into exported, testable `migrateNpcPersistedState`).

Spec: `docs/superpowers/specs/2026-07-08-spell-aoe-metadata-design.md` (not in this PR)

## Test plan

- [x] 21 parser unit tests (real PHB/XPHB prose fixtures, 2014+2024 wordings, HTML/tag stripping, negatives)
- [x] Conversion pipeline tests (compendium pre-fill, explicit-null on save, undefined→null on edit load)
- [x] 6 auto-fill hook tests (detect, clear, lock-on-touch, edit-clobber guard both directions)
- [x] Character + NPC migration tests (back-fill, null preserved, user values preserved, legacy v1 shape)
- [x] Full unit suite: 2427 passed / 1 pre-existing skip; type-check + lint clean
- [x] Manual dev-server check: compendium Fireball pre-fills Circle/20; homebrew cone auto-detects; manual edit locks; pre-existing character migrates; both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)