### PR TITLE
feat(campaign): instant initiative updates via relay WS poke

### DIFF
--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -15,9 +15,11 @@
       },
       "devDependencies": {
         "@types/node": "^20.14.0",
+        "@types/ws": "^8.18.1",
         "tsx": "^4.19.0",
         "typescript": "^5.5.0",
-        "vitest": "^3.0.0"
+        "vitest": "^3.0.0",
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=20"
@@ -939,6 +941,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {

--- a/relay/package.json
+++ b/relay/package.json
@@ -21,8 +21,10 @@
   },
   "devDependencies": {
     "@types/node": "^20.14.0",
+    "@types/ws": "^8.18.1",
     "tsx": "^4.19.0",
     "typescript": "^5.5.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "ws": "^8.21.0"
   }
 }

--- a/relay/src/poke.test.ts
+++ b/relay/src/poke.test.ts
@@ -1,18 +1,30 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { SyncHub } from '@fieldnotes/sync-server';
+import WebSocket from 'ws';
 import { pokeRoom, handlePokeRequest } from './poke.js';
 import { signBattleMapToken } from './token.js';
+import { startRelay, type RelayHandle } from './server.js';
 
 const SECRET = 'test-secret';
 const ROOM = 'CAMP1:map-42';
 
+/** Mirrors the real `SyncHub` shape: `rooms` maps room -> connection ids,
+ * and the actual connection objects (with `send`) live in `conns`. */
 function fakeHub(rooms: Record<string, { send: (m: string) => void }[]>) {
-  const map = new Map<string, Set<{ send: (m: string) => void }>>();
-  for (const [room, conns] of Object.entries(rooms)) {
-    map.set(room, new Set(conns));
+  const conns = new Map<string, { send: (m: string) => void }>();
+  const roomMap = new Map<string, Set<string>>();
+  let counter = 0;
+  for (const [room, list] of Object.entries(rooms)) {
+    const ids = new Set<string>();
+    for (const conn of list) {
+      const id = `c${++counter}`;
+      conns.set(id, conn);
+      ids.add(id);
+    }
+    roomMap.set(room, ids);
   }
-  return { rooms: map } as unknown as SyncHub;
+  return { rooms: roomMap, conns } as unknown as SyncHub;
 }
 
 /** Minimal async-iterable POST request carrying a JSON body. */
@@ -157,5 +169,72 @@ describe('handlePokeRequest', () => {
     const res = fakeRes();
     await handlePokeRequest(fakeHub({}), SECRET, fakeReq('', 'GET'), res);
     expect(res.statusCode).toBe(405);
+  });
+});
+
+describe('poke integration (real relay)', () => {
+  let handle: RelayHandle | null = null;
+  let socket: WebSocket | null = null;
+
+  afterEach(async () => {
+    socket?.close();
+    socket = null;
+    await handle?.close();
+    handle = null;
+  });
+
+  it('delivers a real poke to a live websocket connection in the room', async () => {
+    handle = await startRelay({ secret: SECRET, port: 0 });
+    const port = handle.address().port;
+
+    const playerToken = signBattleMapToken(
+      { userId: 'p1', role: 'player', room: ROOM, exp: Date.now() + 30_000 },
+      SECRET
+    );
+    const wsUrl = `ws://127.0.0.1:${port}?room=${encodeURIComponent(
+      ROOM
+    )}&token=${encodeURIComponent(playerToken)}`;
+    socket = new WebSocket(wsUrl);
+
+    const messages: string[] = [];
+    socket.on('message', data => {
+      messages.push(data.toString());
+    });
+
+    await vi.waitFor(() => {
+      expect(socket?.readyState).toBe(WebSocket.OPEN);
+    });
+
+    // The hub registers the connection asynchronously after the WS upgrade
+    // (authenticate resolves via a microtask), so retry the poke until the
+    // relay reports the connection as a room member.
+    await vi.waitFor(async () => {
+      const response = await fetch(`http://127.0.0.1:${port}/poke`, {
+        method: 'POST',
+        body: JSON.stringify({
+          room: ROOM,
+          feature: 'initiative',
+          token: dmToken(),
+        }),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ sent: 1 });
+    });
+
+    await vi.waitFor(() => {
+      const pokeMessage = messages
+        .map(m => JSON.parse(m) as unknown)
+        .find(
+          (m): m is { from: string; op: { kind: string; data: unknown } } =>
+            typeof m === 'object' &&
+            m !== null &&
+            (m as { op?: { data?: { kind?: unknown } } }).op?.data?.kind ===
+              'poke'
+        );
+      expect(pokeMessage).toEqual({
+        from: '@poke',
+        op: { kind: 'presence', data: { kind: 'poke', feature: 'initiative' } },
+      });
+    });
   });
 });

--- a/relay/src/poke.test.ts
+++ b/relay/src/poke.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { SyncHub } from '@fieldnotes/sync-server';
+import { pokeRoom, handlePokeRequest } from './poke.js';
+import { signBattleMapToken } from './token.js';
+
+const SECRET = 'test-secret';
+const ROOM = 'CAMP1:map-42';
+
+function fakeHub(rooms: Record<string, { send: (m: string) => void }[]>) {
+  const map = new Map<string, Set<{ send: (m: string) => void }>>();
+  for (const [room, conns] of Object.entries(rooms)) {
+    map.set(room, new Set(conns));
+  }
+  return { rooms: map } as unknown as SyncHub;
+}
+
+/** Minimal async-iterable POST request carrying a JSON body. */
+function fakeReq(body: string, method = 'POST'): IncomingMessage {
+  return {
+    method,
+    async *[Symbol.asyncIterator]() {
+      yield Buffer.from(body);
+    },
+  } as unknown as IncomingMessage;
+}
+
+function fakeRes() {
+  const res = {
+    statusCode: 0,
+    body: '',
+    writeHead(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    end(chunk?: string) {
+      if (chunk) res.body = chunk;
+    },
+  };
+  return res as typeof res & ServerResponse;
+}
+
+function dmToken(room = ROOM, exp = Date.now() + 30_000) {
+  return signBattleMapToken(
+    { userId: '@server', role: 'dm', room, exp },
+    SECRET
+  );
+}
+
+describe('pokeRoom', () => {
+  it('sends the poke envelope to every connection in the room', () => {
+    const a = { send: vi.fn() };
+    const b = { send: vi.fn() };
+    const hub = fakeHub({ [ROOM]: [a, b] });
+
+    const sent = pokeRoom(hub, ROOM, 'initiative');
+
+    expect(sent).toBe(2);
+    const expected = JSON.stringify({
+      from: '@poke',
+      op: { kind: 'presence', data: { kind: 'poke', feature: 'initiative' } },
+    });
+    expect(a.send).toHaveBeenCalledWith(expected);
+    expect(b.send).toHaveBeenCalledWith(expected);
+  });
+
+  it('returns 0 for an empty or unknown room', () => {
+    const hub = fakeHub({});
+    expect(pokeRoom(hub, ROOM, 'initiative')).toBe(0);
+  });
+
+  it('survives a connection whose send throws (dead socket)', () => {
+    const dead = {
+      send: vi.fn(() => {
+        throw new Error('EPIPE');
+      }),
+    };
+    const alive = { send: vi.fn() };
+    const hub = fakeHub({ [ROOM]: [dead, alive] });
+    expect(pokeRoom(hub, ROOM, 'initiative')).toBe(1);
+    expect(alive.send).toHaveBeenCalled();
+  });
+});
+
+describe('handlePokeRequest', () => {
+  it('broadcasts and returns 200 {sent} for a valid dm token', async () => {
+    const conn = { send: vi.fn() };
+    const hub = fakeHub({ [ROOM]: [conn] });
+    const res = fakeRes();
+    const body = JSON.stringify({
+      room: ROOM,
+      feature: 'initiative',
+      token: dmToken(),
+    });
+
+    await handlePokeRequest(hub, SECRET, fakeReq(body), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ sent: 1 });
+    expect(conn.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a token for a different room', async () => {
+    const hub = fakeHub({ [ROOM]: [{ send: vi.fn() }] });
+    const res = fakeRes();
+    const body = JSON.stringify({
+      room: ROOM,
+      feature: 'initiative',
+      token: dmToken('CAMP1:other-map'),
+    });
+    await handlePokeRequest(hub, SECRET, fakeReq(body), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a non-dm role token', async () => {
+    const hub = fakeHub({ [ROOM]: [{ send: vi.fn() }] });
+    const res = fakeRes();
+    const token = signBattleMapToken(
+      { userId: 'p1', role: 'player', room: ROOM, exp: Date.now() + 30_000 },
+      SECRET
+    );
+    const body = JSON.stringify({ room: ROOM, feature: 'initiative', token });
+    await handlePokeRequest(hub, SECRET, fakeReq(body), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects an expired token', async () => {
+    const hub = fakeHub({ [ROOM]: [{ send: vi.fn() }] });
+    const res = fakeRes();
+    const body = JSON.stringify({
+      room: ROOM,
+      feature: 'initiative',
+      token: dmToken(ROOM, Date.now() - 1),
+    });
+    await handlePokeRequest(hub, SECRET, fakeReq(body), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects malformed JSON with 400', async () => {
+    const res = fakeRes();
+    await handlePokeRequest(fakeHub({}), SECRET, fakeReq('{nope'), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects missing fields with 400', async () => {
+    const res = fakeRes();
+    await handlePokeRequest(
+      fakeHub({}),
+      SECRET,
+      fakeReq(JSON.stringify({ room: ROOM })),
+      res
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects non-POST with 405', async () => {
+    const res = fakeRes();
+    await handlePokeRequest(fakeHub({}), SECRET, fakeReq('', 'GET'), res);
+    expect(res.statusCode).toBe(405);
+  });
+});

--- a/relay/src/poke.ts
+++ b/relay/src/poke.ts
@@ -20,6 +20,7 @@ interface HubInternals {
  * sender connection — neither applies to a server-originated poke.
  * The sync client's presence dispatch is stateless, so `from: '@poke'`
  * pollutes no client-side bookkeeping.
+ * NOTE: broadcasts only to locally-connected sockets (bypasses hub fanout) — fine for single-instance deploy; revisit if relay runs multiple instances.
  */
 export function pokeRoom(hub: SyncHub, room: string, feature: string): number {
   const internals = hub as unknown as HubInternals;

--- a/relay/src/poke.ts
+++ b/relay/src/poke.ts
@@ -1,0 +1,95 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { SyncHub } from '@fieldnotes/sync-server';
+import { verifyBattleMapToken } from './token.js';
+
+/** Narrow structural view of the hub's private room registry — same
+ * private-access pattern as `corrections.ts`. Connections only need `send`. */
+interface RoomConnection {
+  send(message: string): void;
+}
+interface HubWithRooms {
+  rooms: Map<string, Set<RoomConnection>>;
+}
+
+/**
+ * Broadcasts a content-free poke to every socket in a room as a synthetic
+ * presence message. Bypasses `broadcastPresence` deliberately: that method
+ * records `presenceIds` (driving presence-leave on disconnect) and skips the
+ * sender connection — neither applies to a server-originated poke.
+ * The sync client's presence dispatch is stateless, so `from: '@poke'`
+ * pollutes no client-side bookkeeping.
+ */
+export function pokeRoom(hub: SyncHub, room: string, feature: string): number {
+  const rooms = (hub as unknown as HubWithRooms).rooms;
+  const members = rooms.get(room);
+  if (!members || members.size === 0) return 0;
+  const message = JSON.stringify({
+    from: '@poke',
+    op: { kind: 'presence', data: { kind: 'poke', feature } },
+  });
+  let sent = 0;
+  for (const conn of members) {
+    try {
+      conn.send(message);
+      sent++;
+    } catch {
+      // dead socket — the heartbeat reaps it; poke is best-effort
+    }
+  }
+  return sent;
+}
+
+const MAX_BODY_BYTES = 4096;
+
+/**
+ * HTTP handler for `POST /poke` — server-to-server, authenticated with a
+ * short-lived dm-role battlemap token whose `room` must match the target.
+ */
+export async function handlePokeRequest(
+  hub: SyncHub,
+  secret: string,
+  req: IncomingMessage,
+  res: ServerResponse
+): Promise<void> {
+  if (req.method !== 'POST') {
+    res.writeHead(405);
+    res.end();
+    return;
+  }
+  let raw = '';
+  for await (const chunk of req) {
+    raw += chunk;
+    if (raw.length > MAX_BODY_BYTES) {
+      res.writeHead(413);
+      res.end();
+      return;
+    }
+  }
+  let body: { room?: unknown; feature?: unknown; token?: unknown };
+  try {
+    body = JSON.parse(raw) as typeof body;
+  } catch {
+    res.writeHead(400);
+    res.end();
+    return;
+  }
+  const { room, feature, token } = body;
+  if (
+    typeof room !== 'string' ||
+    typeof feature !== 'string' ||
+    typeof token !== 'string'
+  ) {
+    res.writeHead(400);
+    res.end();
+    return;
+  }
+  const payload = verifyBattleMapToken(token, secret);
+  if (!payload || payload.room !== room || payload.role !== 'dm') {
+    res.writeHead(401);
+    res.end();
+    return;
+  }
+  const sent = pokeRoom(hub, room, feature);
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify({ sent }));
+}

--- a/relay/src/poke.ts
+++ b/relay/src/poke.ts
@@ -2,13 +2,15 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { SyncHub } from '@fieldnotes/sync-server';
 import { verifyBattleMapToken } from './token.js';
 
-/** Narrow structural view of the hub's private room registry — same
- * private-access pattern as `corrections.ts`. Connections only need `send`. */
+/** Narrow structural view of the hub's private registries — same
+ * private-access pattern as `corrections.ts`. `rooms` maps room -> connection
+ * ids; the actual connection objects (with `send`) live in `conns`. */
 interface RoomConnection {
   send(message: string): void;
 }
-interface HubWithRooms {
-  rooms: Map<string, Set<RoomConnection>>;
+interface HubInternals {
+  rooms: Map<string, Set<string>>;
+  conns: Map<string, RoomConnection>;
 }
 
 /**
@@ -20,20 +22,23 @@ interface HubWithRooms {
  * pollutes no client-side bookkeeping.
  */
 export function pokeRoom(hub: SyncHub, room: string, feature: string): number {
-  const rooms = (hub as unknown as HubWithRooms).rooms;
-  const members = rooms.get(room);
-  if (!members || members.size === 0) return 0;
+  const internals = hub as unknown as HubInternals;
+  const memberIds = internals.rooms.get(room);
+  if (!memberIds || memberIds.size === 0) return 0;
   const message = JSON.stringify({
     from: '@poke',
     op: { kind: 'presence', data: { kind: 'poke', feature } },
   });
   let sent = 0;
-  for (const conn of members) {
+  for (const id of memberIds) {
+    const conn = internals.conns.get(id);
+    if (!conn) continue;
     try {
       conn.send(message);
       sent++;
-    } catch {
+    } catch (err) {
       // dead socket — the heartbeat reaps it; poke is best-effort
+      console.warn('[poke] send failed:', err);
     }
   }
   return sent;
@@ -56,15 +61,19 @@ export async function handlePokeRequest(
     res.end();
     return;
   }
-  let raw = '';
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
   for await (const chunk of req) {
-    raw += chunk;
-    if (raw.length > MAX_BODY_BYTES) {
+    const buf = chunk as Buffer;
+    totalBytes += buf.length;
+    if (totalBytes > MAX_BODY_BYTES) {
       res.writeHead(413);
       res.end();
       return;
     }
+    chunks.push(buf);
   }
+  const raw = Buffer.concat(chunks).toString('utf8');
   let body: { room?: unknown; feature?: unknown; token?: unknown };
   try {
     body = JSON.parse(raw) as typeof body;

--- a/relay/src/server.ts
+++ b/relay/src/server.ts
@@ -6,6 +6,7 @@ import type { HubBackend, SyncHub } from '@fieldnotes/sync-server';
 import { makePolicies } from './policies.js';
 import { BufferedRedisBackend } from './backend.js';
 import { patchSendCorrectionLeak } from './corrections.js';
+import { handlePokeRequest } from './poke.js';
 
 export interface StartRelayOptions {
   secret: string;
@@ -28,10 +29,22 @@ export interface RelayHandle {
 export async function startRelay(
   opts: StartRelayOptions
 ): Promise<RelayHandle> {
+  let pokeHandler:
+    | ((req: http.IncomingMessage, res: http.ServerResponse) => void)
+    | null = null;
   const server = http.createServer((req, res) => {
     if (req.url === '/healthz') {
       res.writeHead(200, { 'content-type': 'text/plain' });
       res.end('ok');
+      return;
+    }
+    if (req.url === '/poke') {
+      if (pokeHandler) {
+        pokeHandler(req, res);
+      } else {
+        res.writeHead(503);
+        res.end();
+      }
       return;
     }
     res.writeHead(404);
@@ -46,6 +59,13 @@ export async function startRelay(
   });
   // Upstream sendCorrection leak — see corrections.ts.
   patchSendCorrectionLeak(hub, policies.canRead);
+
+  pokeHandler = (req, res) =>
+    void handlePokeRequest(hub, opts.secret, req, res).catch(err => {
+      console.error('[poke]', err);
+      if (!res.headersSent) res.writeHead(500);
+      res.end();
+    });
 
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);

--- a/src/app/api/campaign/[code]/shared/route.ts
+++ b/src/app/api/campaign/[code]/shared/route.ts
@@ -10,6 +10,7 @@ import {
   SLIDING_TTL_SECONDS,
 } from '@/lib/redis';
 import { verifyDmAuthority } from '@/lib/dmAuth';
+import { sendInitiativePoke } from '@/lib/relayPoke';
 import type {
   DmMessage,
   DmEffect,
@@ -280,13 +281,20 @@ export async function POST(
       return NextResponse.json({ success: true });
     }
 
-    // Default: store as shared feature key (calendar, etc.)
+    // Default: store as shared feature key (calendar, initiative, etc.)
     await Promise.all([
       redis.set(campaignSharedKey(code, feature), JSON.stringify(data), {
         ex: SLIDING_TTL_SECONDS,
       }),
       refreshCampaignTTL(redis, code),
     ]);
+
+    // Latency shave: nudge connected battle-map clients to refetch now.
+    // Awaited (serverless may drop un-awaited work) but never throws; the
+    // adaptive poll remains the guarantee.
+    if (feature === 'initiative') {
+      await sendInitiativePoke(code, redis);
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/hooks/__tests__/useSharedCampaignState.refetch.test.ts
+++ b/src/hooks/__tests__/useSharedCampaignState.refetch.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSharedCampaignState } from '@/hooks/useSharedCampaignState';
+
+const EMPTY_STATE = {
+  calendar: null,
+  messages: [],
+  dmEffects: [],
+  customCounter: null,
+  transfers: [],
+  initiative: null,
+  battleMap: null,
+};
+
+describe('useSharedCampaignState.refetchNow', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn(async () => new Response(JSON.stringify(EMPTY_STATE)));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('triggers an immediate fetch, debounced to one per second', async () => {
+    const { result, unmount } = renderHook(() =>
+      useSharedCampaignState('CAMP1', 'player-1')
+    );
+    // initial mount fetch
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const baseline = fetchMock.mock.calls.length;
+    expect(baseline).toBeGreaterThanOrEqual(1);
+
+    act(() => {
+      result.current.refetchNow();
+      result.current.refetchNow(); // within the same second — swallowed
+      result.current.refetchNow();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock.mock.calls.length).toBe(baseline + 1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100);
+    });
+    const afterCooldown = fetchMock.mock.calls.length;
+    act(() => {
+      result.current.refetchNow();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock.mock.calls.length).toBe(afterCooldown + 1);
+
+    unmount();
+  });
+});

--- a/src/hooks/useSharedCampaignState.ts
+++ b/src/hooks/useSharedCampaignState.ts
@@ -22,6 +22,8 @@ interface UseSharedCampaignStateResult {
   acknowledgeTransfers: () => Promise<void>;
   pendingTransfers: ItemTransfer[];
   clearPendingTransfer: (transferId: string) => void;
+  /** Immediate refetch (e.g. on a relay poke). Debounced: at most one per second. */
+  refetchNow: () => void;
 }
 
 export function useSharedCampaignState(
@@ -87,6 +89,15 @@ export function useSharedCampaignState(
       setLoading(false);
     }
   }, [campaignCode, playerId]);
+
+  const REFETCH_DEBOUNCE_MS = 1000;
+  const lastRefetchNowRef = useRef(0);
+  const refetchNow = useCallback(() => {
+    const now = Date.now();
+    if (now - lastRefetchNowRef.current < REFETCH_DEBOUNCE_MS) return;
+    lastRefetchNowRef.current = now;
+    fetchSharedState();
+  }, [fetchSharedState]);
 
   const startPolling = useCallback(() => {
     stopPolling();
@@ -250,5 +261,6 @@ export function useSharedCampaignState(
     acknowledgeTransfers,
     pendingTransfers,
     clearPendingTransfer,
+    refetchNow,
   };
 }

--- a/src/lib/__tests__/battlemapSync.poke.test.ts
+++ b/src/lib/__tests__/battlemapSync.poke.test.ts
@@ -75,6 +75,7 @@ describe('managed connection onPoke', () => {
       add: () => {},
       update: () => {},
       subscribe: () => () => {},
+      on: () => () => {},
     } as unknown as ElementStore;
 
     const conn = createManagedBattleMapConnection({

--- a/src/lib/__tests__/battlemapSync.poke.test.ts
+++ b/src/lib/__tests__/battlemapSync.poke.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createManagedBattleMapConnection,
+  pokeFeatureFromEnvelope,
+  type BattleMapTransport,
+} from '@/lib/battlemapSync';
+import type { ElementStore } from '@fieldnotes/core';
+
+const POKE_RAW = JSON.stringify({
+  from: '@poke',
+  op: { kind: 'presence', data: { kind: 'poke', feature: 'initiative' } },
+});
+
+describe('pokeFeatureFromEnvelope', () => {
+  it('extracts the feature from a poke envelope', () => {
+    expect(pokeFeatureFromEnvelope(POKE_RAW)).toBe('initiative');
+  });
+
+  it('returns null for non-poke senders, other ops, and junk', () => {
+    expect(
+      pokeFeatureFromEnvelope(
+        JSON.stringify({
+          from: 'user-1',
+          op: { kind: 'presence', data: { kind: 'poke', feature: 'x' } },
+        })
+      )
+    ).toBeNull();
+    expect(
+      pokeFeatureFromEnvelope(
+        JSON.stringify({ from: '@poke', op: { kind: 'upsert' } })
+      )
+    ).toBeNull();
+    expect(pokeFeatureFromEnvelope('not json')).toBeNull();
+    expect(
+      pokeFeatureFromEnvelope(
+        JSON.stringify({ from: '@poke', op: { kind: 'presence', data: {} } })
+      )
+    ).toBeNull();
+  });
+});
+
+describe('managed connection onPoke', () => {
+  let messageHandlers: Array<(raw: string) => void>;
+
+  function fakeTransport(): BattleMapTransport {
+    return {
+      send: vi.fn(),
+      onMessage: (h: (raw: string) => void) => {
+        messageHandlers.push(h);
+        return () => {};
+      },
+      onReconnect: () => () => {},
+      onClose: () => () => {},
+      close: vi.fn(),
+    } as unknown as BattleMapTransport;
+  }
+
+  beforeEach(() => {
+    messageHandlers = [];
+    // mintBattleMapToken fetches the token route — stub it to succeed.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ token: 'tok' })))
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('invokes onPoke for poke envelopes and ignores everything else', async () => {
+    const onPoke = vi.fn();
+    const store = {
+      snapshot: () => [],
+      getById: () => undefined,
+      add: () => {},
+      update: () => {},
+      subscribe: () => () => {},
+    } as unknown as ElementStore;
+
+    const conn = createManagedBattleMapConnection({
+      relayUrl: 'wss://relay.test',
+      campaignCode: 'CAMP1',
+      battleMapId: 'map-42',
+      store,
+      clientId: 'char-1',
+      tokenRequest: {
+        role: 'player',
+        battleMapId: 'map-42',
+        playerId: 'char-1',
+      },
+      transportFactory: () => fakeTransport(),
+      onPoke,
+    });
+
+    // connect() is async (token mint) — wait for the transport to be built.
+    await vi.waitFor(() => expect(messageHandlers.length).toBeGreaterThan(0));
+
+    for (const h of messageHandlers) h(POKE_RAW);
+    expect(onPoke).toHaveBeenCalledWith('initiative');
+    expect(onPoke).toHaveBeenCalledTimes(1); // only one listener fires it
+
+    onPoke.mockClear();
+    for (const h of messageHandlers)
+      h(JSON.stringify({ from: 'u1', op: { kind: 'upsert', elements: [] } }));
+    expect(onPoke).not.toHaveBeenCalled();
+
+    conn.stop();
+  });
+});

--- a/src/lib/__tests__/relayPoke.test.ts
+++ b/src/lib/__tests__/relayPoke.test.ts
@@ -18,11 +18,14 @@ function redisWith(battlemapValue: unknown): MockRedis {
 }
 
 describe('relayHttpUrl', () => {
-  it('converts ws(s) scheme to http(s)', () => {
+  it('converts ws(s) scheme to http(s) and strips trailing slash', () => {
     expect(relayHttpUrl('wss://relay.example.com')).toBe(
       'https://relay.example.com'
     );
     expect(relayHttpUrl('ws://localhost:8787')).toBe('http://localhost:8787');
+    expect(relayHttpUrl('wss://relay.example.com/')).toBe(
+      'https://relay.example.com'
+    );
   });
 });
 

--- a/src/lib/__tests__/relayPoke.test.ts
+++ b/src/lib/__tests__/relayPoke.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sendInitiativePoke, relayHttpUrl } from '@/lib/relayPoke';
+import { verifyBattleMapToken } from '@/lib/battlemapToken';
+
+const CODE = 'CAMP1';
+const SECRET = 'test-secret';
+
+interface MockRedis {
+  get<T = unknown>(key: string): Promise<T | null>;
+}
+
+function redisWith(battlemapValue: unknown): MockRedis {
+  return {
+    get: vi.fn(async (key: string) =>
+      key.includes('battlemap') ? battlemapValue : null
+    ) as <T = unknown>(key: string) => Promise<T | null>,
+  };
+}
+
+describe('relayHttpUrl', () => {
+  it('converts ws(s) scheme to http(s)', () => {
+    expect(relayHttpUrl('wss://relay.example.com')).toBe(
+      'https://relay.example.com'
+    );
+    expect(relayHttpUrl('ws://localhost:8787')).toBe('http://localhost:8787');
+  });
+});
+
+describe('sendInitiativePoke', () => {
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_BATTLEMAP_RELAY_URL', 'wss://relay.example.com');
+    vi.stubEnv('BATTLEMAP_RELAY_SECRET', SECRET);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('POSTs a valid dm token for the active map room', async () => {
+    const fetchFn = vi.fn(async () => new Response('{"sent":1}'));
+    const redis = redisWith(
+      JSON.stringify({ activeBattleMapId: 'map-42', activatedAt: 'x' })
+    );
+
+    await sendInitiativePoke(CODE, redis, { fetchFn, now: 1_000_000 });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const call = fetchFn.mock.calls[0];
+    if (!call || call.length < 2) {
+      throw new Error('fetchFn not called with expected arguments');
+    }
+    const [url, init] = call as unknown as [string, RequestInit];
+    expect(url).toBe('https://relay.example.com/poke');
+    const body = JSON.parse(init.body as string);
+    expect(body.room).toBe('CAMP1:map-42');
+    expect(body.feature).toBe('initiative');
+    const payload = verifyBattleMapToken(body.token, SECRET, 1_000_000);
+    expect(payload).toMatchObject({ role: 'dm', room: 'CAMP1:map-42' });
+  });
+
+  it('does nothing when no battle map is active', async () => {
+    const fetchFn = vi.fn();
+    await sendInitiativePoke(CODE, redisWith(null), { fetchFn });
+    expect(fetchFn).not.toHaveBeenCalled();
+
+    await sendInitiativePoke(
+      CODE,
+      redisWith(JSON.stringify({ activeBattleMapId: null })),
+      { fetchFn }
+    );
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when env vars are missing', async () => {
+    vi.stubEnv('NEXT_PUBLIC_BATTLEMAP_RELAY_URL', '');
+    vi.stubEnv('BATTLEMAP_RELAY_SECRET', '');
+    const fetchFn = vi.fn();
+    await sendInitiativePoke(CODE, redisWith('{"activeBattleMapId":"m"}'), {
+      fetchFn,
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('swallows fetch failures (poll remains the fallback)', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('relay down');
+    });
+    const redis = redisWith(JSON.stringify({ activeBattleMapId: 'map-42' }));
+    await expect(
+      sendInitiativePoke(CODE, redis, { fetchFn })
+    ).resolves.toBeUndefined();
+  });
+
+  it('tolerates an already-parsed battlemap object (Upstash may return objects)', async () => {
+    const fetchFn = vi.fn(async () => new Response('{"sent":0}'));
+    const redis = redisWith({ activeBattleMapId: 'map-42' });
+    await sendInitiativePoke(CODE, redis, { fetchFn });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/battlemapSync.ts
+++ b/src/lib/battlemapSync.ts
@@ -42,6 +42,23 @@ export function computeSeedIds(
   return local.filter(el => !presentIds.has(el.id)).map(el => el.id);
 }
 
+/** Parses a relay poke envelope: `{from:'@poke', op:{kind:'presence', data:{kind:'poke', feature}}}`. */
+export function pokeFeatureFromEnvelope(raw: string): string | null {
+  let env: {
+    from?: string;
+    op?: { kind?: string; data?: { kind?: string; feature?: unknown } };
+  };
+  try {
+    env = JSON.parse(raw) as typeof env;
+  } catch {
+    return null;
+  }
+  if (env?.from !== '@poke') return null;
+  const op = env.op;
+  if (op?.kind !== 'presence' || op.data?.kind !== 'poke') return null;
+  return typeof op.data.feature === 'string' ? op.data.feature : null;
+}
+
 /** Transport surface the connection manager relies on (WebSocketTransport-compatible). */
 export type BattleMapTransport = Pick<
   WebSocketTransport,
@@ -60,6 +77,8 @@ export interface ManagedConnectionOptions {
   /** DM only: push local elements missing from each snapshot. */
   seedLocal?: boolean;
   onStatus?: (s: BattleMapConnectionStatus) => void;
+  /** Fires when the relay pokes this room (e.g. initiative changed → refetch /shared). */
+  onPoke?: (feature: string) => void;
   /** DI seam for tests; defaults to `url => new WebSocketTransport(url)`. */
   transportFactory?: (url: string) => BattleMapTransport;
 }
@@ -161,6 +180,13 @@ export function createManagedBattleMapConnection(
       }
     });
 
+    const unsubPoke = opts.onPoke
+      ? t.onMessage(raw => {
+          const feature = pokeFeatureFromEnvelope(raw);
+          if (feature) opts.onPoke!(feature);
+        })
+      : null;
+
     t.onReconnect(() => {
       if (!stopped) opts.onStatus?.('live');
     });
@@ -170,6 +196,7 @@ export function createManagedBattleMapConnection(
       if (code >= 4000 && code <= 4999) {
         // transport is now terminated — rebuild with a fresh token
         unsubMsg();
+        unsubPoke?.();
         client?.stop();
         client = null;
         transport = null;

--- a/src/lib/relayPoke.ts
+++ b/src/lib/relayPoke.ts
@@ -1,0 +1,59 @@
+import { signBattleMapToken } from '@/lib/battlemapToken';
+import { campaignSharedKey } from '@/lib/redis';
+
+import type { SharedBattleMapState } from '@/types/sharedState';
+
+const POKE_TOKEN_TTL_MS = 30_000;
+const POKE_TIMEOUT_MS = 2_000;
+
+export function relayHttpUrl(wsUrl: string): string {
+  return wsUrl.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
+}
+
+interface RedisReader {
+  get<T = unknown>(key: string): Promise<T | null>;
+}
+
+/**
+ * Best-effort WS poke after an initiative write: tells clients in the active
+ * battle-map room to refetch /shared immediately. Never throws — the 5s poll
+ * is the source-of-truth fallback; this only shaves latency.
+ */
+export async function sendInitiativePoke(
+  code: string,
+  redis: RedisReader,
+  deps: { fetchFn?: typeof fetch; now?: number } = {}
+): Promise<void> {
+  const relayUrl = process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
+  const secret = process.env.BATTLEMAP_RELAY_SECRET;
+  if (!relayUrl || !secret) return;
+  try {
+    const raw = await redis.get<string | SharedBattleMapState>(
+      campaignSharedKey(code, 'battlemap')
+    );
+    if (!raw) return;
+    const battleMap: SharedBattleMapState =
+      typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (!battleMap?.activeBattleMapId) return;
+
+    const room = `${code}:${battleMap.activeBattleMapId}`;
+    const token = signBattleMapToken(
+      {
+        userId: '@server',
+        role: 'dm',
+        room,
+        exp: (deps.now ?? Date.now()) + POKE_TOKEN_TTL_MS,
+      },
+      secret
+    );
+    const fetchFn = deps.fetchFn ?? fetch;
+    await fetchFn(`${relayHttpUrl(relayUrl)}/poke`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ room, feature: 'initiative', token }),
+      signal: AbortSignal.timeout(POKE_TIMEOUT_MS),
+    });
+  } catch (err) {
+    console.warn('[relayPoke] poke failed (poll remains fallback):', err);
+  }
+}

--- a/src/lib/relayPoke.ts
+++ b/src/lib/relayPoke.ts
@@ -7,7 +7,10 @@ const POKE_TOKEN_TTL_MS = 30_000;
 const POKE_TIMEOUT_MS = 2_000;
 
 export function relayHttpUrl(wsUrl: string): string {
-  return wsUrl.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:');
+  return wsUrl
+    .replace(/^wss:/, 'https:')
+    .replace(/^ws:/, 'http:')
+    .replace(/\/$/, '');
 }
 
 interface RedisReader {


### PR DESCRIPTION
## Summary

When the DM pushes initiative state, battle-map clients now learn about it in ~0ms via a WebSocket poke instead of waiting for the 5s poll. **Redis + adaptive polling stay untouched as the source of truth and fallback** — the poke is pure latency acceleration; every failure path (relay down, no active map, missing env) degrades silently to the poll.

- **Relay `POST /poke`** — HMAC dm-token auth (room-scoped, 30s expiry), broadcasts a content-free `{kind:'poke', feature}` presence message to the room. Byte-accurate body guard. Proven by a real-WebSocket integration test through `startRelay` (caught a genuine bug: the hub's `rooms` map holds conn-ids, not connection objects — resolved through the `conns` map).
- **`sendInitiativePoke`** (`src/lib/relayPoke.ts`) — called from the `/shared` POST route after initiative writes; reads `activeBattleMapId` server-side from Redis (never from the client payload), 2s timeout, never throws, never fails the DM's push.
- **`onPoke` callback** on `createManagedBattleMapConnection` + `pokeFeatureFromEnvelope` parser — optional, zero behavior change for existing consumers.
- **`refetchNow()`** on `useSharedCampaignState` — immediate refetch, debounced to 1/s.

No game data travels in the poke — masked state still comes from `/shared`. No new env vars (HTTP URL derived from `NEXT_PUBLIC_BATTLEMAP_RELAY_URL`).

The two client ends (`onPoke` → `refetchNow`) get connected on the player VTT screen (next feature); until then this is inert-but-tested capability. **Deploy note:** relay change ships to Railway with this merge.

Spec: `docs/superpowers/specs/2026-07-08-player-vtt-design.md` §3 (untracked)

## Test plan

- [x] 11 relay poke tests incl. end-to-end integration (real relay + real WS + real tokens asserting the exact wire envelope)
- [x] 6 sender tests (token validity, room derivation, env/error degradation)
- [x] Parser + onPoke wiring tests; debounced refetch tests (fake timers)
- [x] Full unit suite 2437 passing (exit 0), relay 44/44, type-check + lint clean
- [ ] Post-deploy smoke: DM advances turn → player battlemap tab refetches instantly; stop relay → 5s poll fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)