### PR TITLE
feat(vtt): player VTT screen — combat panel, character dock, cast-to-template

### DIFF
--- a/src/app/player/campaign/[code]/battlemap/[id]/page.tsx
+++ b/src/app/player/campaign/[code]/battlemap/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { usePlayerStore } from '@/store/playerStore';
 import { useHydration } from '@/hooks/useHydration';
-import { PlayerBattleMapCanvas } from '@/components/ui/campaign/location-map/PlayerBattleMapCanvas';
+import { PlayerVttScreen } from '@/components/ui/campaign/player-vtt/PlayerVttScreen';
 
 function PlayerBattleMapPage() {
   const params = useParams();
@@ -32,12 +32,10 @@ function PlayerBattleMapPage() {
   }
 
   return (
-    <PlayerBattleMapCanvas
+    <PlayerVttScreen
       campaignCode={code}
       battleMapId={battleMapId}
       characterId={characterId}
-      characterName={character.name}
-      characterAvatar={character.avatar}
     />
   );
 }

--- a/src/app/player/campaign/[code]/battlemap/[id]/page.tsx
+++ b/src/app/player/campaign/[code]/battlemap/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { usePlayerStore } from '@/store/playerStore';
 import { useHydration } from '@/hooks/useHydration';
-import { PlayerBattleMapView } from '@/components/ui/campaign/location-map/PlayerBattleMapView';
+import { PlayerBattleMapCanvas } from '@/components/ui/campaign/location-map/PlayerBattleMapCanvas';
 
 function PlayerBattleMapPage() {
   const params = useParams();
@@ -32,10 +32,11 @@ function PlayerBattleMapPage() {
   }
 
   return (
-    <PlayerBattleMapView
+    <PlayerBattleMapCanvas
       campaignCode={code}
       battleMapId={battleMapId}
       characterId={characterId}
+      characterName={character.name}
       characterAvatar={character.avatar}
     />
   );

--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -31,6 +31,7 @@ import { useStorageQuotaListener } from '@/hooks/useStorageQuotaListener';
 
 import CharacterSheetHeader from '@/components/ui/character/CharacterSheetHeader';
 import { useHydration } from '@/hooks/useHydration';
+import { useCharacterRosterSync } from '@/hooks/useCharacterRosterSync';
 import { ABILITY_NAMES, SKILL_NAMES } from '@/utils/constants';
 import {
   calculateModifier,
@@ -379,67 +380,35 @@ export default function CharacterSheet() {
 
   const { manualSave } = useAutoSave({ onAfterSave: handleAfterSave });
 
-  const lastLoadedCharacterRef = useRef<string | null>(null);
-  const lastSyncedCharacterRef = useRef<CharacterState | null>(null);
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
+  // Auto-migrate existing traits to extended features once a character loads
+  // (mirrors the same load event the roster-sync hook fires on).
+  const handleCharacterLoaded = useCallback(
+    (loadedCharacterData: CharacterState) => {
+      const hasTraits = (loadedCharacterData.trackableTraits || []).length > 0;
+      const hasExtended =
+        (loadedCharacterData.extendedFeatures || []).length > 0;
 
-  // Load character data into store when component mounts or character changes
-  useEffect(() => {
-    if (playerCharacter && hasHydrated) {
-      const currentCharacterId = playerCharacter.characterData.id;
-
-      // Only load if we haven't loaded this character yet or if it's a different character
-      if (lastLoadedCharacterRef.current !== currentCharacterId) {
-        setIsInitialLoad(true);
-        loadCharacterState(playerCharacter.characterData);
-        lastLoadedCharacterRef.current = currentCharacterId;
-        lastSyncedCharacterRef.current = playerCharacter.characterData;
-
-        // Auto-migrate existing traits to extended features if needed
-        const hasTraits =
-          (playerCharacter.characterData.trackableTraits || []).length > 0;
-        const hasExtended =
-          (playerCharacter.characterData.extendedFeatures || []).length > 0;
-
-        if (hasTraits && !hasExtended) {
-          // Small delay to ensure character state is loaded first
-          setTimeout(() => {
-            migrateTraitsToExtendedFeatures();
-          }, 100);
-        }
-
-        // Mark initial load as complete after state has been set
-        const timer = setTimeout(() => {
-          setIsInitialLoad(false);
-        }, 50);
-
-        return () => clearTimeout(timer);
+      if (hasTraits && !hasExtended) {
+        // Small delay to ensure character state is loaded first
+        setTimeout(() => {
+          migrateTraitsToExtendedFeatures();
+        }, 100);
       }
-    }
-  }, [
+    },
+    [migrateTraitsToExtendedFeatures]
+  );
+
+  // Load character data into the store and sync live edits back to the
+  // roster blob (skipping the initial load) — see useCharacterRosterSync.
+  useCharacterRosterSync({
     playerCharacter,
     hasHydrated,
+    characterId,
+    character,
     loadCharacterState,
-    migrateTraitsToExtendedFeatures,
-  ]);
-
-  // Sync character data back to player store when it changes (skip during initial load)
-  useEffect(() => {
-    if (!isInitialLoad && hasHydrated && character.id === characterId) {
-      // Deep comparison to prevent unnecessary updates and infinite loops
-      const hasActualChanges =
-        !lastSyncedCharacterRef.current ||
-        JSON.stringify(lastSyncedCharacterRef.current) !==
-          JSON.stringify(character);
-
-      if (hasActualChanges) {
-        // Create a deep copy to avoid reference issues
-        const characterCopy = JSON.parse(JSON.stringify(character));
-        updateCharacterData(characterId, characterCopy);
-        lastSyncedCharacterRef.current = characterCopy;
-      }
-    }
-  }, [character, characterId, updateCharacterData, hasHydrated, isInitialLoad]);
+    updateCharacterData,
+    onLoad: handleCharacterLoaded,
+  });
 
   // Calculate derived values (needs to be before early returns due to hooks)
   const totalLevel = character.totalLevel || character.level;

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -55,7 +55,8 @@ interface PlayerBattleMapCanvasProps {
   campaignCode: string;
   battleMapId: string;
   characterId: string;
-  characterName: string;
+  /** Unused internally today — reserved for a future map-name/self pill. */
+  characterName?: string;
   characterAvatar?: string;
   /** Chrome rendered INSIDE the ViewportContext.Provider (may use useActiveTool). */
   children?: React.ReactNode;

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import Link from 'next/link';
 import {
   ArrowLeft,
@@ -40,12 +46,27 @@ import {
   tokenAvatarUrl,
   buildCircularTokenUrl,
 } from './PlayerTokenTool';
+import {
+  SpellTemplateTool,
+  type SpellTemplateConfig,
+} from '@/components/ui/campaign/player-vtt/SpellTemplateTool';
 
-interface PlayerBattleMapViewProps {
+interface PlayerBattleMapCanvasProps {
   campaignCode: string;
   battleMapId: string;
   characterId: string;
+  characterName: string;
   characterAvatar?: string;
+  /** Chrome rendered INSIDE the ViewportContext.Provider (may use useActiveTool). */
+  children?: React.ReactNode;
+  /** Connection status surfaced upward (Live chip stays internal too). */
+  onStatus?: (status: BattleMapConnectionStatus) => void;
+  /** Relay poke passthrough (wire to useSharedCampaignState().refetchNow). */
+  onPoke?: (feature: string) => void;
+  /** Mutable config consumed by the registered SpellTemplateTool. */
+  spellTemplateConfigRef?: React.MutableRefObject<SpellTemplateConfig | null>;
+  /** Hide the built-in back-button (the VTT screen renders its own top-left chrome). */
+  hideBackButton?: boolean;
 }
 
 /** Viewport exposes historyRecorder at runtime for batched store ops. */
@@ -121,12 +142,17 @@ function PlayerToolbar({
   );
 }
 
-export function PlayerBattleMapView({
+export function PlayerBattleMapCanvas({
   campaignCode,
   battleMapId,
   characterId,
   characterAvatar,
-}: PlayerBattleMapViewProps) {
+  children,
+  onStatus: onStatusProp,
+  onPoke,
+  spellTemplateConfigRef,
+  hideBackButton = false,
+}: PlayerBattleMapCanvasProps) {
   const [viewport, setViewport] = useState<Viewport | null>(null);
   const [status, setStatus] = useState<BattleMapConnectionStatus>('connecting');
   const [hasSelection, setHasSelection] = useState(false);
@@ -169,8 +195,11 @@ export function PlayerBattleMapView({
         strokeWidth: 2,
         renderStyle: 'geometric',
       }),
+      ...(spellTemplateConfigRef
+        ? [new SpellTemplateTool(spellTemplateConfigRef)]
+        : []),
     ];
-  }, [characterId]);
+  }, [characterId, spellTemplateConfigRef]);
 
   const handleReady = (vp: Viewport) => {
     setViewport(vp);
@@ -222,8 +251,10 @@ export function PlayerBattleMapView({
       tokenRequest: { role: 'player', battleMapId, playerId: characterId },
       onStatus: s => {
         setStatus(s);
+        onStatusProp?.(s);
         if (s === 'live') requestAnimationFrame(() => vp.fitToContent(60));
       },
+      onPoke,
     });
   };
 
@@ -268,17 +299,20 @@ export function PlayerBattleMapView({
             <DmLocationToolOptions mode="battlemap" />
           </div>
         )}
-        <div className="absolute top-3 left-3 z-10">
-          <Link href={`/player/characters/${characterId}`}>
-            <Button
-              variant="ghost"
-              className="flex items-center gap-1.5 text-xs"
-            >
-              <ArrowLeft size={14} />
-              Back to sheet
-            </Button>
-          </Link>
-        </div>
+        {!hideBackButton && (
+          <div className="absolute top-3 left-3 z-10">
+            <Link href={`/player/characters/${characterId}`}>
+              <Button
+                variant="ghost"
+                className="flex items-center gap-1.5 text-xs"
+              >
+                <ArrowLeft size={14} />
+                Back to sheet
+              </Button>
+            </Link>
+          </div>
+        )}
+        {viewport && children}
       </div>
     </ViewportContext.Provider>
   );

--- a/src/components/ui/campaign/player-vtt/CastingBanner.tsx
+++ b/src/components/ui/campaign/player-vtt/CastingBanner.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Button } from '@/components/ui/forms/button';
+import type { SpellAoe } from '@/types/spellAoe';
+
+export interface CastingBannerProps {
+  spellName: string;
+  aoe: SpellAoe;
+  onCancel: () => void;
+}
+
+/** Fixed banner shown while a spell's AoE template placement is armed on the battle map. */
+export function CastingBanner({
+  spellName,
+  aoe,
+  onCancel,
+}: CastingBannerProps) {
+  return (
+    <div className="bg-accent-purple-bg border-accent-purple-border text-accent-purple-text pointer-events-auto fixed top-[64px] left-1/2 z-20 flex -translate-x-1/2 items-center gap-3 rounded-full border px-4 py-2 shadow-xl">
+      <span className="text-sm font-medium">
+        ✨ Placing {spellName} — tap the map to drop the {aoe.shape} ·{' '}
+        {aoe.sizeFeet} ft
+      </span>
+      <Button variant="ghost" size="lg" onClick={onCancel}>
+        Cancel
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.hooks.ts
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.hooks.ts
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+
+import { useCastSpell } from '@/hooks/useCastSpell';
+import type { ToastData } from '@/components/ui/feedback/Toast';
+import type { Spell } from '@/types/character';
+import type { SpellAoe } from '@/types/spellAoe';
+
+import { describeCastPayment } from './DockSpells.utils';
+
+export interface UseDockSpellCastingArgs {
+  addToast: (toast: Omit<ToastData, 'id'>) => void;
+  onCastPlacement: (spellName: string, aoe: NonNullable<SpellAoe>) => void;
+  connectionLive: boolean;
+  hasPendingPlacement: boolean;
+  onCancelPlacement: () => void;
+}
+
+/**
+ * Owns the dock's cast flow: cantrip = immediate cast, leveled = opens
+ * `SpellCastModal`, and the post-cast placement/toast/concentration-cancel
+ * side effects described in spec §4/§6.
+ */
+export function useDockSpellCasting({
+  addToast,
+  onCastPlacement,
+  connectionLive,
+  hasPendingPlacement,
+  onCancelPlacement,
+}: UseDockSpellCastingArgs) {
+  const { castSpell } = useCastSpell();
+  const [castingSpell, setCastingSpell] = useState<Spell | null>(null);
+  const [viewingSpell, setViewingSpell] = useState<Spell | null>(null);
+
+  const finishCast = (
+    spell: Spell,
+    level: number,
+    useFreecast?: boolean,
+    isRitual?: boolean,
+    usePact?: boolean
+  ) => {
+    if (spell.aoe) {
+      if (connectionLive) {
+        onCastPlacement(spell.name, spell.aoe);
+      } else {
+        addToast({
+          type: 'info',
+          title: `${spell.name} cast`,
+          message: 'Offline — template not placed',
+        });
+      }
+      return;
+    }
+
+    addToast({
+      type: 'success',
+      title: `${spell.name} cast`,
+      message: describeCastPayment(level, useFreecast, isRitual, usePact),
+    });
+    if (spell.concentration && hasPendingPlacement) {
+      onCancelPlacement();
+    }
+  };
+
+  const handleCastClick = (spell: Spell) => {
+    if (spell.level === 0) {
+      castSpell(spell, { level: spell.level });
+      finishCast(spell, spell.level);
+      return;
+    }
+    setCastingSpell(spell);
+  };
+
+  const handleModalCast = (
+    level: number,
+    useFreecast: boolean,
+    isRitual?: boolean,
+    usePact?: boolean
+  ) => {
+    if (!castingSpell) return;
+    castSpell(castingSpell, { level, useFreecast, isRitual, usePact });
+    finishCast(castingSpell, level, useFreecast, isRitual, usePact);
+  };
+
+  return {
+    castingSpell,
+    viewingSpell,
+    setViewingSpell,
+    handleCastClick,
+    handleModalCast,
+    closeCastModal: () => setCastingSpell(null),
+    closeDetailsModal: () => setViewingSpell(null),
+  };
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.hooks.ts
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.hooks.ts
@@ -38,8 +38,18 @@ export function useDockSpellCasting({
     isRitual?: boolean,
     usePact?: boolean
   ) => {
+    // A second concentration cast always cancels a stale pending placement
+    // first — regardless of whether this cast is itself an AoE, and
+    // regardless of connection state — so a leftover template-arm banner
+    // never survives past the moment concentration would break it.
+    if (spell.concentration && hasPendingPlacement) {
+      onCancelPlacement();
+    }
+
     if (spell.aoe) {
       if (connectionLive) {
+        // Replaces whatever pending placement remains (including the one
+        // just cancelled above) with this cast's own placement.
         onCastPlacement(spell.name, spell.aoe);
       } else {
         addToast({
@@ -56,9 +66,6 @@ export function useDockSpellCasting({
       title: `${spell.name} cast`,
       message: describeCastPayment(level, useFreecast, isRitual, usePact),
     });
-    if (spell.concentration && hasPendingPlacement) {
-      onCancelPlacement();
-    }
   };
 
   const handleCastClick = (spell: Spell) => {

--- a/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.tsx
@@ -52,9 +52,17 @@ export function DockSpells(props: DockSpellsProps) {
   const spellSaveDC = calculateSpellSaveDC(character);
 
   const filteredSpells = useMemo(() => {
+    // Only show castable spells (prepared or always-prepared)
+    const castableSpells = character.spells.filter(
+      spell =>
+        (spell.level === 0 && spell.isPrepared) || // Only prepared cantrips
+        (spell.level > 0 && spell.isPrepared) || // Prepared spells
+        spell.isAlwaysPrepared // Always prepared spells
+    );
+
     const query = search.trim().toLowerCase();
-    if (!query) return character.spells;
-    return character.spells.filter(spell =>
+    if (!query) return castableSpells;
+    return castableSpells.filter(spell =>
       spell.name.toLowerCase().includes(query)
     );
   }, [character.spells, search]);

--- a/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { Input } from '@/components/ui/forms/input';
+import { SpellCastModal } from '@/components/ui/game/SpellCastModal';
+import SpellDetailsModal from '@/components/ui/game/SpellDetailsModal';
+import type { ToastData } from '@/components/ui/feedback/Toast';
+import { useCharacterStore } from '@/store/characterStore';
+import {
+  calculateSpellAttackBonus,
+  calculateSpellSaveDC,
+  getCharacterSpellcastingAbility,
+} from '@/utils/calculations';
+import type { SpellSlots } from '@/types/character';
+import type { SpellAoe } from '@/types/spellAoe';
+
+import { useDockSpellCasting } from './DockSpells.hooks';
+import { groupSpellsByLevel } from './DockSpells.utils';
+import { SpellLevelGroup } from './SpellLevelGroup';
+import { SpellcastingStatsRow } from './SpellcastingStatsRow';
+
+export interface DockSpellsProps {
+  addToast: (toast: Omit<ToastData, 'id'>) => void;
+  /** Ask the screen to arm template placement (only called when spell.aoe && connectionLive). */
+  onCastPlacement: (spellName: string, aoe: NonNullable<SpellAoe>) => void;
+  connectionLive: boolean;
+  hasPendingPlacement: boolean;
+  onCancelPlacement: () => void;
+}
+
+/** Dock's Spells section: search, per-level groups with slot pips, and the cast flow. */
+export function DockSpells(props: DockSpellsProps) {
+  const { character } = useCharacterStore();
+  const {
+    castingSpell,
+    viewingSpell,
+    setViewingSpell,
+    handleCastClick,
+    handleModalCast,
+    closeCastModal,
+    closeDetailsModal,
+  } = useDockSpellCasting(props);
+
+  const [search, setSearch] = useState('');
+  const [collapsedLevels, setCollapsedLevels] = useState<Set<number>>(
+    new Set()
+  );
+
+  const spellcastingAbility = getCharacterSpellcastingAbility(character);
+  const spellAttackBonus = calculateSpellAttackBonus(character);
+  const spellSaveDC = calculateSpellSaveDC(character);
+
+  const filteredSpells = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return character.spells;
+    return character.spells.filter(spell =>
+      spell.name.toLowerCase().includes(query)
+    );
+  }, [character.spells, search]);
+
+  const groups = useMemo(
+    () => groupSpellsByLevel(filteredSpells),
+    [filteredSpells]
+  );
+
+  if (spellcastingAbility === null || character.spells.length === 0) {
+    return null;
+  }
+
+  const toggleLevel = (level: number) => {
+    setCollapsedLevels(prev => {
+      const next = new Set(prev);
+      if (next.has(level)) next.delete(level);
+      else next.add(level);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <SpellcastingStatsRow
+        spellAttackBonus={spellAttackBonus}
+        spellSaveDC={spellSaveDC}
+        abilityLabel={spellcastingAbility.slice(0, 3).toUpperCase()}
+      />
+
+      <Input
+        aria-label="Search spells"
+        placeholder="Search spells…"
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+      />
+
+      <div className="space-y-2">
+        {groups.map(([level, spells]) => (
+          <SpellLevelGroup
+            key={level}
+            level={level}
+            spells={spells}
+            slot={
+              level > 0 ? character.spellSlots[level as keyof SpellSlots] : null
+            }
+            collapsed={collapsedLevels.has(level)}
+            onToggle={() => toggleLevel(level)}
+            onView={setViewingSpell}
+            onCast={handleCastClick}
+          />
+        ))}
+      </div>
+
+      {castingSpell && (
+        <SpellCastModal
+          isOpen
+          onClose={closeCastModal}
+          spell={castingSpell}
+          spellSlots={character.spellSlots}
+          concentration={character.concentration}
+          pactMagic={character.pactMagic}
+          hasUsedReaction={character.reaction?.hasUsedReaction}
+          onCastSpell={handleModalCast}
+        />
+      )}
+
+      {viewingSpell && (
+        <SpellDetailsModal
+          spell={viewingSpell}
+          isOpen
+          onClose={closeDetailsModal}
+          onCast={() => handleCastClick(viewingSpell)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.utils.ts
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.utils.ts
@@ -1,0 +1,44 @@
+import type { AoeShape } from '@/types/spellAoe';
+import type { Spell } from '@/types/character';
+
+/** Glyph shown next to a row's name when the spell has an AoE template. */
+export const AOE_GLYPHS: Record<AoeShape, string> = {
+  circle: '●',
+  cone: '◮',
+  line: '▬',
+  square: '■',
+};
+
+/**
+ * Groups spells by level (cantrips = 0) ascending, each level's spells
+ * sorted by name. Search filtering happens before this is called.
+ */
+export function groupSpellsByLevel(spells: Spell[]): Array<[number, Spell[]]> {
+  const map = new Map<number, Spell[]>();
+  for (const spell of spells) {
+    const bucket = map.get(spell.level);
+    if (bucket) {
+      bucket.push(spell);
+    } else {
+      map.set(spell.level, [spell]);
+    }
+  }
+  for (const bucket of map.values()) {
+    bucket.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  return Array.from(map.entries()).sort(([a], [b]) => a - b);
+}
+
+/** Human-readable summary of how a cast was paid for, used in the success toast. */
+export function describeCastPayment(
+  level: number,
+  useFreecast?: boolean,
+  isRitual?: boolean,
+  usePact?: boolean
+): string {
+  if (isRitual) return 'Cast as ritual — no slot used';
+  if (usePact) return `Pact slot used (level ${level})`;
+  if (useFreecast) return 'Free cast — no slot used';
+  if (level === 0) return 'Cantrip — no slot used';
+  return `Level ${level} slot used`;
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/DockVitals.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/DockVitals.tsx
@@ -55,7 +55,13 @@ export function DockVitals({ addToast }: DockVitalsProps) {
     if (n === null) return;
     apply(n);
     setAmount('');
-    addToast({ type: 'info', title: toastTitle(n), message: '' });
+    // Read the post-apply state back so the toast reflects the actual
+    // result (temp-first damage, heal capping at max, etc.) rather than
+    // just echoing the typed amount.
+    const { current, max, temporary } =
+      useCharacterStore.getState().character.hitPoints;
+    const message = `HP ${current}/${max}${temporary > 0 ? ` +${temporary} temp` : ''}`;
+    addToast({ type: 'info', title: toastTitle(n), message });
   };
 
   const handleApplyDamage = () =>

--- a/src/components/ui/campaign/player-vtt/CharacterDock/DockVitals.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/DockVitals.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/forms/button';
+import { Input } from '@/components/ui/forms/input';
+import { Badge } from '@/components/ui/layout/badge';
+import type { ToastData } from '@/components/ui/feedback/Toast';
+import { useCharacterStore } from '@/store/characterStore';
+import {
+  calculateCharacterArmorClass,
+  formatModifier,
+} from '@/utils/calculations';
+import { getHpBarColor } from '@/utils/hpColor';
+
+import { getHpCardClasses, parseHpAmount } from './DockVitals.utils';
+import { HeroicInspirationRow } from './HeroicInspirationRow';
+
+export interface DockVitalsProps {
+  addToast: (toast: Omit<ToastData, 'id'>) => void;
+}
+
+export function DockVitals({ addToast }: DockVitalsProps) {
+  const {
+    character,
+    applyDamageToCharacter,
+    applyHealingToCharacter,
+    addTemporaryHPToCharacter,
+    addHeroicInspiration,
+    updateHeroicInspiration,
+    useHeroicInspiration: spendHeroicInspiration,
+  } = useCharacterStore();
+  const [amount, setAmount] = useState('');
+
+  const {
+    current: hpCurrent,
+    max: hpMax,
+    temporary: hpTemp,
+  } = character.hitPoints;
+  const hpPercent = hpMax > 0 ? (hpCurrent / hpMax) * 100 : 0;
+
+  const totalAC = calculateCharacterArmorClass(character);
+  const initiativeModifier = character.initiative.isOverridden
+    ? character.initiative.value
+    : Math.floor((character.abilities.dexterity - 10) / 2);
+
+  const { count: heroicCount, maxCount: heroicMax } =
+    character.heroicInspiration;
+
+  const applyAmount = (
+    apply: (n: number) => void,
+    toastTitle: (n: number) => string
+  ) => {
+    const n = parseHpAmount(amount);
+    if (n === null) return;
+    apply(n);
+    setAmount('');
+    addToast({ type: 'info', title: toastTitle(n), message: '' });
+  };
+
+  const handleApplyDamage = () =>
+    applyAmount(applyDamageToCharacter, n => `Took ${n} damage`);
+  const handleApplyHeal = () =>
+    applyAmount(applyHealingToCharacter, n => `Healed ${n} HP`);
+  const handleApplyTemp = () =>
+    applyAmount(addTemporaryHPToCharacter, n => `+${n} temp HP`);
+
+  const handleUseHeroic = () => {
+    spendHeroicInspiration();
+    const r1 = 1 + Math.floor(Math.random() * 20);
+    const r2 = 1 + Math.floor(Math.random() * 20);
+    addToast({
+      type: 'info',
+      title: `Heroic Inspiration: ${Math.max(r1, r2)}`,
+      message: `(rolled ${r1} & ${r2}, advantage)`,
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className={`rounded-xl border p-4 ${getHpCardClasses(hpPercent)}`}>
+        <div className="flex items-baseline gap-2">
+          <span className="text-heading text-3xl font-bold">
+            {hpCurrent}/{hpMax}
+          </span>
+          {hpTemp > 0 && <Badge variant="info">+{hpTemp} temp</Badge>}
+        </div>
+        <div className="bg-surface-secondary mt-2 h-2 w-full overflow-hidden rounded-full">
+          <div
+            className={`h-full rounded-full ${getHpBarColor(hpCurrent, hpMax)}`}
+            style={{ width: `${Math.min(100, Math.max(0, hpPercent))}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Input
+          aria-label="HP amount"
+          inputMode="numeric"
+          value={amount}
+          onChange={e => setAmount(e.target.value)}
+          className="w-20"
+        />
+        <Button variant="danger" size="lg" onClick={handleApplyDamage}>
+          Damage
+        </Button>
+        <Button variant="success" size="lg" onClick={handleApplyHeal}>
+          Heal
+        </Button>
+        <Button variant="secondary" size="lg" onClick={handleApplyTemp}>
+          Temp
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div className="border-divider rounded-lg border p-3 text-center">
+          <div className="text-heading text-xl font-bold">{totalAC}</div>
+          <div className="text-faint text-xs uppercase">AC</div>
+        </div>
+        <div className="border-divider rounded-lg border p-3 text-center">
+          <div className="text-heading text-xl font-bold">
+            {formatModifier(initiativeModifier)}
+          </div>
+          <div className="text-faint text-xs uppercase">Init</div>
+        </div>
+      </div>
+
+      <HeroicInspirationRow
+        count={heroicCount}
+        maxCount={heroicMax}
+        onIncrement={() => addHeroicInspiration(1)}
+        onDecrement={() =>
+          updateHeroicInspiration({ count: Math.max(0, heroicCount - 1) })
+        }
+        onUse={handleUseHeroic}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/DockVitals.utils.ts
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/DockVitals.utils.ts
@@ -1,0 +1,12 @@
+/** Card background/border by HP percentage: >60 emerald, 31-60 amber, <=30 red. */
+export function getHpCardClasses(percent: number): string {
+  if (percent > 60) return 'bg-accent-emerald-bg border-accent-emerald-border';
+  if (percent > 30) return 'bg-accent-amber-bg border-accent-amber-border';
+  return 'bg-accent-red-bg border-accent-red-border';
+}
+
+/** Parses a raw HP-editor input string; returns null for NaN/empty/non-positive. */
+export function parseHpAmount(raw: string): number | null {
+  const n = parseInt(raw, 10);
+  return Number.isNaN(n) || n <= 0 ? null : n;
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/HeroicInspirationRow.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/HeroicInspirationRow.tsx
@@ -1,0 +1,51 @@
+import { Button } from '@/components/ui/forms/button';
+
+export interface HeroicInspirationRowProps {
+  count: number;
+  maxCount?: number;
+  onIncrement: () => void;
+  onDecrement: () => void;
+  onUse: () => void;
+}
+
+/** Heroic inspiration counter + spend control, shown at the bottom of `DockVitals`. */
+export function HeroicInspirationRow({
+  count,
+  maxCount,
+  onIncrement,
+  onDecrement,
+  onUse,
+}: HeroicInspirationRowProps) {
+  return (
+    <div className="border-divider flex items-center justify-between rounded-lg border p-3">
+      <span className="text-heading font-semibold">✦ Heroic ×{count}</span>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="lg"
+          onClick={onDecrement}
+          aria-label="Remove heroic inspiration"
+        >
+          −
+        </Button>
+        <Button
+          variant="outline"
+          size="lg"
+          onClick={onIncrement}
+          disabled={maxCount != null && count >= maxCount}
+          aria-label="Add heroic inspiration"
+        >
+          +
+        </Button>
+        <Button
+          variant="primary"
+          size="lg"
+          onClick={onUse}
+          disabled={count === 0}
+        >
+          Use
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/SpellLevelGroup.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/SpellLevelGroup.tsx
@@ -1,0 +1,59 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
+import type { Spell, SpellSlot } from '@/types/character';
+
+import { SpellRow } from './SpellRow';
+import { SpellSlotPips } from './SpellSlotPips';
+
+export interface SpellLevelGroupProps {
+  level: number;
+  spells: Spell[];
+  slot: SpellSlot | null;
+  collapsed: boolean;
+  onToggle: () => void;
+  onView: (spell: Spell) => void;
+  onCast: (spell: Spell) => void;
+}
+
+/** One collapsible level group in the dock's spell list: header (+ slot pips) and its rows. */
+export function SpellLevelGroup({
+  level,
+  spells,
+  slot,
+  collapsed,
+  onToggle,
+  onView,
+  onCast,
+}: SpellLevelGroupProps) {
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center justify-between py-1"
+      >
+        <span className="text-faint flex items-center gap-1 text-xs font-bold tracking-wider uppercase">
+          {collapsed ? (
+            <ChevronRight className="h-3 w-3" />
+          ) : (
+            <ChevronDown className="h-3 w-3" />
+          )}
+          {level === 0 ? 'Cantrips' : `Level ${level}`}
+        </span>
+        {slot && <SpellSlotPips slot={slot} />}
+      </button>
+      {!collapsed && (
+        <div className="space-y-1.5">
+          {spells.map(spell => (
+            <SpellRow
+              key={spell.id}
+              spell={spell}
+              onView={() => onView(spell)}
+              onCast={() => onCast(spell)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/SpellRow.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/SpellRow.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@/components/ui/forms/button';
+import { Badge } from '@/components/ui/layout/badge';
+import type { Spell } from '@/types/character';
+
+import { AOE_GLYPHS } from './DockSpells.utils';
+
+export interface SpellRowProps {
+  spell: Spell;
+  /** Row tap (name area) → open SpellDetailsModal. */
+  onView: () => void;
+  /** Cast button → cantrip casts immediately, leveled opens SpellCastModal. */
+  onCast: () => void;
+}
+
+/** Single spell line in the dock's spell list: name/badges + a ≥44px Cast button. */
+export function SpellRow({ spell, onView, onCast }: SpellRowProps) {
+  return (
+    <div className="border-divider flex items-center gap-2 rounded-lg border p-2">
+      <button
+        type="button"
+        onClick={onView}
+        className="min-w-0 flex-1 text-left"
+      >
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span className="text-body truncate text-sm font-medium">
+            {spell.name}
+          </span>
+          {spell.aoe && (
+            <span
+              className="text-accent-purple-text-muted shrink-0 text-xs"
+              aria-label={`${spell.aoe.shape} area of effect`}
+            >
+              {AOE_GLYPHS[spell.aoe.shape]}
+            </span>
+          )}
+        </div>
+        {(spell.concentration || spell.ritual) && (
+          <div className="mt-0.5 flex gap-1">
+            {spell.concentration && (
+              <Badge variant="warning" size="sm">
+                Conc
+              </Badge>
+            )}
+            {spell.ritual && (
+              <Badge variant="info" size="sm">
+                Ritual
+              </Badge>
+            )}
+          </div>
+        )}
+      </button>
+      <Button variant="primary" size="lg" onClick={onCast}>
+        Cast
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/SpellSlotPips.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/SpellSlotPips.tsx
@@ -1,0 +1,36 @@
+import type { SpellSlot } from '@/types/character';
+
+export interface SpellSlotPipsProps {
+  slot: SpellSlot;
+}
+
+/**
+ * Minimal inline slot-usage dots for a level's group header.
+ *
+ * Recon (Task 6): the shared `SpellSlotTracker` compact mode still renders
+ * a full bordered block (title row + Badge + checkbox row) per level — it's
+ * built for a standalone panel, not a one-line inline header, so it doesn't
+ * fit the 338px dock's group-header row. This tiny pip row is the sanctioned
+ * fallback from the task brief.
+ */
+export function SpellSlotPips({ slot }: SpellSlotPipsProps) {
+  if (slot.max === 0) return null;
+
+  return (
+    <div
+      className="flex items-center gap-0.5"
+      aria-label={`${slot.max - slot.used}/${slot.max} slots remaining`}
+    >
+      {Array.from({ length: slot.max }, (_, i) => (
+        <span
+          key={i}
+          className={`h-2 w-2 rounded-full ${
+            i < slot.used
+              ? 'border-accent-purple-border-strong border bg-transparent'
+              : 'bg-accent-purple-text-muted'
+          }`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/SpellcastingStatsRow.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/SpellcastingStatsRow.tsx
@@ -1,0 +1,36 @@
+import { formatModifier } from '@/utils/calculations';
+
+export interface SpellcastingStatsRowProps {
+  spellAttackBonus: number | null;
+  spellSaveDC: number | null;
+  abilityLabel: string;
+}
+
+/** Three stat chips (Attack / Save DC / Ability) at the top of the dock's spell list. */
+export function SpellcastingStatsRow({
+  spellAttackBonus,
+  spellSaveDC,
+  abilityLabel,
+}: SpellcastingStatsRowProps) {
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      <StatChip
+        label="Attack"
+        value={
+          spellAttackBonus === null ? '—' : formatModifier(spellAttackBonus)
+        }
+      />
+      <StatChip label="Save DC" value={spellSaveDC ?? '—'} />
+      <StatChip label="Ability" value={abilityLabel} />
+    </div>
+  );
+}
+
+function StatChip({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="border-divider rounded-lg border p-2 text-center">
+      <div className="text-heading text-sm font-bold">{value}</div>
+      <div className="text-faint text-[10px] uppercase">{label}</div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/CharacterDock/index.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/index.tsx
@@ -7,15 +7,14 @@ import type { ToastData } from '@/components/ui/feedback/Toast';
 import { useCharacterStore } from '@/store/characterStore';
 import type { SpellAoe } from '@/types/spellAoe';
 
+import { DockSpells } from './DockSpells';
 import { DockVitals } from './DockVitals';
 
 export interface CharacterDockProps {
   collapsed: boolean;
   onToggleCollapsed: () => void;
   addToast: (toast: Omit<ToastData, 'id'>) => void;
-  /** DockSpells wiring (Task 6) — pass-through; render nothing in the spells
-      area until Task 6 fills it. */
-  onCastPlacement?: (spellName: string, aoe: NonNullable<SpellAoe>) => void;
+  onCastPlacement: (spellName: string, aoe: NonNullable<SpellAoe>) => void;
   connectionLive: boolean;
   hasPendingPlacement: boolean;
   onCancelPlacement: () => void;
@@ -23,12 +22,16 @@ export interface CharacterDockProps {
 
 /**
  * Right-edge player VTT panel: avatar/name header + `DockVitals` (HP editor,
- * AC/Init, heroic inspiration) + a spells placeholder slot Task 6 fills in.
+ * AC/Init, heroic inspiration) + `DockSpells` (search, cast flow, slot pips).
  */
 export function CharacterDock({
   collapsed,
   onToggleCollapsed,
   addToast,
+  onCastPlacement,
+  connectionLive,
+  hasPendingPlacement,
+  onCancelPlacement,
 }: CharacterDockProps) {
   const character = useCharacterStore(state => state.character);
 
@@ -85,12 +88,13 @@ export function CharacterDock({
       <div className="flex-1 space-y-3 overflow-y-auto px-3 py-3">
         <DockVitals addToast={addToast} />
 
-        <div>
-          <div className="text-faint mb-1 text-xs font-bold tracking-wider uppercase">
-            Spells
-          </div>
-          <div data-testid="dock-spells-slot" />
-        </div>
+        <DockSpells
+          addToast={addToast}
+          onCastPlacement={onCastPlacement}
+          connectionLive={connectionLive}
+          hasPendingPlacement={hasPendingPlacement}
+          onCancelPlacement={onCancelPlacement}
+        />
       </div>
     </div>
   );

--- a/src/components/ui/campaign/player-vtt/CharacterDock/index.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/index.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { ChevronRight } from 'lucide-react';
+
+import { Button } from '@/components/ui/forms/button';
+import type { ToastData } from '@/components/ui/feedback/Toast';
+import { useCharacterStore } from '@/store/characterStore';
+import type { SpellAoe } from '@/types/spellAoe';
+
+import { DockVitals } from './DockVitals';
+
+export interface CharacterDockProps {
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  addToast: (toast: Omit<ToastData, 'id'>) => void;
+  /** DockSpells wiring (Task 6) — pass-through; render nothing in the spells
+      area until Task 6 fills it. */
+  onCastPlacement?: (spellName: string, aoe: NonNullable<SpellAoe>) => void;
+  connectionLive: boolean;
+  hasPendingPlacement: boolean;
+  onCancelPlacement: () => void;
+}
+
+/**
+ * Right-edge player VTT panel: avatar/name header + `DockVitals` (HP editor,
+ * AC/Init, heroic inspiration) + a spells placeholder slot Task 6 fills in.
+ */
+export function CharacterDock({
+  collapsed,
+  onToggleCollapsed,
+  addToast,
+}: CharacterDockProps) {
+  const character = useCharacterStore(state => state.character);
+
+  if (collapsed) {
+    return (
+      <button
+        onClick={onToggleCollapsed}
+        title="Expand character dock"
+        className="bg-surface-raised border-divider pointer-events-auto fixed top-[78px] right-4 flex min-h-[44px] w-11 items-center justify-center rounded-2xl border py-4 text-xs font-bold tracking-wider shadow-xl"
+        style={{ writingMode: 'vertical-rl' }}
+      >
+        CHARACTER
+      </button>
+    );
+  }
+
+  const level = character.totalLevel || character.level;
+  const className = character.class?.name || 'Unknown Class';
+  const initial = character.name?.charAt(0)?.toUpperCase() || '?';
+
+  return (
+    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-[78px] right-4 bottom-6 flex w-[338px] flex-col overflow-hidden rounded-2xl border shadow-xl">
+      <div className="border-divider flex shrink-0 items-center gap-3 border-b px-3 py-2.5">
+        {character.avatar ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={character.avatar}
+            alt={character.name}
+            className="h-10 w-10 shrink-0 rounded-full object-cover"
+          />
+        ) : (
+          <div className="bg-surface-secondary text-heading flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-lg font-bold">
+            {initial}
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="text-heading truncate text-sm font-semibold">
+            {character.name}
+          </div>
+          <div className="text-faint truncate text-xs">
+            {character.race} · {className} {level}
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="lg"
+          onClick={onToggleCollapsed}
+          aria-label="Collapse character dock"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="flex-1 space-y-3 overflow-y-auto px-3 py-3">
+        <DockVitals addToast={addToast} />
+
+        <div>
+          <div className="text-faint mb-1 text-xs font-bold tracking-wider uppercase">
+            Spells
+          </div>
+          <div data-testid="dock-spells-slot" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/CombatPanel.tsx
+++ b/src/components/ui/campaign/player-vtt/CombatPanel.tsx
@@ -1,12 +1,9 @@
 'use client';
 
 import { Button } from '@/components/ui/forms/button';
-import { Badge } from '@/components/ui/layout/badge';
-import { HPBar } from '@/components/shared/combat/HPBar';
-import type {
-  SharedInitiativeState,
-  SharedTurnEntry,
-} from '@/types/sharedState';
+import type { SharedInitiativeState } from '@/types/sharedState';
+
+import { CombatRow } from './CombatRow';
 
 export interface CombatPanelProps {
   state: SharedInitiativeState | null;
@@ -14,96 +11,6 @@ export interface CombatPanelProps {
   onEndTurn: (entityId: string) => void;
   collapsed: boolean;
   onToggleCollapsed: () => void;
-}
-
-/** Disposition-tinted avatar colours: emerald for the player's own row, blue
- * for allies/players, red for everything else (enemies, neutrals). */
-function avatarColorClasses(entry: SharedTurnEntry, characterId: string) {
-  if (entry.playerCharacterId === characterId) {
-    return 'bg-accent-emerald-bg text-accent-emerald-text border-accent-emerald-border';
-  }
-  if (entry.type === 'player' || entry.disposition === 'ally') {
-    return 'bg-accent-blue-bg text-accent-blue-text border-accent-blue-border';
-  }
-  return 'bg-accent-red-bg text-accent-red-text border-accent-red-border';
-}
-
-interface CombatRowProps {
-  entry: SharedTurnEntry;
-  characterId: string;
-  isCurrent: boolean;
-  onEndTurn: (entityId: string) => void;
-}
-
-function CombatRow({
-  entry,
-  characterId,
-  isCurrent,
-  onEndTurn,
-}: CombatRowProps) {
-  const isYou = entry.playerCharacterId === characterId;
-  const isDead = entry.isDead === true;
-  const hasHp = entry.currentHp !== undefined && entry.maxHp !== undefined;
-  const isMyActiveTurn = isCurrent && isYou;
-
-  const handleEndTurnClick = () => onEndTurn(entry.entityId);
-
-  return (
-    <li
-      className={`flex flex-col gap-1.5 rounded-lg px-2 py-2 ${
-        isDead
-          ? 'text-faint line-through opacity-50'
-          : isCurrent
-            ? 'bg-accent-amber-bg border-accent-amber-border animate-pulse border'
-            : ''
-      }`}
-    >
-      <div className="flex items-center gap-2">
-        <span
-          aria-hidden
-          className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs font-bold ${avatarColorClasses(entry, characterId)}`}
-        >
-          {entry.displayName.charAt(0).toUpperCase()}
-        </span>
-        <span className="text-body truncate text-sm font-medium">
-          {entry.displayName}
-        </span>
-        {isYou && <Badge variant="success">YOU</Badge>}
-      </div>
-      <div className="pl-8">
-        {isDead ? (
-          <span className="text-xs">
-            {entry.type === 'player' ? 'Down' : 'Defeated'}
-          </span>
-        ) : hasHp ? (
-          <HPBar
-            current={entry.currentHp as number}
-            max={entry.maxHp as number}
-            size="sm"
-          />
-        ) : entry.hpState ? (
-          <span className="text-faint text-xs">{entry.hpState}</span>
-        ) : entry.hpPercent !== undefined ? (
-          <HPBar
-            current={entry.hpPercent}
-            max={100}
-            size="sm"
-            showLabel={false}
-          />
-        ) : null}
-      </div>
-      {isMyActiveTurn && (
-        <Button
-          variant="primary"
-          size="lg"
-          fullWidth
-          onClick={handleEndTurnClick}
-        >
-          End my turn
-        </Button>
-      )}
-    </li>
-  );
 }
 
 /**
@@ -158,6 +65,7 @@ export function CombatPanel({
             entry={entry}
             characterId={characterId}
             isCurrent={entry.entityId === state.currentEntityId}
+            enemyHpMode={state.enemyHpMode}
             onEndTurn={onEndTurn}
           />
         ))}

--- a/src/components/ui/campaign/player-vtt/CombatPanel.tsx
+++ b/src/components/ui/campaign/player-vtt/CombatPanel.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { Button } from '@/components/ui/forms/button';
+import { Badge } from '@/components/ui/layout/badge';
+import { HPBar } from '@/components/shared/combat/HPBar';
+import type {
+  SharedInitiativeState,
+  SharedTurnEntry,
+} from '@/types/sharedState';
+
+export interface CombatPanelProps {
+  state: SharedInitiativeState | null;
+  characterId: string;
+  onEndTurn: (entityId: string) => void;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}
+
+/** Disposition-tinted avatar colours: emerald for the player's own row, blue
+ * for allies/players, red for everything else (enemies, neutrals). */
+function avatarColorClasses(entry: SharedTurnEntry, characterId: string) {
+  if (entry.playerCharacterId === characterId) {
+    return 'bg-accent-emerald-bg text-accent-emerald-text border-accent-emerald-border';
+  }
+  if (entry.type === 'player' || entry.disposition === 'ally') {
+    return 'bg-accent-blue-bg text-accent-blue-text border-accent-blue-border';
+  }
+  return 'bg-accent-red-bg text-accent-red-text border-accent-red-border';
+}
+
+interface CombatRowProps {
+  entry: SharedTurnEntry;
+  characterId: string;
+  isCurrent: boolean;
+  onEndTurn: (entityId: string) => void;
+}
+
+function CombatRow({
+  entry,
+  characterId,
+  isCurrent,
+  onEndTurn,
+}: CombatRowProps) {
+  const isYou = entry.playerCharacterId === characterId;
+  const isDead = entry.isDead === true;
+  const hasHp = entry.currentHp !== undefined && entry.maxHp !== undefined;
+  const isMyActiveTurn = isCurrent && isYou;
+
+  const handleEndTurnClick = () => onEndTurn(entry.entityId);
+
+  return (
+    <li
+      className={`flex flex-col gap-1.5 rounded-lg px-2 py-2 ${
+        isDead
+          ? 'text-faint line-through opacity-50'
+          : isCurrent
+            ? 'bg-accent-amber-bg border-accent-amber-border animate-pulse border'
+            : ''
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden
+          className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs font-bold ${avatarColorClasses(entry, characterId)}`}
+        >
+          {entry.displayName.charAt(0).toUpperCase()}
+        </span>
+        <span className="text-body truncate text-sm font-medium">
+          {entry.displayName}
+        </span>
+        {isYou && <Badge variant="success">YOU</Badge>}
+      </div>
+      <div className="pl-8">
+        {isDead ? (
+          <span className="text-xs">
+            {entry.type === 'player' ? 'Down' : 'Defeated'}
+          </span>
+        ) : hasHp ? (
+          <HPBar
+            current={entry.currentHp as number}
+            max={entry.maxHp as number}
+            size="sm"
+          />
+        ) : entry.hpState ? (
+          <span className="text-faint text-xs">{entry.hpState}</span>
+        ) : entry.hpPercent !== undefined ? (
+          <HPBar
+            current={entry.hpPercent}
+            max={100}
+            size="sm"
+            showLabel={false}
+          />
+        ) : null}
+      </div>
+      {isMyActiveTurn && (
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          onClick={handleEndTurnClick}
+        >
+          End my turn
+        </Button>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Player-facing combat panel for the VTT screen — a richer left-edge sibling
+ * of `InitiativePanel`. Renders exactly what the (already-masked) shared
+ * initiative state carries; never re-derives HP from raw numbers.
+ */
+export function CombatPanel({
+  state,
+  characterId,
+  onEndTurn,
+  collapsed,
+  onToggleCollapsed,
+}: CombatPanelProps) {
+  if (!state || !state.isActive) return null;
+
+  if (collapsed) {
+    return (
+      <button
+        onClick={onToggleCollapsed}
+        title="Expand combat panel"
+        className="bg-surface-raised border-divider pointer-events-auto fixed top-[78px] left-4 flex min-h-[44px] w-11 items-center justify-center rounded-2xl border py-4 text-xs font-bold tracking-wider shadow-xl"
+        style={{ writingMode: 'vertical-rl' }}
+      >
+        INITIATIVE
+      </button>
+    );
+  }
+
+  return (
+    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-[78px] bottom-6 left-4 flex w-[278px] flex-col overflow-hidden rounded-2xl border shadow-xl">
+      <div className="border-divider flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2.5">
+        <div className="flex min-w-0 flex-col">
+          <span className="text-heading text-sm font-semibold">⚔ Combat</span>
+          <span className="text-faint text-[11px] font-bold tracking-wider uppercase">
+            ROUND {state.round} · {state.turnOrder.length} IN ORDER
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="lg"
+          onClick={onToggleCollapsed}
+          aria-label="Collapse combat panel"
+        >
+          ▸
+        </Button>
+      </div>
+      <ul className="flex-1 space-y-1 overflow-y-auto px-2 py-2">
+        {state.turnOrder.map(entry => (
+          <CombatRow
+            key={entry.entityId}
+            entry={entry}
+            characterId={characterId}
+            isCurrent={entry.entityId === state.currentEntityId}
+            onEndTurn={onEndTurn}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/CombatRow.tsx
+++ b/src/components/ui/campaign/player-vtt/CombatRow.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 import { Button } from '@/components/ui/forms/button';
 import { Badge } from '@/components/ui/layout/badge';
 import { HPBar } from '@/components/shared/combat/HPBar';
@@ -38,7 +40,19 @@ export function CombatRow({
   const hasHp = entry.currentHp !== undefined && entry.maxHp !== undefined;
   const isMyActiveTurn = isCurrent && isYou;
 
-  const handleEndTurnClick = () => onEndTurn(entry.entityId);
+  // Optimistic end-turn: disable the button the instant it's clicked so a
+  // slow poll can't let the player fire a duplicate request; cleared once
+  // the synced state moves off this entity's turn (mirrors InitiativePanel's
+  // pendingFrom pattern, minimal version — no next-entity highlight here).
+  const [pendingEndTurn, setPendingEndTurn] = useState(false);
+  useEffect(() => {
+    if (pendingEndTurn && !isCurrent) setPendingEndTurn(false);
+  }, [isCurrent, pendingEndTurn]);
+
+  const handleEndTurnClick = () => {
+    onEndTurn(entry.entityId);
+    setPendingEndTurn(true);
+  };
 
   return (
     <li
@@ -92,6 +106,7 @@ export function CombatRow({
           size="lg"
           fullWidth
           onClick={handleEndTurnClick}
+          disabled={pendingEndTurn}
         >
           End my turn
         </Button>

--- a/src/components/ui/campaign/player-vtt/CombatRow.tsx
+++ b/src/components/ui/campaign/player-vtt/CombatRow.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { Button } from '@/components/ui/forms/button';
+import { Badge } from '@/components/ui/layout/badge';
+import { HPBar } from '@/components/shared/combat/HPBar';
+import type { EnemyHpDisplay } from '@/types/encounter';
+import type { SharedTurnEntry } from '@/types/sharedState';
+
+/** Disposition-tinted avatar colours: emerald for the player's own row, blue
+ * for allies/players, red for everything else (enemies, neutrals). */
+function avatarColorClasses(entry: SharedTurnEntry, characterId: string) {
+  if (entry.playerCharacterId === characterId) {
+    return 'bg-accent-emerald-bg text-accent-emerald-text border-accent-emerald-border';
+  }
+  if (entry.type === 'player' || entry.disposition === 'ally') {
+    return 'bg-accent-blue-bg text-accent-blue-text border-accent-blue-border';
+  }
+  return 'bg-accent-red-bg text-accent-red-text border-accent-red-border';
+}
+
+interface CombatRowProps {
+  entry: SharedTurnEntry;
+  characterId: string;
+  isCurrent: boolean;
+  enemyHpMode: EnemyHpDisplay;
+  onEndTurn: (entityId: string) => void;
+}
+
+export function CombatRow({
+  entry,
+  characterId,
+  isCurrent,
+  enemyHpMode,
+  onEndTurn,
+}: CombatRowProps) {
+  const isYou = entry.playerCharacterId === characterId;
+  const isDead = entry.isDead === true;
+  const hasHp = entry.currentHp !== undefined && entry.maxHp !== undefined;
+  const isMyActiveTurn = isCurrent && isYou;
+
+  const handleEndTurnClick = () => onEndTurn(entry.entityId);
+
+  return (
+    <li
+      className={`flex flex-col gap-1.5 rounded-lg px-2 py-2 ${
+        isDead
+          ? 'text-faint line-through opacity-50'
+          : isCurrent
+            ? 'bg-accent-amber-bg border-accent-amber-border animate-pulse border'
+            : ''
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden
+          className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs font-bold ${avatarColorClasses(entry, characterId)}`}
+        >
+          {entry.displayName.charAt(0).toUpperCase()}
+        </span>
+        <span className="text-body truncate text-sm font-medium">
+          {entry.displayName}
+        </span>
+        {isYou && <Badge variant="success">YOU</Badge>}
+      </div>
+      <div className="pl-8">
+        {isDead ? (
+          <span className="text-xs">
+            {entry.type === 'player' ? 'Down' : 'Defeated'}
+          </span>
+        ) : hasHp ? (
+          <HPBar
+            current={entry.currentHp as number}
+            max={entry.maxHp as number}
+            size="sm"
+          />
+        ) : entry.hpState ? (
+          <span className="text-faint text-xs">{entry.hpState}</span>
+        ) : entry.hpPercent !== undefined && enemyHpMode === 'percent' ? (
+          <span className="text-faint text-xs">{entry.hpPercent}%</span>
+        ) : entry.hpPercent !== undefined && enemyHpMode === 'bar' ? (
+          <HPBar
+            current={entry.hpPercent}
+            max={100}
+            size="sm"
+            showLabel={false}
+          />
+        ) : null}
+      </div>
+      {isMyActiveTurn && (
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          onClick={handleEndTurnClick}
+        >
+          End my turn
+        </Button>
+      )}
+    </li>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/PlayerVttScreen.hooks.ts
+++ b/src/components/ui/campaign/player-vtt/PlayerVttScreen.hooks.ts
@@ -53,7 +53,7 @@ export function usePlacementFlow(
     addToast({
       type: 'info',
       title: 'Placement cancelled',
-      message: 'Placement cancelled — slot stays spent',
+      message: 'Slot stays spent',
     });
   }, [addToast]);
 

--- a/src/components/ui/campaign/player-vtt/PlayerVttScreen.hooks.ts
+++ b/src/components/ui/campaign/player-vtt/PlayerVttScreen.hooks.ts
@@ -1,0 +1,150 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useAutoSave } from '@/hooks/useAutoSave';
+import { useHydration } from '@/hooks/useHydration';
+import { usePlayerSync } from '@/hooks/usePlayerSync';
+import { useSharedCampaignState } from '@/hooks/useSharedCampaignState';
+import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
+import { useCharacterStore } from '@/store/characterStore';
+import { usePlayerStore } from '@/store/playerStore';
+import { ToastData, useToast } from '@/components/ui/feedback/Toast';
+import type { SpellAoe } from '@/types/spellAoe';
+
+import type { PendingPlacement } from './SpellPlacementController';
+import type { SpellTemplateConfig } from './SpellTemplateTool';
+
+/**
+ * Pending-AoE-placement lifecycle. `config.onPlaced` MUST clear `pending`
+ * synchronously (no await/microtask gap) — see SpellPlacementController's
+ * ordering invariant — or a placement spuriously cancels. Recasting while
+ * one is pending replaces it (spec §6).
+ */
+export function usePlacementFlow(
+  addToast: (toast: Omit<ToastData, 'id'>) => void
+) {
+  const [pendingPlacement, setPendingPlacement] =
+    useState<PendingPlacement | null>(null);
+
+  const requestPlacement = useCallback(
+    (spellName: string, aoe: SpellAoe) => {
+      const config: SpellTemplateConfig = {
+        shape: aoe.shape,
+        sizeFeet: aoe.sizeFeet,
+        widthFeet: aoe.widthFeet,
+        onPlaced: () => {
+          addToast({
+            type: 'success',
+            title: `${spellName} cast`,
+            message: 'Template placed',
+          });
+          setPendingPlacement(null);
+        },
+      };
+      setPendingPlacement({ spellName, aoe, config });
+    },
+    [addToast]
+  );
+
+  const cancelPlacement = useCallback(() => {
+    setPendingPlacement(null);
+    addToast({
+      type: 'info',
+      title: 'Placement cancelled',
+      message: 'Placement cancelled — slot stays spent',
+    });
+  }, [addToast]);
+
+  return { pendingPlacement, requestPlacement, cancelPlacement };
+}
+
+/** Composes character load/sync/shared-state/placement for the player VTT screen. */
+export function usePlayerVttState(campaignCode: string, characterId: string) {
+  const hasHydrated = useHydration();
+  const playerCharacter = usePlayerStore(s =>
+    s.characters.find(c => c.id === characterId)
+  );
+  const character = useCharacterStore(s => s.character);
+  const loadCharacterState = useCharacterStore(s => s.loadCharacterState);
+  const lastLoadedCharacterRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!playerCharacter || !hasHydrated) return;
+    const currentCharacterId = playerCharacter.characterData.id;
+    if (lastLoadedCharacterRef.current !== currentCharacterId) {
+      loadCharacterState(playerCharacter.characterData);
+      lastLoadedCharacterRef.current = currentCharacterId;
+    }
+  }, [playerCharacter, hasHydrated, loadCharacterState]);
+
+  const playerSync = usePlayerSync({ characterId });
+
+  const handleAfterSave = useCallback(() => {
+    if (playerSync.syncEnabled && playerSync.autoSync && character) {
+      playerSync.syncNow(character);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    playerSync.syncEnabled,
+    playerSync.autoSync,
+    playerSync.syncNow,
+    character,
+  ]);
+  useAutoSave({ onAfterSave: handleAfterSave });
+  const { sharedState, refetchNow } = useSharedCampaignState(
+    campaignCode,
+    characterId
+  );
+
+  const handleEndTurn = useCallback(
+    async (entityId: string) => {
+      const init = sharedState?.initiative;
+      if (!campaignCode || !init) return;
+      try {
+        const res = await fetch(`/api/campaign/${campaignCode}/turn-request`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            encounterId: init.encounterId,
+            round: init.round,
+            entityId,
+            playerId: characterId,
+            requestedAt: new Date().toISOString(),
+          }),
+        });
+        if (!res.ok) {
+          console.warn(
+            'End-turn request was rejected by the server:',
+            res.status
+          );
+        }
+      } catch (err) {
+        console.error('Failed to send end-turn request:', err);
+      }
+    },
+    [campaignCode, sharedState?.initiative, characterId]
+  );
+
+  const { toasts, addToast, dismissToast } = useToast();
+  const { pendingPlacement, requestPlacement, cancelPlacement } =
+    usePlacementFlow(addToast);
+  const spellTemplateConfigRef = useRef<SpellTemplateConfig | null>(null);
+  const [connectionStatus, setConnectionStatus] =
+    useState<BattleMapConnectionStatus>('connecting');
+
+  return {
+    character,
+    sharedState,
+    refetchNow,
+    handleEndTurn,
+    pendingPlacement,
+    requestPlacement,
+    cancelPlacement,
+    spellTemplateConfigRef,
+    connectionStatus,
+    setConnectionStatus,
+    toasts,
+    addToast,
+    dismissToast,
+  };
+}

--- a/src/components/ui/campaign/player-vtt/PlayerVttScreen.hooks.ts
+++ b/src/components/ui/campaign/player-vtt/PlayerVttScreen.hooks.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { useAutoSave } from '@/hooks/useAutoSave';
+import { useCharacterRosterSync } from '@/hooks/useCharacterRosterSync';
 import { useHydration } from '@/hooks/useHydration';
 import { usePlayerSync } from '@/hooks/usePlayerSync';
 import { useSharedCampaignState } from '@/hooks/useSharedCampaignState';
@@ -67,16 +68,16 @@ export function usePlayerVttState(campaignCode: string, characterId: string) {
   );
   const character = useCharacterStore(s => s.character);
   const loadCharacterState = useCharacterStore(s => s.loadCharacterState);
-  const lastLoadedCharacterRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!playerCharacter || !hasHydrated) return;
-    const currentCharacterId = playerCharacter.characterData.id;
-    if (lastLoadedCharacterRef.current !== currentCharacterId) {
-      loadCharacterState(playerCharacter.characterData);
-      lastLoadedCharacterRef.current = currentCharacterId;
-    }
-  }, [playerCharacter, hasHydrated, loadCharacterState]);
-
+  const updateCharacterData = usePlayerStore(s => s.updateCharacterData);
+  // Loads character + writes live edits back to the roster (page.tsx:387-442).
+  useCharacterRosterSync({
+    playerCharacter,
+    hasHydrated,
+    characterId,
+    character,
+    loadCharacterState,
+    updateCharacterData,
+  });
   const playerSync = usePlayerSync({ characterId });
 
   const handleAfterSave = useCallback(() => {
@@ -95,7 +96,6 @@ export function usePlayerVttState(campaignCode: string, characterId: string) {
     campaignCode,
     characterId
   );
-
   const handleEndTurn = useCallback(
     async (entityId: string) => {
       const init = sharedState?.initiative;

--- a/src/components/ui/campaign/player-vtt/PlayerVttScreen.tsx
+++ b/src/components/ui/campaign/player-vtt/PlayerVttScreen.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+
+import { Button } from '@/components/ui/forms/button';
+import { PlayerBattleMapCanvas } from '@/components/ui/campaign/location-map/PlayerBattleMapCanvas';
+import { ToastContainer } from '@/components/ui/feedback/Toast';
+
+import { CastingBanner } from './CastingBanner';
+import { CharacterDock } from './CharacterDock';
+import { CombatPanel } from './CombatPanel';
+import { usePlayerVttState } from './PlayerVttScreen.hooks';
+import { SpellPlacementController } from './SpellPlacementController';
+import { StatusEffectTray } from './StatusEffectTray';
+
+interface PlayerVttScreenProps {
+  campaignCode: string;
+  battleMapId: string;
+  characterId: string;
+}
+
+/** Below this viewport width both side panels default to collapsed (spec §1a). */
+const COLLAPSE_BREAKPOINT_PX = 1100;
+const defaultCollapsed = () =>
+  typeof window !== 'undefined' && window.innerWidth < COLLAPSE_BREAKPOINT_PX;
+
+/**
+ * Player VTT screen: battle map canvas + combat panel + character dock +
+ * status tray, composed as canvas children so they share `useActiveTool`
+ * context (required by `SpellPlacementController`).
+ */
+export function PlayerVttScreen({
+  campaignCode,
+  battleMapId,
+  characterId,
+}: PlayerVttScreenProps) {
+  const {
+    character,
+    sharedState,
+    refetchNow,
+    handleEndTurn,
+    pendingPlacement,
+    requestPlacement,
+    cancelPlacement,
+    spellTemplateConfigRef,
+    connectionStatus,
+    setConnectionStatus,
+    toasts,
+    addToast,
+    dismissToast,
+  } = usePlayerVttState(campaignCode, characterId);
+
+  const [combatCollapsed, setCombatCollapsed] = useState(defaultCollapsed);
+  const [dockCollapsed, setDockCollapsed] = useState(defaultCollapsed);
+
+  const handlePoke = useCallback(
+    (feature: string) => {
+      if (feature === 'initiative') refetchNow();
+    },
+    [refetchNow]
+  );
+
+  return (
+    <PlayerBattleMapCanvas
+      campaignCode={campaignCode}
+      battleMapId={battleMapId}
+      characterId={characterId}
+      characterName={character.name}
+      characterAvatar={character.avatar}
+      hideBackButton
+      onStatus={setConnectionStatus}
+      onPoke={handlePoke}
+      spellTemplateConfigRef={spellTemplateConfigRef}
+    >
+      <SpellPlacementController
+        pending={pendingPlacement}
+        configRef={spellTemplateConfigRef}
+        onCancel={cancelPlacement}
+      />
+      {pendingPlacement && (
+        <CastingBanner
+          spellName={pendingPlacement.spellName}
+          aoe={pendingPlacement.aoe}
+          onCancel={cancelPlacement}
+        />
+      )}
+      <div className="pointer-events-none absolute inset-0 z-10">
+        <div className="pointer-events-auto fixed top-3 left-3 z-10">
+          <Link href={`/player/characters/${characterId}`}>
+            <Button
+              variant="ghost"
+              className="flex items-center gap-1.5 text-xs"
+            >
+              <ArrowLeft size={14} />
+              Back to sheet
+            </Button>
+          </Link>
+        </div>
+        <CombatPanel
+          state={sharedState?.initiative ?? null}
+          characterId={characterId}
+          onEndTurn={handleEndTurn}
+          collapsed={combatCollapsed}
+          onToggleCollapsed={() => setCombatCollapsed(v => !v)}
+        />
+        <CharacterDock
+          collapsed={dockCollapsed}
+          onToggleCollapsed={() => setDockCollapsed(v => !v)}
+          addToast={addToast}
+          onCastPlacement={requestPlacement}
+          connectionLive={connectionStatus === 'live'}
+          hasPendingPlacement={pendingPlacement !== null}
+          onCancelPlacement={cancelPlacement}
+        />
+        <StatusEffectTray />
+      </div>
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </PlayerBattleMapCanvas>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/SpellPlacementController.tsx
+++ b/src/components/ui/campaign/player-vtt/SpellPlacementController.tsx
@@ -48,6 +48,12 @@ export function SpellPlacementController({
 
   // If something else steals the tool while armed (e.g. user taps a toolbar
   // button), treat it as a cancel so the banner doesn't dangle.
+  // INVARIANT: the success path stays cancel-free ONLY because the tool's
+  // onPointerUp calls switchTool('select') and onPlaced() synchronously in
+  // one tick, and the parent clears `pending` synchronously inside onPlaced —
+  // React 19 batches both updates into one commit, so this effect never sees
+  // select-with-pending on success. If onPlaced ever gains an async gap
+  // before clearing pending, a successful placement will spuriously cancel.
   useEffect(() => {
     if (pending && wasArmedRef.current && activeTool !== 'spelltemplate') {
       onCancel();

--- a/src/components/ui/campaign/player-vtt/SpellPlacementController.tsx
+++ b/src/components/ui/campaign/player-vtt/SpellPlacementController.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useActiveTool } from '@fieldnotes/react';
+
+import type { MutableRefObject } from 'react';
+import type { SpellTemplateConfig } from './SpellTemplateTool';
+
+export interface PendingPlacement {
+  spellName: string;
+  /** For the banner text ("circle · 20 ft"). */
+  aoe: import('@/types/spellAoe').SpellAoe;
+  config: SpellTemplateConfig;
+}
+
+interface SpellPlacementControllerProps {
+  pending: PendingPlacement | null;
+  configRef: MutableRefObject<SpellTemplateConfig | null>;
+  /** User cancelled (Escape / banner button). Parent clears `pending`. */
+  onCancel: () => void;
+}
+
+/**
+ * Headless bridge between screen state and the canvas tool system: arming a
+ * placement loads the config ref and switches to the spelltemplate tool;
+ * clearing it (placed or cancelled) switches back to select. Escape cancels
+ * (spec §1a desktop keyboard rule).
+ */
+export function SpellPlacementController({
+  pending,
+  configRef,
+  onCancel,
+}: SpellPlacementControllerProps) {
+  const [activeTool, setTool] = useActiveTool();
+  const wasArmedRef = useRef(false);
+
+  useEffect(() => {
+    if (pending) {
+      configRef.current = pending.config;
+      wasArmedRef.current = true;
+      setTool('spelltemplate');
+    } else if (wasArmedRef.current) {
+      configRef.current = null;
+      wasArmedRef.current = false;
+      setTool('select');
+    }
+  }, [pending, configRef, setTool]);
+
+  // If something else steals the tool while armed (e.g. user taps a toolbar
+  // button), treat it as a cancel so the banner doesn't dangle.
+  useEffect(() => {
+    if (pending && wasArmedRef.current && activeTool !== 'spelltemplate') {
+      onCancel();
+    }
+  }, [activeTool, pending, onCancel]);
+
+  useEffect(() => {
+    if (!pending) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [pending, onCancel]);
+
+  return null;
+}

--- a/src/components/ui/campaign/player-vtt/SpellPlacementController.tsx
+++ b/src/components/ui/campaign/player-vtt/SpellPlacementController.tsx
@@ -42,9 +42,13 @@ export function SpellPlacementController({
     } else if (wasArmedRef.current) {
       configRef.current = null;
       wasArmedRef.current = false;
-      setTool('select');
+      // Only force back to select if the tool is still the spelltemplate
+      // this controller armed. If something else already stole it (e.g. the
+      // user picked the pencil, which itself triggered the cancel below),
+      // leave their choice alone instead of stomping it back to select.
+      if (activeTool === 'spelltemplate') setTool('select');
     }
-  }, [pending, configRef, setTool]);
+  }, [pending, configRef, setTool, activeTool]);
 
   // If something else steals the tool while armed (e.g. user taps a toolbar
   // button), treat it as a cancel so the banner doesn't dangle.

--- a/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
+++ b/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
@@ -1,4 +1,6 @@
-import type { Tool, PointerState, ToolContext } from '@fieldnotes/core';
+import { createTemplate, smartSnap } from '@fieldnotes/core';
+
+import type { Point, PointerState, Tool, ToolContext } from '@fieldnotes/core';
 import type { AoeShape } from '@/types/spellAoe';
 
 export interface SpellTemplateConfig {
@@ -9,13 +11,84 @@ export interface SpellTemplateConfig {
   onPlaced: () => void;
 }
 
-// Task 3 fills in behavior (pointer handlers currently no-op stubs).
+const FEET_PER_CELL = 5;
+const SPELL_FILL = '#7C3AB7';
+
+/**
+ * One-shot fixed-size AoE placement, armed by the casting flow via the
+ * mutable configRef (the canvas keeps the FIRST tool instance per name, so
+ * per-cast config must flow through a ref — same pattern as PlayerTokenTool).
+ * circle/square: tap places. cone/line: press places at angle 0, dragging
+ * aims (live element updates sync to everyone), release finalizes.
+ */
 export class SpellTemplateTool implements Tool {
   readonly name = 'spelltemplate';
+
+  private placedId: string | null = null;
+  private origin: Point | null = null;
+  private aiming = false;
+
   constructor(
     private readonly configRef: { current: SpellTemplateConfig | null }
   ) {}
-  onPointerDown(_state: PointerState, _ctx: ToolContext): void {}
-  onPointerMove(_state: PointerState, _ctx: ToolContext): void {}
-  onPointerUp(_state: PointerState, _ctx: ToolContext): void {}
+
+  onPointerDown(state: PointerState, ctx: ToolContext): void {
+    const config = this.configRef.current;
+    if (!config) {
+      ctx.switchTool?.('select');
+      return;
+    }
+    const world = ctx.camera.screenToWorld({ x: state.x, y: state.y });
+    const origin = smartSnap(world, ctx);
+    const cellPx = ctx.gridSize ?? 40;
+    const radiusPx =
+      config.shape === 'square'
+        ? (config.sizeFeet / 2 / FEET_PER_CELL) * cellPx
+        : (config.sizeFeet / FEET_PER_CELL) * cellPx;
+
+    const el = createTemplate({
+      position: origin,
+      templateShape: config.shape,
+      radius: radiusPx,
+      angle: 0,
+      fillColor: SPELL_FILL,
+      strokeColor: SPELL_FILL,
+      opacity: 0.28,
+      feetPerCell: FEET_PER_CELL,
+      radiusFeet: config.sizeFeet,
+      renderStyle: 'geometric',
+      layerId: ctx.activeLayerId ?? '',
+    });
+    ctx.store.add(el);
+    this.placedId = el.id;
+    this.origin = origin;
+    this.aiming = config.shape === 'cone' || config.shape === 'line';
+    ctx.requestRender();
+  }
+
+  onPointerMove(state: PointerState, ctx: ToolContext): void {
+    if (!this.aiming || !this.placedId || !this.origin) return;
+    const world = ctx.camera.screenToWorld({ x: state.x, y: state.y });
+    const angle = Math.atan2(world.y - this.origin.y, world.x - this.origin.x);
+    ctx.store.update(this.placedId, { angle });
+    ctx.requestRender();
+  }
+
+  onPointerUp(_state: PointerState, ctx: ToolContext): void {
+    const config = this.configRef.current;
+    const placed = this.placedId !== null;
+    this.placedId = null;
+    this.origin = null;
+    this.aiming = false;
+    ctx.switchTool?.('select');
+    if (placed) config?.onPlaced();
+  }
+
+  onActivate(ctx: ToolContext): void {
+    ctx.setCursor?.('crosshair');
+  }
+
+  onDeactivate(ctx: ToolContext): void {
+    ctx.setCursor?.('default');
+  }
 }

--- a/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
+++ b/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
@@ -1,0 +1,21 @@
+import type { Tool, PointerState, ToolContext } from '@fieldnotes/core';
+import type { AoeShape } from '@/types/spellAoe';
+
+export interface SpellTemplateConfig {
+  shape: AoeShape;
+  sizeFeet: number;
+  widthFeet?: number;
+  /** Called once after the template lands (tool has already switched to select). */
+  onPlaced: () => void;
+}
+
+// Task 3 fills in behavior (pointer handlers currently no-op stubs).
+export class SpellTemplateTool implements Tool {
+  readonly name = 'spelltemplate';
+  constructor(
+    private readonly configRef: { current: SpellTemplateConfig | null }
+  ) {}
+  onPointerDown(_state: PointerState, _ctx: ToolContext): void {}
+  onPointerMove(_state: PointerState, _ctx: ToolContext): void {}
+  onPointerUp(_state: PointerState, _ctx: ToolContext): void {}
+}

--- a/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
+++ b/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
@@ -6,6 +6,9 @@ import type { AoeShape } from '@/types/spellAoe';
 export interface SpellTemplateConfig {
   shape: AoeShape;
   sizeFeet: number;
+  /** Line-template width; not yet honored — the canvas SDK's createTemplate
+   * has no width param, so line templates render at its default width until
+   * the SDK gains width support. Kept on the type so callers can pass it. */
   widthFeet?: number;
   /** Called once after the template lands (tool has already switched to select). */
   onPlaced: () => void;

--- a/src/components/ui/campaign/player-vtt/StatusEffectTray.tsx
+++ b/src/components/ui/campaign/player-vtt/StatusEffectTray.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/feedback/dialog';
+import {
+  BUFF_PALETTE,
+  DEBUFF_PALETTE,
+} from '@/components/ui/encounter/combat-screen/effectPalettes';
+import { Button } from '@/components/ui/forms/button';
+import { ConditionBadge } from '@/components/shared/combat/ConditionBadge';
+import { useCharacterStore } from '@/store/characterStore';
+
+const QUICK_ADD_PALETTE = [...DEBUFF_PALETTE, ...BUFF_PALETTE];
+
+/**
+ * Fixed top-right pill row for the player VTT screen: concentration status
+ * and active conditions at a glance, plus a quick-add picker. All state is
+ * store-local — reads/writes `characterStore` directly.
+ */
+export function StatusEffectTray() {
+  const concentration = useCharacterStore(s => s.character.concentration);
+  const activeConditions = useCharacterStore(
+    s => s.character.conditionsAndDiseases.activeConditions
+  );
+  const stopConcentration = useCharacterStore(s => s.stopConcentration);
+  const removeCondition = useCharacterStore(s => s.removeCondition);
+  const addCondition = useCharacterStore(s => s.addCondition);
+
+  const [concOpen, setConcOpen] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
+
+  return (
+    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-3 right-4 z-10 flex max-w-[40vw] flex-wrap gap-2 rounded-2xl border p-2 shadow-lg">
+      {concentration.isConcentrating && (
+        <Dialog open={concOpen} onOpenChange={setConcOpen}>
+          <DialogTrigger asChild>
+            <button className="bg-accent-amber-bg border-accent-amber-border text-accent-amber-text flex min-h-[30px] items-center gap-1 rounded-full border px-2.5 text-xs font-semibold">
+              🧠 CONC
+            </button>
+          </DialogTrigger>
+          <DialogContent size="sm">
+            <DialogHeader>
+              <DialogTitle>
+                Concentrating on {concentration.spellName}
+              </DialogTitle>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="danger"
+                size="lg"
+                onClick={() => {
+                  stopConcentration();
+                  setConcOpen(false);
+                }}
+              >
+                End concentration
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {activeConditions.map(condition => (
+        <div key={condition.id} className="flex min-h-[30px] items-center">
+          <ConditionBadge
+            name={condition.name}
+            stackCount={condition.count}
+            sourceSpell={condition.source}
+            size="md"
+            onRemove={() => removeCondition(condition.id)}
+          />
+        </div>
+      ))}
+
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogTrigger asChild>
+          <button
+            aria-label="Add condition"
+            className="border-divider text-faint flex min-h-[30px] min-w-[30px] items-center justify-center rounded-full border border-dashed"
+          >
+            +
+          </button>
+        </DialogTrigger>
+        <DialogContent size="md">
+          <DialogHeader>
+            <DialogTitle>Add condition or buff</DialogTitle>
+          </DialogHeader>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {QUICK_ADD_PALETTE.map(entry => (
+              <Button
+                key={entry.name}
+                variant="outline"
+                size="lg"
+                onClick={() => {
+                  addCondition(entry.name, 'Self', '', 1);
+                  setAddOpen(false);
+                }}
+              >
+                {entry.name}
+              </Button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/player-vtt/__tests__/CombatPanel.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/CombatPanel.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+import { CombatPanel } from '@/components/ui/campaign/player-vtt/CombatPanel';
+import type {
+  SharedInitiativeState,
+  SharedTurnEntry,
+} from '@/types/sharedState';
+
+const CHARACTER_ID = 'char-123';
+
+// Masked enemy — HP arrives as a label string (enemyHpMode: 'label').
+const enemyEntry: SharedTurnEntry = {
+  entityId: 'goblin-1',
+  displayName: 'Goblin',
+  type: 'monster',
+  disposition: 'enemy',
+  hpState: 'Bloodied',
+  hpTier: 'mid',
+};
+
+// The open character's own combatant — players always get numeric HP.
+const playerEntry: SharedTurnEntry = {
+  entityId: 'pc-1',
+  displayName: 'Aria',
+  type: 'player',
+  playerCharacterId: CHARACTER_ID,
+  currentHp: 18,
+  maxHp: 30,
+  isDead: false,
+};
+
+// A defeated enemy — HP fully masked (no hpState carried through once dead).
+const defeatedEntry: SharedTurnEntry = {
+  entityId: 'orc-1',
+  displayName: 'Orc',
+  type: 'monster',
+  disposition: 'enemy',
+  isDead: true,
+};
+
+function buildState(
+  overrides: Partial<SharedInitiativeState> = {}
+): SharedInitiativeState {
+  return {
+    encounterId: 'enc-1',
+    isActive: true,
+    round: 2,
+    currentEntityId: 'goblin-1',
+    turnOrder: [enemyEntry, playerEntry, defeatedEntry],
+    enemyHpMode: 'label',
+    updatedAt: '2026-07-08T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function noop() {
+  // Intentional no-op for props that aren't asserted on in a given test.
+}
+
+describe('CombatPanel', () => {
+  afterEach(() => cleanup());
+
+  it('renders nothing when combat is inactive or state is null', () => {
+    const { container: nullContainer } = render(
+      <CombatPanel
+        state={null}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+    expect(nullContainer).toBeEmptyDOMElement();
+
+    const { container: inactiveContainer } = render(
+      <CombatPanel
+        state={buildState({ isActive: false })}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+    expect(inactiveContainer).toBeEmptyDOMElement();
+  });
+
+  it('renders round header and one row per entry in server order', () => {
+    render(
+      <CombatPanel
+        state={buildState()}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+
+    expect(screen.getByText(/ROUND\s*2/)).toBeInTheDocument();
+    expect(screen.getByText(/3 IN ORDER/i)).toBeInTheDocument();
+
+    const rows = screen.getAllByRole('listitem');
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toHaveTextContent('Goblin');
+    expect(rows[1]).toHaveTextContent('Aria');
+    expect(rows[2]).toHaveTextContent('Orc');
+  });
+
+  it('marks the player row with YOU and shows End my turn only on their active turn', () => {
+    const handleEndTurn = vi.fn();
+    render(
+      <CombatPanel
+        state={buildState({ currentEntityId: 'pc-1' })}
+        characterId={CHARACTER_ID}
+        onEndTurn={handleEndTurn}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+
+    expect(screen.getByText('YOU')).toBeInTheDocument();
+    const endTurnButton = screen.getByRole('button', {
+      name: /end my turn/i,
+    });
+    expect(endTurnButton).toBeInTheDocument();
+
+    fireEvent.click(endTurnButton);
+    expect(handleEndTurn).toHaveBeenCalledWith('pc-1');
+  });
+
+  it("hides End my turn when it is not the player's turn", () => {
+    render(
+      <CombatPanel
+        state={buildState({ currentEntityId: 'goblin-1' })}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+
+    // Identity badge still shows on the player's own row...
+    expect(screen.getByText('YOU')).toBeInTheDocument();
+    // ...but it isn't their turn, so no end-turn control.
+    expect(
+      screen.queryByRole('button', { name: /end my turn/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders masked HP labels verbatim and numeric HP as a bar', () => {
+    render(
+      <CombatPanel
+        state={buildState()}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+
+    // Enemy: masked label string rendered verbatim, no numbers leaked.
+    expect(screen.getByText('Bloodied')).toBeInTheDocument();
+    expect(screen.queryByText(/goblin.*\d/i)).not.toBeInTheDocument();
+
+    // Player: real numeric HP rendered via the HPBar label.
+    expect(screen.getByText('18/30')).toBeInTheDocument();
+  });
+
+  it('applies defeated styling', () => {
+    render(
+      <CombatPanel
+        state={buildState()}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+
+    const rows = screen.getAllByRole('listitem');
+    const orcRow = rows.find(row => row.textContent?.includes('Orc'));
+    expect(orcRow).toBeDefined();
+    expect(orcRow?.className).toEqual(expect.stringContaining('opacity-50'));
+    expect(orcRow?.className).toEqual(expect.stringContaining('line-through'));
+  });
+
+  it('collapses to an edge tab and expands back', () => {
+    const handleToggleCollapsed = vi.fn();
+    const { rerender } = render(
+      <CombatPanel
+        state={buildState()}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={true}
+        onToggleCollapsed={handleToggleCollapsed}
+      />
+    );
+
+    const edgeTab = screen.getByRole('button', { name: /initiative/i });
+    expect(edgeTab).toBeInTheDocument();
+    // The full panel (round header) must not be rendered while collapsed.
+    expect(screen.queryByText(/ROUND/)).not.toBeInTheDocument();
+
+    fireEvent.click(edgeTab);
+    expect(handleToggleCollapsed).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <CombatPanel
+        state={buildState()}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={false}
+        onToggleCollapsed={handleToggleCollapsed}
+      />
+    );
+    expect(screen.getByText(/ROUND/)).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/campaign/player-vtt/__tests__/CombatPanel.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/CombatPanel.test.tsx
@@ -128,6 +128,58 @@ describe('CombatPanel', () => {
     expect(handleEndTurn).toHaveBeenCalledWith('pc-1');
   });
 
+  it('disables End my turn immediately after click, then hides it once the synced turn advances', () => {
+    const handleEndTurn = vi.fn();
+    const { rerender } = render(
+      <CombatPanel
+        state={buildState({ currentEntityId: 'pc-1' })}
+        characterId={CHARACTER_ID}
+        onEndTurn={handleEndTurn}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+
+    const endTurnButton = screen.getByRole('button', {
+      name: /end my turn/i,
+    });
+    fireEvent.click(endTurnButton);
+    expect(handleEndTurn).toHaveBeenCalledWith('pc-1');
+    // Optimistic pending: disabled while we wait for the poll to catch up,
+    // so a slow sync can't let the player double-fire the request.
+    expect(endTurnButton).toBeDisabled();
+
+    // Server catches up: currentEntityId moves off pc-1 — button disappears
+    // entirely since it's no longer this character's turn.
+    rerender(
+      <CombatPanel
+        state={buildState({ currentEntityId: 'goblin-1' })}
+        characterId={CHARACTER_ID}
+        onEndTurn={handleEndTurn}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+    expect(
+      screen.queryByRole('button', { name: /end my turn/i })
+    ).not.toBeInTheDocument();
+
+    // Turn comes back around to the player later — button is re-enabled,
+    // not stuck disabled from the earlier click.
+    rerender(
+      <CombatPanel
+        state={buildState({ currentEntityId: 'pc-1' })}
+        characterId={CHARACTER_ID}
+        onEndTurn={handleEndTurn}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: /end my turn/i })
+    ).not.toBeDisabled();
+  });
+
   it("hides End my turn when it is not the player's turn", () => {
     render(
       <CombatPanel

--- a/src/components/ui/campaign/player-vtt/__tests__/CombatPanel.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/CombatPanel.test.tsx
@@ -166,6 +166,65 @@ describe('CombatPanel', () => {
     expect(screen.getByText('18/30')).toBeInTheDocument();
   });
 
+  it('renders enemy hpPercent as text only when enemyHpMode is percent', () => {
+    const percentEnemy: SharedTurnEntry = {
+      entityId: 'goblin-2',
+      displayName: 'Hobgoblin',
+      type: 'monster',
+      disposition: 'enemy',
+      hpPercent: 42,
+      hpTier: 'mid',
+    };
+    render(
+      <CombatPanel
+        state={buildState({
+          enemyHpMode: 'percent',
+          turnOrder: [percentEnemy],
+        })}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+
+    expect(screen.getByText('42%')).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    const rows = screen.getAllByRole('listitem');
+    expect(
+      rows[0].querySelector('.bg-surface-raised.rounded-full')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders enemy hpPercent as a bar only when enemyHpMode is bar', () => {
+    const barEnemy: SharedTurnEntry = {
+      entityId: 'goblin-3',
+      displayName: 'Bugbear',
+      type: 'monster',
+      disposition: 'enemy',
+      hpPercent: 65,
+      hpTier: 'mid',
+    };
+    render(
+      <CombatPanel
+        state={buildState({
+          enemyHpMode: 'bar',
+          turnOrder: [barEnemy],
+        })}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+
+    expect(screen.queryByText('65%')).not.toBeInTheDocument();
+    const rows = screen.getAllByRole('listitem');
+    expect(
+      rows[0].querySelector('.bg-surface-raised.rounded-full')
+    ).toBeInTheDocument();
+  });
+
   it('applies defeated styling', () => {
     render(
       <CombatPanel

--- a/src/components/ui/campaign/player-vtt/__tests__/DockSpells.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/DockSpells.test.tsx
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  within,
+} from '@testing-library/react';
+
+import { DockSpells } from '@/components/ui/campaign/player-vtt/CharacterDock/DockSpells';
+import { useCharacterStore } from '@/store/characterStore';
+import type { CharacterState, Spell } from '@/types/character';
+
+function makeSpell(
+  overrides: Partial<Spell> & Pick<Spell, 'id' | 'name' | 'level'>
+): Spell {
+  return {
+    school: 'Evocation',
+    castingTime: '1 action',
+    range: '60 feet',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Instantaneous',
+    description: 'Test spell.',
+    createdAt: '',
+    updatedAt: '',
+    ...overrides,
+  };
+}
+
+const FIRE_BOLT = makeSpell({ id: 'firebolt', name: 'Fire Bolt', level: 0 });
+const SHIELD = makeSpell({
+  id: 'shield',
+  name: 'Shield',
+  level: 1,
+  castingTime: '1 reaction',
+  duration: '1 round',
+});
+const FIREBALL = makeSpell({
+  id: 'fireball',
+  name: 'Fireball',
+  level: 3,
+  range: '150 feet',
+  components: { verbal: true, somatic: true, material: true },
+  aoe: { shape: 'circle', sizeFeet: 20 },
+});
+const HOLD_PERSON = makeSpell({
+  id: 'holdperson',
+  name: 'Hold Person',
+  level: 2,
+  concentration: true,
+  duration: 'Concentration, up to 1 minute',
+});
+
+function seedCharacter(overrides: Partial<CharacterState> = {}) {
+  const store = useCharacterStore.getState();
+  const base = store.character;
+  store.loadCharacterState({
+    ...base,
+    class: { name: 'Wizard', isCustom: false, spellcaster: 'full', hitDie: 6 },
+    level: 5,
+    abilities: { ...base.abilities, intelligence: 18 },
+    spellcastingStats: {
+      spellcastingAbility: 'intelligence',
+      isAbilityOverridden: false,
+      spellAttackBonus: undefined,
+      spellSaveDC: undefined,
+    },
+    spellSlots: {
+      1: { max: 4, used: 0 },
+      2: { max: 3, used: 0 },
+      3: { max: 2, used: 0 },
+      4: { max: 0, used: 0 },
+      5: { max: 0, used: 0 },
+      6: { max: 0, used: 0 },
+      7: { max: 0, used: 0 },
+      8: { max: 0, used: 0 },
+      9: { max: 0, used: 0 },
+    },
+    concentration: { isConcentrating: false },
+    reaction: { hasUsedReaction: false },
+    spells: [FIRE_BOLT, SHIELD, FIREBALL, HOLD_PERSON],
+    ...overrides,
+  } as CharacterState);
+}
+
+const getChar = () => useCharacterStore.getState().character;
+
+/** The Cast button that lives in the same row as `spellName`. */
+function castButtonFor(spellName: string): HTMLElement {
+  const row = screen.getByText(spellName).closest('.border-divider');
+  return within(row as HTMLElement).getByRole('button', { name: /^cast$/i });
+}
+
+function renderDock(
+  propOverrides: Partial<Parameters<typeof DockSpells>[0]> = {}
+) {
+  const addToast = vi.fn();
+  const onCastPlacement = vi.fn();
+  const onCancelPlacement = vi.fn();
+  const utils = render(
+    <DockSpells
+      addToast={addToast}
+      onCastPlacement={onCastPlacement}
+      connectionLive
+      hasPendingPlacement={false}
+      onCancelPlacement={onCancelPlacement}
+      {...propOverrides}
+    />
+  );
+  return { ...utils, addToast, onCastPlacement, onCancelPlacement };
+}
+
+describe('DockSpells', () => {
+  beforeEach(() => {
+    seedCharacter();
+  });
+
+  afterEach(() => cleanup());
+
+  it('groups spells by level ascending, cantrips first', () => {
+    renderDock();
+    const headers = screen
+      .getAllByRole('button')
+      .map(b => b.textContent)
+      .filter(t => t && /Cantrips|Level \d/.test(t));
+
+    expect(headers[0]).toMatch(/Cantrips/);
+    expect(headers[1]).toMatch(/Level 1/);
+    expect(headers[2]).toMatch(/Level 2/);
+    expect(headers[3]).toMatch(/Level 3/);
+
+    expect(screen.getByText('Fire Bolt')).toBeInTheDocument();
+    expect(screen.getByText('Shield')).toBeInTheDocument();
+    expect(screen.getByText('Fireball')).toBeInTheDocument();
+  });
+
+  it('search filters spells by name (case-insensitive)', () => {
+    renderDock();
+    fireEvent.change(screen.getByRole('textbox', { name: /search spells/i }), {
+      target: { value: 'fire' },
+    });
+
+    expect(screen.getByText('Fire Bolt')).toBeInTheDocument();
+    expect(screen.getByText('Fireball')).toBeInTheDocument();
+    expect(screen.queryByText('Shield')).not.toBeInTheDocument();
+    expect(screen.queryByText('Hold Person')).not.toBeInTheDocument();
+  });
+
+  it('cantrip Cast casts immediately with no modal, effect visible in store', () => {
+    renderDock();
+    fireEvent.click(castButtonFor('Fire Bolt'));
+
+    // No slot spent (cantrip), no modal opened.
+    expect(screen.queryByText('Cast Spell')).not.toBeInTheDocument();
+    expect(getChar().spellSlots[1].used).toBe(0);
+  });
+
+  it('AoE spell cast via modal spends the slot and calls onCastPlacement with no toast', () => {
+    const { addToast, onCastPlacement } = renderDock();
+
+    fireEvent.click(castButtonFor('Fireball'));
+    fireEvent.click(screen.getByRole('button', { name: /^cast fireball/i }));
+
+    expect(getChar().spellSlots[3].used).toBe(1);
+    expect(onCastPlacement).toHaveBeenCalledWith('Fireball', {
+      shape: 'circle',
+      sizeFeet: 20,
+    });
+    expect(addToast).not.toHaveBeenCalled();
+  });
+
+  it('AoE cast while offline skips onCastPlacement and fires an offline toast', () => {
+    const { addToast, onCastPlacement } = renderDock({ connectionLive: false });
+
+    fireEvent.click(castButtonFor('Fireball'));
+    fireEvent.click(screen.getByRole('button', { name: /^cast fireball/i }));
+
+    expect(onCastPlacement).not.toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        title: 'Fireball cast',
+        message: 'Offline — template not placed',
+      })
+    );
+  });
+
+  it('non-AoE leveled cast fires a success toast', () => {
+    const { addToast } = renderDock();
+
+    fireEvent.click(castButtonFor('Shield'));
+    fireEvent.click(screen.getByRole('button', { name: /^cast shield/i }));
+
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', title: 'Shield cast' })
+    );
+  });
+
+  it('casting a concentration spell with no aoe cancels a stale pending placement', () => {
+    const { onCancelPlacement } = renderDock({ hasPendingPlacement: true });
+
+    fireEvent.click(castButtonFor('Hold Person'));
+    fireEvent.click(screen.getByRole('button', { name: /^cast hold person/i }));
+
+    expect(onCancelPlacement).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing for a non-caster', () => {
+    seedCharacter({
+      class: {
+        name: 'Fighter',
+        isCustom: false,
+        spellcaster: 'none',
+        hitDie: 10,
+      },
+      spellcastingStats: {
+        spellcastingAbility: null,
+        isAbilityOverridden: false,
+        spellAttackBonus: undefined,
+        spellSaveDC: undefined,
+      },
+    });
+    const { container } = renderDock();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the character has zero spells', () => {
+    seedCharacter({ spells: [] });
+    const { container } = renderDock();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/ui/campaign/player-vtt/__tests__/DockSpells.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/DockSpells.test.tsx
@@ -27,13 +27,19 @@ function makeSpell(
   };
 }
 
-const FIRE_BOLT = makeSpell({ id: 'firebolt', name: 'Fire Bolt', level: 0 });
+const FIRE_BOLT = makeSpell({
+  id: 'firebolt',
+  name: 'Fire Bolt',
+  level: 0,
+  isPrepared: true,
+});
 const SHIELD = makeSpell({
   id: 'shield',
   name: 'Shield',
   level: 1,
   castingTime: '1 reaction',
   duration: '1 round',
+  isPrepared: true,
 });
 const FIREBALL = makeSpell({
   id: 'fireball',
@@ -42,6 +48,7 @@ const FIREBALL = makeSpell({
   range: '150 feet',
   components: { verbal: true, somatic: true, material: true },
   aoe: { shape: 'circle', sizeFeet: 20 },
+  isPrepared: true,
 });
 const HOLD_PERSON = makeSpell({
   id: 'holdperson',
@@ -49,6 +56,7 @@ const HOLD_PERSON = makeSpell({
   level: 2,
   concentration: true,
   duration: 'Concentration, up to 1 minute',
+  isPrepared: true,
 });
 
 function seedCharacter(overrides: Partial<CharacterState> = {}) {
@@ -228,5 +236,60 @@ describe('DockSpells', () => {
     seedCharacter({ spells: [] });
     const { container } = renderDock();
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows only castable spells: prepared/always-prepared spells and prepared cantrips', () => {
+    const preparedCantrip = makeSpell({
+      id: 'mage-hand',
+      name: 'Mage Hand',
+      level: 0,
+      isPrepared: true,
+    });
+    const unpreparedCantrip = makeSpell({
+      id: 'prestidigitation',
+      name: 'Prestidigitation',
+      level: 0,
+      isPrepared: false,
+    });
+    const preparedSpell = makeSpell({
+      id: 'magic-missile',
+      name: 'Magic Missile',
+      level: 1,
+      isPrepared: true,
+    });
+    const unpreparedSpell = makeSpell({
+      id: 'sleep',
+      name: 'Sleep',
+      level: 1,
+      isPrepared: false,
+    });
+    const alwaysPreparedSpell = makeSpell({
+      id: 'hunter-mark',
+      name: "Hunter's Mark",
+      level: 1,
+      isPrepared: false,
+      isAlwaysPrepared: true,
+    });
+
+    seedCharacter({
+      spells: [
+        preparedCantrip,
+        unpreparedCantrip,
+        preparedSpell,
+        unpreparedSpell,
+        alwaysPreparedSpell,
+      ],
+    });
+
+    renderDock();
+
+    // Castable spells should render
+    expect(screen.getByText('Mage Hand')).toBeInTheDocument();
+    expect(screen.getByText('Magic Missile')).toBeInTheDocument();
+    expect(screen.getByText("Hunter's Mark")).toBeInTheDocument();
+
+    // Non-castable spells should NOT render
+    expect(screen.queryByText('Prestidigitation')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sleep')).not.toBeInTheDocument();
   });
 });

--- a/src/components/ui/campaign/player-vtt/__tests__/DockSpells.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/DockSpells.test.tsx
@@ -213,6 +213,38 @@ describe('DockSpells', () => {
     expect(onCancelPlacement).toHaveBeenCalledTimes(1);
   });
 
+  it('offline concentration AoE cast cancels a stale pending placement before falling into the offline path', () => {
+    const SPIRIT_GUARDIANS = makeSpell({
+      id: 'spiritguardians',
+      name: 'Spirit Guardians',
+      level: 3,
+      concentration: true,
+      duration: 'Concentration, up to 10 minutes',
+      aoe: { shape: 'circle', sizeFeet: 15 },
+      isPrepared: true,
+    });
+    seedCharacter({ spells: [SPIRIT_GUARDIANS] });
+    const { addToast, onCastPlacement, onCancelPlacement } = renderDock({
+      connectionLive: false,
+      hasPendingPlacement: true,
+    });
+
+    fireEvent.click(castButtonFor('Spirit Guardians'));
+    fireEvent.click(
+      screen.getByRole('button', { name: /^cast spirit guardians/i })
+    );
+
+    expect(onCancelPlacement).toHaveBeenCalledTimes(1);
+    expect(onCastPlacement).not.toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        title: 'Spirit Guardians cast',
+        message: 'Offline — template not placed',
+      })
+    );
+  });
+
   it('renders nothing for a non-caster', () => {
     seedCharacter({
       class: {

--- a/src/components/ui/campaign/player-vtt/__tests__/DockVitals.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/DockVitals.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+import { DockVitals } from '@/components/ui/campaign/player-vtt/CharacterDock/DockVitals';
+import { useCharacterStore } from '@/store/characterStore';
+import type { CharacterState } from '@/types/character';
+
+function seedCharacter(overrides: Partial<CharacterState> = {}) {
+  const store = useCharacterStore.getState();
+  const base = store.character;
+  store.loadCharacterState({
+    ...base,
+    hitPoints: { current: 20, max: 30, temporary: 5, deathSaves: undefined },
+    heroicInspiration: { count: 2, maxCount: 3 },
+    ...overrides,
+  } as CharacterState);
+}
+
+const getChar = () => useCharacterStore.getState().character;
+
+describe('DockVitals', () => {
+  beforeEach(() => {
+    seedCharacter();
+  });
+
+  afterEach(() => cleanup());
+
+  it('applies damage temp-first', () => {
+    render(<DockVitals addToast={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox', { name: /hp amount/i }), {
+      target: { value: '8' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^damage$/i }));
+
+    expect(getChar().hitPoints.temporary).toBe(0);
+    expect(getChar().hitPoints.current).toBe(17);
+  });
+
+  it('fires a toast and clears the input after applying damage', () => {
+    const addToast = vi.fn();
+    render(<DockVitals addToast={addToast} />);
+    fireEvent.change(screen.getByRole('textbox', { name: /hp amount/i }), {
+      target: { value: '8' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^damage$/i }));
+
+    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(addToast.mock.calls[0][0]).toMatchObject({
+      title: 'Took 8 damage',
+    });
+    expect(screen.getByRole('textbox', { name: /hp amount/i })).toHaveValue('');
+  });
+
+  it('heal caps at max', () => {
+    render(<DockVitals addToast={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox', { name: /hp amount/i }), {
+      target: { value: '50' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^heal$/i }));
+
+    expect(getChar().hitPoints.current).toBe(30);
+  });
+
+  it('temp HP takes the larger value instead of stacking', () => {
+    render(<DockVitals addToast={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox', { name: /hp amount/i }), {
+      target: { value: '3' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^temp$/i }));
+
+    // existing temp (5) was already higher than 3, so it stays 5
+    expect(getChar().hitPoints.temporary).toBe(5);
+  });
+
+  it('is a no-op on NaN or empty input', () => {
+    const addToast = vi.fn();
+    render(<DockVitals addToast={addToast} />);
+    fireEvent.click(screen.getByRole('button', { name: /^damage$/i }));
+    expect(getChar().hitPoints.current).toBe(20);
+
+    fireEvent.change(screen.getByRole('textbox', { name: /hp amount/i }), {
+      target: { value: 'abc' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^heal$/i }));
+    expect(getChar().hitPoints.current).toBe(20);
+    expect(addToast).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op on zero or negative input', () => {
+    render(<DockVitals addToast={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox', { name: /hp amount/i }), {
+      target: { value: '-4' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^damage$/i }));
+    expect(getChar().hitPoints.current).toBe(20);
+  });
+
+  it('disables the Use button at 0 heroic inspiration', () => {
+    seedCharacter({ heroicInspiration: { count: 0, maxCount: 3 } });
+    render(<DockVitals addToast={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /^use$/i })).toBeDisabled();
+  });
+
+  it('spends heroic inspiration and fires an advantage toast', () => {
+    const addToast = vi.fn();
+    render(<DockVitals addToast={addToast} />);
+    const useButton = screen.getByRole('button', { name: /^use$/i });
+    expect(useButton).not.toBeDisabled();
+
+    fireEvent.click(useButton);
+
+    expect(getChar().heroicInspiration.count).toBe(1);
+    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(addToast.mock.calls[0][0].title).toMatch(/Heroic Inspiration:/);
+  });
+
+  it('disables the + stepper once maxCount is reached', () => {
+    seedCharacter({ heroicInspiration: { count: 3, maxCount: 3 } });
+    render(<DockVitals addToast={vi.fn()} />);
+    expect(
+      screen.getByRole('button', { name: /add heroic inspiration/i })
+    ).toBeDisabled();
+  });
+
+  it('increments heroic inspiration via the + stepper when under max', () => {
+    render(<DockVitals addToast={vi.fn()} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /add heroic inspiration/i })
+    );
+    expect(getChar().heroicInspiration.count).toBe(3);
+  });
+
+  it('decrements heroic inspiration via the − stepper', () => {
+    render(<DockVitals addToast={vi.fn()} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /remove heroic inspiration/i })
+    );
+    expect(getChar().heroicInspiration.count).toBe(1);
+  });
+});

--- a/src/components/ui/campaign/player-vtt/__tests__/DockVitals.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/DockVitals.test.tsx
@@ -47,6 +47,7 @@ describe('DockVitals', () => {
     expect(addToast).toHaveBeenCalledTimes(1);
     expect(addToast.mock.calls[0][0]).toMatchObject({
       title: 'Took 8 damage',
+      message: 'HP 17/30',
     });
     expect(screen.getByRole('textbox', { name: /hp amount/i })).toHaveValue('');
   });

--- a/src/components/ui/campaign/player-vtt/__tests__/PlayerVttScreen.hooks.test.ts
+++ b/src/components/ui/campaign/player-vtt/__tests__/PlayerVttScreen.hooks.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { usePlacementFlow } from '../PlayerVttScreen.hooks';
+import type { SpellAoe } from '@/types/spellAoe';
+
+const FIREBALL_AOE: SpellAoe = { shape: 'circle', sizeFeet: 20 };
+const CONE_AOE: SpellAoe = { shape: 'cone', sizeFeet: 15 };
+
+describe('usePlacementFlow', () => {
+  it('requestPlacement sets pending with a config carrying the right shape/size', () => {
+    const addToast = vi.fn();
+    const { result } = renderHook(() => usePlacementFlow(addToast));
+
+    act(() => {
+      result.current.requestPlacement('Fireball', FIREBALL_AOE);
+    });
+
+    expect(result.current.pendingPlacement).not.toBeNull();
+    expect(result.current.pendingPlacement?.spellName).toBe('Fireball');
+    expect(result.current.pendingPlacement?.aoe).toBe(FIREBALL_AOE);
+    expect(result.current.pendingPlacement?.config).toMatchObject({
+      shape: 'circle',
+      sizeFeet: 20,
+    });
+    expect(addToast).not.toHaveBeenCalled();
+  });
+
+  it('config.onPlaced clears pending and fires a success toast in the same act()', () => {
+    const addToast = vi.fn();
+    const { result } = renderHook(() => usePlacementFlow(addToast));
+
+    act(() => {
+      result.current.requestPlacement('Fireball', FIREBALL_AOE);
+    });
+    const { config } = result.current.pendingPlacement!;
+
+    // Simulate the tool's synchronous onPlaced callback (the invariant
+    // pinned here: no await/microtask gap between the toast and the clear).
+    act(() => {
+      config.onPlaced();
+    });
+
+    expect(result.current.pendingPlacement).toBeNull();
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'success',
+        title: 'Fireball cast',
+      })
+    );
+  });
+
+  it('cancelPlacement clears pending and fires the slot-stays-spent info toast', () => {
+    const addToast = vi.fn();
+    const { result } = renderHook(() => usePlacementFlow(addToast));
+
+    act(() => {
+      result.current.requestPlacement('Fireball', FIREBALL_AOE);
+    });
+    act(() => {
+      result.current.cancelPlacement();
+    });
+
+    expect(result.current.pendingPlacement).toBeNull();
+    expect(addToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        message: expect.stringContaining('slot stays spent'),
+      })
+    );
+  });
+
+  it('a second requestPlacement while one is pending replaces it', () => {
+    const addToast = vi.fn();
+    const { result } = renderHook(() => usePlacementFlow(addToast));
+
+    act(() => {
+      result.current.requestPlacement('Fireball', FIREBALL_AOE);
+    });
+    act(() => {
+      result.current.requestPlacement('Burning Hands', CONE_AOE);
+    });
+
+    expect(result.current.pendingPlacement?.spellName).toBe('Burning Hands');
+    expect(result.current.pendingPlacement?.aoe).toBe(CONE_AOE);
+    expect(result.current.pendingPlacement?.config).toMatchObject({
+      shape: 'cone',
+      sizeFeet: 15,
+    });
+  });
+});

--- a/src/components/ui/campaign/player-vtt/__tests__/PlayerVttScreen.hooks.test.ts
+++ b/src/components/ui/campaign/player-vtt/__tests__/PlayerVttScreen.hooks.test.ts
@@ -65,7 +65,8 @@ describe('usePlacementFlow', () => {
     expect(addToast).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'info',
-        message: expect.stringContaining('slot stays spent'),
+        title: 'Placement cancelled',
+        message: 'Slot stays spent',
       })
     );
   });

--- a/src/components/ui/campaign/player-vtt/__tests__/SpellTemplateTool.test.ts
+++ b/src/components/ui/campaign/player-vtt/__tests__/SpellTemplateTool.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  ToolContext,
+  PointerState,
+  TemplateElement,
+} from '@fieldnotes/core';
+import {
+  SpellTemplateTool,
+  type SpellTemplateConfig,
+} from '@/components/ui/campaign/player-vtt/SpellTemplateTool';
+
+function fakeCtx() {
+  const added: TemplateElement[] = [];
+  const updates: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const ctx = {
+    camera: { screenToWorld: (p: { x: number; y: number }) => p },
+    store: {
+      add: vi.fn((el: TemplateElement) => {
+        added.push(el);
+        return el;
+      }),
+      update: vi.fn((id: string, patch: Record<string, unknown>) => {
+        updates.push({ id, patch });
+      }),
+    },
+    requestRender: vi.fn(),
+    switchTool: vi.fn(),
+    setCursor: vi.fn(),
+    gridSize: 40,
+    activeLayerId: 'layer-1',
+    snapToGrid: false, // smartSnap becomes identity without grid snap
+  } as unknown as ToolContext;
+  return { ctx, added, updates };
+}
+
+const down = (x: number, y: number) => ({ x, y }) as PointerState;
+
+function armed(config: Partial<SpellTemplateConfig> = {}) {
+  const onPlaced = vi.fn();
+  const ref = {
+    current: {
+      shape: 'circle',
+      sizeFeet: 20,
+      onPlaced,
+      ...config,
+    } as SpellTemplateConfig,
+  };
+  return { tool: new SpellTemplateTool(ref), ref, onPlaced };
+}
+
+describe('SpellTemplateTool', () => {
+  let f: ReturnType<typeof fakeCtx>;
+  beforeEach(() => {
+    f = fakeCtx();
+  });
+
+  it('places a circle sized from feet at the tap point (20ft radius @5ft/40px = 160px)', () => {
+    const { tool, onPlaced } = armed({ shape: 'circle', sizeFeet: 20 });
+    tool.onPointerDown(down(100, 200), f.ctx);
+    expect(f.added).toHaveLength(1);
+    const el = f.added[0];
+    expect(el.templateShape).toBe('circle');
+    expect(el.radius).toBe(160);
+    expect(el.radiusFeet).toBe(20);
+    expect(el.feetPerCell).toBe(5);
+    expect(el.position).toEqual({ x: 100, y: 200 });
+    tool.onPointerUp(down(100, 200), f.ctx);
+    expect(f.ctx.switchTool).toHaveBeenCalledWith('select');
+    expect(onPlaced).toHaveBeenCalledTimes(1);
+  });
+
+  it('squares use sizeFeet as the SIDE (15ft cube @5ft/40px → radius 60px)', () => {
+    const { tool } = armed({ shape: 'square', sizeFeet: 15 });
+    tool.onPointerDown(down(0, 0), f.ctx);
+    expect(f.added[0].templateShape).toBe('square');
+    expect(f.added[0].radius).toBe(60);
+  });
+
+  it('cones aim by drag: angle updates on move, final on release', () => {
+    const { tool, onPlaced } = armed({ shape: 'cone', sizeFeet: 15 });
+    tool.onPointerDown(down(0, 0), f.ctx);
+    expect(f.added[0].angle).toBe(0);
+    tool.onPointerMove(down(10, 10), f.ctx);
+    expect(f.updates).toHaveLength(1);
+    expect(f.updates[0].patch.angle).toBeCloseTo(Math.PI / 4);
+    tool.onPointerUp(down(10, 10), f.ctx);
+    expect(onPlaced).toHaveBeenCalledTimes(1);
+    expect(f.ctx.switchTool).toHaveBeenCalledWith('select');
+  });
+
+  it('does not update angle for circles on move', () => {
+    const { tool } = armed({ shape: 'circle', sizeFeet: 20 });
+    tool.onPointerDown(down(0, 0), f.ctx);
+    tool.onPointerMove(down(50, 0), f.ctx);
+    expect(f.updates).toHaveLength(0);
+  });
+
+  it('with a null config, bails to select without placing', () => {
+    const ref = { current: null };
+    const tool = new SpellTemplateTool(ref);
+    tool.onPointerDown(down(0, 0), f.ctx);
+    expect(f.added).toHaveLength(0);
+    expect(f.ctx.switchTool).toHaveBeenCalledWith('select');
+  });
+
+  it('sets crosshair cursor on activate, default on deactivate', () => {
+    const { tool } = armed();
+    tool.onActivate?.(f.ctx);
+    expect(f.ctx.setCursor).toHaveBeenCalledWith('crosshair');
+    tool.onDeactivate?.(f.ctx);
+    expect(f.ctx.setCursor).toHaveBeenCalledWith('default');
+  });
+});

--- a/src/components/ui/campaign/player-vtt/__tests__/StatusEffectTray.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/StatusEffectTray.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+import { StatusEffectTray } from '@/components/ui/campaign/player-vtt/StatusEffectTray';
+import { useCharacterStore } from '@/store/characterStore';
+import type { CharacterState, ActiveCondition } from '@/types/character';
+
+function seedCharacter(overrides: Partial<CharacterState> = {}) {
+  const store = useCharacterStore.getState();
+  const base = store.character;
+  store.loadCharacterState({
+    ...base,
+    ...overrides,
+  } as CharacterState);
+}
+
+const getChar = () => useCharacterStore.getState().character;
+
+const makeCondition = (
+  over: Partial<ActiveCondition> = {}
+): ActiveCondition => ({
+  id: 'poisoned-1',
+  name: 'Poisoned',
+  source: 'Self',
+  description: '',
+  stackable: false,
+  count: 1,
+  appliedAt: new Date().toISOString(),
+  ...over,
+});
+
+describe('StatusEffectTray', () => {
+  beforeEach(() => {
+    seedCharacter();
+  });
+
+  afterEach(() => cleanup());
+
+  it('does not render a CONC chip while not concentrating', () => {
+    seedCharacter({
+      concentration: { isConcentrating: false },
+    });
+    render(<StatusEffectTray />);
+    expect(screen.queryByText(/conc/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a CONC chip while concentrating and ends concentration from the dialog', () => {
+    seedCharacter({
+      concentration: { isConcentrating: true, spellName: 'Bless' },
+    });
+    render(<StatusEffectTray />);
+
+    fireEvent.click(screen.getByRole('button', { name: /conc/i }));
+    expect(screen.getByText(/Concentrating on Bless/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /end concentration/i }));
+
+    expect(getChar().concentration.isConcentrating).toBe(false);
+  });
+
+  it('renders a condition chip per active condition and removes it', () => {
+    seedCharacter({
+      conditionsAndDiseases: {
+        ...getChar().conditionsAndDiseases,
+        activeConditions: [makeCondition()],
+      },
+    });
+    render(<StatusEffectTray />);
+
+    expect(screen.getByText('Poisoned')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /remove poisoned/i }));
+
+    expect(getChar().conditionsAndDiseases.activeConditions).toHaveLength(0);
+  });
+
+  it('adds a condition from the quick-add picker', () => {
+    render(<StatusEffectTray />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add condition/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Blinded$/ }));
+
+    const conditions = getChar().conditionsAndDiseases.activeConditions;
+    expect(conditions).toHaveLength(1);
+    expect(conditions[0]).toMatchObject({
+      name: 'Blinded',
+      source: 'Self',
+      count: 1,
+    });
+  });
+});

--- a/src/components/ui/campaign/player-vtt/__tests__/usePlayerVttState.rosterSync.test.ts
+++ b/src/components/ui/campaign/player-vtt/__tests__/usePlayerVttState.rosterSync.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { usePlayerVttState } from '../PlayerVttScreen.hooks';
+import { usePlayerStore } from '@/store/playerStore';
+import { useCharacterStore } from '@/store/characterStore';
+import { makeCharacter } from '@/utils/__tests__/test-utils';
+
+const EMPTY_SHARED_STATE = {
+  calendar: null,
+  messages: [],
+  dmEffects: [],
+  customCounter: null,
+  transfers: [],
+  initiative: null,
+  battleMap: null,
+};
+
+const CHARACTER_ID = 'char-vtt-1';
+
+function seedRoster() {
+  const characterData = makeCharacter({ id: CHARACTER_ID });
+  usePlayerStore.setState({
+    characters: [
+      {
+        id: CHARACTER_ID,
+        name: characterData.name,
+        race: characterData.race,
+        class: 'Fighter',
+        level: characterData.level,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastPlayed: new Date(),
+        characterData,
+        tags: [],
+        isArchived: false,
+        syncEnabled: false,
+        autoSync: false,
+      },
+    ],
+  });
+  return characterData;
+}
+
+describe('usePlayerVttState — roster write-back', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(EMPTY_SHARED_STATE)))
+    );
+    usePlayerStore.setState({ characters: [], activeCharacterId: null });
+    useCharacterStore.setState({ hasHydrated: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('persists live characterStore changes (e.g. damage) back into the playerStore roster blob', async () => {
+    seedRoster();
+
+    const { result, unmount } = renderHook(() =>
+      usePlayerVttState('CAMP1', CHARACTER_ID)
+    );
+
+    // Let the load effect run and the initial-load guard window (50ms) clear.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60);
+    });
+
+    expect(result.current.character.id).toBe(CHARACTER_ID);
+    expect(result.current.character.hitPoints.current).toBe(44);
+
+    // A store action mutates characterStore directly, mirroring what any VTT
+    // panel (e.g. DockVitals) does when the player takes damage mid-session.
+    act(() => {
+      useCharacterStore.getState().applyDamageToCharacter(5);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const roster = usePlayerStore
+      .getState()
+      .characters.find(c => c.id === CHARACTER_ID);
+    expect(roster?.characterData.hitPoints.current).toBe(39);
+
+    unmount();
+  });
+});

--- a/src/hooks/__tests__/useCastSpell.test.ts
+++ b/src/hooks/__tests__/useCastSpell.test.ts
@@ -133,4 +133,14 @@ describe('useCastSpell', () => {
     );
     expect(getChar().reaction?.hasUsedReaction).toBe(true);
   });
+
+  it('usePact without pactMagic spends nothing (defensive guard)', () => {
+    useCharacterStore.getState().updateCharacter({ pactMagic: undefined });
+    const { result } = renderHook(() => useCastSpell());
+    act(() =>
+      result.current.castSpell(makeSpell(), { level: 3, usePact: true })
+    );
+    expect(getChar().spellSlots[3].used).toBe(0);
+    expect(getChar().pactMagic).toBeUndefined();
+  });
 });

--- a/src/hooks/__tests__/useCharacterRosterSync.test.ts
+++ b/src/hooks/__tests__/useCharacterRosterSync.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useCharacterRosterSync } from '../useCharacterRosterSync';
+import { makeCharacter } from '@/utils/__tests__/test-utils';
+import type { CharacterState } from '@/types/character';
+
+type Props = Parameters<typeof useCharacterRosterSync>[0];
+
+function makeProps(overrides: Partial<Props> = {}): Props {
+  const rosterData = makeCharacter({ id: 'char-1' });
+  return {
+    playerCharacter: { characterData: rosterData },
+    hasHydrated: true,
+    characterId: 'char-1',
+    character: makeCharacter({ id: 'unloaded' }),
+    loadCharacterState: vi.fn(),
+    updateCharacterData: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('useCharacterRosterSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('loads the roster character into the store exactly once per characterId', () => {
+    const rosterData = makeCharacter({ id: 'char-1' });
+    const loadCharacterState = vi.fn();
+    const props = makeProps({
+      playerCharacter: { characterData: rosterData },
+      loadCharacterState,
+    });
+
+    const { rerender } = renderHook(p => useCharacterRosterSync(p), {
+      initialProps: props,
+    });
+
+    expect(loadCharacterState).toHaveBeenCalledTimes(1);
+    expect(loadCharacterState).toHaveBeenCalledWith(rosterData);
+
+    // Re-render with the same characterId — must not reload.
+    rerender({ ...props, character: rosterData });
+    expect(loadCharacterState).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not write back to the roster during the initial-load guard window', () => {
+    const rosterData = makeCharacter({
+      id: 'char-1',
+      hitPoints: { ...makeCharacter().hitPoints, current: 44 },
+    });
+    const updateCharacterData = vi.fn();
+    const props = makeProps({
+      playerCharacter: { characterData: rosterData },
+      character: rosterData,
+      updateCharacterData,
+    });
+
+    const { rerender } = renderHook(p => useCharacterRosterSync(p), {
+      initialProps: props,
+    });
+
+    // Character changes immediately after load, before the 50ms guard clears.
+    const damaged: CharacterState = {
+      ...rosterData,
+      hitPoints: { ...rosterData.hitPoints, current: 30 },
+    };
+    rerender({ ...props, character: damaged });
+
+    expect(updateCharacterData).not.toHaveBeenCalled();
+  });
+
+  it('writes live character changes back to the roster once past the guard window', () => {
+    const rosterData = makeCharacter({ id: 'char-1' });
+    const updateCharacterData = vi.fn();
+    const props = makeProps({
+      playerCharacter: { characterData: rosterData },
+      character: rosterData,
+      updateCharacterData,
+    });
+
+    const { rerender } = renderHook(p => useCharacterRosterSync(p), {
+      initialProps: props,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(60);
+    });
+
+    const damaged: CharacterState = {
+      ...rosterData,
+      hitPoints: { ...rosterData.hitPoints, current: 30 },
+    };
+    rerender({ ...props, character: damaged });
+
+    expect(updateCharacterData).toHaveBeenCalledTimes(1);
+    expect(updateCharacterData).toHaveBeenCalledWith(
+      'char-1',
+      expect.objectContaining({
+        hitPoints: expect.objectContaining({ current: 30 }),
+      })
+    );
+  });
+
+  it('skips redundant writes when the character has not actually changed', () => {
+    const rosterData = makeCharacter({ id: 'char-1' });
+    const updateCharacterData = vi.fn();
+    const props = makeProps({
+      playerCharacter: { characterData: rosterData },
+      character: rosterData,
+      updateCharacterData,
+    });
+
+    const { rerender } = renderHook(p => useCharacterRosterSync(p), {
+      initialProps: props,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(60);
+    });
+
+    // Same character reference/content re-rendered — no real change.
+    rerender({ ...props, character: { ...rosterData } });
+
+    expect(updateCharacterData).not.toHaveBeenCalled();
+  });
+
+  it('fires onLoad synchronously with the freshly loaded character data', () => {
+    const rosterData = makeCharacter({ id: 'char-1' });
+    const onLoad = vi.fn();
+    const props = makeProps({
+      playerCharacter: { characterData: rosterData },
+      onLoad,
+    });
+
+    renderHook(p => useCharacterRosterSync(p), { initialProps: props });
+
+    expect(onLoad).toHaveBeenCalledTimes(1);
+    expect(onLoad).toHaveBeenCalledWith(rosterData);
+  });
+});

--- a/src/hooks/useCastSpell.ts
+++ b/src/hooks/useCastSpell.ts
@@ -48,19 +48,25 @@ export function useCastSpell() {
         // at-will (freeCastMax === 0): nothing to track
       } else if (options.isRitual) {
         // ritual casting spends no slot
-      } else if (options.usePact && character.pactMagic) {
-        updateCharacter({
-          pactMagic: {
-            ...character.pactMagic,
-            slots: {
-              ...character.pactMagic.slots,
-              used: Math.min(
-                character.pactMagic.slots.used + 1,
-                character.pactMagic.slots.max
-              ),
+      } else if (options.usePact) {
+        if (!character.pactMagic) {
+          console.warn(
+            '[useCastSpell] usePact without pactMagic — spending nothing'
+          );
+        } else {
+          updateCharacter({
+            pactMagic: {
+              ...character.pactMagic,
+              slots: {
+                ...character.pactMagic.slots,
+                used: Math.min(
+                  character.pactMagic.slots.used + 1,
+                  character.pactMagic.slots.max
+                ),
+              },
             },
-          },
-        });
+          });
+        }
       } else if (spell.level > 0) {
         const level = options.level as keyof SpellSlots;
         updateSpellSlot(level, character.spellSlots[level].used + 1);

--- a/src/hooks/useCharacterRosterSync.ts
+++ b/src/hooks/useCharacterRosterSync.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { CharacterState } from '@/types/character';
+
+/** Minimal roster-entry shape both callers need — avoids importing the full
+ * `PlayerCharacter` type just for its `characterData` field. */
+interface RosterCharacter {
+  characterData: CharacterState;
+}
+
+interface UseCharacterRosterSyncOptions {
+  /** The roster entry for this character, as looked up from `playerStore`. */
+  playerCharacter: RosterCharacter | null | undefined;
+  hasHydrated: boolean;
+  characterId: string;
+  /** Live character from `characterStore`. */
+  character: CharacterState;
+  loadCharacterState: (characterState: CharacterState) => void;
+  updateCharacterData: (
+    characterId: string,
+    characterData: CharacterState
+  ) => void;
+  /**
+   * Fired synchronously right after `loadCharacterState` runs for a newly
+   * loaded character — mirrors where the sheet page hangs its trait-migration
+   * side effect (`page.tsx:398-409`).
+   */
+  onLoad?: (loadedCharacterData: CharacterState) => void;
+}
+
+/**
+ * Ports the sheet page's paired character-load / write-back effects
+ * (`src/app/player/characters/[characterId]/page.tsx:387-442`) so both the
+ * sheet and the VTT screen keep `characterStore` and the `playerStore`
+ * roster blob in sync, with identical guards and timing.
+ */
+export function useCharacterRosterSync({
+  playerCharacter,
+  hasHydrated,
+  characterId,
+  character,
+  loadCharacterState,
+  updateCharacterData,
+  onLoad,
+}: UseCharacterRosterSyncOptions) {
+  const lastLoadedCharacterRef = useRef<string | null>(null);
+  const lastSyncedCharacterRef = useRef<CharacterState | null>(null);
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+  // Load character data into store when component mounts or character changes
+  useEffect(() => {
+    if (playerCharacter && hasHydrated) {
+      const currentCharacterId = playerCharacter.characterData.id;
+
+      // Only load if we haven't loaded this character yet or if it's a different character
+      if (lastLoadedCharacterRef.current !== currentCharacterId) {
+        setIsInitialLoad(true);
+        loadCharacterState(playerCharacter.characterData);
+        lastLoadedCharacterRef.current = currentCharacterId;
+        lastSyncedCharacterRef.current = playerCharacter.characterData;
+
+        onLoad?.(playerCharacter.characterData);
+
+        // Mark initial load as complete after state has been set
+        const timer = setTimeout(() => {
+          setIsInitialLoad(false);
+        }, 50);
+
+        return () => clearTimeout(timer);
+      }
+    }
+  }, [playerCharacter, hasHydrated, loadCharacterState, onLoad]);
+
+  // Sync character data back to player store when it changes (skip during initial load)
+  useEffect(() => {
+    if (!isInitialLoad && hasHydrated && character.id === characterId) {
+      // Deep comparison to prevent unnecessary updates and infinite loops
+      const hasActualChanges =
+        !lastSyncedCharacterRef.current ||
+        JSON.stringify(lastSyncedCharacterRef.current) !==
+          JSON.stringify(character);
+
+      if (hasActualChanges) {
+        // Create a deep copy to avoid reference issues
+        const characterCopy = JSON.parse(JSON.stringify(character));
+        updateCharacterData(characterId, characterCopy);
+        lastSyncedCharacterRef.current = characterCopy;
+      }
+    }
+  }, [character, characterId, updateCharacterData, hasHydrated, isInitialLoad]);
+
+  return { isInitialLoad };
+}


### PR DESCRIPTION
## Summary

The player battle-map page becomes a VTT: floating chrome over the live canvas, so players run their character without leaving the map. Implements the player VTT spec (Plan C of 3; consumes the merged initiative-poke and cast-foundation work).

- **Combat panel** (left, collapsible) — masked shared initiative with server-side HP presentation fidelity (exact/bar/percent/label modes), active-turn pulse, YOU badge, optimistic "End my turn".
- **Character dock** (right, collapsible) — HP editor (temp-first damage / capped heal / temp via existing store actions), AC/INIT, heroic inspiration with `maxCount` clamp; spells tab with prepared-only list, search, slot pips, `SpellCastModal` reuse (slots/pact/ritual/free), spell details modal.
- **Cast → place template** — casting an AoE spell arms a one-shot `SpellTemplateTool`: tap places circles/squares sized exactly from `spell.aoe` (20ft Fireball = 20ft circle), press-drag aims cones/lines with a live synced preview; the template is a real FieldNotes element everyone sees. Casting banner + Escape/Cancel (slot stays spent); offline casts keep bookkeeping and skip placement.
- **Status tray** (top-right) — concentration chip with end-confirmation, condition chips, quick-add palette.
- **Instant initiative** — the relay poke now has its receiving end: `onPoke → refetchNow()`, with the 5s poll as fallback.
- **Canvas refactor** — `PlayerBattleMapView` → `PlayerBattleMapCanvas` with a purely additive chrome seam; behavior unchanged when new props are omitted.
- **Data-integrity fix found in review** — character load/write-back extracted into shared `useCharacterRosterSync` (sheet page refactored onto it, behavior-preserving); VTT edits now persist to the roster round-trip, pinned by an integration test.

## Notes for review

- The dock filters to **prepared/always-prepared spells** (mirrors QuickSpells) — this was a spec gap resolved during execution; flag if you want unprepared spells visible.
- Line templates render at the canvas library's default width (`createTemplate` has no width param); `widthFeet` is carried for future SDK support.
- Touch-first per spec §1a (pointer events, ≥44px targets, panels collapse under 1100px) with full desktop support (Escape, crosshair cursor, hover states).

## Test plan

- [x] 47 new tests across 7 files (tool geometry/aiming, placement invariant, combat panel HP modes, dock vitals/spells cast branching, tray, roster write-back integration)
- [x] Full unit suite 2502 passing (exit 0); relay 44/44; type-check clean; zero lint findings in branch files
- [ ] Manual two-browser checklist (below)

## Manual checklist (spec §7)

DM tab + player tab, local relay + redis: join map (canvas unchanged) · cast Fireball → slot picker → banner → tap → purple 20ft circle on the DM screen + slot spent · drag-aim a line spell · Escape cancels, slot stays spent · relay down → offline toast, bookkeeping applied · dock damage → DM dashboard updates · DM advances turn → panel updates instantly (poke) / ≤5s with relay stopped · concentration chip + replacement · condition add/remove syncs · both themes · iPad landscape (panels open, map usable) + portrait (collapsed) + touch drag-aim · warlock pact option in the dock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)