### PR TITLE
fix(vtt): pan grab-through applies to tokens only

### DIFF
--- a/src/components/ui/campaign/location-map/PlayerHandTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerHandTool.ts
@@ -7,12 +7,18 @@ import type {
   ToolContext,
 } from '@fieldnotes/core';
 
-/** Whether this player could grab the element: visible and not locked at the
- * element or layer level. Mirrored DM layers are locked on player canvases,
- * so DM content (map image, grid, DM drawings) keeps panning. */
+/** Token element types: PlayerTokenTool stamps an `image` (avatar) or a
+ * `shape` ellipse fallback. ONLY these grab-through from pan — templates,
+ * strokes, and arrows can cover large map areas, and treating them as
+ * grabbable made panning nearly impossible after a big AoE was placed. */
+const TOKEN_TYPES = new Set(['image', 'shape']);
+
+/** Whether this player could grab the element: a token that is visible and
+ * not locked at the element or layer level. Mirrored DM layers are locked on
+ * player canvases, so DM content (map image, grid) keeps panning. */
 function isGrabbable(el: CanvasElement, ctx: ToolContext): boolean {
+  if (!TOKEN_TYPES.has(el.type)) return false;
   if (el.locked) return false;
-  if (el.type === 'grid') return false;
   if (el.layerId) {
     if (ctx.isLayerVisible && !ctx.isLayerVisible(el.layerId)) return false;
     if (ctx.isLayerLocked?.(el.layerId)) return false;
@@ -30,7 +36,7 @@ function hits(worldX: number, worldY: number, el: CanvasElement): boolean {
 
 /**
  * Pan tool that hands off to Select when the press lands on something the
- * player can actually move (their token, templates, drawings): the SAME
+ * player can actually move (their TOKEN — see TOKEN_TYPES): the SAME
  * gesture starts dragging the element, and the toolbar flips to Select.
  * Presses on DM content or empty map pan as usual.
  */

--- a/src/components/ui/campaign/location-map/__tests__/PlayerHandTool.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerHandTool.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { SelectTool, createImage } from '@fieldnotes/core';
+import { SelectTool, createImage, createTemplate } from '@fieldnotes/core';
 import { PlayerHandTool } from '@/components/ui/campaign/location-map/PlayerHandTool';
 
 import type {
@@ -76,6 +76,22 @@ describe('PlayerHandTool', () => {
 
   it('pointer-down on empty canvas pans (no switch)', () => {
     const ctx = fakeCtx([ownToken(500, 500)]);
+    const tool = new PlayerHandTool(selectTool);
+    tool.onPointerDown(down(20, 20), ctx);
+    expect(ctx.switchTool).not.toHaveBeenCalled();
+    expect(selectDown).not.toHaveBeenCalled();
+  });
+
+  it('pointer-down on an own TEMPLATE pans — only tokens grab-through', () => {
+    // Templates often cover large map areas; treating them as grabbable made
+    // panning nearly impossible after a big AoE was placed.
+    const template = createTemplate({
+      position: { x: 20, y: 20 },
+      templateShape: 'circle',
+      radius: 200,
+      layerId: OWN_LAYER,
+    });
+    const ctx = fakeCtx([template]);
     const tool = new PlayerHandTool(selectTool);
     tool.onPointerDown(down(20, 20), ctx);
     expect(ctx.switchTool).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Hotfix for the grab-through pan from #154: pressing a movable element in Pan mode switched to Select for ANY own element — including templates, which often cover large map areas, making panning nearly impossible after placing a big AoE.

`PlayerHandTool` now hands off to Select only for **token** element types (`image` avatar discs and the `shape` ellipse fallback — what `PlayerTokenTool` stamps). Templates, strokes, and arrows pan through; they remain movable via the Select tool as before.

## Test plan
- [x] New regression test: press on an own template → pans (no tool switch); existing token/DM-content/empty-map/lock tests unchanged
- [x] Full unit suite 2522 passing, type-check clean
- [x] Manual: place a large AoE, pan across it in hand mode; token press still drags

🤖 Generated with [Claude Code](https://claude.com/claude-code)