### PR TITLE
feat(dm-vtt): token-combatant linkage foundation

### DIFF
--- a/src/components/ui/campaign/dm-vtt/TokenPlacementController.tsx
+++ b/src/components/ui/campaign/dm-vtt/TokenPlacementController.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useActiveTool } from '@fieldnotes/react';
+
+import type { MutableRefObject } from 'react';
+import type { DmTokenConfig } from './combatantToken';
+
+export interface PendingTokenPlacement {
+  /** For the board banner. */
+  entityName: string;
+  config: DmTokenConfig;
+}
+
+interface TokenPlacementControllerProps {
+  pending: PendingTokenPlacement | null;
+  configRef: MutableRefObject<DmTokenConfig | null>;
+  /** User cancelled (Escape / banner button). Parent clears `pending`. */
+  onCancel: () => void;
+}
+
+/**
+ * Headless bridge between screen state and the canvas tool system: arming a
+ * placement loads the config ref and switches to the dmtoken tool; clearing
+ * it (placed or cancelled) switches back to select. Escape cancels (spec
+ * §1a desktop keyboard rule).
+ */
+export function TokenPlacementController({
+  pending,
+  configRef,
+  onCancel,
+}: TokenPlacementControllerProps) {
+  const [activeTool, setTool] = useActiveTool();
+  // True only once we have OBSERVED the token tool actually active while
+  // this placement is pending. `setTool` propagates to `activeTool` on the
+  // NEXT render, so the steal detector must not react to the stale value in
+  // the arming commit — doing so cancelled every placement instantly.
+  const sawTokenToolRef = useRef(false);
+  // Latest tool for the disarm branch without re-running it on tool changes.
+  const activeToolRef = useRef(activeTool);
+  activeToolRef.current = activeTool;
+
+  // Arm/disarm strictly on `pending` transitions.
+  useEffect(() => {
+    if (pending) {
+      configRef.current = pending.config;
+      sawTokenToolRef.current = false;
+      setTool('dmtoken');
+    } else {
+      configRef.current = null;
+      // Only force back to select if the token tool is still active; a
+      // steal-cancel already left the user's chosen tool in place.
+      if (activeToolRef.current === 'dmtoken') setTool('select');
+      sawTokenToolRef.current = false;
+    }
+  }, [pending, configRef, setTool]);
+
+  // Observe tool changes: record when arming has actually taken effect, and
+  // treat a change AWAY from the token tool after that as a user cancel
+  // (e.g. tapping a toolbar button).
+  // INVARIANT: the success path stays cancel-free ONLY because the tool's
+  // onPointerUp calls switchTool('select') and onPlaced() synchronously in
+  // one tick, and the parent clears `pending` synchronously inside onPlaced —
+  // React batches both updates into one commit, so this effect never sees
+  // select-with-pending on success. If onPlaced ever gains an async gap
+  // before clearing pending, a successful placement will spuriously cancel.
+  useEffect(() => {
+    if (!pending) return;
+    if (activeTool === 'dmtoken') {
+      sawTokenToolRef.current = true;
+      return;
+    }
+    if (sawTokenToolRef.current) onCancel();
+  }, [activeTool, pending, onCancel]);
+
+  useEffect(() => {
+    if (!pending) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [pending, onCancel]);
+
+  return null;
+}

--- a/src/components/ui/campaign/dm-vtt/__tests__/TokenPlacementController.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/TokenPlacementController.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { TokenPlacementController } from '@/components/ui/campaign/dm-vtt/TokenPlacementController';
+
+import type { MutableRefObject } from 'react';
+import type { PendingTokenPlacement } from '@/components/ui/campaign/dm-vtt/TokenPlacementController';
+import type { DmTokenConfig } from '@/components/ui/campaign/dm-vtt/combatantToken';
+
+// Faithful stand-in for @fieldnotes/react's useActiveTool: an external store
+// read via useSyncExternalStore, so a setTool() inside an effect only becomes
+// visible to components on the NEXT render — the exact timing that caused the
+// arm→instant-cancel race in production.
+const toolStore = {
+  current: 'select',
+  listeners: new Set<() => void>(),
+  set(name: string) {
+    toolStore.current = name;
+    toolStore.listeners.forEach(l => l());
+  },
+  reset() {
+    toolStore.current = 'select';
+    toolStore.listeners.clear();
+  },
+};
+
+vi.mock('@fieldnotes/react', async () => {
+  const { useSyncExternalStore } = await import('react');
+  return {
+    useActiveTool: () => {
+      const tool = useSyncExternalStore(
+        (cb: () => void) => {
+          toolStore.listeners.add(cb);
+          return () => toolStore.listeners.delete(cb);
+        },
+        () => toolStore.current
+      );
+      return [tool, toolStore.set] as const;
+    },
+  };
+});
+
+function makePending(onPlaced: () => void = () => {}): PendingTokenPlacement {
+  return {
+    entityName: 'Goblin',
+    config: { entityId: 'e1', name: 'Goblin', color: '#C0392B', onPlaced },
+  };
+}
+
+function setup(pending: PendingTokenPlacement | null) {
+  const onCancel = vi.fn();
+  const configRef: MutableRefObject<DmTokenConfig | null> = {
+    current: null,
+  };
+  const view = render(
+    <TokenPlacementController
+      pending={pending}
+      configRef={configRef}
+      onCancel={onCancel}
+    />
+  );
+  const rerenderWith = (p: PendingTokenPlacement | null) =>
+    view.rerender(
+      <TokenPlacementController
+        pending={p}
+        configRef={configRef}
+        onCancel={onCancel}
+      />
+    );
+  return { onCancel, configRef, rerenderWith };
+}
+
+describe('TokenPlacementController', () => {
+  beforeEach(() => {
+    toolStore.reset();
+  });
+
+  it('arming does NOT fire onCancel while the tool switch is still propagating (the race)', () => {
+    const { onCancel, configRef } = setup(makePending());
+    // Arm effect ran: config loaded, tool switch requested. The steal
+    // detector must not misread the not-yet-propagated tool as a steal.
+    expect(configRef.current).not.toBeNull();
+    expect(toolStore.current).toBe('dmtoken');
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('a real steal (user picks another tool after arming took effect) cancels once', () => {
+    const { onCancel } = setup(makePending());
+    // let the dmtoken activation render land
+    act(() => {});
+    expect(onCancel).not.toHaveBeenCalled();
+
+    act(() => toolStore.set('pencil'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('successful placement (tool→select + pending cleared together) does not cancel and does not stomp the tool', () => {
+    const { onCancel, rerenderWith } = setup(makePending());
+    act(() => {});
+    // The tool's onPointerUp switches to select and onPlaced clears pending
+    // synchronously; both land in one commit.
+    act(() => {
+      toolStore.set('select');
+      rerenderWith(null);
+    });
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(toolStore.current).toBe('select');
+  });
+
+  it('cancel (pending cleared while tool still armed) returns the tool to select', () => {
+    const { configRef, rerenderWith } = setup(makePending());
+    act(() => {});
+    expect(toolStore.current).toBe('dmtoken');
+    act(() => rerenderWith(null));
+    expect(toolStore.current).toBe('select');
+    expect(configRef.current).toBeNull();
+  });
+
+  it('steal-cancel leaves the user’s chosen tool alone after pending clears', () => {
+    const { onCancel, rerenderWith } = setup(makePending());
+    act(() => {});
+    act(() => toolStore.set('pencil'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    // parent reacts to onCancel by clearing pending
+    act(() => rerenderWith(null));
+    expect(toolStore.current).toBe('pencil');
+  });
+
+  it('Escape cancels while pending', () => {
+    const { onCancel } = setup(makePending());
+    act(() => {});
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  COMBATANT_TOKEN_KIND,
+  isCombatantToken,
+  dispositionColor,
+  stampCombatantToken,
+  DmTokenTool,
+  type DmTokenConfig,
+} from '@/components/ui/campaign/dm-vtt/combatantToken';
+
+import type {
+  CanvasElement,
+  PointerState,
+  ToolContext,
+} from '@fieldnotes/core';
+
+function fakeCtx(overrides: Record<string, unknown> = {}) {
+  const added: CanvasElement[] = [];
+  const ctx = {
+    camera: { screenToWorld: (p: { x: number; y: number }) => p },
+    store: {
+      add: vi.fn((el: CanvasElement) => {
+        added.push(el);
+        return el;
+      }),
+    },
+    requestRender: vi.fn(),
+    switchTool: vi.fn(),
+    setCursor: vi.fn(),
+    gridSize: 40,
+    gridType: 'square',
+    activeLayerId: 'dm-layer',
+    snapToGrid: false,
+    ...overrides,
+  } as unknown as ToolContext;
+  return { ctx, added };
+}
+
+const down = (x: number, y: number) => ({ x, y }) as PointerState;
+
+describe('dispositionColor', () => {
+  it('players are emerald regardless of disposition', () => {
+    expect(dispositionColor({ type: 'player' })).toBe('#12855C');
+  });
+  it('legendary creatures are boss purple', () => {
+    expect(
+      dispositionColor({
+        type: 'monster',
+        legendaryActions: { count: 3, usedActions: 0, actions: [] },
+      } as never)
+    ).toBe('#7C4DBC');
+  });
+  it('allies blue, neutral gray, enemies (default) red', () => {
+    expect(dispositionColor({ type: 'npc', playerDisposition: 'ally' })).toBe(
+      '#2F6FD0'
+    );
+    expect(
+      dispositionColor({ type: 'npc', playerDisposition: 'neutral' })
+    ).toBe('#6B7280');
+    expect(dispositionColor({ type: 'monster' })).toBe('#C0392B');
+  });
+});
+
+describe('stampCombatantToken', () => {
+  it('stamps an avatar image token with linkage keys, sized to one cell', () => {
+    const { ctx, added } = fakeCtx();
+    stampCombatantToken(
+      {
+        entityId: 'e1',
+        name: 'Goblin',
+        avatarUrl: 'https://x/y.png',
+        color: '#C0392B',
+      },
+      { x: 100, y: 100 },
+      ctx
+    );
+    expect(added).toHaveLength(1);
+    const el = added[0] as CanvasElement & {
+      entityId?: string;
+      tokenKind?: string;
+      size?: { w: number };
+    };
+    expect(el.type).toBe('image');
+    expect(el.entityId).toBe('e1');
+    expect(el.tokenKind).toBe(COMBATANT_TOKEN_KIND);
+    expect(el.size?.w).toBe(40); // one square cell
+    expect(isCombatantToken(el)).toBe(true);
+  });
+
+  it('falls back to a tinted ellipse without an http avatar', () => {
+    const { ctx, added } = fakeCtx();
+    stampCombatantToken(
+      { entityId: 'e2', name: 'Wolf', color: '#6B7280' },
+      { x: 0, y: 0 },
+      ctx
+    );
+    const el = added[0] as unknown as CanvasElement & {
+      shape?: string;
+      fillColor?: string;
+    };
+    expect(el.type).toBe('shape');
+    expect(el.shape).toBe('ellipse');
+    expect(el.fillColor).toBe('#6B7280');
+    expect(isCombatantToken(el as CanvasElement)).toBe(true);
+  });
+
+  it('sizes to the hex cell unit on hex grids', () => {
+    const { ctx, added } = fakeCtx({ gridType: 'hex' });
+    stampCombatantToken(
+      { entityId: 'e3', name: 'Ogre', color: '#C0392B' },
+      { x: 0, y: 0 },
+      ctx
+    );
+    const el = added[0] as CanvasElement & { size?: { w: number } };
+    expect(el.size?.w).toBeCloseTo(Math.sqrt(3) * 40, 6);
+  });
+});
+
+describe('isCombatantToken', () => {
+  it('rejects plain elements and wrong kinds', () => {
+    const { ctx, added } = fakeCtx();
+    stampCombatantToken(
+      { entityId: 'e1', name: 'G', color: '#C0392B' },
+      { x: 0, y: 0 },
+      ctx
+    );
+    expect(isCombatantToken(added[0])).toBe(true);
+    expect(
+      isCombatantToken({
+        ...added[0],
+        tokenKind: 'other',
+      } as unknown as CanvasElement)
+    ).toBe(false);
+    expect(
+      isCombatantToken({
+        ...added[0],
+        entityId: undefined,
+      } as unknown as CanvasElement)
+    ).toBe(false);
+  });
+});
+
+describe('DmTokenTool', () => {
+  let onPlaced: ReturnType<typeof vi.fn>;
+  let ref: { current: DmTokenConfig | null };
+
+  beforeEach(() => {
+    onPlaced = vi.fn(() => {});
+    ref = {
+      current: {
+        entityId: 'e1',
+        name: 'Goblin',
+        color: '#C0392B',
+        onPlaced: onPlaced as () => void,
+      },
+    };
+  });
+
+  it('places once, then hands to select and fires onPlaced', () => {
+    const { ctx, added } = fakeCtx();
+    const tool = new DmTokenTool(ref);
+    tool.onPointerDown(down(10, 10), ctx);
+    expect(added).toHaveLength(1);
+    tool.onPointerUp(down(10, 10), ctx);
+    expect(ctx.switchTool).toHaveBeenCalledWith('select');
+    expect(onPlaced).toHaveBeenCalledTimes(1);
+  });
+
+  it('bails to select without placing when config is null', () => {
+    const { ctx, added } = fakeCtx();
+    const tool = new DmTokenTool({ current: null });
+    tool.onPointerDown(down(10, 10), ctx);
+    expect(added).toHaveLength(0);
+    expect(ctx.switchTool).toHaveBeenCalledWith('select');
+  });
+
+  it('crosshair on activate, default on deactivate', () => {
+    const { ctx } = fakeCtx();
+    const tool = new DmTokenTool(ref);
+    tool.onActivate?.(ctx);
+    expect(ctx.setCursor).toHaveBeenCalledWith('crosshair');
+    tool.onDeactivate?.(ctx);
+    expect(ctx.setCursor).toHaveBeenCalledWith('default');
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/useCombatantTokens.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useCombatantTokens.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  combatantTokenIndex,
+  useCombatantTokens,
+  selectedEntityId,
+} from '@/components/ui/campaign/dm-vtt/useCombatantTokens';
+
+import type { CanvasElement, ElementStore } from '@fieldnotes/core';
+
+type Listener = (data: CanvasElement | null) => void;
+
+function fakeStore(initial: CanvasElement[] = []) {
+  const elements = new Map(initial.map(el => [el.id, el]));
+  const listeners = new Map<string, Set<Listener>>();
+  const emit = (event: string, data: CanvasElement | null) =>
+    listeners.get(event)?.forEach(l => l(data));
+  const store = {
+    getAll: () => [...elements.values()],
+    getById: (id: string) => elements.get(id),
+    on: vi.fn((event: string, listener: Listener) => {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(listener);
+      return () => listeners.get(event)!.delete(listener);
+    }),
+  } as unknown as ElementStore;
+  return {
+    store,
+    addEl(el: CanvasElement) {
+      elements.set(el.id, el);
+      emit('add', el);
+    },
+    removeEl(id: string) {
+      const el = elements.get(id)!;
+      elements.delete(id);
+      emit('remove', el);
+    },
+    listeners,
+  };
+}
+
+const token = (id: string, entityId: string): CanvasElement =>
+  ({
+    id,
+    type: 'shape',
+    position: { x: 0, y: 0 },
+    zIndex: 0,
+    locked: false,
+    layerId: 'l1',
+    entityId,
+    tokenKind: 'combatant',
+  }) as unknown as CanvasElement;
+
+const plain = (id: string): CanvasElement =>
+  ({
+    id,
+    type: 'shape',
+    position: { x: 0, y: 0 },
+    zIndex: 0,
+    locked: false,
+    layerId: 'l1',
+  }) as unknown as CanvasElement;
+
+describe('combatantTokenIndex', () => {
+  it('indexes only combatant tokens, grouped by entityId', () => {
+    const { store } = fakeStore([
+      token('t1', 'e1'),
+      token('t2', 'e1'),
+      plain('p1'),
+    ]);
+    const index = combatantTokenIndex(store);
+    expect(index.get('e1')).toEqual(['t1', 't2']);
+    expect(index.size).toBe(1);
+  });
+});
+
+describe('useCombatantTokens', () => {
+  it('returns a live index that updates on add and remove', () => {
+    const f = fakeStore();
+    const { result } = renderHook(() => useCombatantTokens(f.store));
+    expect(result.current.size).toBe(0);
+
+    act(() => f.addEl(token('t1', 'e1')));
+    expect(result.current.get('e1')).toEqual(['t1']);
+
+    act(() => f.removeEl('t1'));
+    expect(result.current.size).toBe(0);
+  });
+
+  it('subscribes to add/remove/clear but NOT update (drags stay cheap)', () => {
+    const f = fakeStore();
+    renderHook(() => useCombatantTokens(f.store));
+    const events = (f.store.on as ReturnType<typeof vi.fn>).mock.calls.map(
+      c => c[0]
+    );
+    expect(events).toContain('add');
+    expect(events).toContain('remove');
+    expect(events).toContain('clear');
+    expect(events).not.toContain('update');
+  });
+
+  it('null store yields an empty index', () => {
+    const { result } = renderHook(() => useCombatantTokens(null));
+    expect(result.current.size).toBe(0);
+  });
+});
+
+describe('selectedEntityId', () => {
+  it('maps the first combatant token in the selection to its entity', () => {
+    const { store } = fakeStore([token('t1', 'e1'), plain('p1')]);
+    expect(selectedEntityId(['p1', 't1'], store)).toBe('e1');
+  });
+  it('returns null when nothing selected carries an entity', () => {
+    const { store } = fakeStore([plain('p1')]);
+    expect(selectedEntityId(['p1'], store)).toBeNull();
+    expect(selectedEntityId([], store)).toBeNull();
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/combatantToken.ts
+++ b/src/components/ui/campaign/dm-vtt/combatantToken.ts
@@ -1,0 +1,132 @@
+import { createImage, createShape, smartSnap } from '@fieldnotes/core';
+
+import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
+
+import type {
+  CanvasElement,
+  Point,
+  PointerState,
+  Tool,
+  ToolContext,
+} from '@fieldnotes/core';
+import type { EncounterEntity } from '@/types/encounter';
+
+export const COMBATANT_TOKEN_KIND = 'combatant';
+
+/** Extra top-level keys carried on token elements — they survive the
+ * FieldNotes store, export, and sync round-trips (verified in the spec). */
+export interface CombatantTokenKeys {
+  entityId: string;
+  tokenKind: typeof COMBATANT_TOKEN_KIND;
+}
+
+export function isCombatantToken(
+  el: CanvasElement
+): el is CanvasElement & CombatantTokenKeys {
+  const rec = el as Partial<CombatantTokenKeys>;
+  return (
+    rec.tokenKind === COMBATANT_TOKEN_KIND && typeof rec.entityId === 'string'
+  );
+}
+
+/** Handoff ring colors: player emerald, legendary purple, then disposition. */
+export function dispositionColor(
+  entity: Pick<EncounterEntity, 'type' | 'playerDisposition'> &
+    Partial<Pick<EncounterEntity, 'legendaryActions'>>
+): string {
+  if (entity.type === 'player') return '#12855C';
+  if (entity.legendaryActions) return '#7C4DBC';
+  if (entity.playerDisposition === 'ally') return '#2F6FD0';
+  if (entity.playerDisposition === 'neutral') return '#6B7280';
+  return '#C0392B';
+}
+
+export interface DmTokenConfig {
+  entityId: string;
+  name: string;
+  avatarUrl?: string;
+  color: string;
+  /** Fired once after placement (tool has handed back to select). */
+  onPlaced: () => void;
+}
+
+/** Stamps a grid-snapped one-cell combatant token and adds it to the store. */
+export function stampCombatantToken(
+  config: Omit<DmTokenConfig, 'onPlaced'>,
+  world: Point,
+  ctx: ToolContext
+): CanvasElement {
+  const center = smartSnap(world, ctx);
+  const size = cellUnit(ctx);
+  const position = { x: center.x - size / 2, y: center.y - size / 2 };
+  const layerId = ctx.activeLayerId ?? '';
+
+  const base =
+    config.avatarUrl && config.avatarUrl.startsWith('http')
+      ? createImage({
+          position,
+          size: { w: size, h: size },
+          src: config.avatarUrl,
+          layerId,
+        })
+      : createShape({
+          position,
+          size: { w: size, h: size },
+          shape: 'ellipse',
+          fillColor: config.color,
+          strokeColor: '#1e293b',
+          strokeWidth: 2,
+          layerId,
+        });
+
+  const token: CanvasElement & CombatantTokenKeys = {
+    ...base,
+    entityId: config.entityId,
+    tokenKind: COMBATANT_TOKEN_KIND,
+  };
+  ctx.store.add(token);
+  ctx.requestRender();
+  return token;
+}
+
+/**
+ * One-shot combatant placement, armed by the roster via the mutable
+ * configRef (the canvas keeps the FIRST tool instance per name — same
+ * pattern as SpellTemplateTool/PlayerTokenTool).
+ */
+export class DmTokenTool implements Tool {
+  readonly name = 'dmtoken';
+
+  private placed = false;
+
+  constructor(private readonly configRef: { current: DmTokenConfig | null }) {}
+
+  onPointerDown(state: PointerState, ctx: ToolContext): void {
+    const config = this.configRef.current;
+    if (!config) {
+      ctx.switchTool?.('select');
+      return;
+    }
+    const world = ctx.camera.screenToWorld({ x: state.x, y: state.y });
+    stampCombatantToken(config, world, ctx);
+    this.placed = true;
+  }
+
+  onPointerMove(): void {}
+
+  onPointerUp(_state: PointerState, ctx: ToolContext): void {
+    const config = this.configRef.current;
+    const placed = this.placed;
+    this.placed = false;
+    ctx.switchTool?.('select');
+    if (placed) config?.onPlaced();
+  }
+
+  onActivate(ctx: ToolContext): void {
+    ctx.setCursor?.('crosshair');
+  }
+
+  onDeactivate(ctx: ToolContext): void {
+    ctx.setCursor?.('default');
+  }
+}

--- a/src/components/ui/campaign/dm-vtt/useCombatantTokens.ts
+++ b/src/components/ui/campaign/dm-vtt/useCombatantTokens.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+
+import { isCombatantToken } from './combatantToken';
+
+import type { ElementStore } from '@fieldnotes/core';
+
+/** entityId → element ids for every combatant token currently in the store. */
+export function combatantTokenIndex(
+  store: Pick<ElementStore, 'getAll'>
+): Map<string, string[]> {
+  const index = new Map<string, string[]>();
+  for (const el of store.getAll()) {
+    if (!isCombatantToken(el)) continue;
+    const ids = index.get(el.entityId) ?? [];
+    ids.push(el.id);
+    index.set(el.entityId, ids);
+  }
+  return index;
+}
+
+/**
+ * Live placed-state index. Recomputes on membership changes only
+ * (add/remove/clear) — position updates during drags don't re-render.
+ */
+export function useCombatantTokens(
+  store: ElementStore | null
+): Map<string, string[]> {
+  const [index, setIndex] = useState<Map<string, string[]>>(() =>
+    store ? combatantTokenIndex(store) : new Map()
+  );
+
+  useEffect(() => {
+    if (!store) {
+      setIndex(new Map());
+      return;
+    }
+    const recompute = () => setIndex(combatantTokenIndex(store));
+    recompute();
+    const unsubs = [
+      store.on('add', recompute),
+      store.on('remove', recompute),
+      store.on('clear', recompute),
+    ];
+    return () => unsubs.forEach(u => u());
+  }, [store]);
+
+  return index;
+}
+
+/** The entity behind the first combatant token in a selection, if any. */
+export function selectedEntityId(
+  selectedIds: readonly string[],
+  store: Pick<ElementStore, 'getById'>
+): string | null {
+  for (const id of selectedIds) {
+    const el = store.getById(id);
+    if (el && isCombatantToken(el)) return el.entityId;
+  }
+  return null;
+}

--- a/src/components/ui/campaign/location-map/__tests__/cellUnit.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/cellUnit.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
+
+describe('cellUnit', () => {
+  it('square grids: the unit is gridSize', () => {
+    expect(cellUnit({ gridSize: 50, gridType: 'square' })).toBe(50);
+  });
+
+  it('hex grids: the unit is √3 × gridSize (the SDK snapUnit)', () => {
+    expect(cellUnit({ gridSize: 40, gridType: 'hex' })).toBeCloseTo(
+      Math.sqrt(3) * 40,
+      9
+    );
+  });
+
+  it('no grid type behaves like square', () => {
+    expect(cellUnit({ gridSize: 40 })).toBe(40);
+  });
+
+  it('missing gridSize falls back to 40', () => {
+    expect(cellUnit({})).toBe(40);
+    expect(cellUnit({ gridType: 'hex' })).toBeCloseTo(Math.sqrt(3) * 40, 9);
+  });
+});

--- a/src/components/ui/campaign/location-map/cellUnit.ts
+++ b/src/components/ui/campaign/location-map/cellUnit.ts
@@ -1,0 +1,15 @@
+import type { ToolContext } from '@fieldnotes/core';
+
+/**
+ * One grid cell in world pixels, matching the SDK's own conversion
+ * (TemplateTool drag-to-size and computeTemplateResize): on hex grids the
+ * cell unit is √3 × gridSize, not gridSize. Single source of truth — using
+ * raw gridSize on hex maps undersized spell templates by √3 (fixed in
+ * fix/vtt-polish) and must never be re-derived inline.
+ */
+export function cellUnit(
+  ctx: Pick<ToolContext, 'gridSize' | 'gridType'>
+): number {
+  const gridSize = ctx.gridSize ?? 40;
+  return ctx.gridType === 'hex' ? Math.sqrt(3) * gridSize : gridSize;
+}

--- a/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
+++ b/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
@@ -2,6 +2,7 @@ import { createTemplate, smartSnap } from '@fieldnotes/core';
 
 import type { Point, PointerState, Tool, ToolContext } from '@fieldnotes/core';
 import type { AoeShape } from '@/types/spellAoe';
+import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
 
 export interface SpellTemplateConfig {
   shape: AoeShape;
@@ -43,12 +44,7 @@ export class SpellTemplateTool implements Tool {
     }
     const world = ctx.camera.screenToWorld({ x: state.x, y: state.y });
     const origin = smartSnap(world, ctx);
-    // One cell in pixels, matching the SDK's own conversion (TemplateTool
-    // drag-to-size and computeTemplateResize): on hex grids the cell unit is
-    // √3 × gridSize, not gridSize — using the raw value undersized templates
-    // by √3 and the resize snap read them back at half their labeled feet.
-    const gridSize = ctx.gridSize ?? 40;
-    const cellPx = ctx.gridType === 'hex' ? Math.sqrt(3) * gridSize : gridSize;
+    const cellPx = cellUnit(ctx);
     // The renderer draws squares as fillRect(cx - r/2, cy - r/2, r, r):
     // `radius` is the FULL side, so a 20ft cube = 20ft across, same formula
     // as circle (where radius really is a radius).

--- a/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
+++ b/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
@@ -1,8 +1,9 @@
 import { createTemplate, smartSnap } from '@fieldnotes/core';
 
+import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
+
 import type { Point, PointerState, Tool, ToolContext } from '@fieldnotes/core';
 import type { AoeShape } from '@/types/spellAoe';
-import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
 
 export interface SpellTemplateConfig {
   shape: AoeShape;


### PR DESCRIPTION
## Summary

Foundation layer for the DM battle-map VTT (Plan A of 2, per the DM VTT spec). Pure utilities + tools — no screen chrome yet; Plan B (the Focus Studio screen) composes these.

- **`cellUnit(ctx)`** — the hex `√3 × gridSize` rule single-sourced (was inlined in `SpellTemplateTool` after the sizing bugfix; now shared, refactor behavior-preserving with the hex regression test untouched and green).
- **Combatant-token linkage** — tokens are `image`/`shape` elements carrying `entityId` + `tokenKind: 'combatant'` (extra top-level keys; verified to survive FieldNotes store/export/sync round-trips). `isCombatantToken` guard, `dispositionColor` (player emerald / legendary purple / ally blue / neutral gray / enemy red), `stampCombatantToken` (grid-snapped, one-cell-sized incl. hex, avatar-or-tinted-ellipse).
- **`DmTokenTool`** — one-shot placement tool (`'dmtoken'`), configRef-armed, same proven pattern as the spell template tool.
- **`TokenPlacementController`** — 1:1 adaptation of the player-side placement controller, carrying over the observed-armed race fix and the sync-clear invariant.
- **`useCombatantTokens`** — live placed-state index (entityId → element ids; recomputes on add/remove/clear only, so token drags stay cheap) + `selectedEntityId` mapping for click-token→select.

## Test plan
- [x] 33 tests across 5 files (cellUnit, stamping/colors/tool lifecycle, controller race scenarios, index/selection)
- [x] Full unit suite 2548 passing (exit 0), type-check + lint clean
- [x] Final review verified the Plan-B contract signatures verbatim and the sync-safety of extra element keys against the SDK dist

🤖 Generated with [Claude Code](https://claude.com/claude-code)