### PR TITLE
feat(dm-vtt): Focus Studio play mode — run combat from the battle map

### DIFF
--- a/src/app/dm/campaign/[code]/battlemaps/[id]/page.tsx
+++ b/src/app/dm/campaign/[code]/battlemaps/[id]/page.tsx
@@ -7,6 +7,8 @@ import { ArrowLeft, Map } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import DmLocationEditor from '@/components/ui/campaign/location-map/DmLocationEditor';
+import { DmVttScreen } from '@/components/ui/campaign/dm-vtt/DmVttScreen';
+import { useBattleMapMode } from '@/components/ui/campaign/dm-vtt/useBattleMapMode';
 import { useBattleMapStore } from '@/store/battleMapStore';
 import { useHydration } from '@/hooks/useHydration';
 import { useDmStore } from '@/store/dmStore';
@@ -19,7 +21,11 @@ export default function BattleMapEditorPage() {
   const { getBattleMap, updateBattleMap } = useBattleMapStore();
   const { dmId } = useDmStore();
 
-  if (!hasHydrated) {
+  const { mode, handleModeChange } = useBattleMapMode(id, hasHydrated, () =>
+    getBattleMap(code, id)
+  );
+
+  if (!hasHydrated || mode === null) {
     return (
       <div className="bg-surface flex min-h-screen items-center justify-center">
         <div className="text-muted animate-pulse">Loading...</div>
@@ -44,6 +50,18 @@ export default function BattleMapEditorPage() {
     );
   }
 
+  if (mode === 'play') {
+    return (
+      <DmVttScreen
+        campaignCode={code}
+        battleMapId={id}
+        dmId={dmId}
+        mode={mode}
+        onModeChange={handleModeChange}
+      />
+    );
+  }
+
   function handleSave(canvasState: string) {
     updateBattleMap(code, id, {
       canvasState,
@@ -58,6 +76,22 @@ export default function BattleMapEditorPage() {
 
   return (
     <div className="bg-surface flex h-screen flex-col overflow-hidden">
+      <div className="border-divider bg-surface-raised fixed top-4 right-4 z-50 flex items-center gap-0.5 rounded-lg border p-0.5 shadow-lg">
+        <Button
+          variant="primary"
+          size="lg"
+          onClick={() => handleModeChange('setup')}
+        >
+          Setup
+        </Button>
+        <Button
+          variant="ghost"
+          size="lg"
+          onClick={() => handleModeChange('play')}
+        >
+          Play
+        </Button>
+      </div>
       <header className="border-divider bg-surface-secondary border-b shadow-sm">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="flex h-16 items-center justify-between">

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -119,6 +119,7 @@ export function useDmBattleMapCanvas({
           .getState()
           .updateBattleMap(campaignCode, battleMapId, {
             canvasState: vp.exportJSON(),
+            updatedAt: new Date().toISOString(),
           });
       };
       vp.store.on('add', saveOnLocalOps);

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  SelectTool,
+  PencilTool,
+  ArrowTool,
+  MeasureTool,
+  TemplateTool,
+  AutoSave,
+  type Tool,
+  type Viewport,
+} from '@fieldnotes/core';
+import { PlayerHandTool } from '@/components/ui/campaign/location-map/PlayerHandTool';
+import {
+  createManagedBattleMapConnection,
+  type BattleMapConnectionStatus,
+} from '@/lib/battlemapSync';
+import { useBattleMapStore } from '@/store/battleMapStore';
+import {
+  DmTokenTool,
+  isCombatantToken,
+  type DmTokenConfig,
+} from '@/components/ui/campaign/dm-vtt/combatantToken';
+
+export interface DmBattleMapCanvasProps {
+  campaignCode: string;
+  battleMapId: string;
+  dmId: string;
+  /** Chrome rendered inside the ViewportContext.Provider. */
+  children?: React.ReactNode;
+  onStatus?: (status: BattleMapConnectionStatus) => void;
+  onViewportReady?: (vp: Viewport) => void;
+  tokenConfigRef: React.MutableRefObject<DmTokenConfig | null>;
+  /** Select-tool selection changes (element ids) — Task 8 maps to entities. */
+  onSelectionChange?: (selectedIds: string[]) => void;
+}
+
+/** Viewport exposes historyRecorder at runtime for batched store ops. */
+type ViewportHistoryAccess = {
+  historyRecorder: { begin: () => void; commit: () => void };
+};
+
+const DRAWING_TYPES = new Set(['stroke', 'arrow', 'template']);
+
+export interface DmBattleMapCanvasState {
+  viewport: Viewport | null;
+  status: BattleMapConnectionStatus;
+  tools: Tool[];
+  handleReady: (vp: Viewport) => void;
+  handleClearDrawings: () => void;
+}
+
+/**
+ * Init/persistence/connection wiring for `DmBattleMapCanvas` — mirrors
+ * `DmLocationEditor.hooks.ts`'s battlemap-mode path (loadJSON guard, AutoSave
+ * + save-on-local-ops with remote-origin filtering, `createManagedBattleMapConnection`
+ * with a live `dmOnlyElements` `resolveAudience`) while composing like
+ * `PlayerBattleMapCanvas` (tools memo, provider/children seam, teardown).
+ */
+export function useDmBattleMapCanvas({
+  campaignCode,
+  battleMapId,
+  dmId,
+  onStatus: onStatusProp,
+  onViewportReady,
+  tokenConfigRef,
+  onSelectionChange,
+}: DmBattleMapCanvasProps): DmBattleMapCanvasState {
+  const [viewport, setViewport] = useState<Viewport | null>(null);
+  const [status, setStatus] = useState<BattleMapConnectionStatus>('connecting');
+  const autoSaveRef = useRef<AutoSave | null>(null);
+  const connectionRef = useRef<{ stop: () => void } | null>(null);
+
+  const tools = useMemo<Tool[]>(() => {
+    const selectTool = new SelectTool();
+    return [
+      new PlayerHandTool(selectTool, el => isCombatantToken(el)),
+      selectTool,
+      new PencilTool({ color: '#F4C430', width: 2.6 }),
+      new ArrowTool({ color: '#F4C430', width: 2 }),
+      new MeasureTool({ feetPerCell: 5 }),
+      new TemplateTool({
+        templateShape: 'circle',
+        feetPerCell: 5,
+        renderStyle: 'geometric',
+      }),
+      new DmTokenTool(tokenConfigRef),
+    ];
+  }, [tokenConfigRef]);
+
+  const handleReady = useCallback(
+    (vp: Viewport) => {
+      setViewport(vp);
+
+      const battleMap = useBattleMapStore
+        .getState()
+        .getBattleMap(campaignCode, battleMapId);
+      if (battleMap?.canvasState && battleMap.canvasState.trim().length > 0) {
+        try {
+          vp.loadJSON(battleMap.canvasState);
+        } catch {
+          // Corrupt state — start with an empty canvas.
+        }
+      }
+
+      const autoSave = new AutoSave(vp.store, vp.camera, {
+        key: `battlemap-canvas-${battleMapId}`,
+        debounceMs: 1500,
+        layerManager: vp.layerManager,
+      });
+      autoSave.start();
+      autoSaveRef.current = autoSave;
+
+      // Remote-origin ops (relayed from another client) must not thrash
+      // zustand/localStorage on every incoming drag frame (mirrors the
+      // DmLocationEditor battlemap-mode save path).
+      const saveOnLocalOps = (_data: unknown, meta?: { origin?: string }) => {
+        if (meta?.origin !== undefined && meta.origin !== 'local') return;
+        useBattleMapStore
+          .getState()
+          .updateBattleMap(campaignCode, battleMapId, {
+            canvasState: vp.exportJSON(),
+          });
+      };
+      vp.store.on('add', saveOnLocalOps);
+      vp.store.on('remove', saveOnLocalOps);
+      vp.store.on('update', saveOnLocalOps);
+
+      const selectTool = vp.toolManager.getTool<SelectTool>('select');
+      selectTool?.onSelectionChange(() => {
+        onSelectionChange?.(selectTool.selectedIds);
+      });
+
+      // Live sync — resolver reads Zustand LIVE via getState() (a captured
+      // snapshot would go stale after the first dm-only toggle).
+      const relayUrl = process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
+      if (relayUrl) {
+        connectionRef.current?.stop();
+        connectionRef.current = createManagedBattleMapConnection({
+          relayUrl,
+          campaignCode,
+          battleMapId,
+          store: vp.store,
+          clientId: dmId,
+          tokenRequest: { role: 'dm', battleMapId, dmId },
+          seedLocal: true,
+          resolveAudience: el =>
+            useBattleMapStore.getState().battleMaps[campaignCode]?.[battleMapId]
+              ?.dmOnlyElements[el.id]
+              ? 'dm'
+              : undefined,
+          onStatus: s => {
+            setStatus(s);
+            onStatusProp?.(s);
+          },
+        });
+      }
+
+      onViewportReady?.(vp);
+    },
+    [
+      campaignCode,
+      battleMapId,
+      dmId,
+      onStatusProp,
+      onViewportReady,
+      onSelectionChange,
+    ]
+  );
+
+  useEffect(() => {
+    return () => {
+      autoSaveRef.current?.stop();
+      connectionRef.current?.stop();
+    };
+  }, []);
+
+  const handleClearDrawings = useCallback(() => {
+    if (!viewport) return;
+    const ids = viewport.store
+      .snapshot()
+      .filter(el => DRAWING_TYPES.has(el.type))
+      .map(el => el.id);
+    if (ids.length === 0) return;
+    if (!window.confirm('Clear all drawings (pencil, arrows, templates)?')) {
+      return;
+    }
+    const { historyRecorder } = viewport as unknown as ViewportHistoryAccess;
+    historyRecorder.begin();
+    for (const id of ids) {
+      viewport.store.remove(id);
+    }
+    historyRecorder.commit();
+    viewport.requestRender();
+  }, [viewport]);
+
+  return { viewport, status, tools, handleReady, handleClearDrawings };
+}

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { FieldNotesCanvas, ViewportContext } from '@fieldnotes/react';
+import DmLocationToolOptions from '@/components/ui/campaign/location-map/DmLocationToolOptions';
+import { DmVttToolbar } from './DmVttToolbar';
+import {
+  useDmBattleMapCanvas,
+  type DmBattleMapCanvasProps,
+} from './DmBattleMapCanvas.hooks';
+
+export type { DmBattleMapCanvasProps };
+
+/**
+ * DM-role battle-map canvas: play tools (pan/select/draw/arrow/measure/
+ * template) + a hidden `dmtoken` tool armed from the roster (Task 8), with
+ * editor-identical persistence/live-sync and player-canvas-identical
+ * provider/toolbar composition. See `DmBattleMapCanvas.hooks.ts` for the
+ * init/persistence/connection wiring.
+ */
+export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
+  const { children } = props;
+  const { viewport, status, tools, handleReady, handleClearDrawings } =
+    useDmBattleMapCanvas(props);
+
+  return (
+    <ViewportContext.Provider value={viewport}>
+      <div className="bg-surface fixed inset-0">
+        <FieldNotesCanvas
+          tools={tools}
+          defaultTool="hand"
+          onReady={handleReady}
+          className="h-full w-full"
+          snapToGrid
+        />
+        {viewport && (
+          <DmVttToolbar status={status} onClearDrawings={handleClearDrawings} />
+        )}
+        {viewport && (
+          <div className="border-divider absolute top-16 left-1/2 z-10 max-w-[92vw] -translate-x-1/2 overflow-hidden rounded-xl border shadow-lg">
+            <DmLocationToolOptions mode="battlemap" />
+          </div>
+        )}
+        {viewport && children}
+      </div>
+    </ViewportContext.Provider>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/DmVttNpcDialog.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttNpcDialog.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { NPCDetailDialog } from '@/components/ui/campaign/NPCDetailDialog';
+import { useNPCStore } from '@/store/npcStore';
+
+import type { CampaignNPC } from '@/types/encounter';
+
+interface DmVttNpcDialogProps {
+  campaignCode: string;
+  encounterId?: string;
+  npc: CampaignNPC | null;
+  entityId: string | null;
+  onClose: () => void;
+}
+
+/**
+ * Read-only NPC statblock dialog for the Selected tab's "View NPC details"
+ * eye icon (`DetailHeader.tsx` gates on `npcSourceId && actions.onViewNPC`) —
+ * mirrors the dialog `EncounterView` mounts for the same action
+ * (`EncounterView.tsx:322-342`). Re-fetches the live NPC record so edits
+ * made elsewhere (e.g. the NPC roster) show up, falling back to the
+ * snapshot captured at click time if the NPC was since deleted.
+ */
+export function DmVttNpcDialog({
+  campaignCode,
+  encounterId,
+  npc,
+  entityId,
+  onClose,
+}: DmVttNpcDialogProps) {
+  const getNPC = useNPCStore(state => state.getNPC);
+  if (!npc) return null;
+
+  return (
+    <NPCDetailDialog
+      npc={getNPC(campaignCode, npc.id) ?? npc}
+      open
+      onOpenChange={open => !open && onClose()}
+      readOnly
+      encounterId={encounterId}
+      npcEntityId={entityId ?? undefined}
+    />
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
@@ -1,0 +1,130 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+import { useToast } from '@/components/ui/feedback/Toast';
+
+import { useCombatantTokens } from './useCombatantTokens';
+import { useDmVttActions } from './useDmVttActions';
+import { useDmVttGrid } from './useDmVttGrid';
+import { useDmVttInitiative } from './useDmVttInitiative';
+import { useDmVttPlacementAndSelection } from './useDmVttPlacementAndSelection';
+import { useDmVttRoster } from './useDmVttRoster';
+import { useRosterDrag } from './useRosterDrag';
+
+import type { Viewport } from '@fieldnotes/core';
+import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
+
+interface UseDmVttScreenOptions {
+  campaignCode: string;
+  battleMapId: string;
+  dmId: string;
+}
+
+/**
+ * Composes the DM VTT play-mode screen: linked-encounter roster join
+ * (`useDmVttRoster`), followed-encounter initiative (Task 6), entity
+ * actions (`useDmVttActions`, mirrors `EncounterView.tsx:177-249`), grid
+ * control (`useDmVttGrid`), and tap/drag placement + canvas-selection
+ * mapping (`useDmVttPlacementAndSelection`). Split across sibling hook
+ * files to stay under the 150-line file cap.
+ * `armPlacement` returned here is NOT yet gated on drag — the screen must
+ * skip it when `wasDrag()` is true (a completed roster drag-drop fires a
+ * trailing synthetic click on the same row).
+ */
+export function useDmVttScreen({
+  campaignCode,
+  battleMapId,
+  dmId,
+}: UseDmVttScreenOptions) {
+  const { battleMap, linkedEncounterIds, linkedEntities } = useDmVttRoster({
+    campaignCode,
+    battleMapId,
+  });
+
+  const {
+    encounter,
+    followNote,
+    activeEntity,
+    handleNextTurn,
+    handlePrevTurn,
+  } = useDmVttInitiative({ campaignCode, dmId, linkedEncounterIds });
+
+  const actions = useDmVttActions({ campaignCode, dmId, encounter });
+
+  const { toasts, addToast, dismissToast } = useToast();
+
+  const [viewport, setViewport] = useState<Viewport | null>(null);
+  const viewportRef = useRef<Viewport | null>(null);
+  viewportRef.current = viewport;
+  const [status, setStatus] = useState<BattleMapConnectionStatus>('connecting');
+  const getViewport = useCallback(() => viewportRef.current, []);
+  const getCanvasEl = useCallback(
+    () => viewportRef.current?.domLayer ?? null,
+    []
+  );
+
+  const placedIndex = useCombatantTokens(viewport?.store ?? null);
+
+  const {
+    pendingPlacement,
+    tokenConfigRef,
+    armPlacement,
+    cancelPlacement,
+    selectedEntityId,
+    studioTab,
+    setStudioTab,
+    selectEntity,
+    handleSelectionChange,
+  } = useDmVttPlacementAndSelection({
+    status,
+    linkedEntities,
+    getViewport,
+    addToast,
+  });
+
+  const { drag, startDrag, wasDrag } = useRosterDrag({
+    getViewport,
+    getCanvasEl,
+    onDropPlaced: selectEntity,
+  });
+
+  const { setGridMode } = useDmVttGrid({
+    campaignCode,
+    battleMapId,
+    battleMap,
+    getViewport,
+  });
+
+  return {
+    battleMap,
+    linkedEntities,
+    placedIndex,
+    encounter,
+    followNote,
+    activeEntity,
+    handleNextTurn,
+    handlePrevTurn,
+    actions,
+    viewport,
+    status,
+    onViewportReady: setViewport,
+    onStatus: setStatus,
+    onSelectionChange: handleSelectionChange,
+    tokenConfigRef,
+    pendingPlacement,
+    armPlacement,
+    wasDrag,
+    cancelPlacement,
+    selectedEntityId,
+    selectEntity,
+    studioTab,
+    setStudioTab,
+    drag,
+    startDrag,
+    getCanvasEl,
+    setGridMode,
+    toasts,
+    dismissToast,
+  };
+}

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
@@ -7,11 +7,11 @@ import { useNPCStore } from '@/store/npcStore';
 
 import { useCombatantTokens } from './useCombatantTokens';
 import { useDmVttActions } from './useDmVttActions';
+import { useDmVttDragPlacement } from './useDmVttDragPlacement';
 import { useDmVttGrid } from './useDmVttGrid';
 import { useDmVttInitiative } from './useDmVttInitiative';
 import { useDmVttPlacementAndSelection } from './useDmVttPlacementAndSelection';
 import { useDmVttRoster } from './useDmVttRoster';
-import { useRosterDrag } from './useRosterDrag';
 
 import type { Viewport } from '@fieldnotes/core';
 import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
@@ -28,7 +28,9 @@ interface UseDmVttScreenOptions {
  * followed-encounter initiative, entity actions + NPC-dialog state
  * (`useDmVttActions`, mirrors `EncounterView.tsx:177-249`), grid control,
  * and tap/drag placement + canvas-selection mapping. Split across sibling
- * hook files to stay under the 150-line file cap. `armPlacement` is NOT
+ * hook files to stay under the 150-line file cap — `useDmVttDragPlacement`
+ * gates drag-start on `status === 'live'` (same toast as tap-to-arm) and
+ * clears any tap-armed pending placement on drop. `armPlacement` is NOT
  * gated on drag — the screen must skip it when `wasDrag()` is true (a
  * completed drag-drop fires a trailing synthetic click on the same row).
  */
@@ -97,10 +99,13 @@ export function useDmVttScreen({
     addToast,
   });
 
-  const { drag, startDrag, wasDrag } = useRosterDrag({
+  const { drag, startDrag, wasDrag } = useDmVttDragPlacement({
+    status,
     getViewport,
     getCanvasEl,
-    onDropPlaced: selectEntity,
+    addToast,
+    selectEntity,
+    clearPendingPlacement: cancelPlacement,
   });
 
   const { setGridMode } = useDmVttGrid({

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from 'react';
 
 import { useToast } from '@/components/ui/feedback/Toast';
+import { useNPCStore } from '@/store/npcStore';
 
 import { useCombatantTokens } from './useCombatantTokens';
 import { useDmVttActions } from './useDmVttActions';
@@ -14,6 +15,7 @@ import { useRosterDrag } from './useRosterDrag';
 
 import type { Viewport } from '@fieldnotes/core';
 import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
+import type { CampaignNPC } from '@/types/encounter';
 
 interface UseDmVttScreenOptions {
   campaignCode: string;
@@ -22,15 +24,13 @@ interface UseDmVttScreenOptions {
 }
 
 /**
- * Composes the DM VTT play-mode screen: linked-encounter roster join
- * (`useDmVttRoster`), followed-encounter initiative (Task 6), entity
- * actions (`useDmVttActions`, mirrors `EncounterView.tsx:177-249`), grid
- * control (`useDmVttGrid`), and tap/drag placement + canvas-selection
- * mapping (`useDmVttPlacementAndSelection`). Split across sibling hook
- * files to stay under the 150-line file cap.
- * `armPlacement` returned here is NOT yet gated on drag — the screen must
- * skip it when `wasDrag()` is true (a completed roster drag-drop fires a
- * trailing synthetic click on the same row).
+ * Composes the DM VTT play-mode screen: linked-encounter roster join,
+ * followed-encounter initiative, entity actions + NPC-dialog state
+ * (`useDmVttActions`, mirrors `EncounterView.tsx:177-249`), grid control,
+ * and tap/drag placement + canvas-selection mapping. Split across sibling
+ * hook files to stay under the 150-line file cap. `armPlacement` is NOT
+ * gated on drag — the screen must skip it when `wasDrag()` is true (a
+ * completed drag-drop fires a trailing synthetic click on the same row).
  */
 export function useDmVttScreen({
   campaignCode,
@@ -50,7 +50,21 @@ export function useDmVttScreen({
     handlePrevTurn,
   } = useDmVttInitiative({ campaignCode, dmId, linkedEncounterIds });
 
-  const actions = useDmVttActions({ campaignCode, dmId, encounter });
+  const { getNPCsForCampaign } = useNPCStore();
+  const npcs = getNPCsForCampaign(campaignCode);
+  const [viewingNpc, setViewingNpc] = useState<{
+    npc: CampaignNPC;
+    entityId: string;
+  } | null>(null);
+  const onViewNPC = useCallback(
+    (npcSourceId: string, entityId: string) => {
+      const npc = npcs.find(n => n.id === npcSourceId);
+      if (npc) setViewingNpc({ npc, entityId });
+    },
+    [npcs]
+  );
+
+  const actions = useDmVttActions({ campaignCode, dmId, encounter, onViewNPC });
 
   const { toasts, addToast, dismissToast } = useToast();
 
@@ -126,5 +140,10 @@ export function useDmVttScreen({
     setGridMode,
     toasts,
     dismissToast,
+    npcDialog: {
+      npc: viewingNpc?.npc ?? null,
+      entityId: viewingNpc?.entityId ?? null,
+      onClose: () => setViewingNpc(null),
+    },
   };
 }

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+
+import { ToastContainer } from '@/components/ui/feedback/Toast';
+
+import { DmBattleMapCanvas } from './DmBattleMapCanvas';
+import { useDmVttScreen } from './DmVttScreen.hooks';
+import { DmVttTopBar } from './DmVttTopBar';
+import { PlacementBanner } from './PlacementBanner';
+import { RosterDragGhost } from './RosterDragGhost';
+import { RosterTray } from './RosterTray';
+import { StudioPanel } from './StudioPanel';
+import { TokenDragDistanceBadge } from './TokenDragDistanceBadge';
+import { TokenPlacementController } from './TokenPlacementController';
+import { TurnControl } from './TurnControl';
+
+import type { DmVttGridMode, DmVttMode } from './DmVttTopBar';
+
+interface DmVttScreenProps {
+  campaignCode: string;
+  battleMapId: string;
+  dmId: string;
+  mode: DmVttMode;
+  onModeChange: (mode: DmVttMode) => void;
+}
+
+/**
+ * DM VTT play-mode screen: battle map canvas with the roster tray, studio
+ * panel, turn control, drag-distance badge, and top chrome composed as
+ * canvas children (so they share `useActiveTool` context, per
+ * `TokenPlacementController`).
+ */
+export function DmVttScreen({
+  campaignCode,
+  battleMapId,
+  dmId,
+  mode,
+  onModeChange,
+}: DmVttScreenProps) {
+  const {
+    battleMap,
+    linkedEntities,
+    placedIndex,
+    encounter,
+    activeEntity,
+    handleNextTurn,
+    handlePrevTurn,
+    actions,
+    viewport,
+    status,
+    onViewportReady,
+    onStatus,
+    onSelectionChange,
+    tokenConfigRef,
+    pendingPlacement,
+    armPlacement,
+    wasDrag,
+    cancelPlacement,
+    selectedEntityId,
+    selectEntity,
+    studioTab,
+    setStudioTab,
+    drag,
+    startDrag,
+    getCanvasEl,
+    setGridMode,
+    toasts,
+    dismissToast,
+  } = useDmVttScreen({ campaignCode, battleMapId, dmId });
+
+  const [rosterCollapsed, setRosterCollapsed] = useState(false);
+  const [studioCollapsed, setStudioCollapsed] = useState(false);
+
+  const gridMode: DmVttGridMode = battleMap?.gridEnabled
+    ? (battleMap.gridSettings?.gridType ?? 'hex')
+    : 'off';
+
+  return (
+    <DmBattleMapCanvas
+      campaignCode={campaignCode}
+      battleMapId={battleMapId}
+      dmId={dmId}
+      onStatus={onStatus}
+      onViewportReady={onViewportReady}
+      tokenConfigRef={tokenConfigRef}
+      onSelectionChange={onSelectionChange}
+    >
+      <TokenPlacementController
+        pending={pendingPlacement}
+        configRef={tokenConfigRef}
+        onCancel={cancelPlacement}
+      />
+      {pendingPlacement && (
+        <PlacementBanner
+          entityName={pendingPlacement.entityName}
+          onCancel={cancelPlacement}
+        />
+      )}
+      <div className="pointer-events-none absolute inset-0 z-10">
+        <DmVttTopBar
+          campaignCode={campaignCode}
+          battleMapId={battleMapId}
+          dmId={dmId}
+          mapName={battleMap?.name ?? 'Battle Map'}
+          status={status}
+          gridMode={gridMode}
+          onSetGridMode={setGridMode}
+          mode={mode}
+          onModeChange={onModeChange}
+        />
+        <RosterTray
+          entities={linkedEntities}
+          placedIndex={placedIndex}
+          armedEntityId={pendingPlacement?.config.entityId ?? null}
+          onArmPlacement={entity => !wasDrag() && armPlacement(entity)}
+          onSelectEntity={selectEntity}
+          onDragStart={startDrag}
+          collapsed={rosterCollapsed}
+          onToggleCollapsed={() => setRosterCollapsed(v => !v)}
+          hasLinkedEncounter={linkedEntities.length > 0}
+        />
+        <RosterDragGhost drag={drag} />
+        {actions && (
+          <StudioPanel
+            encounter={encounter}
+            selectedEntityId={selectedEntityId}
+            onSelectEntity={selectEntity}
+            actions={actions}
+            activeTab={studioTab}
+            onTabChange={setStudioTab}
+            encounterHref={`/dm/campaign/${campaignCode}/encounters/${encounter?.id ?? ''}`}
+            collapsed={studioCollapsed}
+            onToggleCollapsed={() => setStudioCollapsed(v => !v)}
+          />
+        )}
+        {encounter?.isActive && (
+          <TurnControl
+            round={encounter.round}
+            activeName={activeEntity?.name ?? '—'}
+            onNext={handleNextTurn}
+            onPrev={handlePrevTurn}
+          />
+        )}
+        <TokenDragDistanceBadge viewport={viewport} canvasEl={getCanvasEl()} />
+      </div>
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </DmBattleMapCanvas>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -6,6 +6,7 @@ import { ToastContainer } from '@/components/ui/feedback/Toast';
 
 import { DmBattleMapCanvas } from './DmBattleMapCanvas';
 import { useDmVttScreen } from './DmVttScreen.hooks';
+import { DmVttNpcDialog } from './DmVttNpcDialog';
 import { DmVttTopBar } from './DmVttTopBar';
 import { PlacementBanner } from './PlacementBanner';
 import { RosterDragGhost } from './RosterDragGhost';
@@ -29,7 +30,9 @@ interface DmVttScreenProps {
  * DM VTT play-mode screen: battle map canvas with the roster tray, studio
  * panel, turn control, drag-distance badge, and top chrome composed as
  * canvas children (so they share `useActiveTool` context, per
- * `TokenPlacementController`).
+ * `TokenPlacementController`). The Selected tab's "View NPC details" action
+ * is delegated to `DmVttNpcDialog` (mirrors `EncounterView`'s NPC statblock
+ * viewer).
  */
 export function DmVttScreen({
   campaignCode,
@@ -38,42 +41,12 @@ export function DmVttScreen({
   mode,
   onModeChange,
 }: DmVttScreenProps) {
-  const {
-    battleMap,
-    linkedEntities,
-    placedIndex,
-    encounter,
-    activeEntity,
-    handleNextTurn,
-    handlePrevTurn,
-    actions,
-    viewport,
-    status,
-    onViewportReady,
-    onStatus,
-    onSelectionChange,
-    tokenConfigRef,
-    pendingPlacement,
-    armPlacement,
-    wasDrag,
-    cancelPlacement,
-    selectedEntityId,
-    selectEntity,
-    studioTab,
-    setStudioTab,
-    drag,
-    startDrag,
-    getCanvasEl,
-    setGridMode,
-    toasts,
-    dismissToast,
-  } = useDmVttScreen({ campaignCode, battleMapId, dmId });
-
+  const vtt = useDmVttScreen({ campaignCode, battleMapId, dmId });
   const [rosterCollapsed, setRosterCollapsed] = useState(false);
   const [studioCollapsed, setStudioCollapsed] = useState(false);
 
-  const gridMode: DmVttGridMode = battleMap?.gridEnabled
-    ? (battleMap.gridSettings?.gridType ?? 'hex')
+  const gridMode: DmVttGridMode = vtt.battleMap?.gridEnabled
+    ? (vtt.battleMap.gridSettings?.gridType ?? 'hex')
     : 'off';
 
   return (
@@ -81,20 +54,20 @@ export function DmVttScreen({
       campaignCode={campaignCode}
       battleMapId={battleMapId}
       dmId={dmId}
-      onStatus={onStatus}
-      onViewportReady={onViewportReady}
-      tokenConfigRef={tokenConfigRef}
-      onSelectionChange={onSelectionChange}
+      onStatus={vtt.onStatus}
+      onViewportReady={vtt.onViewportReady}
+      tokenConfigRef={vtt.tokenConfigRef}
+      onSelectionChange={vtt.onSelectionChange}
     >
       <TokenPlacementController
-        pending={pendingPlacement}
-        configRef={tokenConfigRef}
-        onCancel={cancelPlacement}
+        pending={vtt.pendingPlacement}
+        configRef={vtt.tokenConfigRef}
+        onCancel={vtt.cancelPlacement}
       />
-      {pendingPlacement && (
+      {vtt.pendingPlacement && (
         <PlacementBanner
-          entityName={pendingPlacement.entityName}
-          onCancel={cancelPlacement}
+          entityName={vtt.pendingPlacement.entityName}
+          onCancel={vtt.cancelPlacement}
         />
       )}
       <div className="pointer-events-none absolute inset-0 z-10">
@@ -102,49 +75,57 @@ export function DmVttScreen({
           campaignCode={campaignCode}
           battleMapId={battleMapId}
           dmId={dmId}
-          mapName={battleMap?.name ?? 'Battle Map'}
-          status={status}
+          mapName={vtt.battleMap?.name ?? 'Battle Map'}
+          status={vtt.status}
           gridMode={gridMode}
-          onSetGridMode={setGridMode}
+          onSetGridMode={vtt.setGridMode}
           mode={mode}
           onModeChange={onModeChange}
         />
         <RosterTray
-          entities={linkedEntities}
-          placedIndex={placedIndex}
-          armedEntityId={pendingPlacement?.config.entityId ?? null}
-          onArmPlacement={entity => !wasDrag() && armPlacement(entity)}
-          onSelectEntity={selectEntity}
-          onDragStart={startDrag}
+          entities={vtt.linkedEntities}
+          placedIndex={vtt.placedIndex}
+          armedEntityId={vtt.pendingPlacement?.config.entityId ?? null}
+          onArmPlacement={entity => !vtt.wasDrag() && vtt.armPlacement(entity)}
+          onSelectEntity={vtt.selectEntity}
+          onDragStart={vtt.startDrag}
           collapsed={rosterCollapsed}
           onToggleCollapsed={() => setRosterCollapsed(v => !v)}
-          hasLinkedEncounter={linkedEntities.length > 0}
+          hasLinkedEncounter={vtt.linkedEntities.length > 0}
         />
-        <RosterDragGhost drag={drag} />
-        {actions && (
+        <RosterDragGhost drag={vtt.drag} />
+        {vtt.actions && (
           <StudioPanel
-            encounter={encounter}
-            selectedEntityId={selectedEntityId}
-            onSelectEntity={selectEntity}
-            actions={actions}
-            activeTab={studioTab}
-            onTabChange={setStudioTab}
-            encounterHref={`/dm/campaign/${campaignCode}/encounters/${encounter?.id ?? ''}`}
+            encounter={vtt.encounter}
+            selectedEntityId={vtt.selectedEntityId}
+            onSelectEntity={vtt.selectEntity}
+            actions={vtt.actions}
+            activeTab={vtt.studioTab}
+            onTabChange={vtt.setStudioTab}
+            encounterHref={`/dm/campaign/${campaignCode}/encounters/${vtt.encounter?.id ?? ''}`}
             collapsed={studioCollapsed}
             onToggleCollapsed={() => setStudioCollapsed(v => !v)}
           />
         )}
-        {encounter?.isActive && (
+        {vtt.encounter?.isActive && (
           <TurnControl
-            round={encounter.round}
-            activeName={activeEntity?.name ?? '—'}
-            onNext={handleNextTurn}
-            onPrev={handlePrevTurn}
+            round={vtt.encounter.round}
+            activeName={vtt.activeEntity?.name ?? '—'}
+            onNext={vtt.handleNextTurn}
+            onPrev={vtt.handlePrevTurn}
           />
         )}
-        <TokenDragDistanceBadge viewport={viewport} canvasEl={getCanvasEl()} />
+        <TokenDragDistanceBadge
+          viewport={vtt.viewport}
+          canvasEl={vtt.getCanvasEl()}
+        />
       </div>
-      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+      <ToastContainer toasts={vtt.toasts} onDismiss={vtt.dismissToast} />
+      <DmVttNpcDialog
+        campaignCode={campaignCode}
+        encounterId={vtt.encounter?.id}
+        {...vtt.npcDialog}
+      />
     </DmBattleMapCanvas>
   );
 }

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -105,6 +105,7 @@ export function DmVttScreen({
             encounterHref={`/dm/campaign/${campaignCode}/encounters/${vtt.encounter?.id ?? ''}`}
             collapsed={studioCollapsed}
             onToggleCollapsed={() => setStudioCollapsed(v => !v)}
+            followNote={vtt.followNote}
           />
         )}
         {vtt.encounter?.isActive && (

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import {
+  Hand,
+  MousePointer2,
+  Pencil,
+  MoveUpRight,
+  Ruler,
+  Circle,
+  Eraser,
+} from 'lucide-react';
+import { Button } from '@/components/ui/forms/button';
+import { useActiveTool } from '@fieldnotes/react';
+import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
+
+const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
+  { name: 'hand', label: 'Pan', Icon: Hand },
+  { name: 'select', label: 'Select', Icon: MousePointer2 },
+  { name: 'pencil', label: 'Draw', Icon: Pencil },
+  { name: 'arrow', label: 'Arrow', Icon: MoveUpRight },
+  { name: 'measure', label: 'Measure', Icon: Ruler },
+  { name: 'template', label: 'Template', Icon: Circle },
+];
+
+export interface DmVttToolbarProps {
+  status: BattleMapConnectionStatus;
+  onClearDrawings: () => void;
+}
+
+/** Top-center tool pill for the DM battle-map canvas — structurally mirrors
+ * `PlayerBattleMapCanvas`'s `PlayerToolbar`, minus the token tool (placed via
+ * the roster in Task 8, never through this toolbar) plus a Clear-drawings
+ * action. */
+export function DmVttToolbar({ status, onClearDrawings }: DmVttToolbarProps) {
+  const [activeTool, setTool] = useActiveTool();
+  return (
+    <div className="bg-surface-raised border-divider absolute top-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-xl border p-1 shadow-lg">
+      {DM_TOOLS.map(({ name, label, Icon }) => (
+        <Button
+          key={name}
+          variant={activeTool === name ? 'primary' : 'ghost'}
+          onClick={() => setTool(name)}
+          className="h-8 w-8 p-0"
+          title={label}
+          aria-label={label}
+        >
+          <Icon size={16} />
+        </Button>
+      ))}
+      <Button
+        variant="ghost"
+        onClick={onClearDrawings}
+        className="h-8 w-8 p-0"
+        title="Clear drawings"
+        aria-label="Clear drawings"
+      >
+        <Eraser size={16} />
+      </Button>
+      <span
+        className={`ml-2 rounded-full px-2 py-0.5 text-xs ${
+          status === 'live'
+            ? 'bg-accent-emerald-bg text-accent-emerald-text'
+            : status === 'denied'
+              ? 'bg-accent-red-bg text-accent-red-text'
+              : 'bg-accent-amber-bg text-accent-amber-text'
+        }`}
+      >
+        {status === 'live'
+          ? 'Live'
+          : status === 'denied'
+            ? 'Access denied'
+            : 'Connecting…'}
+      </span>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/DmVttTopBar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttTopBar.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft, Monitor } from 'lucide-react';
+
+import { Button } from '@/components/ui/forms/button';
+import { openTvDisplay } from '@/lib/openTvDisplay';
+
+import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
+
+export type DmVttMode = 'setup' | 'play';
+export type DmVttGridMode = 'hex' | 'square' | 'off';
+
+interface DmVttTopBarProps {
+  campaignCode: string;
+  battleMapId: string;
+  dmId: string;
+  mapName: string;
+  status: BattleMapConnectionStatus;
+  gridMode: DmVttGridMode;
+  onSetGridMode: (mode: DmVttGridMode) => void;
+  mode: DmVttMode;
+  onModeChange: (mode: DmVttMode) => void;
+}
+
+const GRID_OPTIONS: { key: DmVttGridMode; label: string }[] = [
+  { key: 'hex', label: 'Hex' },
+  { key: 'square', label: 'Square' },
+  { key: 'off', label: 'Off' },
+];
+
+const MODE_OPTIONS: { key: DmVttMode; label: string }[] = [
+  { key: 'setup', label: 'Setup' },
+  { key: 'play', label: 'Play' },
+];
+
+/**
+ * Top chrome bar for the DM VTT play screen: back link, map name, grid
+ * segmented control (mirrors `useDmVttGrid`'s `setGridMode`), TV display
+ * launcher (Task 1's `openTvDisplay` helper), a live-status chip (mirrors
+ * `DmVttToolbar`'s status pill), and the Setup|Play mode switch (state +
+ * persistence owned by the page).
+ */
+export function DmVttTopBar({
+  campaignCode,
+  battleMapId,
+  dmId,
+  mapName,
+  status,
+  gridMode,
+  onSetGridMode,
+  mode,
+  onModeChange,
+}: DmVttTopBarProps) {
+  return (
+    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-3 left-4 flex min-h-[44px] items-center gap-3 rounded-2xl border px-3 py-1.5 shadow-xl">
+      <Link href={`/dm/campaign/${campaignCode}/battlemaps`}>
+        <Button variant="ghost" size="lg" aria-label="Back to battle maps">
+          <ArrowLeft size={18} />
+        </Button>
+      </Link>
+      <span className="text-heading max-w-[160px] truncate text-sm font-semibold">
+        {mapName}
+      </span>
+      <div className="border-divider flex items-center gap-0.5 rounded-lg border p-0.5">
+        {GRID_OPTIONS.map(({ key, label }) => (
+          <Button
+            key={key}
+            variant={gridMode === key ? 'primary' : 'ghost'}
+            onClick={() => onSetGridMode(key)}
+            className="h-8 px-2 text-xs"
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+      <Button
+        variant="ghost"
+        size="lg"
+        leftIcon={<Monitor size={16} />}
+        onClick={() => openTvDisplay(campaignCode, battleMapId, dmId)}
+        className="text-xs"
+      >
+        Open Display
+      </Button>
+      <span
+        className={`rounded-full px-2 py-0.5 text-xs ${
+          status === 'live'
+            ? 'bg-accent-emerald-bg text-accent-emerald-text'
+            : status === 'denied'
+              ? 'bg-accent-red-bg text-accent-red-text'
+              : 'bg-accent-amber-bg text-accent-amber-text'
+        }`}
+      >
+        {status === 'live'
+          ? 'Live'
+          : status === 'denied'
+            ? 'Access denied'
+            : 'Connecting…'}
+      </span>
+      <div className="border-divider flex items-center gap-0.5 rounded-lg border p-0.5">
+        {MODE_OPTIONS.map(({ key, label }) => (
+          <Button
+            key={key}
+            variant={mode === key ? 'primary' : 'ghost'}
+            onClick={() => onModeChange(key)}
+            className="h-8 px-2 text-xs"
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/PlacementBanner.tsx
+++ b/src/components/ui/campaign/dm-vtt/PlacementBanner.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/forms/button';
+
+interface PlacementBannerProps {
+  entityName: string;
+  onCancel: () => void;
+}
+
+/** Top-center banner shown while a tap-armed placement is pending — sibling
+ * extraction from `DmVttScreen.tsx` to stay under the 150-line file cap. */
+export function PlacementBanner({
+  entityName,
+  onCancel,
+}: PlacementBannerProps) {
+  return (
+    <div className="pointer-events-auto fixed top-16 left-1/2 z-20 -translate-x-1/2">
+      <div className="bg-accent-blue-bg border-accent-blue-border flex min-h-[44px] items-center gap-2 rounded-xl border px-3 py-1.5 shadow-lg">
+        <span className="text-accent-blue-text text-sm font-medium">
+          📍 Click the map to place {entityName}
+        </span>
+        <Button variant="ghost" size="lg" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/RosterDragGhost.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterDragGhost.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { dispositionColor } from './combatantToken';
+
+import type { RosterDragState } from './useRosterDrag';
+
+export interface RosterDragGhostProps {
+  drag: RosterDragState | null;
+}
+
+/**
+ * Fixed-position chip that follows the pointer while a roster row is being
+ * dragged toward the canvas — disc (avatar image or disposition color) plus
+ * first-word name, centered on `drag.x/y`. `pointer-events-none` so it never
+ * intercepts the drop itself (drop math reads the underlying pointer event,
+ * not this element).
+ */
+export function RosterDragGhost({ drag }: RosterDragGhostProps) {
+  if (!drag) return null;
+
+  const { entity, x, y } = drag;
+  const color = dispositionColor(entity);
+  const firstName = entity.name.split(' ')[0];
+  const isImage = entity.avatarUrl?.startsWith('http') ?? false;
+
+  return (
+    <div
+      className="bg-surface-raised border-divider pointer-events-none fixed z-50 flex -translate-x-1/2 -translate-y-1/2 items-center gap-1.5 rounded-full border px-2 py-1 shadow-xl"
+      style={{ left: x, top: y }}
+    >
+      <span
+        className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-full text-[10px] font-bold text-white"
+        style={isImage ? undefined : { backgroundColor: color }}
+      >
+        {isImage ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={entity.avatarUrl}
+            alt=""
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          firstName.charAt(0).toUpperCase()
+        )}
+      </span>
+      <span className="text-heading text-xs font-medium whitespace-nowrap">
+        {firstName}
+      </span>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/RosterRow.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterRow.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { dispositionColor } from './combatantToken';
+
+import type { PointerEvent } from 'react';
+import type { EncounterEntity } from '@/types/encounter';
+
+export interface RosterRowProps {
+  entity: EncounterEntity;
+  placed: boolean;
+  armed: boolean;
+  onArmPlacement: (entity: EncounterEntity) => void;
+  onSelectEntity: (entityId: string) => void;
+  onDragStart: (entity: EncounterEntity, e: PointerEvent) => void;
+}
+
+/**
+ * Single roster row: avatar disc, first-word name, placed/unplaced state
+ * line. Unplaced rows arm placement on click and forward pointerdown to
+ * `onDragStart` (Task 4's drag logic decides tap-vs-drag by movement
+ * threshold — this row just forwards both). Placed rows select the token.
+ */
+export function RosterRow({
+  entity,
+  placed,
+  armed,
+  onArmPlacement,
+  onSelectEntity,
+  onDragStart,
+}: RosterRowProps) {
+  const color = dispositionColor(entity);
+  const firstName = entity.name.split(' ')[0];
+  const isImage = entity.avatarUrl?.startsWith('http') ?? false;
+
+  const handleClick = () => {
+    if (placed) onSelectEntity(entity.id);
+    else onArmPlacement(entity);
+  };
+
+  const handlePointerDown = (e: PointerEvent) => {
+    if (!placed) onDragStart(entity, e);
+  };
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={handleClick}
+        onPointerDown={handlePointerDown}
+        className={`flex min-h-[44px] w-full items-center gap-2 rounded-lg border border-transparent px-1.5 py-1 text-left transition-colors ${
+          placed ? 'opacity-60' : ''
+        } ${
+          armed
+            ? 'bg-accent-blue-bg border-accent-blue-border'
+            : 'hover:bg-surface-secondary'
+        }`}
+      >
+        <span
+          className="flex h-[30px] w-[30px] shrink-0 items-center justify-center overflow-hidden rounded-full text-xs font-bold text-white"
+          style={isImage ? undefined : { backgroundColor: color }}
+        >
+          {isImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={entity.avatarUrl}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            firstName.charAt(0).toUpperCase()
+          )}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="text-body block truncate text-xs font-medium">
+            {firstName}
+          </span>
+          <span className="text-faint block text-[10px]">
+            {placed ? 'On map' : 'Tap → place'}
+          </span>
+        </span>
+      </button>
+    </li>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/RosterTray.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterTray.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { Button } from '@/components/ui/forms/button';
+
+import { RosterRow } from './RosterRow';
+import { groupRosterEntities } from './rosterGroups';
+
+import type { PointerEvent } from 'react';
+import type { EncounterEntity } from '@/types/encounter';
+import type { RosterGroups } from './rosterGroups';
+
+export interface RosterTrayProps {
+  entities: EncounterEntity[];
+  placedIndex: Map<string, string[]>;
+  armedEntityId: string | null;
+  onArmPlacement: (entity: EncounterEntity) => void;
+  onSelectEntity: (entityId: string) => void;
+  onDragStart: (entity: EncounterEntity, e: PointerEvent) => void;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  hasLinkedEncounter: boolean;
+}
+
+const GROUP_SECTIONS: { key: keyof RosterGroups; label: string }[] = [
+  { key: 'players', label: 'PLAYERS' },
+  { key: 'npcs', label: 'NPCS' },
+  { key: 'monsters', label: 'MONSTERS' },
+];
+
+/**
+ * Roster tray for the DM VTT studio — lists every linked encounter's
+ * entities grouped by type, and forwards tap/drag placement intents up to
+ * the canvas. Store-free: everything arrives via props for testability.
+ */
+export function RosterTray({
+  entities,
+  placedIndex,
+  armedEntityId,
+  onArmPlacement,
+  onSelectEntity,
+  onDragStart,
+  collapsed,
+  onToggleCollapsed,
+  hasLinkedEncounter,
+}: RosterTrayProps) {
+  if (collapsed) {
+    return (
+      <button
+        onClick={onToggleCollapsed}
+        title="Expand roster"
+        className="bg-surface-raised border-divider text-heading pointer-events-auto fixed top-[78px] left-4 flex min-h-[44px] items-center gap-1.5 rounded-2xl border px-3 text-xs font-bold tracking-wider shadow-xl"
+      >
+        <span aria-hidden>👥</span> ROSTER
+      </button>
+    );
+  }
+
+  const groups = groupRosterEntities(entities);
+
+  return (
+    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-[78px] left-4 flex max-h-[calc(100vh-102px)] w-[180px] flex-col overflow-hidden rounded-2xl border shadow-xl">
+      <div className="border-divider flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2.5">
+        <span className="text-heading text-sm font-semibold">👥 Roster</span>
+        <Button
+          variant="ghost"
+          size="lg"
+          onClick={onToggleCollapsed}
+          aria-label="Collapse roster"
+        >
+          ▸
+        </Button>
+      </div>
+      <div className="flex-1 overflow-y-auto px-2 py-2">
+        {!hasLinkedEncounter ? (
+          <p className="text-muted px-1 py-2 text-xs">
+            Link an encounter in Setup mode
+          </p>
+        ) : (
+          GROUP_SECTIONS.map(({ key, label }) => {
+            const list = groups[key];
+            if (list.length === 0) return null;
+            return (
+              <div key={key} className="mb-2">
+                <div className="text-faint px-1 pb-1 text-[10px] font-bold tracking-wider uppercase">
+                  {label}
+                </div>
+                <ul className="space-y-1">
+                  {list.map(entity => (
+                    <RosterRow
+                      key={entity.id}
+                      entity={entity}
+                      placed={(placedIndex.get(entity.id)?.length ?? 0) > 0}
+                      armed={armedEntityId === entity.id}
+                      onArmPlacement={onArmPlacement}
+                      onSelectEntity={onSelectEntity}
+                      onDragStart={onDragStart}
+                    />
+                  ))}
+                </ul>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/InitiativeRow.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/InitiativeRow.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { Badge } from '@/components/ui/layout/badge';
+import { HPBar } from '@/components/shared/combat/HPBar';
+
+import { dispositionColor } from '../combatantToken';
+
+import type { EncounterEntity } from '@/types/encounter';
+
+export interface InitiativeRowProps {
+  entity: EncounterEntity;
+  isActive: boolean;
+  isSelected: boolean;
+  onSelect: (entityId: string) => void;
+}
+
+/**
+ * Single initiative-tab row: initiative value, disposition stripe, name
+ * (+ concentration/hidden glyphs), HP bar, and AC. Active row (the entity at
+ * `sorted[encounter.currentTurn]`) gets an amber pulse; the DM-selected row
+ * gets a blue border.
+ */
+export function InitiativeRow({
+  entity,
+  isActive,
+  isSelected,
+  onSelect,
+}: InitiativeRowProps) {
+  const stripeColor = dispositionColor(entity);
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(entity.id)}
+        className={`flex min-h-[44px] w-full items-center gap-2 rounded-lg border px-2 py-1.5 text-left transition-colors ${
+          isActive
+            ? 'bg-accent-amber-bg border-accent-amber-border animate-pulse'
+            : 'hover:bg-surface-secondary border-transparent'
+        } ${isSelected ? 'border-accent-blue-border' : ''}`}
+      >
+        <span
+          className="h-8 w-1 shrink-0 rounded-full"
+          style={{ backgroundColor: stripeColor }}
+          aria-hidden
+        />
+        <span className="text-heading w-6 shrink-0 text-center text-sm font-bold tabular-nums">
+          {entity.initiative ?? '—'}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-1">
+            <span className="text-body truncate text-xs font-medium">
+              {entity.name}
+            </span>
+            {entity.concentrationSpell && (
+              <span title={`Concentrating: ${entity.concentrationSpell}`}>
+                🧠
+              </span>
+            )}
+            {entity.isHidden && (
+              <Badge variant="neutral" size="sm">
+                hidden
+              </Badge>
+            )}
+          </span>
+          <HPBar
+            current={entity.currentHp}
+            max={entity.maxHp}
+            temp={entity.tempHp}
+            size="sm"
+          />
+        </span>
+        <span className="text-faint shrink-0 text-[10px] font-semibold">
+          AC {entity.armorClass}
+        </span>
+      </button>
+    </li>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/InitiativeTab.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/InitiativeTab.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import Link from 'next/link';
+
+import { getSortedEntities } from '@/store/encounterStore';
+
+import { InitiativeRow } from './InitiativeRow';
+
+import type { Encounter } from '@/types/encounter';
+
+export interface InitiativeTabProps {
+  encounter: Encounter | null;
+  selectedEntityId: string | null;
+  onSelectEntity: (entityId: string) => void;
+  encounterHref: string;
+}
+
+/**
+ * Initiative order list for the studio panel. Sorts with the same
+ * `getSortedEntities` util `buildSharedInitiative` uses for the player-facing
+ * turn order, so the DM's row order matches what players see. The entity at
+ * `sorted[encounter.currentTurn]` is highlighted as the active turn.
+ */
+export function InitiativeTab({
+  encounter,
+  selectedEntityId,
+  onSelectEntity,
+  encounterHref,
+}: InitiativeTabProps) {
+  if (!encounter) {
+    return (
+      <p className="text-muted px-3 py-4 text-xs">No encounter linked yet.</p>
+    );
+  }
+
+  if (!encounter.isActive) {
+    return (
+      <div className="space-y-2 px-3 py-4">
+        <p className="text-muted text-xs">
+          Start combat from the encounter page.
+        </p>
+        <Link
+          href={encounterHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent-blue-text text-xs font-semibold hover:underline"
+        >
+          Encounter page ↗
+        </Link>
+      </div>
+    );
+  }
+
+  const sorted = getSortedEntities(encounter.entities);
+
+  return (
+    <ul className="space-y-1 px-2 py-2">
+      {sorted.map((entity, index) => (
+        <InitiativeRow
+          key={entity.id}
+          entity={entity}
+          isActive={index === encounter.currentTurn}
+          isSelected={entity.id === selectedEntityId}
+          onSelect={onSelectEntity}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
@@ -20,6 +20,8 @@ export interface StudioPanelProps {
   encounterHref: string; // "Encounter page ↗"
   collapsed: boolean;
   onToggleCollapsed: () => void;
+  /** "Following: {name}" when 2+ linked encounters are active; else null. */
+  followNote?: string | null;
 }
 
 const TABS: { key: 'initiative' | 'selected'; icon: string; label: string }[] =
@@ -43,6 +45,7 @@ export function StudioPanel({
   encounterHref,
   collapsed,
   onToggleCollapsed,
+  followNote,
 }: StudioPanelProps) {
   if (collapsed) {
     return (
@@ -95,6 +98,11 @@ export function StudioPanel({
           </Button>
         </div>
       </div>
+      {followNote && (
+        <p className="text-faint border-divider border-b px-3 py-1 text-xs">
+          {followNote}
+        </p>
+      )}
       <div className="flex-1 overflow-y-auto">
         {activeTab === 'initiative' ? (
           <InitiativeTab

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/forms/button';
+import { CombatantDetail } from '@/components/ui/encounter/combat-screen/detail/CombatantDetail';
+
+import { InitiativeTab } from './InitiativeTab';
+
+import type { Encounter } from '@/types/encounter';
+import type { EntityActions } from '@/components/ui/encounter/combat-screen/types';
+
+export interface StudioPanelProps {
+  encounter: Encounter | null; // the followed encounter (Task 6 resolves it)
+  selectedEntityId: string | null;
+  onSelectEntity: (entityId: string) => void;
+  actions: EntityActions; // built by Task 8 via buildEntityActions
+  activeTab: 'initiative' | 'selected';
+  onTabChange: (tab: 'initiative' | 'selected') => void;
+  encounterHref: string; // "Encounter page ↗"
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}
+
+const TABS: { key: 'initiative' | 'selected'; icon: string; label: string }[] =
+  [
+    { key: 'initiative', icon: '⚔', label: 'Initiative' },
+    { key: 'selected', icon: '📋', label: 'Selected' },
+  ];
+
+/**
+ * DM VTT studio panel: right-edge collapsible panel with an Initiative tab
+ * (turn order, mirrors the player-facing sort) and a Selected tab that
+ * reuses the combat-screen `CombatantDetail` for full entity management.
+ */
+export function StudioPanel({
+  encounter,
+  selectedEntityId,
+  onSelectEntity,
+  actions,
+  activeTab,
+  onTabChange,
+  encounterHref,
+  collapsed,
+  onToggleCollapsed,
+}: StudioPanelProps) {
+  if (collapsed) {
+    return (
+      <button
+        onClick={onToggleCollapsed}
+        title="Expand combat panel"
+        className="bg-surface-raised border-divider text-heading pointer-events-auto fixed top-[78px] right-4 flex min-h-[44px] items-center gap-1.5 rounded-2xl border px-3 text-xs font-bold tracking-wider shadow-xl"
+      >
+        <span aria-hidden>📋</span> COMBAT
+      </button>
+    );
+  }
+
+  const selectedEntity = encounter?.entities.find(
+    e => e.id === selectedEntityId
+  );
+
+  return (
+    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-[78px] right-4 flex max-h-[calc(100vh-102px)] w-[390px] flex-col overflow-hidden rounded-2xl border shadow-xl">
+      <div className="border-divider flex shrink-0 items-center justify-between gap-2 border-b px-2 py-1.5">
+        <div className="flex items-center gap-1">
+          {TABS.map(({ key, icon, label }) => (
+            <Button
+              key={key}
+              variant={activeTab === key ? 'primary' : 'ghost'}
+              onClick={() => onTabChange(key)}
+              className="min-h-[44px] text-xs"
+              aria-label={label}
+            >
+              <span aria-hidden>{icon}</span> {label}
+            </Button>
+          ))}
+        </div>
+        <div className="flex items-center gap-1">
+          <Link
+            href={encounterHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-blue-text px-1 text-xs font-semibold hover:underline"
+          >
+            Encounter page ↗
+          </Link>
+          <Button
+            variant="ghost"
+            size="lg"
+            onClick={onToggleCollapsed}
+            aria-label="Collapse combat panel"
+          >
+            ▸
+          </Button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {activeTab === 'initiative' ? (
+          <InitiativeTab
+            encounter={encounter}
+            selectedEntityId={selectedEntityId}
+            onSelectEntity={onSelectEntity}
+            encounterHref={encounterHref}
+          />
+        ) : selectedEntity ? (
+          <CombatantDetail entity={selectedEntity} actions={actions} />
+        ) : (
+          <p className="text-muted px-3 py-4 text-xs">
+            Select a combatant or token.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/TokenDragDistanceBadge.tsx
+++ b/src/components/ui/campaign/dm-vtt/TokenDragDistanceBadge.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  SelectTool,
+  type Viewport,
+  type CanvasElement,
+} from '@fieldnotes/core';
+import {
+  dragDistanceFeet,
+  type Point,
+} from '@/components/ui/campaign/dm-vtt/dragDistance';
+import { isCombatantToken } from '@/components/ui/campaign/dm-vtt/combatantToken';
+
+interface TokenDragDistanceBadgeProps {
+  viewport: Viewport | null;
+  canvasEl: HTMLElement | null;
+}
+
+interface BadgeState {
+  isVisible: boolean;
+  distance: number;
+  x: number;
+  y: number;
+}
+
+/**
+ * Headless canvas child component that displays distance during combatant token drags.
+ * Listens to pointer events; when select tool has a combatant token selected,
+ * shows a fixed badge tracking the cursor distance from the drag origin.
+ */
+export function TokenDragDistanceBadge({
+  viewport,
+  canvasEl,
+}: TokenDragDistanceBadgeProps) {
+  const [badge, setBadge] = useState<BadgeState>({
+    isVisible: false,
+    distance: 0,
+    x: 0,
+    y: 0,
+  });
+
+  const originRef = useRef<Point | null>(null);
+  const dragStartedRef = useRef(false);
+  const selectedElementRef = useRef<CanvasElement | null>(null);
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent) => {
+      if (!viewport || !dragStartedRef.current || !originRef.current) {
+        return;
+      }
+
+      // Get the current world position of the selected element
+      const element = selectedElementRef.current;
+      if (!element || !element.position) {
+        setBadge(prev => ({ ...prev, isVisible: false }));
+        return;
+      }
+
+      // Calculate distance in feet
+      const distance = dragDistanceFeet(
+        originRef.current,
+        element.position,
+        viewport.toolContext,
+        5
+      );
+
+      // Update badge position: +12px right, -24px up from cursor
+      setBadge({
+        isVisible: true,
+        distance,
+        x: e.clientX + 12,
+        y: e.clientY - 24,
+      });
+    },
+    [viewport]
+  );
+
+  const handlePointerDown = useCallback(() => {
+    if (!viewport || !canvasEl) {
+      return;
+    }
+
+    // Check if select tool is active and has a combatant token selected
+    const selectTool = viewport.toolManager.getTool<SelectTool>('select');
+    if (!selectTool || selectTool.selectedIds.length === 0) {
+      return;
+    }
+
+    // Get the first selected element
+    const firstId = selectTool.selectedIds[0];
+    const element = viewport.store.getById(firstId);
+
+    if (!element || !isCombatantToken(element)) {
+      return;
+    }
+
+    // Capture the drag origin and element
+    selectedElementRef.current = element;
+    originRef.current = element.position as Point;
+    dragStartedRef.current = true;
+  }, [viewport, canvasEl]);
+
+  const handlePointerUp = useCallback(() => {
+    dragStartedRef.current = false;
+    originRef.current = null;
+    selectedElementRef.current = null;
+    setBadge(prev => ({ ...prev, isVisible: false }));
+  }, []);
+
+  useEffect(() => {
+    if (!canvasEl) {
+      return;
+    }
+
+    canvasEl.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+
+    return () => {
+      canvasEl.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [canvasEl, handlePointerDown, handlePointerMove, handlePointerUp]);
+
+  if (!badge.isVisible) {
+    return null;
+  }
+
+  return (
+    <div
+      className="bg-surface-raised border-divider pointer-events-none fixed z-30 rounded border px-1.5 py-0.5 text-xs font-bold shadow"
+      style={{
+        left: `${badge.x}px`,
+        top: `${badge.y}px`,
+        transform: 'translate(-50%, 0)',
+      }}
+    >
+      {badge.distance} ft
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/TokenDragDistanceBadge.tsx
+++ b/src/components/ui/campaign/dm-vtt/TokenDragDistanceBadge.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import {
-  SelectTool,
-  type Viewport,
-  type CanvasElement,
-} from '@fieldnotes/core';
+import { SelectTool, type Viewport } from '@fieldnotes/core';
 import {
   dragDistanceFeet,
   type Point,
@@ -26,8 +22,9 @@ interface BadgeState {
 
 /**
  * Headless canvas child component that displays distance during combatant token drags.
- * Listens to pointer events; when select tool has a combatant token selected,
- * shows a fixed badge tracking the cursor distance from the drag origin.
+ * Listens to pointer events; when the select tool is active with a combatant
+ * token selected, shows a fixed badge tracking the cursor distance from the
+ * drag origin.
  */
 export function TokenDragDistanceBadge({
   viewport,
@@ -40,27 +37,66 @@ export function TokenDragDistanceBadge({
     y: 0,
   });
 
+  // pointerdown only records "a press started" — the SDK hasn't necessarily
+  // processed the click's selection yet at that point. Combatant detection
+  // and the one-time origin capture happen on the first pointermove instead,
+  // gated by captureAttemptedRef so it only ever runs once per gesture.
+  const pointerDownRef = useRef(false);
+  const captureAttemptedRef = useRef(false);
   const originRef = useRef<Point | null>(null);
-  const dragStartedRef = useRef(false);
-  const selectedElementRef = useRef<CanvasElement | null>(null);
+  const selectedIdRef = useRef<string | null>(null);
+
+  const resetGesture = useCallback(() => {
+    pointerDownRef.current = false;
+    captureAttemptedRef.current = false;
+    originRef.current = null;
+    selectedIdRef.current = null;
+  }, []);
 
   const handlePointerMove = useCallback(
     (e: PointerEvent) => {
-      if (!viewport || !dragStartedRef.current || !originRef.current) {
+      if (!viewport || !pointerDownRef.current) {
         return;
       }
 
-      // Get the current world position of the selected element
-      const element = selectedElementRef.current;
-      if (!element || !element.position) {
+      if (!captureAttemptedRef.current) {
+        captureAttemptedRef.current = true;
+
+        const isSelectToolActive =
+          viewport.toolManager.activeTool?.name === 'select';
+        const selectTool = viewport.toolManager.getTool<SelectTool>('select');
+        const firstId = selectTool?.selectedIds[0];
+        const element = firstId ? viewport.store.getById(firstId) : undefined;
+
+        if (
+          isSelectToolActive &&
+          firstId &&
+          element &&
+          isCombatantToken(element)
+        ) {
+          selectedIdRef.current = firstId;
+          originRef.current = { x: element.position.x, y: element.position.y };
+        }
+      }
+
+      const origin = originRef.current;
+      const selectedId = selectedIdRef.current;
+      if (!origin || !selectedId) {
+        return;
+      }
+
+      // Re-fetch by id on every move: the store replaces the element object
+      // on each position update, so a captured reference goes stale.
+      const current = viewport.store.getById(selectedId);
+      if (!current || !current.position) {
         setBadge(prev => ({ ...prev, isVisible: false }));
         return;
       }
 
       // Calculate distance in feet
       const distance = dragDistanceFeet(
-        originRef.current,
-        element.position,
+        origin,
+        current.position,
         viewport.toolContext,
         5
       );
@@ -81,32 +117,18 @@ export function TokenDragDistanceBadge({
       return;
     }
 
-    // Check if select tool is active and has a combatant token selected
-    const selectTool = viewport.toolManager.getTool<SelectTool>('select');
-    if (!selectTool || selectTool.selectedIds.length === 0) {
-      return;
-    }
-
-    // Get the first selected element
-    const firstId = selectTool.selectedIds[0];
-    const element = viewport.store.getById(firstId);
-
-    if (!element || !isCombatantToken(element)) {
-      return;
-    }
-
-    // Capture the drag origin and element
-    selectedElementRef.current = element;
-    originRef.current = element.position as Point;
-    dragStartedRef.current = true;
+    // Only mark that a press started; combatant detection + origin capture
+    // happen on the first subsequent pointermove (see handlePointerMove).
+    pointerDownRef.current = true;
+    captureAttemptedRef.current = false;
+    originRef.current = null;
+    selectedIdRef.current = null;
   }, [viewport, canvasEl]);
 
   const handlePointerUp = useCallback(() => {
-    dragStartedRef.current = false;
-    originRef.current = null;
-    selectedElementRef.current = null;
+    resetGesture();
     setBadge(prev => ({ ...prev, isVisible: false }));
-  }, []);
+  }, [resetGesture]);
 
   useEffect(() => {
     if (!canvasEl) {

--- a/src/components/ui/campaign/dm-vtt/TurnControl.tsx
+++ b/src/components/ui/campaign/dm-vtt/TurnControl.tsx
@@ -1,0 +1,53 @@
+import { Rewind, Play } from 'lucide-react';
+
+import { Button } from '@/components/ui/forms/button';
+
+interface TurnControlProps {
+  round: number;
+  activeName: string;
+  onNext: () => void;
+  onPrev: () => void;
+}
+
+/**
+ * Bottom-center pill showing the current round/turn and driving
+ * next/previous turn — mirrors the fixed-pill styling used by
+ * `RosterTray`/`StudioPanel` elsewhere in the DM VTT studio.
+ */
+export function TurnControl({
+  round,
+  activeName,
+  onNext,
+  onPrev,
+}: TurnControlProps) {
+  return (
+    <div className="bg-surface-raised border-divider pointer-events-auto fixed bottom-6 left-1/2 flex min-h-[44px] -translate-x-1/2 items-center gap-3 rounded-2xl border px-4 py-2 shadow-xl">
+      <div className="flex flex-col leading-tight">
+        <span className="text-muted text-[10px] font-bold tracking-wider">
+          ROUND {round} · NOW
+        </span>
+        <span className="text-heading text-sm font-semibold">{activeName}</span>
+      </div>
+
+      <Button
+        variant="ghost"
+        size="lg"
+        aria-label="Previous turn"
+        onClick={onPrev}
+        className="min-h-[44px] min-w-[44px] px-3"
+      >
+        <Rewind size={18} />
+      </Button>
+
+      <Button
+        variant="primary"
+        size="lg"
+        onClick={onNext}
+        rightIcon={<Play size={16} />}
+        className="min-h-[44px]"
+      >
+        Next
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/__tests__/DmVttScreen.hooks.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/DmVttScreen.hooks.test.ts
@@ -29,8 +29,25 @@ function makeBattleMap(overrides: Partial<BattleMap> = {}): BattleMap {
 }
 
 /** Fake canvas store: `getAll`/`on` satisfy `useCombatantTokens`, `getById`
- * resolves the ids seeded in `tokensById` to combatant-token elements. */
+ * resolves the ids seeded in `tokensById` to combatant-token elements, `add`
+ * records stamped tokens for the drag-to-place tests. Also supplies
+ * `domLayer` (drop-bounds element) and `camera`/`toolContext` so a full
+ * pointer drag-and-drop can be simulated end to end via `startDrag`. */
 function makeFakeViewport(tokensById: Record<string, string>): Viewport {
+  const domLayer = document.createElement('div');
+  domLayer.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: 1000,
+      bottom: 1000,
+      width: 1000,
+      height: 1000,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+
   const store = {
     getAll: () => [],
     on: () => () => {},
@@ -38,8 +55,22 @@ function makeFakeViewport(tokensById: Record<string, string>): Viewport {
       const entityId = tokensById[id];
       return entityId ? { id, tokenKind: 'combatant', entityId } : undefined;
     },
+    add: () => {},
   };
-  return { store } as unknown as Viewport;
+  const toolContext = {
+    store,
+    requestRender: () => {},
+    gridSize: 40,
+    gridType: 'square',
+    activeLayerId: 'dm-layer',
+    snapToGrid: false,
+  };
+  return {
+    store,
+    domLayer,
+    camera: { screenToWorld: (p: { x: number; y: number }) => p },
+    toolContext,
+  } as unknown as Viewport;
 }
 
 function makeNPC(overrides: Partial<CampaignNPC> = {}): CampaignNPC {
@@ -164,6 +195,108 @@ describe('useDmVttScreen', () => {
     act(() => result.current.cancelPlacement());
 
     expect(result.current.pendingPlacement).toBeNull();
+  });
+
+  it('startDrag is a no-op while offline and fires the not-connected toast', () => {
+    seed();
+    const { result } = renderHook(() =>
+      useDmVttScreen({ campaignCode: 'ABC', battleMapId: 'bm-1', dmId: 'dm-1' })
+    );
+    act(() => result.current.onViewportReady(makeFakeViewport({})));
+    // Never call onStatus('live') — status stays at its 'connecting' default.
+
+    act(() =>
+      result.current.startDrag(
+        createMockEncounterEntity({
+          id: 'known-1',
+          name: 'Aria',
+          type: 'player',
+        }),
+        { clientX: 100, clientY: 100 } as React.PointerEvent
+      )
+    );
+
+    expect(result.current.drag).toBeNull();
+    expect(
+      result.current.toasts.some(
+        t => t.type === 'info' && t.title === 'Not connected'
+      )
+    ).toBe(true);
+  });
+
+  it("drag-drop of a different entity clears an armed entity's pending placement and selects the dropped one", () => {
+    seed();
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: true,
+          entities: [
+            createMockEncounterEntity({
+              id: 'known-1',
+              name: 'Aria',
+              type: 'player',
+            }),
+            createMockEncounterEntity({
+              id: 'known-2',
+              name: 'Boss',
+              type: 'monster',
+            }),
+          ],
+        }),
+      ],
+    });
+    const { result } = renderHook(() =>
+      useDmVttScreen({ campaignCode: 'ABC', battleMapId: 'bm-1', dmId: 'dm-1' })
+    );
+    act(() => result.current.onStatus('live'));
+    act(() => result.current.onViewportReady(makeFakeViewport({})));
+
+    // Arm entity A via tap.
+    act(() =>
+      result.current.armPlacement(
+        createMockEncounterEntity({
+          id: 'known-1',
+          name: 'Aria',
+          type: 'player',
+        })
+      )
+    );
+    expect(result.current.pendingPlacement?.config.entityId).toBe('known-1');
+
+    // Drag entity B onto the canvas and drop it.
+    act(() =>
+      result.current.startDrag(
+        createMockEncounterEntity({
+          id: 'known-2',
+          name: 'Boss',
+          type: 'monster',
+        }),
+        { clientX: 100, clientY: 100 } as React.PointerEvent
+      )
+    );
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointermove', {
+          clientX: 130,
+          clientY: 140,
+          bubbles: true,
+        })
+      );
+    });
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointerup', {
+          clientX: 130,
+          clientY: 140,
+          bubbles: true,
+        })
+      );
+    });
+
+    expect(result.current.pendingPlacement).toBeNull();
+    expect(result.current.selectedEntityId).toBe('known-2');
   });
 
   it('onSelectionChange maps a known combatant token to its entity and flips the tab', () => {

--- a/src/components/ui/campaign/dm-vtt/__tests__/DmVttScreen.hooks.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/DmVttScreen.hooks.test.ts
@@ -3,11 +3,13 @@ import { renderHook, act } from '@testing-library/react';
 
 import { useBattleMapStore } from '@/store/battleMapStore';
 import { useEncounterStore } from '@/store/encounterStore';
+import { useNPCStore } from '@/store/npcStore';
 import { createMockEncounter, createMockEncounterEntity } from '@/test/helpers';
 import { useDmVttScreen } from '../DmVttScreen.hooks';
 
 import type { Viewport } from '@fieldnotes/core';
 import type { BattleMap } from '@/types/battlemap';
+import type { CampaignNPC } from '@/types/encounter';
 
 function makeBattleMap(overrides: Partial<BattleMap> = {}): BattleMap {
   return {
@@ -40,9 +42,24 @@ function makeFakeViewport(tokensById: Record<string, string>): Viewport {
   return { store } as unknown as Viewport;
 }
 
+function makeNPC(overrides: Partial<CampaignNPC> = {}): CampaignNPC {
+  return {
+    id: 'npc-1',
+    campaignCode: 'ABC',
+    name: 'Grizzlebeard',
+    armorClass: 14,
+    maxHp: 22,
+    speed: '30 ft.',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
 function resetStores() {
   useBattleMapStore.setState({ battleMaps: {} });
   useEncounterStore.setState({ encounters: [], activeEncounterId: null });
+  useNPCStore.setState({ npcsByCampaign: {} });
 }
 
 describe('useDmVttScreen', () => {
@@ -190,5 +207,36 @@ describe('useDmVttScreen', () => {
           t.message.includes('no longer in the encounter')
       )
     ).toBe(true);
+  });
+
+  it('actions.onViewNPC opens npcDialog with the matching NPC and entityId; onClose resets it', () => {
+    seed();
+    useNPCStore.setState({ npcsByCampaign: { ABC: [makeNPC()] } });
+    const { result } = renderHook(() =>
+      useDmVttScreen({ campaignCode: 'ABC', battleMapId: 'bm-1', dmId: 'dm-1' })
+    );
+
+    expect(result.current.npcDialog.npc).toBeNull();
+
+    act(() => result.current.actions?.onViewNPC?.('npc-1', 'known-1'));
+
+    expect(result.current.npcDialog.npc?.id).toBe('npc-1');
+    expect(result.current.npcDialog.entityId).toBe('known-1');
+
+    act(() => result.current.npcDialog.onClose());
+
+    expect(result.current.npcDialog.npc).toBeNull();
+    expect(result.current.npcDialog.entityId).toBeNull();
+  });
+
+  it('actions.onViewNPC is a no-op for an npcSourceId with no matching NPC', () => {
+    seed();
+    const { result } = renderHook(() =>
+      useDmVttScreen({ campaignCode: 'ABC', battleMapId: 'bm-1', dmId: 'dm-1' })
+    );
+
+    act(() => result.current.actions?.onViewNPC?.('does-not-exist', 'known-1'));
+
+    expect(result.current.npcDialog.npc).toBeNull();
   });
 });

--- a/src/components/ui/campaign/dm-vtt/__tests__/DmVttScreen.hooks.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/DmVttScreen.hooks.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useBattleMapStore } from '@/store/battleMapStore';
+import { useEncounterStore } from '@/store/encounterStore';
+import { createMockEncounter, createMockEncounterEntity } from '@/test/helpers';
+import { useDmVttScreen } from '../DmVttScreen.hooks';
+
+import type { Viewport } from '@fieldnotes/core';
+import type { BattleMap } from '@/types/battlemap';
+
+function makeBattleMap(overrides: Partial<BattleMap> = {}): BattleMap {
+  return {
+    id: 'bm-1',
+    campaignCode: 'ABC',
+    name: 'The Ruins',
+    mapImageUrl: '',
+    mapImageSize: { w: 100, h: 100 },
+    canvasState: '',
+    dmOnlyElements: {},
+    gridEnabled: false,
+    linkedEncounterIds: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** Fake canvas store: `getAll`/`on` satisfy `useCombatantTokens`, `getById`
+ * resolves the ids seeded in `tokensById` to combatant-token elements. */
+function makeFakeViewport(tokensById: Record<string, string>): Viewport {
+  const store = {
+    getAll: () => [],
+    on: () => () => {},
+    getById: (id: string) => {
+      const entityId = tokensById[id];
+      return entityId ? { id, tokenKind: 'combatant', entityId } : undefined;
+    },
+  };
+  return { store } as unknown as Viewport;
+}
+
+function resetStores() {
+  useBattleMapStore.setState({ battleMaps: {} });
+  useEncounterStore.setState({ encounters: [], activeEncounterId: null });
+}
+
+describe('useDmVttScreen', () => {
+  beforeEach(() => {
+    resetStores();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true }))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  function seed() {
+    useBattleMapStore.setState({
+      battleMaps: {
+        ABC: { 'bm-1': makeBattleMap({ linkedEncounterIds: ['enc-1'] }) },
+      },
+    });
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: true,
+          entities: [
+            createMockEncounterEntity({
+              id: 'known-1',
+              name: 'Aria',
+              type: 'player',
+            }),
+          ],
+        }),
+      ],
+    });
+  }
+
+  it('armPlacement sets pending with the correct config/color once live', () => {
+    seed();
+    const { result } = renderHook(() =>
+      useDmVttScreen({ campaignCode: 'ABC', battleMapId: 'bm-1', dmId: 'dm-1' })
+    );
+
+    act(() => result.current.onStatus('live'));
+    act(() =>
+      result.current.armPlacement(
+        createMockEncounterEntity({
+          id: 'known-1',
+          name: 'Aria',
+          type: 'player',
+        })
+      )
+    );
+
+    expect(result.current.pendingPlacement?.entityName).toBe('Aria');
+    expect(result.current.pendingPlacement?.config).toMatchObject({
+      entityId: 'known-1',
+      name: 'Aria',
+      color: '#12855C',
+    });
+  });
+
+  it('config.onPlaced clears pending SYNCHRONOUSLY and selects the entity', () => {
+    seed();
+    const { result } = renderHook(() =>
+      useDmVttScreen({ campaignCode: 'ABC', battleMapId: 'bm-1', dmId: 'dm-1' })
+    );
+    act(() => result.current.onStatus('live'));
+    act(() =>
+      result.current.armPlacement(
+        createMockEncounterEntity({
+          id: 'known-1',
+          name: 'Aria',
+          type: 'player',
+        })
+      )
+    );
+    const { config } = result.current.pendingPlacement!;
+
+    act(() => config.onPlaced());
+
+    expect(result.current.pendingPlacement).toBeNull();
+    expect(result.current.selectedEntityId).toBe('known-1');
+    expect(result.current.studioTab).toBe('selected');
+  });
+
+  it('cancelPlacement clears pending', () => {
+    seed();
+    const { result } = renderHook(() =>
+      useDmVttScreen({ campaignCode: 'ABC', battleMapId: 'bm-1', dmId: 'dm-1' })
+    );
+    act(() => result.current.onStatus('live'));
+    act(() =>
+      result.current.armPlacement(
+        createMockEncounterEntity({
+          id: 'known-1',
+          name: 'Aria',
+          type: 'player',
+        })
+      )
+    );
+
+    act(() => result.current.cancelPlacement());
+
+    expect(result.current.pendingPlacement).toBeNull();
+  });
+
+  it('onSelectionChange maps a known combatant token to its entity and flips the tab', () => {
+    seed();
+    const { result } = renderHook(() =>
+      useDmVttScreen({ campaignCode: 'ABC', battleMapId: 'bm-1', dmId: 'dm-1' })
+    );
+    act(() =>
+      result.current.onViewportReady(makeFakeViewport({ tokenElId: 'known-1' }))
+    );
+
+    act(() => result.current.onSelectionChange(['tokenElId']));
+
+    expect(result.current.selectedEntityId).toBe('known-1');
+    expect(result.current.studioTab).toBe('selected');
+  });
+
+  it('onSelectionChange fires an info toast and leaves selection unset for an unlinked token', () => {
+    seed();
+    const { result } = renderHook(() =>
+      useDmVttScreen({ campaignCode: 'ABC', battleMapId: 'bm-1', dmId: 'dm-1' })
+    );
+    act(() =>
+      result.current.onViewportReady(
+        makeFakeViewport({ tokenElId: 'known-1', staleTokenEl: 'ghost-1' })
+      )
+    );
+    // First select the known entity so we can prove the stale selection
+    // actually clears it back to null, rather than merely starting null.
+    act(() => result.current.onSelectionChange(['tokenElId']));
+    expect(result.current.selectedEntityId).toBe('known-1');
+
+    act(() => result.current.onSelectionChange(['staleTokenEl']));
+
+    expect(result.current.selectedEntityId).toBeNull();
+    expect(
+      result.current.toasts.some(
+        t =>
+          t.type === 'info' &&
+          t.title === 'Unlinked token' &&
+          t.message.includes('no longer in the encounter')
+      )
+    ).toBe(true);
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/RosterTray.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/RosterTray.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+import { groupRosterEntities } from '@/components/ui/campaign/dm-vtt/rosterGroups';
+import { RosterTray } from '@/components/ui/campaign/dm-vtt/RosterTray';
+
+import type { EncounterEntity } from '@/types/encounter';
+import type { RosterTrayProps } from '@/components/ui/campaign/dm-vtt/RosterTray';
+
+function makeEntity(overrides: Partial<EncounterEntity>): EncounterEntity {
+  return {
+    id: 'e1',
+    type: 'monster',
+    name: 'Goblin',
+    initiative: null,
+    initiativeModifier: 0,
+    currentHp: 7,
+    maxHp: 7,
+    tempHp: 0,
+    armorClass: 15,
+    conditions: [],
+    ...overrides,
+  } as EncounterEntity;
+}
+
+const player = makeEntity({ id: 'p1', type: 'player', name: 'Aria Windrider' });
+const npc = makeEntity({ id: 'n1', type: 'npc', name: 'Barkeep Tomas' });
+const monster = makeEntity({ id: 'm1', type: 'monster', name: 'Goblin' });
+const lair = makeEntity({ id: 'l1', type: 'lair', name: 'Lair Action' });
+
+function baseProps(overrides: Partial<RosterTrayProps> = {}): RosterTrayProps {
+  return {
+    entities: [player, npc, monster],
+    placedIndex: new Map(),
+    armedEntityId: null,
+    onArmPlacement: vi.fn(),
+    onSelectEntity: vi.fn(),
+    onDragStart: vi.fn(),
+    collapsed: false,
+    onToggleCollapsed: vi.fn(),
+    hasLinkedEncounter: true,
+    ...overrides,
+  };
+}
+
+describe('groupRosterEntities', () => {
+  it('splits entities into players/npcs/monsters and drops lair entities', () => {
+    const groups = groupRosterEntities([player, npc, monster, lair]);
+    expect(groups.players).toEqual([player]);
+    expect(groups.npcs).toEqual([npc]);
+    expect(groups.monsters).toEqual([monster]);
+  });
+
+  it('returns empty arrays for groups with no matching entities', () => {
+    const groups = groupRosterEntities([player]);
+    expect(groups.npcs).toEqual([]);
+    expect(groups.monsters).toEqual([]);
+  });
+});
+
+describe('RosterTray', () => {
+  afterEach(() => cleanup());
+
+  it('shows a no-encounter prompt when hasLinkedEncounter is false', () => {
+    render(<RosterTray {...baseProps({ hasLinkedEncounter: false })} />);
+    expect(
+      screen.getByText(/link an encounter in setup mode/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Aria')).not.toBeInTheDocument();
+  });
+
+  it('renders group labels and first-word names for each entity', () => {
+    render(<RosterTray {...baseProps()} />);
+    expect(screen.getByText('PLAYERS')).toBeInTheDocument();
+    expect(screen.getByText('NPCS')).toBeInTheDocument();
+    expect(screen.getByText('MONSTERS')).toBeInTheDocument();
+    expect(screen.getByText('Aria')).toBeInTheDocument();
+    expect(screen.getByText('Barkeep')).toBeInTheDocument();
+    expect(screen.getByText('Goblin')).toBeInTheDocument();
+  });
+
+  it('dims a placed row and shows "On map"; clicking it calls onSelectEntity', () => {
+    const onSelectEntity = vi.fn();
+    const onArmPlacement = vi.fn();
+    const placedIndex = new Map([['m1', ['token-1']]]);
+    render(
+      <RosterTray
+        {...baseProps({ placedIndex, onSelectEntity, onArmPlacement })}
+      />
+    );
+
+    const label = screen.getByText('On map');
+    expect(label).toBeInTheDocument();
+    const row = label.closest('button');
+    expect(row).not.toBeNull();
+    expect(row?.className).toMatch(/opacity-60/);
+
+    fireEvent.click(row!);
+    expect(onSelectEntity).toHaveBeenCalledWith('m1');
+    expect(onArmPlacement).not.toHaveBeenCalled();
+  });
+
+  it('clicking an unplaced row calls onArmPlacement with the entity', () => {
+    const onArmPlacement = vi.fn();
+    const onSelectEntity = vi.fn();
+    render(<RosterTray {...baseProps({ onArmPlacement, onSelectEntity })} />);
+
+    const row = screen.getByText('Goblin').closest('button')!;
+    fireEvent.click(row);
+
+    expect(onArmPlacement).toHaveBeenCalledWith(monster);
+    expect(onSelectEntity).not.toHaveBeenCalled();
+  });
+
+  it('forwards pointerdown on an unplaced row to onDragStart', () => {
+    const onDragStart = vi.fn();
+    render(<RosterTray {...baseProps({ onDragStart })} />);
+
+    const row = screen.getByText('Goblin').closest('button')!;
+    fireEvent.pointerDown(row);
+
+    expect(onDragStart).toHaveBeenCalledTimes(1);
+    expect(onDragStart.mock.calls[0][0]).toEqual(monster);
+  });
+
+  it('highlights the armed row with the accent-blue classes', () => {
+    render(<RosterTray {...baseProps({ armedEntityId: 'm1' })} />);
+    const row = screen.getByText('Goblin').closest('button')!;
+    expect(row.className).toMatch(/bg-accent-blue-bg/);
+    expect(row.className).toMatch(/border-accent-blue-border/);
+  });
+
+  it('renders a collapsed pill and expands on click', () => {
+    const onToggleCollapsed = vi.fn();
+    render(
+      <RosterTray {...baseProps({ collapsed: true, onToggleCollapsed })} />
+    );
+
+    const pill = screen.getByText('ROSTER').closest('button')!;
+    expect(pill).toBeInTheDocument();
+    expect(screen.queryByText('PLAYERS')).not.toBeInTheDocument();
+
+    fireEvent.click(pill);
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+import { StudioPanel } from '@/components/ui/campaign/dm-vtt/StudioPanel';
+
+import type { Encounter, EncounterEntity } from '@/types/encounter';
+import type { EntityActions } from '@/components/ui/encounter/combat-screen/types';
+import type { StudioPanelProps } from '@/components/ui/campaign/dm-vtt/StudioPanel';
+
+function makeEntity(overrides: Partial<EncounterEntity>): EncounterEntity {
+  return {
+    id: 'e1',
+    type: 'monster',
+    name: 'Goblin',
+    initiative: 10,
+    initiativeModifier: 0,
+    currentHp: 7,
+    maxHp: 7,
+    tempHp: 0,
+    armorClass: 15,
+    conditions: [],
+    ...overrides,
+  } as EncounterEntity;
+}
+
+function makeEncounter(overrides: Partial<Encounter> = {}): Encounter {
+  return {
+    id: 'enc1',
+    name: 'Goblin Ambush',
+    entities: [],
+    currentTurn: 0,
+    round: 1,
+    isActive: true,
+    sortOrder: 'initiative',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as Encounter;
+}
+
+// Every member of EntityActions (src/components/ui/encounter/combat-screen/types.ts)
+// stubbed with vi.fn() so CombatantDetail (and its sub-sections) never crash on a
+// missing callback.
+function makeActions(): EntityActions {
+  return {
+    onUpdate: vi.fn(),
+    onRemove: vi.fn(),
+    onDamage: vi.fn(),
+    onHeal: vi.fn(),
+    onAddTempHp: vi.fn(),
+    onSetMaxHp: vi.fn(),
+    onAddCondition: vi.fn(),
+    onRemoveCondition: vi.fn(),
+    onSetConditionRounds: vi.fn(),
+    onUseAbility: vi.fn(),
+    onRestoreAbility: vi.fn(),
+    onUseLegendaryAction: vi.fn(),
+    onResetLegendaryActions: vi.fn(),
+    onSetConcentration: vi.fn(),
+    onUseLairAction: vi.fn(),
+    onSetInitiative: vi.fn(),
+    onLongRest: vi.fn(),
+    onViewPlayer: vi.fn(),
+    onViewNPC: vi.fn(),
+    onChangePlayerColor: vi.fn(),
+    onAdjustCounter: vi.fn(),
+  };
+}
+
+const aria = makeEntity({
+  id: 'p1',
+  type: 'player',
+  name: 'Aria Windrider',
+  initiative: 18,
+  currentHp: 24,
+  maxHp: 30,
+  tempHp: 3,
+  armorClass: 16,
+});
+const goblin1 = makeEntity({
+  id: 'm1',
+  type: 'monster',
+  name: 'Goblin Scout',
+  initiative: 14,
+  currentHp: 5,
+  maxHp: 7,
+});
+const goblin2 = makeEntity({
+  id: 'm2',
+  type: 'monster',
+  name: 'Goblin Boss',
+  initiative: 9,
+  currentHp: 20,
+  maxHp: 20,
+  concentrationSpell: 'Bane',
+  isHidden: true,
+});
+
+function baseProps(
+  overrides: Partial<StudioPanelProps> = {}
+): StudioPanelProps {
+  return {
+    encounter: makeEncounter({ entities: [aria, goblin1, goblin2] }),
+    selectedEntityId: null,
+    onSelectEntity: vi.fn(),
+    actions: makeActions(),
+    activeTab: 'initiative',
+    onTabChange: vi.fn(),
+    encounterHref: '/dm/campaign/ABCD/encounters/enc1',
+    collapsed: false,
+    onToggleCollapsed: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('StudioPanel', () => {
+  afterEach(() => cleanup());
+
+  it('renders a collapsed pill and expands on click', () => {
+    const onToggleCollapsed = vi.fn();
+    render(
+      <StudioPanel {...baseProps({ collapsed: true, onToggleCollapsed })} />
+    );
+
+    const pill = screen.getByText(/combat/i).closest('button')!;
+    expect(pill).toBeInTheDocument();
+    expect(screen.queryByText('Aria')).not.toBeInTheDocument();
+
+    fireEvent.click(pill);
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders sorted initiative rows on the initiative tab', () => {
+    render(<StudioPanel {...baseProps()} />);
+    const names = screen.getAllByText(
+      /Aria Windrider|Goblin Scout|Goblin Boss/
+    );
+    // Order should follow initiative descending: Aria(18) > Scout(14) > Boss(9)
+    expect(names.map(n => n.textContent)).toEqual([
+      'Aria Windrider',
+      'Goblin Scout',
+      'Goblin Boss',
+    ]);
+  });
+
+  it('clicking a row calls onSelectEntity with that entity id', () => {
+    const onSelectEntity = vi.fn();
+    render(<StudioPanel {...baseProps({ onSelectEntity })} />);
+
+    fireEvent.click(screen.getByText('Goblin Scout').closest('button')!);
+    expect(onSelectEntity).toHaveBeenCalledWith('m1');
+  });
+
+  it('highlights the active row (sorted[currentTurn]) with amber + pulse styling', () => {
+    // Sorted order is [Aria(18), Scout(14), Boss(9)] — currentTurn 1 → Scout is active.
+    render(
+      <StudioPanel
+        {...baseProps({
+          encounter: makeEncounter({
+            entities: [aria, goblin1, goblin2],
+            currentTurn: 1,
+          }),
+        })}
+      />
+    );
+    const activeRow = screen.getByText('Goblin Scout').closest('button')!;
+    expect(activeRow.className).toMatch(/bg-accent-amber-bg/);
+    expect(activeRow.className).toMatch(/animate-pulse/);
+    const otherRow = screen.getByText('Aria Windrider').closest('button')!;
+    expect(otherRow.className).not.toMatch(/animate-pulse/);
+  });
+
+  it('gives the selected row a blue border', () => {
+    render(<StudioPanel {...baseProps({ selectedEntityId: 'm2' })} />);
+    const selectedRow = screen.getByText('Goblin Boss').closest('button')!;
+    expect(selectedRow.className).toMatch(/border-accent-blue-border/);
+  });
+
+  it('shows a hidden badge and concentration glyph on the roster row', () => {
+    render(<StudioPanel {...baseProps()} />);
+    const row = screen.getByText('Goblin Boss').closest('button')!;
+    expect(row).toHaveTextContent(/hidden/i);
+    expect(row).toHaveTextContent('🧠');
+  });
+
+  it('shows the not-started prompt when combat has not begun', () => {
+    render(
+      <StudioPanel
+        {...baseProps({
+          encounter: makeEncounter({
+            entities: [aria, goblin1],
+            isActive: false,
+          }),
+        })}
+      />
+    );
+    expect(
+      screen.getByText(/start combat from the encounter page/i)
+    ).toBeInTheDocument();
+    const links = screen.getAllByRole('link', { name: /encounter page/i });
+    expect(links.length).toBeGreaterThan(0);
+    links.forEach(link =>
+      expect(link).toHaveAttribute('href', '/dm/campaign/ABCD/encounters/enc1')
+    );
+  });
+
+  it('flips to the selected tab and renders CombatantDetail for the selected entity', () => {
+    const onTabChange = vi.fn();
+    const { rerender } = render(
+      <StudioPanel {...baseProps({ selectedEntityId: 'm1', onTabChange })} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /selected/i }));
+    expect(onTabChange).toHaveBeenCalledWith('selected');
+
+    rerender(
+      <StudioPanel
+        {...baseProps({
+          activeTab: 'selected',
+          selectedEntityId: 'm1',
+          onTabChange,
+        })}
+      />
+    );
+    // CombatantDetail renders the entity's name in its header.
+    expect(screen.getByText('Goblin Scout')).toBeInTheDocument();
+  });
+
+  it('shows a hint on the selected tab when nothing is selected', () => {
+    render(
+      <StudioPanel
+        {...baseProps({ activeTab: 'selected', selectedEntityId: null })}
+      />
+    );
+    expect(
+      screen.getByText(/select a combatant or token/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
@@ -236,4 +236,16 @@ describe('StudioPanel', () => {
       screen.getByText(/select a combatant or token/i)
     ).toBeInTheDocument();
   });
+
+  it('renders the follow note when provided', () => {
+    render(
+      <StudioPanel {...baseProps({ followNote: 'Following: Fight A' })} />
+    );
+    expect(screen.getByText('Following: Fight A')).toBeInTheDocument();
+  });
+
+  it('renders no follow note when null/absent', () => {
+    render(<StudioPanel {...baseProps({ followNote: null })} />);
+    expect(screen.queryByText(/^Following:/)).not.toBeInTheDocument();
+  });
 });

--- a/src/components/ui/campaign/dm-vtt/__tests__/TokenDragDistanceBadge.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/TokenDragDistanceBadge.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import { TokenDragDistanceBadge } from '@/components/ui/campaign/dm-vtt/TokenDragDistanceBadge';
+import { COMBATANT_TOKEN_KIND } from '@/components/ui/campaign/dm-vtt/combatantToken';
+
+import type { CanvasElement, Viewport } from '@fieldnotes/core';
+
+type FakeElement = {
+  id: string;
+  position: { x: number; y: number };
+  tokenKind?: typeof COMBATANT_TOKEN_KIND;
+  entityId?: string;
+};
+
+/**
+ * Minimal stand-in for the SDK's Viewport. `toolManager`/`store` are plain
+ * objects (not the real classes, which have private fields) — cast to the
+ * SDK types at the call site, matching this repo's other dm-vtt fakes.
+ */
+function makeFakeViewport() {
+  let activeToolName: string | null = 'select';
+  const elements = new Map<string, FakeElement>();
+  let selectedIds: string[] = [];
+
+  const viewport = {
+    toolContext: { gridSize: 50, gridType: 'square' as const },
+    toolManager: {
+      get activeTool() {
+        return activeToolName ? { name: activeToolName } : null;
+      },
+      getTool: <T,>(name: string): T | undefined => {
+        if (name !== 'select') return undefined;
+        return { selectedIds } as unknown as T;
+      },
+    },
+    store: {
+      getById: (id: string) => elements.get(id) as unknown as CanvasElement,
+    },
+  } as unknown as Viewport;
+
+  return {
+    viewport,
+    setActiveTool: (name: string | null) => {
+      activeToolName = name;
+    },
+    setSelectedIds: (ids: string[]) => {
+      selectedIds = ids;
+    },
+    putElement: (el: FakeElement) => {
+      elements.set(el.id, el);
+    },
+    moveElement: (id: string, position: { x: number; y: number }) => {
+      const existing = elements.get(id);
+      if (!existing) return;
+      // Mirror the real ElementStore.update: replace the object rather than
+      // mutate it in place, so a stale captured reference would go stale.
+      elements.set(id, { ...existing, position });
+    },
+  };
+}
+
+function combatant(
+  id: string,
+  position: { x: number; y: number }
+): FakeElement {
+  return {
+    id,
+    position,
+    tokenKind: COMBATANT_TOKEN_KIND,
+    entityId: 'entity-1',
+  };
+}
+
+function nonCombatant(
+  id: string,
+  position: { x: number; y: number }
+): FakeElement {
+  return { id, position };
+}
+
+function press(canvasEl: HTMLElement) {
+  act(() => {
+    canvasEl.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, clientX: 0, clientY: 0 })
+    );
+  });
+}
+
+function move(clientX: number, clientY: number) {
+  act(() => {
+    window.dispatchEvent(
+      new PointerEvent('pointermove', { bubbles: true, clientX, clientY })
+    );
+  });
+}
+
+function release() {
+  act(() => {
+    window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+  });
+}
+
+describe('TokenDragDistanceBadge', () => {
+  let canvasEl: HTMLDivElement;
+
+  beforeEach(() => {
+    canvasEl = document.createElement('div');
+    document.body.appendChild(canvasEl);
+  });
+
+  afterEach(() => {
+    cleanup();
+    canvasEl.remove();
+  });
+
+  it('engages and tracks distance from the original origin across multiple moves', () => {
+    const fake = makeFakeViewport();
+    fake.setActiveTool('select');
+    fake.putElement(combatant('tok-1', { x: 0, y: 0 }));
+    fake.setSelectedIds(['tok-1']);
+
+    render(
+      <TokenDragDistanceBadge viewport={fake.viewport} canvasEl={canvasEl} />
+    );
+
+    press(canvasEl);
+    move(0, 0); // first move: captures origin at {0,0}, then computes distance (0 ft)
+
+    expect(document.body.textContent).toContain('0 ft');
+
+    // Move the element via the store, as the SDK's SelectTool would during drag.
+    fake.moveElement('tok-1', { x: 100, y: 0 }); // 100px / 50px cell * 5ft = 10 ft
+    move(50, 50);
+    expect(document.body.textContent).toContain('10 ft');
+
+    // Origin must NOT be re-captured: distance keeps growing from the
+    // ORIGINAL {0,0} origin, not from the position at the second move.
+    fake.moveElement('tok-1', { x: 200, y: 0 }); // 200px / 50px * 5ft = 20 ft
+    move(100, 100);
+    expect(document.body.textContent).toContain('20 ft');
+
+    release();
+  });
+
+  it('simulates select-then-drag ordering: selection lands between pointerdown and the first pointermove', () => {
+    const fake = makeFakeViewport();
+    fake.setActiveTool('select');
+    fake.putElement(combatant('tok-1', { x: 0, y: 0 }));
+    // No selection yet at pointerdown time — the SDK hasn't processed the
+    // click's selection. This pins Finding 2's fix: engagement must still
+    // happen because detection runs on the first pointermove, not pointerdown.
+    fake.setSelectedIds([]);
+
+    render(
+      <TokenDragDistanceBadge viewport={fake.viewport} canvasEl={canvasEl} />
+    );
+
+    press(canvasEl);
+    // SDK processes the click's selection sometime between down and the
+    // first move.
+    fake.setSelectedIds(['tok-1']);
+
+    // First move: origin capture reads the CURRENT (pre-drag) position —
+    // this only succeeds because detection ran on pointermove, not on the
+    // (pre-selection) pointerdown.
+    move(0, 0);
+    fake.moveElement('tok-1', { x: 100, y: 0 }); // 100px / 50px cell * 5ft = 10 ft
+    move(10, 10);
+
+    expect(document.body.textContent).toContain('10 ft');
+  });
+
+  it('does not show a badge when a non-select tool is active, even with a combatant selected', () => {
+    const fake = makeFakeViewport();
+    fake.setActiveTool('hand');
+    fake.putElement(combatant('tok-1', { x: 0, y: 0 }));
+    fake.setSelectedIds(['tok-1']);
+
+    render(
+      <TokenDragDistanceBadge viewport={fake.viewport} canvasEl={canvasEl} />
+    );
+
+    press(canvasEl);
+    fake.moveElement('tok-1', { x: 100, y: 0 });
+    move(10, 10);
+
+    expect(document.body.textContent).not.toContain('ft');
+  });
+
+  it('does not show a badge when the selection is not a combatant token', () => {
+    const fake = makeFakeViewport();
+    fake.setActiveTool('select');
+    fake.putElement(nonCombatant('deco-1', { x: 0, y: 0 }));
+    fake.setSelectedIds(['deco-1']);
+
+    render(
+      <TokenDragDistanceBadge viewport={fake.viewport} canvasEl={canvasEl} />
+    );
+
+    press(canvasEl);
+    move(10, 10);
+
+    expect(document.body.textContent).not.toContain('ft');
+  });
+
+  it('hides and resets the drag state on pointerup', () => {
+    const fake = makeFakeViewport();
+    fake.setActiveTool('select');
+    fake.putElement(combatant('tok-1', { x: 0, y: 0 }));
+    fake.setSelectedIds(['tok-1']);
+
+    render(
+      <TokenDragDistanceBadge viewport={fake.viewport} canvasEl={canvasEl} />
+    );
+
+    press(canvasEl);
+    move(0, 0); // captures origin at the pre-drag position
+    fake.moveElement('tok-1', { x: 100, y: 0 }); // 100px / 50px cell * 5ft = 10 ft
+    move(10, 10);
+    expect(document.body.textContent).toContain('10 ft');
+
+    release();
+    expect(document.body.textContent).not.toContain('ft');
+
+    // A move after release (no new press) must not re-show a stale badge.
+    move(20, 20);
+    expect(document.body.textContent).not.toContain('ft');
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/dragDistance.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/dragDistance.test.ts
@@ -99,11 +99,13 @@ describe('dragDistanceFeet', () => {
     });
 
     it('uses default gridSize of 40 when not provided', () => {
-      // When gridSize is undefined, cellUnit should default to 40 for square
-      const ctx = makeCtx(40, 'square'); // Explicitly set to 40
+      // gridSize genuinely omitted — cellUnit should default it to 40 for square.
+      const ctx: Pick<ToolContext, 'gridSize' | 'gridType'> = {
+        gridType: 'square',
+      };
       const start: Point = { x: 0, y: 0 };
       const current: Point = { x: 40, y: 0 };
-      // 40px / 40px = 1 cell * 5 ft = 5 ft
+      // 40px / 40px (default) = 1 cell * 5 ft = 5 ft
       expect(dragDistanceFeet(start, current, ctx)).toBe(5);
     });
   });

--- a/src/components/ui/campaign/dm-vtt/__tests__/dragDistance.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/dragDistance.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { dragDistanceFeet } from '@/components/ui/campaign/dm-vtt/dragDistance';
+import type { ToolContext } from '@fieldnotes/core';
+
+type Point = { x: number; y: number };
+
+function makeCtx(
+  gridSize: number,
+  gridType: 'square' | 'hex'
+): Pick<ToolContext, 'gridSize' | 'gridType'> {
+  return { gridSize, gridType };
+}
+
+describe('dragDistanceFeet', () => {
+  describe('square grid', () => {
+    it('calculates 10 ft for a 100px move with 50px cells', () => {
+      const ctx = makeCtx(50, 'square');
+      const start: Point = { x: 0, y: 0 };
+      const current: Point = { x: 100, y: 0 };
+      expect(dragDistanceFeet(start, current, ctx)).toBe(10);
+    });
+
+    it('handles vertical movement correctly', () => {
+      const ctx = makeCtx(50, 'square');
+      const start: Point = { x: 0, y: 0 };
+      const current: Point = { x: 0, y: 100 };
+      expect(dragDistanceFeet(start, current, ctx)).toBe(10);
+    });
+
+    it('calculates diagonal euclidean distance', () => {
+      const ctx = makeCtx(50, 'square');
+      const start: Point = { x: 0, y: 0 };
+      // Move 50px right, 50px down = sqrt(2500 + 2500) = 50*sqrt(2) ≈ 70.71px
+      // = 70.71 / 50 ≈ 1.414 cells = 1.414 * 5 ≈ 7.07 ft → rounds to 7 ft
+      const current: Point = { x: 50, y: 50 };
+      expect(dragDistanceFeet(start, current, ctx)).toBe(7);
+    });
+
+    it('rounds correctly', () => {
+      const ctx = makeCtx(50, 'square');
+      const start: Point = { x: 0, y: 0 };
+      // Move 37px = 37/50 = 0.74 cells = 0.74 * 5 = 3.7 ft → rounds to 4 ft
+      const current: Point = { x: 37, y: 0 };
+      expect(dragDistanceFeet(start, current, ctx)).toBe(4);
+    });
+
+    it('respects custom feetPerCell', () => {
+      const ctx = makeCtx(50, 'square');
+      const start: Point = { x: 0, y: 0 };
+      const current: Point = { x: 100, y: 0 };
+      expect(dragDistanceFeet(start, current, ctx, 10)).toBe(20);
+    });
+  });
+
+  describe('hex grid', () => {
+    it('calculates 5 ft for a √3×40 move with 40px gridSize', () => {
+      const ctx = makeCtx(40, 'hex');
+      const start: Point = { x: 0, y: 0 };
+      const moveDistance = Math.sqrt(3) * 40;
+      const current: Point = { x: moveDistance, y: 0 };
+      expect(dragDistanceFeet(start, current, ctx)).toBe(5);
+    });
+
+    it('handles diagonal movement on hex grid', () => {
+      const ctx = makeCtx(40, 'hex');
+      const start: Point = { x: 0, y: 0 };
+      // Move by cellUnit in both directions
+      const cellU = Math.sqrt(3) * 40;
+      const current: Point = { x: cellU, y: cellU };
+      // Distance = sqrt(cellU^2 + cellU^2) = cellU * sqrt(2)
+      // = cellU * sqrt(2) / cellU = sqrt(2) cells ≈ 1.414 cells = 1.414 * 5 ≈ 7.07 ft → rounds to 7 ft
+      expect(dragDistanceFeet(start, current, ctx)).toBe(7);
+    });
+
+    it('rounds correctly on hex grid', () => {
+      const ctx = makeCtx(40, 'hex');
+      const start: Point = { x: 0, y: 0 };
+      const cellU = Math.sqrt(3) * 40;
+      // Move 0.4 cells = 0.4 * cellU ≈ 27.71px
+      const current: Point = { x: 0.4 * cellU, y: 0 };
+      // 0.4 cells * 5 ft/cell = 2.0 ft → rounds to 2 ft
+      expect(dragDistanceFeet(start, current, ctx)).toBe(2);
+    });
+
+    it('respects custom feetPerCell on hex grid', () => {
+      const ctx = makeCtx(40, 'hex');
+      const start: Point = { x: 0, y: 0 };
+      const moveDistance = Math.sqrt(3) * 40;
+      const current: Point = { x: moveDistance, y: 0 };
+      expect(dragDistanceFeet(start, current, ctx, 10)).toBe(10);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns 0 when start and current are the same', () => {
+      const ctx = makeCtx(50, 'square');
+      const point: Point = { x: 100, y: 100 };
+      expect(dragDistanceFeet(point, point, ctx)).toBe(0);
+    });
+
+    it('uses default gridSize of 40 when not provided', () => {
+      // When gridSize is undefined, cellUnit should default to 40 for square
+      const ctx = makeCtx(40, 'square'); // Explicitly set to 40
+      const start: Point = { x: 0, y: 0 };
+      const current: Point = { x: 40, y: 0 };
+      // 40px / 40px = 1 cell * 5 ft = 5 ft
+      expect(dragDistanceFeet(start, current, ctx)).toBe(5);
+    });
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/useDmVttInitiative.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useDmVttInitiative.test.ts
@@ -75,6 +75,28 @@ describe('useDmVttInitiative', () => {
     expect(result.current.encounter?.id).toBe('enc-1');
   });
 
+  it('falls back to the resolved encounter when one of two linked ids is stale/deleted', () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: false,
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1', 'deleted-enc'],
+      })
+    );
+
+    expect(result.current.encounter?.id).toBe('enc-1');
+  });
+
   it('returns null when there are no linked encounters', () => {
     const { result } = renderHook(() =>
       useDmVttInitiative({

--- a/src/components/ui/campaign/dm-vtt/__tests__/useDmVttInitiative.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useDmVttInitiative.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useEncounterStore } from '@/store/encounterStore';
+import { createMockEncounter, createMockEncounterEntity } from '@/test/helpers';
+import { useDmVttInitiative } from '../useDmVttInitiative';
+
+function resetStore() {
+  useEncounterStore.setState({
+    encounters: [],
+    activeEncounterId: null,
+  });
+}
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+describe('useDmVttInitiative', () => {
+  beforeEach(() => {
+    resetStore();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true }))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('follows the first linked encounter with combat started (isActive)', () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: false,
+          name: 'Not Started',
+        }),
+        createMockEncounter({
+          id: 'enc-2',
+          campaignCode: 'ABC',
+          isActive: true,
+          name: 'Started Fight',
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1', 'enc-2'],
+      })
+    );
+
+    expect(result.current.encounter?.id).toBe('enc-2');
+  });
+
+  it('falls back to the single linked encounter when none has started', () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: false,
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1'],
+      })
+    );
+
+    expect(result.current.encounter?.id).toBe('enc-1');
+  });
+
+  it('returns null when there are no linked encounters', () => {
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: [],
+      })
+    );
+
+    expect(result.current.encounter).toBeNull();
+    expect(result.current.activeEntity).toBeNull();
+    expect(result.current.followNote).toBeNull();
+  });
+
+  it('sets followNote only when 2+ linked encounters have started', () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: true,
+          name: 'Fight A',
+        }),
+        createMockEncounter({
+          id: 'enc-2',
+          campaignCode: 'ABC',
+          isActive: true,
+          name: 'Fight B',
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1', 'enc-2'],
+      })
+    );
+
+    expect(result.current.followNote).toBe('Following: Fight A');
+  });
+
+  it('leaves followNote null when only one linked encounter has started', () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: true,
+          name: 'Fight A',
+        }),
+        createMockEncounter({
+          id: 'enc-2',
+          campaignCode: 'ABC',
+          isActive: false,
+          name: 'Fight B',
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1', 'enc-2'],
+      })
+    );
+
+    expect(result.current.followNote).toBeNull();
+  });
+
+  it('computes activeEntity from getSortedEntities at currentTurn when started', () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: true,
+          currentTurn: 1,
+          entities: [
+            createMockEncounterEntity({
+              id: 'a',
+              initiative: 20,
+              name: 'Aria',
+            }),
+            createMockEncounterEntity({
+              id: 'b',
+              initiative: 15,
+              name: 'Boss',
+            }),
+            createMockEncounterEntity({
+              id: 'c',
+              initiative: 5,
+              name: 'Cleric',
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1'],
+      })
+    );
+
+    expect(result.current.activeEntity?.id).toBe('b');
+  });
+
+  it('activeEntity is null when the followed encounter has not started', () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: false,
+          entities: [createMockEncounterEntity({ id: 'a', initiative: 20 })],
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1'],
+      })
+    );
+
+    expect(result.current.activeEntity).toBeNull();
+  });
+
+  it('handleNextTurn advances currentTurn and pushes a /shared initiative POST', async () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: true,
+          currentTurn: 0,
+          round: 1,
+          entities: [
+            createMockEncounterEntity({ id: 'a', initiative: 20 }),
+            createMockEncounterEntity({ id: 'b', initiative: 10 }),
+          ],
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1'],
+      })
+    );
+
+    (fetch as FetchMock).mockClear();
+
+    await act(async () => {
+      result.current.handleNextTurn();
+    });
+
+    expect(useEncounterStore.getState().encounters[0].currentTurn).toBe(1);
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/campaign/ABC/shared',
+      expect.objectContaining({ method: 'POST' })
+    );
+    const lastCall = (fetch as FetchMock).mock.calls[
+      (fetch as FetchMock).mock.calls.length - 1
+    ];
+    const body = JSON.parse(lastCall[1].body);
+    expect(body.feature).toBe('initiative');
+    expect(body.data.encounterId).toBe('enc-1');
+  });
+
+  it('handlePrevTurn calls the store prevTurn action for the followed encounter', async () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: true,
+          currentTurn: 1,
+          round: 1,
+          entities: [
+            createMockEncounterEntity({ id: 'a', initiative: 20 }),
+            createMockEncounterEntity({ id: 'b', initiative: 10 }),
+          ],
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1'],
+      })
+    );
+
+    await act(async () => {
+      result.current.handlePrevTurn();
+    });
+
+    expect(useEncounterStore.getState().encounters[0].currentTurn).toBe(0);
+  });
+
+  it('handleNextTurn/handlePrevTurn are no-ops when there is no followed encounter', async () => {
+    const { result } = renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: [],
+      })
+    );
+
+    await act(async () => {
+      result.current.handleNextTurn();
+      result.current.handlePrevTurn();
+    });
+
+    expect(useEncounterStore.getState().encounters).toHaveLength(0);
+  });
+
+  it('push guard: does not POST when the followed encounter has no campaignCode', async () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: undefined,
+          isActive: true,
+          entities: [createMockEncounterEntity({ id: 'a', initiative: 20 })],
+        }),
+      ],
+    });
+
+    renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1'],
+      })
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('pushes on mount for an already-started campaign-linked encounter', () => {
+    useEncounterStore.setState({
+      encounters: [
+        createMockEncounter({
+          id: 'enc-1',
+          campaignCode: 'ABC',
+          isActive: true,
+          entities: [createMockEncounterEntity({ id: 'a', initiative: 20 })],
+        }),
+      ],
+    });
+
+    renderHook(() =>
+      useDmVttInitiative({
+        campaignCode: 'ABC',
+        dmId: 'dm-1',
+        linkedEncounterIds: ['enc-1'],
+      })
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/campaign/ABC/shared',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/useRosterDrag.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useRosterDrag.test.ts
@@ -88,6 +88,29 @@ describe('stampAtScreenPoint', () => {
 });
 
 describe('useRosterDrag', () => {
+  it('does not set drag state on bare pointerdown (no ghost flicker before the tap threshold)', () => {
+    const { vp } = fakeViewport();
+    const canvasEl = fakeCanvasEl({});
+    const onDropPlaced = vi.fn();
+
+    const { result } = renderHook(() =>
+      useRosterDrag({
+        getViewport: () => vp,
+        getCanvasEl: () => canvasEl,
+        onDropPlaced,
+      })
+    );
+
+    act(() => {
+      result.current.startDrag(makeEntity(), {
+        clientX: 100,
+        clientY: 100,
+      } as React.PointerEvent);
+    });
+
+    expect(result.current.drag).toBeNull();
+  });
+
   it('does not stamp on a plain tap (movement below the 6px threshold)', () => {
     const { vp } = fakeViewport();
     const canvasEl = fakeCanvasEl({});

--- a/src/components/ui/campaign/dm-vtt/__tests__/useRosterDrag.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useRosterDrag.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import {
+  useRosterDrag,
+  stampAtScreenPoint,
+} from '@/components/ui/campaign/dm-vtt/useRosterDrag';
+import * as combatantToken from '@/components/ui/campaign/dm-vtt/combatantToken';
+
+import type { CanvasElement, ToolContext, Viewport } from '@fieldnotes/core';
+import type { EncounterEntity } from '@/types/encounter';
+
+function makeEntity(overrides: Partial<EncounterEntity> = {}): EncounterEntity {
+  return {
+    id: 'e1',
+    type: 'monster',
+    name: 'Goblin',
+    initiative: null,
+    initiativeModifier: 0,
+    currentHp: 7,
+    maxHp: 7,
+    tempHp: 0,
+    armorClass: 15,
+    conditions: [],
+    ...overrides,
+  } as EncounterEntity;
+}
+
+function fakeCanvasEl(rect: Partial<DOMRect>): HTMLElement {
+  const el = document.createElement('div');
+  el.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: 1000,
+      bottom: 1000,
+      width: 1000,
+      height: 1000,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+      ...rect,
+    }) as DOMRect;
+  return el;
+}
+
+function fakeViewport(overrides: Partial<ToolContext> = {}): {
+  vp: Viewport;
+  added: CanvasElement[];
+} {
+  const added: CanvasElement[] = [];
+  const toolContext = {
+    camera: { screenToWorld: (p: { x: number; y: number }) => p },
+    store: { add: vi.fn((el: CanvasElement) => added.push(el)) },
+    requestRender: vi.fn(),
+    gridSize: 40,
+    gridType: 'square',
+    activeLayerId: 'dm-layer',
+    snapToGrid: false,
+    ...overrides,
+  } as unknown as ToolContext;
+  const vp = {
+    camera: toolContext.camera,
+    toolContext,
+  } as unknown as Viewport;
+  return { vp, added };
+}
+
+function pointerEvent(type: string, x: number, y: number): PointerEvent {
+  return new PointerEvent(type, {
+    clientX: x,
+    clientY: y,
+    bubbles: true,
+  });
+}
+
+describe('stampAtScreenPoint', () => {
+  it('converts screen -> canvas-relative -> world using rect offset + identity camera', () => {
+    const { vp, added } = fakeViewport();
+    const canvasEl = fakeCanvasEl({ left: 100, top: 50 });
+    const entity = makeEntity();
+
+    stampAtScreenPoint(vp, canvasEl, entity, { x: 150, y: 90 });
+
+    expect(added).toHaveLength(1);
+    expect(added[0].position).toEqual({ x: 30, y: 20 }); // world (50,40) - half cell (20,20)
+  });
+});
+
+describe('useRosterDrag', () => {
+  it('does not stamp on a plain tap (movement below the 6px threshold)', () => {
+    const { vp } = fakeViewport();
+    const canvasEl = fakeCanvasEl({});
+    const onDropPlaced = vi.fn();
+    const spy = vi.spyOn(combatantToken, 'stampCombatantToken');
+
+    const { result } = renderHook(() =>
+      useRosterDrag({
+        getViewport: () => vp,
+        getCanvasEl: () => canvasEl,
+        onDropPlaced,
+      })
+    );
+
+    act(() => {
+      result.current.startDrag(makeEntity(), {
+        clientX: 100,
+        clientY: 100,
+      } as React.PointerEvent);
+    });
+    act(() => {
+      window.dispatchEvent(pointerEvent('pointerup', 102, 101));
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(onDropPlaced).not.toHaveBeenCalled();
+    expect(result.current.wasDrag()).toBe(false);
+    expect(result.current.drag).toBeNull();
+    spy.mockRestore();
+  });
+
+  it('stamps once and calls onDropPlaced when dropped inside canvas bounds', () => {
+    const { vp, added } = fakeViewport();
+    const canvasEl = fakeCanvasEl({
+      left: 0,
+      top: 0,
+      right: 1000,
+      bottom: 1000,
+    });
+    const onDropPlaced = vi.fn();
+    const entity = makeEntity({ id: 'm1' });
+
+    const { result } = renderHook(() =>
+      useRosterDrag({
+        getViewport: () => vp,
+        getCanvasEl: () => canvasEl,
+        onDropPlaced,
+      })
+    );
+
+    act(() => {
+      result.current.startDrag(entity, {
+        clientX: 100,
+        clientY: 100,
+      } as React.PointerEvent);
+    });
+    act(() => {
+      window.dispatchEvent(pointerEvent('pointermove', 130, 140));
+    });
+    expect(result.current.drag).toEqual({ entity, x: 130, y: 140 });
+
+    act(() => {
+      window.dispatchEvent(pointerEvent('pointerup', 130, 140));
+    });
+
+    expect(added).toHaveLength(1);
+    expect(onDropPlaced).toHaveBeenCalledWith('m1');
+    expect(onDropPlaced).toHaveBeenCalledTimes(1);
+    expect(result.current.wasDrag()).toBe(true);
+    expect(result.current.drag).toBeNull();
+  });
+
+  it('cancels (no stamp) when the drop lands outside the canvas bounds', () => {
+    const { vp, added } = fakeViewport();
+    const canvasEl = fakeCanvasEl({ left: 0, top: 0, right: 200, bottom: 200 });
+    const onDropPlaced = vi.fn();
+    const entity = makeEntity();
+
+    const { result } = renderHook(() =>
+      useRosterDrag({
+        getViewport: () => vp,
+        getCanvasEl: () => canvasEl,
+        onDropPlaced,
+      })
+    );
+
+    act(() => {
+      result.current.startDrag(entity, {
+        clientX: 100,
+        clientY: 100,
+      } as React.PointerEvent);
+    });
+    act(() => {
+      window.dispatchEvent(pointerEvent('pointerup', 500, 500));
+    });
+
+    expect(added).toHaveLength(0);
+    expect(onDropPlaced).not.toHaveBeenCalled();
+    expect(result.current.wasDrag()).toBe(true);
+    expect(result.current.drag).toBeNull();
+  });
+
+  it('removes window listeners after pointerup (a later stray move does nothing)', () => {
+    const { vp } = fakeViewport();
+    const canvasEl = fakeCanvasEl({});
+    const onDropPlaced = vi.fn();
+
+    const { result } = renderHook(() =>
+      useRosterDrag({
+        getViewport: () => vp,
+        getCanvasEl: () => canvasEl,
+        onDropPlaced,
+      })
+    );
+
+    act(() => {
+      result.current.startDrag(makeEntity(), {
+        clientX: 100,
+        clientY: 100,
+      } as React.PointerEvent);
+    });
+    act(() => {
+      window.dispatchEvent(pointerEvent('pointerup', 100, 100));
+    });
+    act(() => {
+      window.dispatchEvent(pointerEvent('pointermove', 900, 900));
+    });
+
+    expect(result.current.drag).toBeNull();
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/useRosterDrag.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useRosterDrag.test.ts
@@ -218,4 +218,67 @@ describe('useRosterDrag', () => {
 
     expect(result.current.drag).toBeNull();
   });
+
+  it('cleans up window listeners on unmount (mid-drag unmount leaks no listeners)', () => {
+    const { vp, added } = fakeViewport();
+    const canvasEl = fakeCanvasEl({
+      left: 0,
+      top: 0,
+      right: 1000,
+      bottom: 1000,
+    });
+    const onDropPlaced = vi.fn();
+    const spy = vi.spyOn(combatantToken, 'stampCombatantToken');
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { result, unmount } = renderHook(() =>
+      useRosterDrag({
+        getViewport: () => vp,
+        getCanvasEl: () => canvasEl,
+        onDropPlaced,
+      })
+    );
+
+    // Start drag and move beyond threshold
+    act(() => {
+      result.current.startDrag(makeEntity(), {
+        clientX: 100,
+        clientY: 100,
+      } as React.PointerEvent);
+    });
+    act(() => {
+      window.dispatchEvent(pointerEvent('pointermove', 130, 140));
+    });
+    expect(result.current.wasDrag()).toBe(true);
+    expect(result.current.drag).not.toBeNull();
+
+    // Unmount mid-drag
+    act(() => {
+      unmount();
+    });
+
+    // Dispatch window events after unmount — should have no effect
+    act(() => {
+      window.dispatchEvent(pointerEvent('pointermove', 150, 150));
+    });
+    act(() => {
+      window.dispatchEvent(pointerEvent('pointerup', 150, 150));
+    });
+
+    // Verify: no stamp, no onDropPlaced, no errors; listeners were cleaned up
+    expect(spy).not.toHaveBeenCalled();
+    expect(onDropPlaced).not.toHaveBeenCalled();
+    expect(added).toHaveLength(0);
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'pointermove',
+      expect.any(Function)
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'pointerup',
+      expect.any(Function)
+    );
+
+    spy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
 });

--- a/src/components/ui/campaign/dm-vtt/dragDistance.ts
+++ b/src/components/ui/campaign/dm-vtt/dragDistance.ts
@@ -1,0 +1,39 @@
+import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
+import type { ToolContext } from '@fieldnotes/core';
+
+export type Point = { x: number; y: number };
+
+/**
+ * Calculate distance in feet between two world points.
+ *
+ * Formula: euclidean distance ÷ cellUnit × feetPerCell, then Math.round.
+ * - Square grid: cellUnit = gridSize (e.g., 50px = 10ft)
+ * - Hex grid: cellUnit = √3 × gridSize (e.g., √3×40px = 5ft)
+ *
+ * @param start Starting world position
+ * @param current Current world position
+ * @param ctx Grid configuration (gridSize, gridType)
+ * @param feetPerCell Feet per cell (default 5)
+ * @returns Distance in feet, rounded to nearest integer
+ */
+export function dragDistanceFeet(
+  start: Point,
+  current: Point,
+  ctx: Pick<ToolContext, 'gridSize' | 'gridType'>,
+  feetPerCell: number = 5
+): number {
+  // Calculate euclidean distance in world pixels
+  const dx = current.x - start.x;
+  const dy = current.y - start.y;
+  const distancePixels = Math.hypot(dx, dy);
+
+  // Get the cell unit (accounts for hex vs square grids)
+  const unit = cellUnit(ctx);
+
+  // Convert pixels to cells, then to feet
+  const distanceCells = distancePixels / unit;
+  const distanceFt = distanceCells * feetPerCell;
+
+  // Round to nearest integer
+  return Math.round(distanceFt);
+}

--- a/src/components/ui/campaign/dm-vtt/rosterGroups.ts
+++ b/src/components/ui/campaign/dm-vtt/rosterGroups.ts
@@ -1,0 +1,19 @@
+import type { EncounterEntity } from '@/types/encounter';
+
+export interface RosterGroups {
+  players: EncounterEntity[];
+  npcs: EncounterEntity[];
+  monsters: EncounterEntity[];
+}
+
+/** Splits roster entities into the tray's three display groups. Lair
+ * entities (`type: 'lair'`) carry no token and are omitted entirely. */
+export function groupRosterEntities(entities: EncounterEntity[]): RosterGroups {
+  const groups: RosterGroups = { players: [], npcs: [], monsters: [] };
+  for (const entity of entities) {
+    if (entity.type === 'player') groups.players.push(entity);
+    else if (entity.type === 'npc') groups.npcs.push(entity);
+    else if (entity.type === 'monster') groups.monsters.push(entity);
+  }
+  return groups;
+}

--- a/src/components/ui/campaign/dm-vtt/useBattleMapMode.ts
+++ b/src/components/ui/campaign/dm-vtt/useBattleMapMode.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import type { BattleMap } from '@/types/battlemap';
+
+export type BattleMapPageMode = 'setup' | 'play';
+
+function modeStorageKey(battleMapId: string): string {
+  return `rollkeeper-battlemap-mode:${battleMapId}`;
+}
+
+/**
+ * Setup|Play mode for the battle map page, persisted per-map to
+ * localStorage. Resolves once, after hydration: stored value if present,
+ * else 'play' when the map already has a linked encounter, otherwise
+ * 'setup'. Returns `null` while unresolved so the page can show a loading
+ * state instead of flashing the wrong mode.
+ */
+export function useBattleMapMode(
+  battleMapId: string,
+  hasHydrated: boolean,
+  getBattleMap: () => BattleMap | undefined
+) {
+  const [mode, setMode] = useState<BattleMapPageMode | null>(null);
+
+  useEffect(() => {
+    if (!hasHydrated || mode !== null) return;
+    const stored = window.localStorage.getItem(modeStorageKey(battleMapId));
+    if (stored === 'setup' || stored === 'play') {
+      setMode(stored);
+      return;
+    }
+    const hasLinkedEncounter =
+      (getBattleMap()?.linkedEncounterIds.length ?? 0) > 0;
+    setMode(hasLinkedEncounter ? 'play' : 'setup');
+  }, [hasHydrated, mode, battleMapId, getBattleMap]);
+
+  const handleModeChange = (next: BattleMapPageMode) => {
+    setMode(next);
+    window.localStorage.setItem(modeStorageKey(battleMapId), next);
+  };
+
+  return { mode, handleModeChange };
+}

--- a/src/components/ui/campaign/dm-vtt/useDmVttActions.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttActions.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { buildEntityActions } from '@/components/ui/encounter/combat-screen/buildEntityActions';
+import { useDmEffectsSync } from '@/hooks/useDmEffectsSync';
+import { useEncounterStore } from '@/store/encounterStore';
+
+import type { EntityActions } from '@/components/ui/encounter/combat-screen/types';
+import type { Encounter } from '@/types/encounter';
+
+interface UseDmVttActionsOptions {
+  campaignCode: string;
+  dmId: string;
+  encounter: Encounter | null;
+}
+
+/**
+ * `EntityActions` for the followed encounter (brief item 4) — mirrors
+ * `EncounterView.tsx:177-249`, with `syncPlayerEffects` from
+ * `useDmEffectsSync`. Recomputes whenever the followed encounter changes.
+ * Sibling extraction from `DmVttScreen.hooks.ts` to stay under the
+ * 150-line file cap.
+ */
+export function useDmVttActions({
+  campaignCode,
+  dmId,
+  encounter,
+}: UseDmVttActionsOptions): EntityActions | null {
+  const { syncPlayerEffects } = useDmEffectsSync({ campaignCode, dmId });
+
+  return useMemo<EntityActions | null>(
+    () =>
+      encounter
+        ? buildEntityActions({
+            encounterId: encounter.id,
+            encounter,
+            store: useEncounterStore.getState(),
+            syncPlayerEffects,
+          })
+        : null,
+    [encounter, syncPlayerEffects]
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/useDmVttActions.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttActions.ts
@@ -13,19 +13,23 @@ interface UseDmVttActionsOptions {
   campaignCode: string;
   dmId: string;
   encounter: Encounter | null;
+  onViewNPC?: (npcSourceId: string, entityId: string) => void;
 }
 
 /**
  * `EntityActions` for the followed encounter (brief item 4) — mirrors
  * `EncounterView.tsx:177-249`, with `syncPlayerEffects` from
- * `useDmEffectsSync`. Recomputes whenever the followed encounter changes.
- * Sibling extraction from `DmVttScreen.hooks.ts` to stay under the
- * 150-line file cap.
+ * `useDmEffectsSync`. `onViewNPC` is passed through as-is from
+ * `DmVttScreen.hooks`, which owns the NPC-dialog state — this hook only
+ * builds the actions object. Recomputes whenever the followed encounter,
+ * `syncPlayerEffects`, or `onViewNPC` identity changes. Sibling extraction
+ * from `DmVttScreen.hooks.ts` to stay under the 150-line file cap.
  */
 export function useDmVttActions({
   campaignCode,
   dmId,
   encounter,
+  onViewNPC,
 }: UseDmVttActionsOptions): EntityActions | null {
   const { syncPlayerEffects } = useDmEffectsSync({ campaignCode, dmId });
 
@@ -37,8 +41,9 @@ export function useDmVttActions({
             encounter,
             store: useEncounterStore.getState(),
             syncPlayerEffects,
+            onViewNPC,
           })
         : null,
-    [encounter, syncPlayerEffects]
+    [encounter, syncPlayerEffects, onViewNPC]
   );
 }

--- a/src/components/ui/campaign/dm-vtt/useDmVttDragPlacement.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttDragPlacement.ts
@@ -1,0 +1,79 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { useRosterDrag } from './useRosterDrag';
+
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import type { Viewport } from '@fieldnotes/core';
+import type { ToastData } from '@/components/ui/feedback/Toast';
+import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
+import type { EncounterEntity } from '@/types/encounter';
+import type { RosterDragState } from './useRosterDrag';
+
+export interface UseDmVttDragPlacementOptions {
+  status: BattleMapConnectionStatus;
+  getViewport: () => Viewport | null;
+  getCanvasEl: () => HTMLElement | null;
+  addToast: (toast: Omit<ToastData, 'id'>) => void;
+  selectEntity: (entityId: string) => void;
+  /** Clears any tap-armed pending placement (`cancelPlacement`). */
+  clearPendingPlacement: () => void;
+}
+
+export interface UseDmVttDragPlacementResult {
+  drag: RosterDragState | null;
+  startDrag: (entity: EncounterEntity, e: ReactPointerEvent) => void;
+  wasDrag: () => boolean;
+}
+
+/**
+ * Wraps `useRosterDrag` for the DM VTT studio, sibling-extracted from
+ * `DmVttScreen.hooks.ts` to stay under the 150-line file cap:
+ *
+ * - Gates drag-to-place on a live connection with the SAME toast as the
+ *   tap-to-arm path (`useDmVttPlacementAndSelection.armPlacement`) — a drag
+ *   must never stamp a token while offline.
+ * - A completed drop clears any tap-armed `pendingPlacement` for a
+ *   DIFFERENT entity before selecting the dropped one, so the two
+ *   placement gestures can't leave stale armed state behind.
+ */
+export function useDmVttDragPlacement({
+  status,
+  getViewport,
+  getCanvasEl,
+  addToast,
+  selectEntity,
+  clearPendingPlacement,
+}: UseDmVttDragPlacementOptions): UseDmVttDragPlacementResult {
+  const onDropPlaced = useCallback(
+    (entityId: string) => {
+      clearPendingPlacement();
+      selectEntity(entityId);
+    },
+    [clearPendingPlacement, selectEntity]
+  );
+
+  const {
+    drag,
+    startDrag: rawStartDrag,
+    wasDrag,
+  } = useRosterDrag({ getViewport, getCanvasEl, onDropPlaced });
+
+  const startDrag = useCallback(
+    (entity: EncounterEntity, e: ReactPointerEvent) => {
+      if (status !== 'live') {
+        addToast({
+          type: 'info',
+          title: 'Not connected',
+          message: 'Waiting for a live connection before placing tokens.',
+        });
+        return;
+      }
+      rawStartDrag(entity, e);
+    },
+    [status, addToast, rawStartDrag]
+  );
+
+  return { drag, startDrag, wasDrag };
+}

--- a/src/components/ui/campaign/dm-vtt/useDmVttGrid.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttGrid.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { useBattleMapStore } from '@/store/battleMapStore';
+
+import type { Viewport } from '@fieldnotes/core';
+import type { BattleMap } from '@/types/battlemap';
+import type { GridSettings } from '@/types/location';
+
+/** Mirrors the initial useState defaults in DmLocationEditor.hooks.ts:174-181. */
+const DEFAULT_GRID: Omit<GridSettings, 'gridType' | 'hexOrientation'> = {
+  cellSize: 50,
+  strokeColor: '#94a3b8',
+  strokeWidth: 1,
+  opacity: 0.5,
+};
+
+/**
+ * Map + grid must live on a layer-locked background so hit-testing skips
+ * them, and grid elements must be `locked` so Select can't drag them.
+ * Replicated verbatim from `DmLocationEditor.hooks.ts:62-89`
+ * (`pinGridToMapBackgroundLayer`) — that helper is module-private there, so
+ * it's copied here rather than imported. Keep in sync if the source changes.
+ */
+function pinGridToMapBackgroundLayer(vp: Viewport): void {
+  let layers = vp.layerManager.getLayers();
+  if (layers.length === 0) return;
+
+  if (layers.length === 1) {
+    vp.layerManager.createLayer('Annotations');
+    layers = vp.layerManager.getLayers();
+  }
+
+  const bgLayer = layers[0];
+  vp.layerManager.renameLayer(bgLayer.id, 'Map Background');
+
+  if (vp.layerManager.activeLayerId === bgLayer.id) {
+    const fallback = layers.find(l => l.id !== bgLayer.id);
+    if (fallback) vp.layerManager.setActiveLayer(fallback.id);
+  }
+
+  vp.layerManager.setLayerLocked(bgLayer.id, true);
+
+  for (const g of vp.store.getElementsByType('grid')) {
+    vp.layerManager.moveElementToLayer(g.id, bgLayer.id);
+    vp.store.update(g.id, { locked: true });
+  }
+
+  vp.requestRender();
+}
+
+interface UseDmVttGridOptions {
+  campaignCode: string;
+  battleMapId: string;
+  battleMap: BattleMap | undefined;
+  getViewport: () => Viewport | null;
+}
+
+/**
+ * Grid on/off/type control for the DM VTT studio — mirrors
+ * `handleSetGridType`'s persistence exactly (`DmLocationEditor.hooks.ts:
+ * 461-547`), but against `useBattleMapStore` instead of `useLocationStore`.
+ */
+export function useDmVttGrid({
+  campaignCode,
+  battleMapId,
+  battleMap,
+  getViewport,
+}: UseDmVttGridOptions) {
+  const updateBattleMap = useBattleMapStore(s => s.updateBattleMap);
+
+  const setGridMode = useCallback(
+    (target: 'hex' | 'square' | 'off') => {
+      const vp = getViewport();
+      if (!vp || !battleMap) return;
+
+      // Always remove the existing grid first, whatever the target.
+      if (battleMap.gridEnabled) vp.removeGrid();
+
+      if (target === 'off') {
+        updateBattleMap(campaignCode, battleMapId, { gridEnabled: false });
+        return;
+      }
+
+      const settings: GridSettings = {
+        ...DEFAULT_GRID,
+        ...battleMap.gridSettings,
+        gridType: target,
+        hexOrientation: target === 'hex' ? 'pointy' : undefined,
+      };
+      vp.addGrid(settings);
+      pinGridToMapBackgroundLayer(vp);
+
+      updateBattleMap(campaignCode, battleMapId, {
+        gridEnabled: true,
+        gridSettings: settings,
+      });
+    },
+    [battleMap, campaignCode, battleMapId, getViewport, updateBattleMap]
+  );
+
+  return { setGridMode };
+}

--- a/src/components/ui/campaign/dm-vtt/useDmVttInitiative.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttInitiative.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { useEncounterStore, getSortedEntities } from '@/store/encounterStore';
+import { useDmInitiativeSync } from '@/hooks/useDmInitiativeSync';
+import { buildSharedInitiative } from '@/utils/buildSharedInitiative';
+
+import type { Encounter, EncounterEntity } from '@/types/encounter';
+
+interface UseDmVttInitiativeOptions {
+  campaignCode: string;
+  dmId: string;
+  linkedEncounterIds: string[];
+}
+
+interface UseDmVttInitiativeResult {
+  encounter: Encounter | null;
+  followNote: string | null;
+  activeEntity: EncounterEntity | null;
+  handleNextTurn: () => void;
+  handlePrevTurn: () => void;
+}
+
+/**
+ * Resolve the encounter the DM VTT studio should follow: the first
+ * campaign-linked encounter with combat started (`isActive`), else the
+ * single linked encounter (not yet started), else null.
+ */
+function resolveFollowed(
+  linked: Encounter[],
+  linkedEncounterIds: string[]
+): { followed: Encounter | null; started: Encounter[] } {
+  const started = linked.filter(e => e.isActive);
+  if (started.length > 0) return { followed: started[0], started };
+  if (linkedEncounterIds.length === 1) {
+    return { followed: linked[0] ?? null, started };
+  }
+  return { followed: null, started };
+}
+
+/**
+ * Drives the DM VTT studio's turn tracker: picks which linked encounter to
+ * follow, exposes the currently-active entity, and pushes initiative state
+ * to `/shared` (feature `initiative`) on every turn/round/entity change so
+ * players get an instant WS-driven update — mirrors the push effect in
+ * `EncounterView.tsx` verbatim (guard + dependency list).
+ */
+export function useDmVttInitiative({
+  campaignCode,
+  dmId,
+  linkedEncounterIds,
+}: UseDmVttInitiativeOptions): UseDmVttInitiativeResult {
+  const encounters = useEncounterStore(state => state.encounters);
+  const combatConfig = useEncounterStore(state => state.combatConfig);
+  const nextTurn = useEncounterStore(state => state.nextTurn);
+  const prevTurn = useEncounterStore(state => state.prevTurn);
+
+  const { pushInitiative } = useDmInitiativeSync({ campaignCode, dmId });
+
+  const linked = useMemo(
+    () => encounters.filter(e => linkedEncounterIds.includes(e.id)),
+    [encounters, linkedEncounterIds]
+  );
+
+  const { followed: encounter, started } = useMemo(
+    () => resolveFollowed(linked, linkedEncounterIds),
+    [linked, linkedEncounterIds]
+  );
+
+  const followNote = useMemo(
+    () =>
+      encounter && started.length > 1 ? `Following: ${encounter.name}` : null,
+    [encounter, started]
+  );
+
+  const activeEntity = useMemo(() => {
+    if (!encounter || !encounter.isActive) return null;
+    return getSortedEntities(encounter.entities)[encounter.currentTurn] ?? null;
+  }, [encounter]);
+
+  // Push initiative state to Redis whenever turn/round/entities change.
+  // Only fires for campaign-linked encounters; safe when encounter is null.
+  useEffect(() => {
+    if (!encounter || !encounter.campaignCode) return;
+    pushInitiative(buildSharedInitiative(encounter, combatConfig));
+  }, [
+    encounter,
+    encounter?.isActive,
+    encounter?.round,
+    encounter?.currentTurn,
+    encounter?.entities,
+    combatConfig,
+    pushInitiative,
+  ]);
+
+  const handleNextTurn = useCallback(() => {
+    if (!encounter) return;
+    nextTurn(encounter.id);
+  }, [encounter, nextTurn]);
+
+  const handlePrevTurn = useCallback(() => {
+    if (!encounter) return;
+    prevTurn(encounter.id);
+  }, [encounter, prevTurn]);
+
+  return {
+    encounter,
+    followNote,
+    activeEntity,
+    handleNextTurn,
+    handlePrevTurn,
+  };
+}

--- a/src/components/ui/campaign/dm-vtt/useDmVttInitiative.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttInitiative.ts
@@ -23,16 +23,18 @@ interface UseDmVttInitiativeResult {
 /**
  * Resolve the encounter the DM VTT studio should follow: the first
  * campaign-linked encounter with combat started (`isActive`), else the
- * single linked encounter (not yet started), else null.
+ * single RESOLVED linked encounter (not yet started), else null. Uses
+ * `linked.length` (not `linkedEncounterIds.length`) so a stale/deleted
+ * linked id doesn't block following the one real encounter.
  */
-function resolveFollowed(
-  linked: Encounter[],
-  linkedEncounterIds: string[]
-): { followed: Encounter | null; started: Encounter[] } {
+function resolveFollowed(linked: Encounter[]): {
+  followed: Encounter | null;
+  started: Encounter[];
+} {
   const started = linked.filter(e => e.isActive);
   if (started.length > 0) return { followed: started[0], started };
-  if (linkedEncounterIds.length === 1) {
-    return { followed: linked[0] ?? null, started };
+  if (linked.length === 1) {
+    return { followed: linked[0], started };
   }
   return { followed: null, started };
 }
@@ -62,8 +64,8 @@ export function useDmVttInitiative({
   );
 
   const { followed: encounter, started } = useMemo(
-    () => resolveFollowed(linked, linkedEncounterIds),
-    [linked, linkedEncounterIds]
+    () => resolveFollowed(linked),
+    [linked]
   );
 
   const followNote = useMemo(

--- a/src/components/ui/campaign/dm-vtt/useDmVttPlacementAndSelection.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttPlacementAndSelection.ts
@@ -1,0 +1,114 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+import { dispositionColor } from './combatantToken';
+import { selectedEntityId as resolveSelectedEntity } from './useCombatantTokens';
+
+import type { Viewport } from '@fieldnotes/core';
+import type { ToastData } from '@/components/ui/feedback/Toast';
+import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
+import type { EncounterEntity } from '@/types/encounter';
+import type { DmTokenConfig } from './combatantToken';
+import type { PendingTokenPlacement } from './TokenPlacementController';
+
+export type StudioTab = 'initiative' | 'selected';
+
+interface UseDmVttPlacementAndSelectionOptions {
+  status: BattleMapConnectionStatus;
+  linkedEntities: EncounterEntity[];
+  getViewport: () => Viewport | null;
+  addToast: (toast: Omit<ToastData, 'id'>) => void;
+}
+
+/**
+ * Tap-to-arm placement lifecycle (gated on a live connection, spec §7) +
+ * canvas-selection -> entity mapping for the DM VTT studio.
+ *
+ * `onPlaced` clears `pendingPlacement` SYNCHRONOUSLY — `TokenPlacementController`
+ * only stays cancel-free on a successful placement because the tool's
+ * `onPointerUp` and this callback both run in the same commit; an
+ * await/microtask gap here would make every placement spuriously cancel.
+ */
+export function useDmVttPlacementAndSelection({
+  status,
+  linkedEntities,
+  getViewport,
+  addToast,
+}: UseDmVttPlacementAndSelectionOptions) {
+  const [pendingPlacement, setPendingPlacement] =
+    useState<PendingTokenPlacement | null>(null);
+  const tokenConfigRef = useRef<DmTokenConfig | null>(null);
+  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+  const [studioTab, setStudioTab] = useState<StudioTab>('initiative');
+
+  const linkedEntitiesRef = useRef(linkedEntities);
+  linkedEntitiesRef.current = linkedEntities;
+
+  const selectEntity = useCallback((entityId: string) => {
+    setSelectedEntityId(entityId);
+    setStudioTab('selected');
+  }, []);
+
+  const armPlacement = useCallback(
+    (entity: EncounterEntity) => {
+      if (status !== 'live') {
+        addToast({
+          type: 'info',
+          title: 'Not connected',
+          message: 'Waiting for a live connection before placing tokens.',
+        });
+        return;
+      }
+      const config: DmTokenConfig = {
+        entityId: entity.id,
+        name: entity.name,
+        avatarUrl: entity.avatarUrl,
+        color: dispositionColor(entity),
+        onPlaced: () => {
+          setPendingPlacement(null); // SYNCHRONOUS — see comment above.
+          selectEntity(entity.id);
+        },
+      };
+      setPendingPlacement({ entityName: entity.name, config });
+    },
+    [status, addToast, selectEntity]
+  );
+
+  const cancelPlacement = useCallback(() => setPendingPlacement(null), []);
+
+  const handleSelectionChange = useCallback(
+    (ids: string[]) => {
+      const store = getViewport()?.store;
+      if (!store) return;
+      const id = resolveSelectedEntity(ids, store);
+      if (id === null) return; // no combatant token in this selection
+      const known = linkedEntitiesRef.current.some(e => e.id === id);
+      if (!known) {
+        // Entity deleted or its encounter unlinked since the token was
+        // stamped — leave the selection unset rather than showing a dead id.
+        addToast({
+          type: 'info',
+          title: 'Unlinked token',
+          message: 'its combatant is no longer in the encounter',
+        });
+        setSelectedEntityId(null);
+        return;
+      }
+      selectEntity(id);
+    },
+    [getViewport, addToast, selectEntity]
+  );
+
+  return {
+    pendingPlacement,
+    tokenConfigRef,
+    armPlacement,
+    cancelPlacement,
+    selectedEntityId,
+    studioTab,
+    setStudioTab,
+    selectEntity,
+    handleSelectionChange,
+  };
+}

--- a/src/components/ui/campaign/dm-vtt/useDmVttRoster.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttRoster.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useBattleMapStore } from '@/store/battleMapStore';
+import { useEncounterStore } from '@/store/encounterStore';
+
+import type { EncounterEntity } from '@/types/encounter';
+
+interface UseDmVttRosterOptions {
+  campaignCode: string;
+  battleMapId: string;
+}
+
+/**
+ * Battle-map record + linked-encounter roster join (brief items 1-2): every
+ * linked encounter's entities, flattened for the roster tray. Sibling
+ * extraction from `DmVttScreen.hooks.ts` to stay under the 150-line file cap.
+ */
+export function useDmVttRoster({
+  campaignCode,
+  battleMapId,
+}: UseDmVttRosterOptions) {
+  const battleMap = useBattleMapStore(s =>
+    s.getBattleMap(campaignCode, battleMapId)
+  );
+  const linkedEncounterIds = useMemo(
+    () => battleMap?.linkedEncounterIds ?? [],
+    [battleMap]
+  );
+
+  const encounters = useEncounterStore(s => s.encounters);
+  const linkedEntities = useMemo<EncounterEntity[]>(
+    () =>
+      encounters
+        .filter(e => linkedEncounterIds.includes(e.id))
+        .flatMap(e => e.entities),
+    [encounters, linkedEncounterIds]
+  );
+
+  return { battleMap, linkedEncounterIds, linkedEntities };
+}

--- a/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
+++ b/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { dispositionColor, stampCombatantToken } from './combatantToken';
 
@@ -145,6 +145,16 @@ export function useRosterDrag({
   );
 
   const wasDrag = useCallback(() => movedRef.current, []);
+
+  // Clean up listeners if unmounted mid-drag.
+  useEffect(() => {
+    return () => {
+      cleanupRef.current?.();
+      startPointRef.current = null;
+      movedRef.current = false;
+      setDrag(null);
+    };
+  }, []);
 
   return { drag, startDrag, wasDrag };
 }

--- a/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
+++ b/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
@@ -99,14 +99,17 @@ export function useRosterDrag({
       const { clientX, clientY } = e;
       startPointRef.current = { x: clientX, y: clientY };
       movedRef.current = false;
-      setDrag({ entity, x: clientX, y: clientY });
+      // Don't set drag state yet — a bare pointerdown must not flicker the
+      // ghost. It only appears once movement crosses the tap threshold.
 
       const handleMove = (ev: PointerEvent) => {
         const start = startPointRef.current;
         if (start && pastThreshold(start, ev.clientX, ev.clientY)) {
           movedRef.current = true;
         }
-        setDrag({ entity, x: ev.clientX, y: ev.clientY });
+        if (movedRef.current) {
+          setDrag({ entity, x: ev.clientX, y: ev.clientY });
+        }
       };
 
       const handleUp = (ev: PointerEvent) => {

--- a/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
+++ b/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
@@ -1,0 +1,150 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+import { dispositionColor, stampCombatantToken } from './combatantToken';
+
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import type { Viewport } from '@fieldnotes/core';
+import type { EncounterEntity } from '@/types/encounter';
+import type { DmTokenConfig } from './combatantToken';
+
+/** Screen-space ghost position, tracked while a roster row is being dragged. */
+export interface RosterDragState {
+  entity: EncounterEntity;
+  x: number;
+  y: number;
+}
+
+export interface UseRosterDragOptions {
+  getViewport: () => Viewport | null;
+  /** The canvas container element (drop target bounds). */
+  getCanvasEl: () => HTMLElement | null;
+  onDropPlaced: (entityId: string) => void;
+}
+
+export interface UseRosterDragResult {
+  drag: RosterDragState | null;
+  startDrag: (entity: EncounterEntity, e: ReactPointerEvent) => void;
+  /** True if the pointer moved beyond the 6px tap threshold (tap = arm instead). */
+  wasDrag: () => boolean;
+}
+
+/** Below this many CSS px of pointer travel, a gesture counts as a tap. */
+const TAP_THRESHOLD_PX = 6;
+
+function isInsideRect(rect: DOMRect, x: number, y: number): boolean {
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+}
+
+function pastThreshold(
+  start: { x: number; y: number },
+  x: number,
+  y: number
+): boolean {
+  return Math.hypot(x - start.x, y - start.y) >= TAP_THRESHOLD_PX;
+}
+
+/**
+ * Stamps a combatant token at a screen point.
+ *
+ * RECON (Task 4): `Viewport` (`@fieldnotes/core` dist/index.d.ts) publicly
+ * exposes `readonly toolContext: ToolContext`, kept live by the Viewport
+ * itself — its grid controller/layer manager write gridSize/gridType/
+ * hexOrientation/activeLayerId/snapToGrid into that SAME object as the map
+ * changes, and it's the identical object every `Tool` receives in
+ * onPointerDown/onPointerUp (e.g. `DmTokenTool`). So `vp.toolContext`
+ * already IS the minimal ToolContext view — no need to hand-roll one or
+ * re-derive grid values from `getElementsByType('grid')`.
+ */
+export function stampAtScreenPoint(
+  vp: Viewport,
+  canvasEl: HTMLElement,
+  entity: EncounterEntity,
+  screen: { x: number; y: number }
+): void {
+  const rect = canvasEl.getBoundingClientRect();
+  const rel = { x: screen.x - rect.left, y: screen.y - rect.top };
+  const world = vp.camera.screenToWorld(rel);
+  const config: Omit<DmTokenConfig, 'onPlaced'> = {
+    entityId: entity.id,
+    name: entity.name,
+    avatarUrl: entity.avatarUrl,
+    color: dispositionColor(entity),
+  };
+  stampCombatantToken(config, world, vp.toolContext);
+}
+
+/**
+ * Pointer drag-to-place from a roster row onto the canvas. `startDrag`
+ * captures window pointermove/pointerup listeners (pointer events unify
+ * touch + mouse) and tracks the ghost position; under the 6px tap
+ * threshold counts as a tap (caller's click handler arms placement — see
+ * `RosterRow`). Drop inside canvas bounds stamps + fires `onDropPlaced`;
+ * outside cancels silently.
+ */
+export function useRosterDrag({
+  getViewport,
+  getCanvasEl,
+  onDropPlaced,
+}: UseRosterDragOptions): UseRosterDragResult {
+  const [drag, setDrag] = useState<RosterDragState | null>(null);
+  const startPointRef = useRef<{ x: number; y: number } | null>(null);
+  const movedRef = useRef(false);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  const startDrag = useCallback(
+    (entity: EncounterEntity, e: ReactPointerEvent) => {
+      cleanupRef.current?.(); // a stale gesture's listeners must not overlap
+      const { clientX, clientY } = e;
+      startPointRef.current = { x: clientX, y: clientY };
+      movedRef.current = false;
+      setDrag({ entity, x: clientX, y: clientY });
+
+      const handleMove = (ev: PointerEvent) => {
+        const start = startPointRef.current;
+        if (start && pastThreshold(start, ev.clientX, ev.clientY)) {
+          movedRef.current = true;
+        }
+        setDrag({ entity, x: ev.clientX, y: ev.clientY });
+      };
+
+      const handleUp = (ev: PointerEvent) => {
+        // Also judged here, not just in handleMove — a fast gesture can
+        // arrive as a single up event with no moves in between.
+        const start = startPointRef.current;
+        if (start && pastThreshold(start, ev.clientX, ev.clientY)) {
+          movedRef.current = true;
+        }
+        cleanupRef.current?.();
+        cleanupRef.current = null;
+        startPointRef.current = null;
+        setDrag(null);
+
+        if (!movedRef.current) return;
+        const vp = getViewport();
+        const canvasEl = getCanvasEl();
+        if (!vp || !canvasEl) return;
+        const rect = canvasEl.getBoundingClientRect();
+        if (!isInsideRect(rect, ev.clientX, ev.clientY)) return;
+        stampAtScreenPoint(vp, canvasEl, entity, {
+          x: ev.clientX,
+          y: ev.clientY,
+        });
+        onDropPlaced(entity.id);
+      };
+
+      window.addEventListener('pointermove', handleMove);
+      window.addEventListener('pointerup', handleUp);
+      cleanupRef.current = () => {
+        window.removeEventListener('pointermove', handleMove);
+        window.removeEventListener('pointerup', handleUp);
+      };
+    },
+    [getViewport, getCanvasEl, onDropPlaced]
+  );
+
+  const wasDrag = useCallback(() => movedRef.current, []);
+
+  return { drag, startDrag, wasDrag };
+}

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -23,6 +23,7 @@ import {
   createManagedBattleMapConnection,
   type BattleMapConnectionStatus,
 } from '@/lib/battlemapSync';
+import { openTvDisplay } from '@/lib/openTvDisplay';
 import type { DmLocationEditorProps } from './DmLocationEditor.types';
 import type { GridSettings } from '@/types/location';
 
@@ -827,38 +828,10 @@ export function useDmLocationEditor(
     [getVp]
   );
 
-  const handleOpenTvDisplay = useCallback(async () => {
-    // Open the tab synchronously, in direct response to the user gesture —
-    // Safari (and sometimes Chrome) revokes transient user activation across
-    // an `await`, so opening after the fetch below would silently no-op.
-    const win = window.open('', '_blank');
-
-    let dk = '';
-    try {
-      const res = await fetch(`/api/campaign/${campaignCode}/display-key`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ dmId }),
-      });
-      if (res.ok) {
-        dk = ((await res.json()) as { displayKey?: string }).displayKey ?? '';
-      }
-    } catch {
-      // relay not configured — the display page will show its own error state
-    }
-
-    const url = `/dm/campaign/${campaignCode}/battlemaps/${location.id}/display${
-      dk ? `?dk=${encodeURIComponent(dk)}` : ''
-    }`;
-
-    if (win) {
-      win.location.href = url;
-    } else {
-      // Popup blocked despite the synchronous open attempt — fall back to
-      // the old behavior so at least some browsers still get a new tab.
-      window.open(url, '_blank');
-    }
-  }, [campaignCode, dmId, location.id]);
+  const handleOpenTvDisplay = useCallback(
+    () => openTvDisplay(campaignCode, location.id, dmId),
+    [campaignCode, dmId, location.id]
+  );
 
   const handleFitToMap = useCallback(() => {
     const vp = getVp();

--- a/src/components/ui/campaign/location-map/PlayerHandTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerHandTool.ts
@@ -15,8 +15,11 @@ const TOKEN_TYPES = new Set(['image', 'shape']);
 
 /** Whether this player could grab the element: a token that is visible and
  * not locked at the element or layer level. Mirrored DM layers are locked on
- * player canvases, so DM content (map image, grid) keeps panning. */
-function isGrabbable(el: CanvasElement, ctx: ToolContext): boolean {
+ * player canvases, so DM content (map image, grid) keeps panning. This is
+ * the DEFAULT predicate — callers may override it entirely (see
+ * `PlayerHandTool`'s constructor) rather than layering additional checks on
+ * top of it. */
+function defaultIsGrabbable(el: CanvasElement, ctx: ToolContext): boolean {
   if (!TOKEN_TYPES.has(el.type)) return false;
   if (el.locked) return false;
   if (el.layerId) {
@@ -39,9 +42,20 @@ function hits(worldX: number, worldY: number, el: CanvasElement): boolean {
  * player can actually move (their TOKEN — see TOKEN_TYPES): the SAME
  * gesture starts dragging the element, and the toolbar flips to Select.
  * Presses on DM content or empty map pan as usual.
+ *
+ * `isGrabbable` is an optional override for what counts as "grabbable" —
+ * when provided it REPLACES `defaultIsGrabbable` entirely (it is not ANDed
+ * with the token-type/lock checks). The DM canvas passes
+ * `el => isCombatantToken(el)` so only combatant tokens hand off to Select.
  */
 export class PlayerHandTool extends HandTool {
-  constructor(private readonly selectTool: SelectTool) {
+  constructor(
+    private readonly selectTool: SelectTool,
+    private readonly isGrabbable: (
+      el: CanvasElement,
+      ctx: ToolContext
+    ) => boolean = defaultIsGrabbable
+  ) {
     super();
   }
 
@@ -49,7 +63,7 @@ export class PlayerHandTool extends HandTool {
     const world = ctx.camera.screenToWorld({ x: state.x, y: state.y });
     const grabbed = ctx.store
       .snapshot()
-      .some(el => isGrabbable(el, ctx) && hits(world.x, world.y, el));
+      .some(el => this.isGrabbable(el, ctx) && hits(world.x, world.y, el));
     if (grabbed) {
       ctx.switchTool?.('select');
       this.selectTool.onPointerDown(state, ctx);

--- a/src/components/ui/campaign/location-map/__tests__/PlayerHandTool.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerHandTool.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SelectTool, createImage, createTemplate } from '@fieldnotes/core';
 import { PlayerHandTool } from '@/components/ui/campaign/location-map/PlayerHandTool';
+import { isCombatantToken } from '@/components/ui/campaign/dm-vtt/combatantToken';
 
 import type {
   CanvasElement,
@@ -10,6 +11,19 @@ import type {
 
 const OWN_LAYER = 'player-char-1';
 const DM_LAYER = 'dm-layer';
+
+function combatantToken(x = 0, y = 0): CanvasElement {
+  return {
+    ...createImage({
+      position: { x, y },
+      size: { w: 40, h: 40 },
+      src: 'data:image/png;base64,',
+      layerId: OWN_LAYER,
+    }),
+    entityId: 'entity-1',
+    tokenKind: 'combatant',
+  } as CanvasElement;
+}
 
 function ownToken(x = 0, y = 0): CanvasElement {
   return createImage({
@@ -104,5 +118,23 @@ describe('PlayerHandTool', () => {
     const tool = new PlayerHandTool(selectTool);
     tool.onPointerDown(down(20, 20), ctx);
     expect(ctx.switchTool).not.toHaveBeenCalled();
+  });
+
+  describe('with a custom isGrabbable predicate (e.g. DM canvas)', () => {
+    it('pointer-down on an element matching the predicate hands off to select', () => {
+      const ctx = fakeCtx([combatantToken(0, 0)]);
+      const tool = new PlayerHandTool(selectTool, el => isCombatantToken(el));
+      tool.onPointerDown(down(20, 20), ctx);
+      expect(ctx.switchTool).toHaveBeenCalledWith('select');
+      expect(selectDown).toHaveBeenCalledTimes(1);
+    });
+
+    it('pointer-down on a plain own-layer image (not matching the predicate) pans, even though it would be grabbable under the default predicate', () => {
+      const ctx = fakeCtx([ownToken(0, 0)]);
+      const tool = new PlayerHandTool(selectTool, el => isCombatantToken(el));
+      tool.onPointerDown(down(20, 20), ctx);
+      expect(ctx.switchTool).not.toHaveBeenCalled();
+      expect(selectDown).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/lib/__tests__/openTvDisplay.test.ts
+++ b/src/lib/__tests__/openTvDisplay.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { openTvDisplay } from '@/lib/openTvDisplay';
+
+describe('openTvDisplay', () => {
+  let fakeWin: { location: { href: string } };
+  let openSpy: ReturnType<typeof vi.fn>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fakeWin = { location: { href: '' } };
+    openSpy = vi.fn(() => fakeWin);
+    vi.stubGlobal('open', openSpy);
+    fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ displayKey: 'KEY123' }))
+    );
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('opens the tab synchronously, then navigates it to the keyed display URL', async () => {
+    await openTvDisplay('CAMP1', 'map-1', 'dm-1');
+    // opened BEFORE the fetch resolved (synchronous blank tab)
+    expect(openSpy).toHaveBeenCalledWith('', '_blank');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/campaign/CAMP1/display-key',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(fakeWin.location.href).toBe(
+      '/dm/campaign/CAMP1/battlemaps/map-1/display?dk=KEY123'
+    );
+  });
+
+  it('omits ?dk when the key fetch fails, still navigating', async () => {
+    fetchMock.mockImplementation(async () => {
+      throw new Error('relay down');
+    });
+    await openTvDisplay('CAMP1', 'map-1', 'dm-1');
+    expect(fakeWin.location.href).toBe(
+      '/dm/campaign/CAMP1/battlemaps/map-1/display'
+    );
+  });
+
+  it('falls back to window.open(url) when the popup was blocked', async () => {
+    openSpy.mockImplementation((url: string) => (url === '' ? null : fakeWin));
+    await openTvDisplay('CAMP1', 'map-1', 'dm-1');
+    expect(openSpy).toHaveBeenLastCalledWith(
+      '/dm/campaign/CAMP1/battlemaps/map-1/display?dk=KEY123',
+      '_blank'
+    );
+  });
+});

--- a/src/lib/openTvDisplay.ts
+++ b/src/lib/openTvDisplay.ts
@@ -1,0 +1,36 @@
+export async function openTvDisplay(
+  campaignCode: string,
+  battleMapId: string,
+  dmId: string
+): Promise<void> {
+  // Open the tab synchronously, in direct response to the user gesture —
+  // Safari (and sometimes Chrome) revokes transient user activation across
+  // an `await`, so opening after the fetch below would silently no-op.
+  const win = window.open('', '_blank');
+
+  let dk = '';
+  try {
+    const res = await fetch(`/api/campaign/${campaignCode}/display-key`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dmId }),
+    });
+    if (res.ok) {
+      dk = ((await res.json()) as { displayKey?: string }).displayKey ?? '';
+    }
+  } catch {
+    // relay not configured — the display page will show its own error state
+  }
+
+  const url = `/dm/campaign/${campaignCode}/battlemaps/${battleMapId}/display${
+    dk ? `?dk=${encodeURIComponent(dk)}` : ''
+  }`;
+
+  if (win) {
+    win.location.href = url;
+  } else {
+    // Popup blocked despite the synchronous open attempt — fall back to
+    // the old behavior so at least some browsers still get a new tab.
+    window.open(url, '_blank');
+  }
+}

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -161,6 +161,7 @@ export interface EncounterEntity {
 
   // Visual
   color?: string; // For grouping same monsters
+  avatarUrl?: string; // Portrait shown on DM VTT roster/tokens (players, NPCs, monsters)
   isHidden?: boolean; // DM can hide the real name from players (they see a generic label)
   playerAlias?: string; // Optional name players see instead (DM-controlled entities); takes precedence over the hidden generic label
   playerDisposition?: PlayerDisposition; // Allegiance players see (disguise); defaults to enemy for non-players


### PR DESCRIPTION
## Summary

The DM battle map gains a **Setup | Play** mode switch (Plan B of the DM VTT spec; consumes the merged linkage foundation #156). Setup is the existing editor, untouched. Play is the Focus Studio:

- **Roster tray** (left) — linked-encounter combatants grouped PLAYERS/NPCS/MONSTERS; tap-to-arm → click-map placement (race-safe controller) or **drag-to-place** (pointer-based, 6px tap threshold, offline-gated); placed rows dim and select instead.
- **Linked tokens** — placed tokens carry `entityId`; clicking one selects its combatant in the studio panel.
- **Studio panel** (right) — ⚔ Initiative tab (DM-truth rows in the exact order players see, active-turn pulse, hidden/concentration badges) and 📋 Selected tab reusing the combat screen's `CombatantDetail` wholesale (damage/heal, abilities with Use rolls, legendary, conditions, NPC statblock view). "Following: {name}" note when several linked encounters are active.
- **Turn control** — ROUND · NOW pill with ⏮/Next ▶ driving `encounterStore`; the initiative push mirrors the encounter page's, so **players' VTT panels update instantly via the WS poke**.
- **Top bar** — Hex/Square/Off grid control (persistence mirrors the editor), Open Display (extracted shared helper), Live chip, mode switch.
- **Distance badge** — "X ft" while dragging a combatant token (SDK-exact cell math incl. the hex √3 rule).

## Bugs caught by review along the way
- The distance badge held a stale element **object** (the SDK replaces objects on update) — it would have frozen at 0 ft permanently; now re-fetches by id.
- A zustand selector-loop pattern (`getNPCsForCampaign` allocating fresh arrays) — avoided via the EncounterView precedent.
- Plan-level: `combatStarted` didn't exist (`Encounter.isActive` is the real field); `EncounterEntity.avatarUrl` was missing (added, optional, dormant until populated).

## Test plan
- [x] ~90 new tests across 10 files (stamping/controller/roster/drag/panel/turn-push/badge/screen hooks), full suite 2618 passing exit 0, type-check + lint clean
- [x] Editor untouched (only the planned `openTvDisplay` extraction); `PlayerHandTool` predicate default preserves player-screen behavior
- [x] Manual two-browser checklist (below)

## Manual checklist
DM (Play mode) + player + display tabs, local relay: Setup↔Play round-trip preserves canvas · tap-arm and drag-place a monster → token lands, visible to player+display, roster dims · click token → Selected tab, damage flows to the encounter page · Next ▶ → player panel updates instantly · grid Hex/Square/Off persists, templates still size right · Open Display works · distance badge ≈5ft/cell · relay stopped → placement disabled with hint · **check ~1280px width: Setup pill vs ThemeToggle, top bar vs toolbar overlap** · both themes · iPad touch.

Note: Clear-drawings removes ALL strokes/arrows/templates (incl. player-drawn) — kept deliberately; flag if you want ownership-filtered clearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)