### PR TITLE
feat(vtt): fieldnotes core 0.48 — true-width line spells via rectangle templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@3d-dice/dice-box": "^1.1.3",
         "@3d-dice/dice-ui": "^0.5.2",
         "@aws-sdk/client-s3": "^3.922.0",
-        "@fieldnotes/core": "^0.46.1",
+        "@fieldnotes/core": "^0.48.0",
         "@fieldnotes/react": "^0.7.0",
         "@fieldnotes/sync": "^0.7.0",
         "@radix-ui/react-checkbox": "^1.3.2",
@@ -2173,9 +2173,9 @@
       }
     },
     "node_modules/@fieldnotes/core": {
-      "version": "0.46.1",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.46.1.tgz",
-      "integrity": "sha512-BVJK6EqVGGyH52Yz4N8akiAVkCm72fpg4UCiQuZxInyxQrmN/pVb6idDYRIKAGSMuUK8uPg95GUXGxJSNAG/yg==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.48.0.tgz",
+      "integrity": "sha512-PY2Xi8bPgFgxtxEAoRUo/mKXt8dkoGDmxgieJotRplvFRTSRxyruZQ1ky0+Aua16L2B6kg/s8MTDLbk0F70NxA==",
       "license": "MIT"
     },
     "node_modules/@fieldnotes/react": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@3d-dice/dice-box": "^1.1.3",
     "@3d-dice/dice-ui": "^0.5.2",
     "@aws-sdk/client-s3": "^3.922.0",
-    "@fieldnotes/core": "^0.46.1",
+    "@fieldnotes/core": "^0.48.0",
     "@fieldnotes/react": "^0.7.0",
     "@fieldnotes/sync": "^0.7.0",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/src/components/ui/campaign/location-map/DmLocationToolOptions.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolOptions.tsx
@@ -313,22 +313,28 @@ export default function DmLocationToolOptions({
           <div className="bg-divider h-6 w-px" />
           <span className="text-muted text-xs font-medium">Template</span>
           <div className="border-divider bg-surface flex items-center gap-0.5 rounded-md border p-0.5">
-            {(['circle', 'cone', 'line', 'square'] as TemplateShape[]).map(
-              shape => (
-                <button
-                  key={shape}
-                  type="button"
-                  onClick={() => setTemplateOpts({ templateShape: shape })}
-                  className={`rounded px-2 py-0.5 text-xs capitalize transition-colors ${
-                    (templateOpts.templateShape ?? 'circle') === shape
-                      ? 'bg-accent-blue-bg text-accent-blue-text font-semibold'
-                      : 'text-muted hover:bg-surface-raised hover:text-body'
-                  }`}
-                >
-                  {shape}
-                </button>
-              )
-            )}
+            {(
+              [
+                'circle',
+                'cone',
+                'line',
+                'square',
+                'rectangle',
+              ] as TemplateShape[]
+            ).map(shape => (
+              <button
+                key={shape}
+                type="button"
+                onClick={() => setTemplateOpts({ templateShape: shape })}
+                className={`rounded px-2 py-0.5 text-xs capitalize transition-colors ${
+                  (templateOpts.templateShape ?? 'circle') === shape
+                    ? 'bg-accent-blue-bg text-accent-blue-text font-semibold'
+                    : 'text-muted hover:bg-surface-raised hover:text-body'
+                }`}
+              >
+                {shape}
+              </button>
+            ))}
           </div>
           <div className="bg-divider h-6 w-px" />
           <span className="text-muted text-xs font-medium">Render</span>

--- a/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
+++ b/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
@@ -50,12 +50,20 @@ export class SpellTemplateTool implements Tool {
     // `radius` is the FULL side, so a 20ft cube = 20ft across, same formula
     // as circle (where radius really is a radius).
     const radiusPx = (config.sizeFeet / FEET_PER_CELL) * cellPx;
+    // Line spells render as RECTANGLE templates (core 0.48): a directional
+    // AoE with independent length and width, so Lightning-Bolt-style lines
+    // finally honor their real widthFeet instead of the default line width.
+    const isLine = config.shape === 'line';
+    const widthPx = isLine
+      ? ((config.widthFeet ?? FEET_PER_CELL) / FEET_PER_CELL) * cellPx
+      : undefined;
 
     const el = createTemplate({
       position: origin,
-      templateShape: config.shape,
+      templateShape: isLine ? 'rectangle' : config.shape,
       radius: radiusPx,
       angle: 0,
+      ...(widthPx !== undefined ? { width: widthPx } : {}),
       fillColor: SPELL_FILL,
       strokeColor: SPELL_FILL,
       opacity: 0.28,

--- a/src/components/ui/campaign/player-vtt/__tests__/SpellTemplateTool.test.ts
+++ b/src/components/ui/campaign/player-vtt/__tests__/SpellTemplateTool.test.ts
@@ -108,6 +108,34 @@ describe('SpellTemplateTool', () => {
     expect(f.added[0].radiusFeet).toBe(20);
   });
 
+  it('line spells place as RECTANGLE templates honoring widthFeet (100×10ft @5ft/40px)', () => {
+    // core 0.48: rectangle = directional AoE with independent length/width —
+    // finally renders Lightning-Bolt-style lines at their real width.
+    const { tool } = armed({ shape: 'line', sizeFeet: 100, widthFeet: 10 });
+    tool.onPointerDown(down(0, 0), f.ctx);
+    const el = f.added[0];
+    expect(el.templateShape).toBe('rectangle');
+    expect(el.radius).toBe((100 / 5) * 40);
+    expect(el.width).toBe((10 / 5) * 40);
+    expect(el.radiusFeet).toBe(100);
+  });
+
+  it('line spells default to 5ft width (one cell)', () => {
+    const { tool } = armed({ shape: 'line', sizeFeet: 60 });
+    tool.onPointerDown(down(0, 0), f.ctx);
+    expect(f.added[0].templateShape).toBe('rectangle');
+    expect(f.added[0].width).toBe(40);
+  });
+
+  it('line (rectangle) placement aims by drag like cones', () => {
+    const { tool, onPlaced } = armed({ shape: 'line', sizeFeet: 30 });
+    tool.onPointerDown(down(0, 0), f.ctx);
+    tool.onPointerMove(down(0, 10), f.ctx);
+    expect(f.updates[0].patch.angle).toBeCloseTo(Math.PI / 2);
+    tool.onPointerUp(down(0, 10), f.ctx);
+    expect(onPlaced).toHaveBeenCalledTimes(1);
+  });
+
   it('with a null config, bails to select without placing', () => {
     const ref = { current: null };
     const tool = new SpellTemplateTool(ref);


### PR DESCRIPTION
## Summary

Upgrades `@fieldnotes/core` 0.46.1 → 0.48.0 and integrates the new capabilities.

- **Line spells finally render at their real width.** Core 0.48's new `rectangle` template shape has independent length + `width`, so `SpellTemplateTool` now places line-shaped spell AoEs as rectangles: Lightning Bolt casts a true 100×5 ft corridor, and wider lines (e.g. 10 ft) honor `spell.aoe.widthFeet` — the field we've carried dormant since the player VTT shipped, annotated in the spec as "waiting for SDK width support." Drag-aiming works unchanged (rectangles are directional like cones).
- **Rectangle added to the template shape picker** (`DmLocationToolOptions`, battlemap mode) — both the DM screens and the player toolbar can now hand-place wall/corridor AoEs with the SDK's length/width/aim handles.
- **Free from 0.47 (no code needed):** cone/line/rectangle templates can be re-aimed after placement via the tip handle (Shift-snaps 15°/60°-hex), and all templates show a live "N ft" readout while placing plus a persistent readout on placed elements — our stamped templates already set `feetPerCell`/`radiusFeet`, so they participate automatically.

`@fieldnotes/react` 0.7.0 / `@fieldnotes/sync` 0.7.0 unchanged (peer ranges satisfied, deduped to core 0.48). Rectangles sync as ordinary template elements — no relay changes.

## Test plan
- [x] 3 new SpellTemplateTool tests (100×10 ft rectangle mapping, 5 ft default width, drag-aim on line placement); hex √3 and all prior template tests unchanged and green
- [x] Full unit suite 2621 passing (exit 0) on the upgraded SDK; type-check + lint clean
- [ ] Manual: cast Lightning Bolt → 5ft-wide corridor (not the old thin line); place a rectangle from the picker and resize length/width/aim; select a placed cone and re-aim via the tip handle; ft readouts visible while placing and on placed templates; hex map sizing still exact

🤖 Generated with [Claude Code](https://claude.com/claude-code)