### PR TITLE
fix(vtt): stability & polish pass — hex tokens, escape cleanup, error boundaries, relay/auth hardening, responsive DM chrome

### DIFF
--- a/relay/src/reservedSenders.test.ts
+++ b/relay/src/reservedSenders.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import WebSocket from 'ws';
+import { signBattleMapToken } from './token.js';
+import { startRelay, type RelayHandle } from './server.js';
+
+const SECRET = 'test-secret';
+const ROOM = 'CAMP1:map-99';
+
+function playerToken(userId: string, room = ROOM) {
+  return signBattleMapToken(
+    { userId, role: 'player', room, exp: Date.now() + 30_000 },
+    SECRET
+  );
+}
+
+function dmToken(room = ROOM) {
+  return signBattleMapToken(
+    { userId: '@server', role: 'dm', room, exp: Date.now() + 30_000 },
+    SECRET
+  );
+}
+
+function connect(port: number, token: string): WebSocket {
+  return new WebSocket(
+    `ws://127.0.0.1:${port}?room=${encodeURIComponent(
+      ROOM
+    )}&token=${encodeURIComponent(token)}`
+  );
+}
+
+async function waitOpen(socket: WebSocket): Promise<void> {
+  await vi.waitFor(() => {
+    expect(socket.readyState).toBe(WebSocket.OPEN);
+  });
+}
+
+describe('reserved presence senders (real relay)', () => {
+  let handle: RelayHandle | null = null;
+  let a: WebSocket | null = null;
+  let b: WebSocket | null = null;
+
+  afterEach(async () => {
+    a?.close();
+    a = null;
+    b?.close();
+    b = null;
+    await handle?.close();
+    handle = null;
+  });
+
+  it('drops a forged @-prefixed presence sender but relays a normal one, and never breaks server pokes', async () => {
+    handle = await startRelay({ secret: SECRET, port: 0 });
+    const port = handle.address().port;
+
+    a = connect(port, playerToken('player-a'));
+    b = connect(port, playerToken('player-b'));
+    await waitOpen(a);
+    await waitOpen(b);
+
+    const bMessages: Array<Record<string, unknown>> = [];
+    b.on('message', data => {
+      bMessages.push(JSON.parse(data.toString()) as Record<string, unknown>);
+    });
+
+    // Give the hub a beat to register both connections as room members
+    // before we start sending (mirrors poke.test.ts's retry-until-registered
+    // pattern, but here we just need both sockets joined).
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // 1) Forged server-reserved sender — must NOT reach B.
+    a.send(
+      JSON.stringify({
+        from: '@poke',
+        op: { kind: 'presence', data: { kind: 'poke', feature: 'initiative' } },
+      })
+    );
+
+    // 2) Normal presence — must reach B.
+    a.send(
+      JSON.stringify({
+        from: 'player-a',
+        op: { kind: 'presence', data: { x: 1 } },
+      })
+    );
+
+    await vi.waitFor(() => {
+      const normal = bMessages.find(m => m.from === 'player-a');
+      expect(normal).toEqual({
+        from: 'player-a',
+        op: { kind: 'presence', data: { x: 1 } },
+      });
+    });
+
+    // Give any (incorrectly) forwarded forged frame time to arrive too.
+    await new Promise(resolve => setTimeout(resolve, 100));
+    const forged = bMessages.find(m => m.from === '@poke');
+    expect(forged).toBeUndefined();
+
+    // 3) A real server poke must still be delivered — pokeRoom bypasses
+    // broadcastPresence entirely, so it must be unaffected by the patch.
+    const response = await fetch(`http://127.0.0.1:${port}/poke`, {
+      method: 'POST',
+      body: JSON.stringify({
+        room: ROOM,
+        feature: 'initiative',
+        token: dmToken(),
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ sent: 2 });
+
+    await vi.waitFor(() => {
+      const pokeMessage = bMessages.find(
+        m =>
+          (m as { op?: { data?: { kind?: unknown } } }).op?.data?.kind ===
+          'poke'
+      );
+      expect(pokeMessage).toEqual({
+        from: '@poke',
+        op: { kind: 'presence', data: { kind: 'poke', feature: 'initiative' } },
+      });
+    });
+  });
+});

--- a/relay/src/reservedSenders.ts
+++ b/relay/src/reservedSenders.ts
@@ -1,0 +1,26 @@
+import type { SyncHub } from '@fieldnotes/sync-server';
+
+type BroadcastPresence = (conn: unknown, from: string, data: unknown) => void;
+
+/** Narrow structural view of the hub's private presence broadcaster —
+ * same private-access pattern as `corrections.ts` / `poke.ts`. */
+interface HubWithPresence {
+  broadcastPresence: BroadcastPresence;
+}
+
+/**
+ * `@`-prefixed presence senders are RESERVED for server-originated messages
+ * (the /poke endpoint). The vendored hub relays client presence verbatim
+ * with no `from` validation, so any room member could forge `@poke` nudges.
+ * Drop them here. Server pokes are unaffected: `pokeRoom` writes directly
+ * to sockets and never passes through `broadcastPresence`.
+ * Remove if @fieldnotes/sync-server gains sender validation upstream.
+ */
+export function patchReservedPresenceSenders(hub: SyncHub): void {
+  const h = hub as unknown as HubWithPresence;
+  const original = h.broadcastPresence.bind(hub);
+  h.broadcastPresence = (conn, from, data) => {
+    if (typeof from === 'string' && from.startsWith('@')) return;
+    original(conn, from, data);
+  };
+}

--- a/relay/src/server.ts
+++ b/relay/src/server.ts
@@ -6,6 +6,7 @@ import type { HubBackend, SyncHub } from '@fieldnotes/sync-server';
 import { makePolicies } from './policies.js';
 import { BufferedRedisBackend } from './backend.js';
 import { patchSendCorrectionLeak } from './corrections.js';
+import { patchReservedPresenceSenders } from './reservedSenders.js';
 import { handlePokeRequest } from './poke.js';
 
 export interface StartRelayOptions {
@@ -59,6 +60,7 @@ export async function startRelay(
   });
   // Upstream sendCorrection leak — see corrections.ts.
   patchSendCorrectionLeak(hub, policies.canRead);
+  patchReservedPresenceSenders(hub);
 
   pokeHandler = (req, res) =>
     void handlePokeRequest(hub, opts.secret, req, res).catch(err => {

--- a/src/app/api/campaign/[code]/battlemaps/[id]/route.ts
+++ b/src/app/api/campaign/[code]/battlemaps/[id]/route.ts
@@ -57,9 +57,9 @@ export async function POST(
 
     const redis = getRedis();
     const dmAuth = await verifyDmAuthority(redis, code, dmId);
-    if (dmAuth === 'mismatch') {
+    if (dmAuth !== 'ok') {
       return NextResponse.json(
-        { error: 'dmId does not match campaign owner' },
+        { error: 'dmId is not authorized for this campaign' },
         { status: 403 }
       );
     }
@@ -116,9 +116,9 @@ export async function DELETE(
 
     const redis = getRedis();
     const dmAuth = await verifyDmAuthority(redis, code, dmId);
-    if (dmAuth === 'mismatch') {
+    if (dmAuth !== 'ok') {
       return NextResponse.json(
-        { error: 'dmId does not match campaign owner' },
+        { error: 'dmId is not authorized for this campaign' },
         { status: 403 }
       );
     }

--- a/src/app/api/campaign/[code]/locations/[id]/route.ts
+++ b/src/app/api/campaign/[code]/locations/[id]/route.ts
@@ -56,9 +56,9 @@ export async function POST(
     const redis = getRedis();
 
     const dmAuth = await verifyDmAuthority(redis, code, dmId);
-    if (dmAuth === 'mismatch') {
+    if (dmAuth !== 'ok') {
       return NextResponse.json(
-        { error: 'dmId does not match campaign owner' },
+        { error: 'dmId is not authorized for this campaign' },
         { status: 403 }
       );
     }
@@ -120,9 +120,9 @@ export async function DELETE(
     const redis = getRedis();
 
     const dmAuth = await verifyDmAuthority(redis, code, dmId);
-    if (dmAuth === 'mismatch') {
+    if (dmAuth !== 'ok') {
       return NextResponse.json(
-        { error: 'dmId does not match campaign owner' },
+        { error: 'dmId is not authorized for this campaign' },
         { status: 403 }
       );
     }

--- a/src/app/api/campaign/[code]/shared/route.ts
+++ b/src/app/api/campaign/[code]/shared/route.ts
@@ -175,9 +175,9 @@ export async function POST(
     // (it would let anyone mint DM battle-map tokens and see hidden elements).
     if (dmId) {
       const dmAuth = await verifyDmAuthority(redis, code, dmId);
-      if (dmAuth === 'mismatch') {
+      if (dmAuth !== 'ok') {
         return NextResponse.json(
-          { error: 'dmId does not match campaign owner' },
+          { error: 'dmId is not authorized for this campaign' },
           { status: 403 }
         );
       }

--- a/src/app/dm/campaign/[code]/battlemaps/[id]/page.tsx
+++ b/src/app/dm/campaign/[code]/battlemaps/[id]/page.tsx
@@ -80,7 +80,7 @@ export default function BattleMapEditorPage() {
 
   return (
     <div className="bg-surface flex h-screen flex-col overflow-hidden">
-      <div className="border-divider bg-surface-raised fixed top-4 right-4 z-50 flex items-center gap-0.5 rounded-lg border p-0.5 shadow-lg">
+      <div className="border-divider bg-surface-raised fixed top-20 right-4 z-50 flex items-center gap-0.5 rounded-lg border p-0.5 shadow-lg">
         <Button
           variant="primary"
           size="lg"

--- a/src/app/dm/campaign/[code]/battlemaps/[id]/page.tsx
+++ b/src/app/dm/campaign/[code]/battlemaps/[id]/page.tsx
@@ -6,8 +6,10 @@ import { useParams } from 'next/navigation';
 import { ArrowLeft, Map } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
+import ErrorBoundary from '@/components/ui/feedback/ErrorBoundary';
 import DmLocationEditor from '@/components/ui/campaign/location-map/DmLocationEditor';
 import { DmVttScreen } from '@/components/ui/campaign/dm-vtt/DmVttScreen';
+import { VttErrorFallback } from '@/components/ui/campaign/dm-vtt/VttErrorFallback';
 import { useBattleMapMode } from '@/components/ui/campaign/dm-vtt/useBattleMapMode';
 import { useBattleMapStore } from '@/store/battleMapStore';
 import { useHydration } from '@/hooks/useHydration';
@@ -52,13 +54,15 @@ export default function BattleMapEditorPage() {
 
   if (mode === 'play') {
     return (
-      <DmVttScreen
-        campaignCode={code}
-        battleMapId={id}
-        dmId={dmId}
-        mode={mode}
-        onModeChange={handleModeChange}
-      />
+      <ErrorBoundary fallback={<VttErrorFallback />}>
+        <DmVttScreen
+          campaignCode={code}
+          battleMapId={id}
+          dmId={dmId}
+          mode={mode}
+          onModeChange={handleModeChange}
+        />
+      </ErrorBoundary>
     );
   }
 

--- a/src/app/player/campaign/[code]/battlemap/[id]/page.tsx
+++ b/src/app/player/campaign/[code]/battlemap/[id]/page.tsx
@@ -5,7 +5,9 @@ import { useParams, useSearchParams } from 'next/navigation';
 import { usePlayerStore } from '@/store/playerStore';
 import { useHydration } from '@/hooks/useHydration';
 import { markBattleMapJoined } from '@/hooks/useJoinedBattleMap';
+import ErrorBoundary from '@/components/ui/feedback/ErrorBoundary';
 import { PlayerVttScreen } from '@/components/ui/campaign/player-vtt/PlayerVttScreen';
+import { VttErrorFallback } from '@/components/ui/campaign/dm-vtt/VttErrorFallback';
 
 function PlayerBattleMapPage() {
   const params = useParams();
@@ -39,11 +41,13 @@ function PlayerBattleMapPage() {
   }
 
   return (
-    <PlayerVttScreen
-      campaignCode={code}
-      battleMapId={battleMapId}
-      characterId={characterId}
-    />
+    <ErrorBoundary fallback={<VttErrorFallback />}>
+      <PlayerVttScreen
+        campaignCode={code}
+        battleMapId={battleMapId}
+        characterId={characterId}
+      />
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -19,7 +19,7 @@ export type { DmBattleMapCanvasProps };
  */
 export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
   const { children } = props;
-  const { viewport, status, tools, handleReady, handleClearDrawings } =
+  const { viewport, tools, handleReady, handleClearDrawings } =
     useDmBattleMapCanvas(props);
 
   return (
@@ -32,9 +32,7 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
           className="h-full w-full"
           snapToGrid
         />
-        {viewport && (
-          <DmVttToolbar status={status} onClearDrawings={handleClearDrawings} />
-        )}
+        {viewport && <DmVttToolbar onClearDrawings={handleClearDrawings} />}
         {viewport && (
           <div className="border-divider absolute top-16 left-1/2 z-10 max-w-[92vw] -translate-x-1/2 overflow-hidden rounded-xl border shadow-lg">
             <DmLocationToolOptions mode="battlemap" />

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -34,7 +34,7 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
         />
         {viewport && <DmVttToolbar onClearDrawings={handleClearDrawings} />}
         {viewport && (
-          <div className="border-divider absolute top-16 left-1/2 z-10 max-w-[92vw] -translate-x-1/2 overflow-hidden rounded-xl border shadow-lg">
+          <div className="border-divider absolute top-[7.25rem] left-1/2 z-10 max-w-[92vw] -translate-x-1/2 overflow-hidden rounded-xl border shadow-lg min-[1350px]:top-16">
             <DmLocationToolOptions mode="battlemap" />
           </div>
         )}

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
@@ -117,6 +117,7 @@ export function useDmVttScreen({
 
   return {
     battleMap,
+    linkedEncounterIds,
     linkedEntities,
     placedIndex,
     encounter,

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -91,7 +91,7 @@ export function DmVttScreen({
           onDragStart={vtt.startDrag}
           collapsed={rosterCollapsed}
           onToggleCollapsed={() => setRosterCollapsed(v => !v)}
-          hasLinkedEncounter={vtt.linkedEntities.length > 0}
+          hasLinkedEncounter={vtt.linkedEncounterIds.length > 0}
         />
         <RosterDragGhost drag={vtt.drag} />
         {vtt.actions && (

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -11,7 +11,6 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { useActiveTool } from '@fieldnotes/react';
-import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
 
 const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
   { name: 'hand', label: 'Pan', Icon: Hand },
@@ -23,18 +22,18 @@ const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
 ];
 
 export interface DmVttToolbarProps {
-  status: BattleMapConnectionStatus;
   onClearDrawings: () => void;
 }
 
 /** Top-center tool pill for the DM battle-map canvas — structurally mirrors
  * `PlayerBattleMapCanvas`'s `PlayerToolbar`, minus the token tool (placed via
  * the roster in Task 8, never through this toolbar) plus a Clear-drawings
- * action. */
-export function DmVttToolbar({ status, onClearDrawings }: DmVttToolbarProps) {
+ * action. The connection-status chip lives solely in `DmVttTopBar` now (see
+ * P7c) — this toolbar no longer duplicates it. */
+export function DmVttToolbar({ onClearDrawings }: DmVttToolbarProps) {
   const [activeTool, setTool] = useActiveTool();
   return (
-    <div className="bg-surface-raised border-divider absolute top-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-xl border p-1 shadow-lg">
+    <div className="bg-surface-raised border-divider absolute top-16 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-xl border p-1 shadow-lg min-[1350px]:top-3">
       {DM_TOOLS.map(({ name, label, Icon }) => (
         <Button
           key={name}
@@ -56,21 +55,6 @@ export function DmVttToolbar({ status, onClearDrawings }: DmVttToolbarProps) {
       >
         <Eraser size={16} />
       </Button>
-      <span
-        className={`ml-2 rounded-full px-2 py-0.5 text-xs ${
-          status === 'live'
-            ? 'bg-accent-emerald-bg text-accent-emerald-text'
-            : status === 'denied'
-              ? 'bg-accent-red-bg text-accent-red-text'
-              : 'bg-accent-amber-bg text-accent-amber-text'
-        }`}
-      >
-        {status === 'live'
-          ? 'Live'
-          : status === 'denied'
-            ? 'Access denied'
-            : 'Connecting…'}
-      </span>
     </div>
   );
 }

--- a/src/components/ui/campaign/dm-vtt/DmVttTopBar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttTopBar.tsx
@@ -68,7 +68,7 @@ export function DmVttTopBar({
             key={key}
             variant={gridMode === key ? 'primary' : 'ghost'}
             onClick={() => onSetGridMode(key)}
-            className="h-8 px-2 text-xs"
+            className="min-h-[44px] px-2 text-xs"
           >
             {label}
           </Button>
@@ -104,7 +104,7 @@ export function DmVttTopBar({
             key={key}
             variant={mode === key ? 'primary' : 'ghost'}
             onClick={() => onModeChange(key)}
-            className="h-8 px-2 text-xs"
+            className="min-h-[44px] px-2 text-xs"
           >
             {label}
           </Button>

--- a/src/components/ui/campaign/dm-vtt/DmVttTopBar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttTopBar.tsx
@@ -37,9 +37,9 @@ const MODE_OPTIONS: { key: DmVttMode; label: string }[] = [
 /**
  * Top chrome bar for the DM VTT play screen: back link, map name, grid
  * segmented control (mirrors `useDmVttGrid`'s `setGridMode`), TV display
- * launcher (Task 1's `openTvDisplay` helper), a live-status chip (mirrors
- * `DmVttToolbar`'s status pill), and the Setup|Play mode switch (state +
- * persistence owned by the page).
+ * launcher (Task 1's `openTvDisplay` helper), a live-status chip (the
+ * chip's single home — the Play toolbar no longer duplicates it), and the
+ * Setup|Play mode switch (state + persistence owned by the page).
  */
 export function DmVttTopBar({
   campaignCode,

--- a/src/components/ui/campaign/dm-vtt/RosterTray.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterTray.tsx
@@ -75,6 +75,10 @@ export function RosterTray({
           <p className="text-muted px-1 py-2 text-xs">
             Link an encounter in Setup mode
           </p>
+        ) : entities.length === 0 ? (
+          <p className="text-muted px-1 py-2 text-xs">
+            No combatants in the linked encounter yet
+          </p>
         ) : (
           GROUP_SECTIONS.map(({ key, label }) => {
             const list = groups[key];

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/InitiativeRow.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/InitiativeRow.tsx
@@ -35,9 +35,15 @@ export function InitiativeRow({
         onClick={() => onSelect(entity.id)}
         className={`flex min-h-[44px] w-full items-center gap-2 rounded-lg border px-2 py-1.5 text-left transition-colors ${
           isActive
-            ? 'bg-accent-amber-bg border-accent-amber-border animate-pulse'
-            : 'hover:bg-surface-secondary border-transparent'
-        } ${isSelected ? 'border-accent-blue-border' : ''}`}
+            ? 'bg-accent-amber-bg animate-pulse'
+            : 'hover:bg-surface-secondary'
+        } ${
+          isSelected
+            ? 'border-accent-blue-border'
+            : isActive
+              ? 'border-accent-amber-border'
+              : 'border-divider'
+        }`}
       >
         <span
           className="h-8 w-1 shrink-0 rounded-full"

--- a/src/components/ui/campaign/dm-vtt/TokenPlacementController.tsx
+++ b/src/components/ui/campaign/dm-vtt/TokenPlacementController.tsx
@@ -76,10 +76,20 @@ export function TokenPlacementController({
   useEffect(() => {
     if (!pending) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel();
+      if (e.key !== 'Escape') return;
+      // Defer to any open dialog: registered in the CAPTURE phase so this
+      // runs BEFORE Radix's document-level listener flushes the dialog
+      // closed — a bubble listener could observe data-state already
+      // "closed" and cancel placement anyway. Escape closes the dialog
+      // first; the next Escape cancels placement.
+      if (document.querySelector('[role="dialog"][data-state="open"]')) {
+        return;
+      }
+      onCancel();
     };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () =>
+      window.removeEventListener('keydown', handleKeyDown, { capture: true });
   }, [pending, onCancel]);
 
   return null;

--- a/src/components/ui/campaign/dm-vtt/VttErrorFallback.tsx
+++ b/src/components/ui/campaign/dm-vtt/VttErrorFallback.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Button } from '@/components/ui/forms/button';
+
+/** Scoped fallback for the VTT screens: canvas state lives in the relay +
+ * local store, so a full reload is lossless and beats the app-root
+ * "Component Spell Failed!" page mid-session. */
+export function VttErrorFallback() {
+  return (
+    <div className="bg-surface flex min-h-screen flex-col items-center justify-center gap-4">
+      <p className="text-heading text-lg font-semibold">
+        The battle map hit an error.
+      </p>
+      <p className="text-muted text-sm">
+        Your map is safe — reloading brings everything back.
+      </p>
+      <Button
+        variant="primary"
+        size="lg"
+        onClick={() => window.location.reload()}
+      >
+        Reload map
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/__tests__/RosterTray.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/RosterTray.test.tsx
@@ -69,6 +69,18 @@ describe('RosterTray', () => {
     expect(screen.queryByText('Aria')).not.toBeInTheDocument();
   });
 
+  it('shows an empty-encounter prompt when linked but no entities', () => {
+    render(
+      <RosterTray {...baseProps({ hasLinkedEncounter: true, entities: [] })} />
+    );
+    expect(
+      screen.getByText(/no combatants in the linked encounter yet/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/link an encounter in setup mode/i)
+    ).not.toBeInTheDocument();
+  });
+
   it('renders group labels and first-word names for each entity', () => {
     render(<RosterTray {...baseProps()} />);
     expect(screen.getByText('PLAYERS')).toBeInTheDocument();

--- a/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
@@ -176,6 +176,27 @@ describe('StudioPanel', () => {
     expect(selectedRow.className).toMatch(/border-accent-blue-border/);
   });
 
+  it('gives an active AND selected row the selected (blue) border, not amber', () => {
+    // Sorted order is [Aria(18), Scout(14), Boss(9)] — currentTurn 1 → Scout is active.
+    render(
+      <StudioPanel
+        {...baseProps({
+          encounter: makeEncounter({
+            entities: [aria, goblin1, goblin2],
+            currentTurn: 1,
+          }),
+          selectedEntityId: 'm1',
+        })}
+      />
+    );
+    const row = screen.getByText('Goblin Scout').closest('button')!;
+    expect(row.className).toMatch(/border-accent-blue-border/);
+    expect(row.className).not.toMatch(/border-accent-amber-border/);
+    // Non-border active styling (bg + pulse) is preserved.
+    expect(row.className).toMatch(/bg-accent-amber-bg/);
+    expect(row.className).toMatch(/animate-pulse/);
+  });
+
   it('shows a hidden badge and concentration glyph on the roster row', () => {
     render(<StudioPanel {...baseProps()} />);
     const row = screen.getByText('Goblin Boss').closest('button')!;

--- a/src/components/ui/campaign/dm-vtt/__tests__/TokenPlacementController.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/TokenPlacementController.test.tsx
@@ -133,4 +133,22 @@ describe('TokenPlacementController', () => {
     });
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
+
+  it('Escape defers to an open dialog (closes it first, does not cancel)', () => {
+    const { onCancel } = setup(makePending());
+    act(() => {});
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('data-state', 'open');
+    document.body.appendChild(dialog);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onCancel).not.toHaveBeenCalled();
+    dialog.remove();
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/ui/campaign/dm-vtt/__tests__/VttErrorFallback.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/VttErrorFallback.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { VttErrorFallback } from '@/components/ui/campaign/dm-vtt/VttErrorFallback';
+
+describe('VttErrorFallback', () => {
+  afterEach(() => cleanup());
+
+  it('renders the error message and a reload button', () => {
+    render(<VttErrorFallback />);
+    expect(
+      screen.getByText(/the battle map hit an error/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /reload map/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
@@ -23,6 +23,7 @@ function fakeCtx(overrides: Record<string, unknown> = {}) {
         added.push(el);
         return el;
       }),
+      remove: vi.fn(),
     },
     requestRender: vi.fn(),
     switchTool: vi.fn(),
@@ -181,5 +182,24 @@ describe('DmTokenTool', () => {
     expect(ctx.setCursor).toHaveBeenCalledWith('crosshair');
     tool.onDeactivate?.(ctx);
     expect(ctx.setCursor).toHaveBeenCalledWith('default');
+  });
+
+  it('deactivation mid-gesture removes the in-flight token (Escape cancel)', () => {
+    const { ctx, added } = fakeCtx();
+    const tool = new DmTokenTool(ref);
+    tool.onPointerDown(down(10, 10), ctx);
+    expect(added).toHaveLength(1);
+    tool.onDeactivate?.(ctx);
+    expect(ctx.store.remove).toHaveBeenCalledWith(added[0].id);
+  });
+
+  it('deactivation after normal completion removes nothing', () => {
+    const { ctx, added } = fakeCtx();
+    const tool = new DmTokenTool(ref);
+    tool.onPointerDown(down(10, 10), ctx);
+    tool.onPointerUp(down(10, 10), ctx);
+    tool.onDeactivate?.(ctx);
+    expect(ctx.store.remove).not.toHaveBeenCalled();
+    expect(onPlaced).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ui/campaign/dm-vtt/combatantToken.ts
+++ b/src/components/ui/campaign/dm-vtt/combatantToken.ts
@@ -97,7 +97,7 @@ export function stampCombatantToken(
 export class DmTokenTool implements Tool {
   readonly name = 'dmtoken';
 
-  private placed = false;
+  private placedId: string | null = null;
 
   constructor(private readonly configRef: { current: DmTokenConfig | null }) {}
 
@@ -108,16 +108,16 @@ export class DmTokenTool implements Tool {
       return;
     }
     const world = ctx.camera.screenToWorld({ x: state.x, y: state.y });
-    stampCombatantToken(config, world, ctx);
-    this.placed = true;
+    const token = stampCombatantToken(config, world, ctx);
+    this.placedId = token.id;
   }
 
   onPointerMove(): void {}
 
   onPointerUp(_state: PointerState, ctx: ToolContext): void {
     const config = this.configRef.current;
-    const placed = this.placed;
-    this.placed = false;
+    const placed = this.placedId !== null;
+    this.placedId = null;
     ctx.switchTool?.('select');
     if (placed) config?.onPlaced();
   }
@@ -127,6 +127,11 @@ export class DmTokenTool implements Tool {
   }
 
   onDeactivate(ctx: ToolContext): void {
+    if (this.placedId) {
+      ctx.store.remove(this.placedId);
+      this.placedId = null;
+      ctx.requestRender();
+    }
     ctx.setCursor?.('default');
   }
 }

--- a/src/components/ui/campaign/location-map/PlayerTokenTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerTokenTool.ts
@@ -7,6 +7,7 @@ import {
   type ToolContext,
   type PointerState,
 } from '@fieldnotes/core';
+import { cellUnit } from './cellUnit';
 
 const TOKEN_COLORS = [
   '#ef4444',
@@ -26,7 +27,6 @@ export function tokenColorForId(id: string): string {
   return TOKEN_COLORS[h % TOKEN_COLORS.length];
 }
 
-const TOKEN_SIZE = 40; // ≈ one 5-ft cell at default 50px grid
 const TOKEN_RENDER_PX = 128;
 const TOKEN_RING_PX = 8;
 
@@ -140,7 +140,7 @@ export class PlayerTokenTool implements Tool {
   onPointerDown(state: PointerState, ctx: ToolContext): void {
     const world = ctx.camera.screenToWorld({ x: state.x, y: state.y });
     const center = smartSnap(world, ctx);
-    const size = ctx.gridSize ?? TOKEN_SIZE;
+    const size = cellUnit(ctx);
     const src = this.srcRef.current;
 
     if (src) {

--- a/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PlayerTokenTool } from '@/components/ui/campaign/location-map/PlayerTokenTool';
+
+import type {
+  CanvasElement,
+  PointerState,
+  ToolContext,
+} from '@fieldnotes/core';
+
+function fakeCtx(overrides: Record<string, unknown> = {}) {
+  const added: CanvasElement[] = [];
+  const ctx = {
+    camera: { screenToWorld: (p: { x: number; y: number }) => p },
+    store: {
+      add: vi.fn((el: CanvasElement) => {
+        added.push(el);
+      }),
+    },
+    requestRender: vi.fn(),
+    switchTool: vi.fn(),
+    gridSize: 40,
+    gridType: 'square',
+    activeLayerId: 'player-1',
+    snapToGrid: false,
+    ...overrides,
+  } as unknown as ToolContext;
+  return { ctx, added };
+}
+
+const down = (x: number, y: number) => ({ x, y }) as PointerState;
+
+describe('PlayerTokenTool sizing', () => {
+  it('square grids: token fills one cell (gridSize px)', () => {
+    const { ctx, added } = fakeCtx();
+    const tool = new PlayerTokenTool('#12855C', { current: null });
+    tool.onPointerDown(down(100, 100), ctx);
+    const el = added[0] as CanvasElement & { size?: { w: number } };
+    expect(el.size?.w).toBe(40);
+  });
+
+  it('hex grids: token fills one cell = √3 × gridSize (SDK cell unit)', () => {
+    const { ctx, added } = fakeCtx({ gridType: 'hex' });
+    const tool = new PlayerTokenTool('#12855C', { current: null });
+    tool.onPointerDown(down(0, 0), ctx);
+    const el = added[0] as CanvasElement & { size?: { w: number } };
+    expect(el.size?.w).toBeCloseTo(Math.sqrt(3) * 40, 6);
+  });
+
+  it('avatar tokens size identically (image branch)', () => {
+    const { ctx, added } = fakeCtx({ gridType: 'hex' });
+    const tool = new PlayerTokenTool('#12855C', {
+      current: 'https://x/avatar.png',
+    });
+    tool.onPointerDown(down(0, 0), ctx);
+    const el = added[0] as CanvasElement & {
+      size?: { w: number };
+      type: string;
+    };
+    expect(el.type).toBe('image');
+    expect(el.size?.w).toBeCloseTo(Math.sqrt(3) * 40, 6);
+  });
+});

--- a/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.tsx
@@ -51,21 +51,25 @@ export function DockSpells(props: DockSpellsProps) {
   const spellAttackBonus = calculateSpellAttackBonus(character);
   const spellSaveDC = calculateSpellSaveDC(character);
 
-  const filteredSpells = useMemo(() => {
-    // Only show castable spells (prepared or always-prepared)
-    const castableSpells = character.spells.filter(
-      spell =>
-        (spell.level === 0 && spell.isPrepared) || // Only prepared cantrips
-        (spell.level > 0 && spell.isPrepared) || // Prepared spells
-        spell.isAlwaysPrepared // Always prepared spells
-    );
+  // Only show castable spells (prepared or always-prepared)
+  const castableSpells = useMemo(
+    () =>
+      character.spells.filter(
+        spell =>
+          (spell.level === 0 && spell.isPrepared) || // Only prepared cantrips
+          (spell.level > 0 && spell.isPrepared) || // Prepared spells
+          spell.isAlwaysPrepared // Always prepared spells
+      ),
+    [character.spells]
+  );
 
+  const filteredSpells = useMemo(() => {
     const query = search.trim().toLowerCase();
     if (!query) return castableSpells;
     return castableSpells.filter(spell =>
       spell.name.toLowerCase().includes(query)
     );
-  }, [character.spells, search]);
+  }, [castableSpells, search]);
 
   const groups = useMemo(
     () => groupSpellsByLevel(filteredSpells),
@@ -74,6 +78,18 @@ export function DockSpells(props: DockSpellsProps) {
 
   if (spellcastingAbility === null || character.spells.length === 0) {
     return null;
+  }
+
+  if (castableSpells.length === 0) {
+    return (
+      <div className="border-divider bg-surface-raised rounded-lg border-2 p-8 text-center">
+        <div className="mb-3 text-5xl">🔮</div>
+        <p className="text-heading text-lg font-semibold">No spells prepared</p>
+        <p className="text-muted mt-2 text-sm">
+          Prepare spells in the Spellcasting tab to see them here.
+        </p>
+      </div>
+    );
   }
 
   const toggleLevel = (level: number) => {

--- a/src/components/ui/campaign/player-vtt/CombatRow.tsx
+++ b/src/components/ui/campaign/player-vtt/CombatRow.tsx
@@ -5,17 +5,21 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/forms/button';
 import { Badge } from '@/components/ui/layout/badge';
 import { HPBar } from '@/components/shared/combat/HPBar';
+import { getHpTierTextColor } from '@/utils/hpColor';
 import type { EnemyHpDisplay } from '@/types/encounter';
 import type { SharedTurnEntry } from '@/types/sharedState';
 
 /** Disposition-tinted avatar colours: emerald for the player's own row, blue
- * for allies/players, red for everything else (enemies, neutrals). */
+ * for allies/players, muted neutral for neutrals, red for enemies. */
 function avatarColorClasses(entry: SharedTurnEntry, characterId: string) {
   if (entry.playerCharacterId === characterId) {
     return 'bg-accent-emerald-bg text-accent-emerald-text border-accent-emerald-border';
   }
   if (entry.type === 'player' || entry.disposition === 'ally') {
     return 'bg-accent-blue-bg text-accent-blue-text border-accent-blue-border';
+  }
+  if (entry.disposition === 'neutral') {
+    return 'bg-surface-secondary text-muted border-divider';
   }
   return 'bg-accent-red-bg text-accent-red-text border-accent-red-border';
 }
@@ -90,7 +94,11 @@ export function CombatRow({
         ) : entry.hpState ? (
           <span className="text-faint text-xs">{entry.hpState}</span>
         ) : entry.hpPercent !== undefined && enemyHpMode === 'percent' ? (
-          <span className="text-faint text-xs">{entry.hpPercent}%</span>
+          <span
+            className={`text-xs ${entry.hpTier ? getHpTierTextColor(entry.hpTier) : 'text-faint'}`}
+          >
+            {entry.hpPercent}%
+          </span>
         ) : entry.hpPercent !== undefined && enemyHpMode === 'bar' ? (
           <HPBar
             current={entry.hpPercent}

--- a/src/components/ui/campaign/player-vtt/SpellPlacementController.tsx
+++ b/src/components/ui/campaign/player-vtt/SpellPlacementController.tsx
@@ -77,10 +77,20 @@ export function SpellPlacementController({
   useEffect(() => {
     if (!pending) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel();
+      if (e.key !== 'Escape') return;
+      // Defer to any open dialog: registered in the CAPTURE phase so this
+      // runs BEFORE Radix's document-level listener flushes the dialog
+      // closed — a bubble listener could observe data-state already
+      // "closed" and cancel placement anyway. Escape closes the dialog
+      // first; the next Escape cancels placement.
+      if (document.querySelector('[role="dialog"][data-state="open"]')) {
+        return;
+      }
+      onCancel();
     };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () =>
+      window.removeEventListener('keydown', handleKeyDown, { capture: true });
   }, [pending, onCancel]);
 
   return null;

--- a/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
+++ b/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
@@ -102,6 +102,16 @@ export class SpellTemplateTool implements Tool {
   }
 
   onDeactivate(ctx: ToolContext): void {
+    // An in-flight id here means the gesture was aborted (Escape / disarm)
+    // between pointer-down and pointer-up — remove the half-placed element.
+    // Normal completion clears placedId BEFORE switching tools.
+    if (this.placedId) {
+      ctx.store.remove(this.placedId);
+      this.placedId = null;
+      this.origin = null;
+      this.aiming = false;
+      ctx.requestRender();
+    }
     ctx.setCursor?.('default');
   }
 }

--- a/src/components/ui/campaign/player-vtt/__tests__/CombatPanel.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/CombatPanel.test.tsx
@@ -240,12 +240,38 @@ describe('CombatPanel', () => {
       />
     );
 
-    expect(screen.getByText('42%')).toBeInTheDocument();
+    const percentText = screen.getByText('42%');
+    expect(percentText).toBeInTheDocument();
+    // 'mid' tier renders with the shared amber tier colour, not the flat faint tone.
+    expect(percentText.className).toMatch(/text-accent-amber-text/);
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     const rows = screen.getAllByRole('listitem');
     expect(
       rows[0].querySelector('.bg-surface-raised.rounded-full')
     ).not.toBeInTheDocument();
+  });
+
+  it('gives a neutral-disposition entry the muted avatar bucket, not the enemy red one', () => {
+    const neutralEntry: SharedTurnEntry = {
+      entityId: 'villager-1',
+      displayName: 'Villager',
+      type: 'npc',
+      disposition: 'neutral',
+      hpState: 'Unharmed',
+    };
+    render(
+      <CombatPanel
+        state={buildState({ turnOrder: [neutralEntry] })}
+        characterId={CHARACTER_ID}
+        onEndTurn={noop}
+        collapsed={false}
+        onToggleCollapsed={noop}
+      />
+    );
+
+    const avatar = screen.getByText('V', { selector: 'span[aria-hidden]' });
+    expect(avatar.className).not.toMatch(/text-accent-red-text/);
+    expect(avatar.className).not.toMatch(/bg-accent-red-bg/);
   });
 
   it('renders enemy hpPercent as a bar only when enemyHpMode is bar', () => {

--- a/src/components/ui/campaign/player-vtt/__tests__/DockSpells.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/DockSpells.test.tsx
@@ -324,4 +324,25 @@ describe('DockSpells', () => {
     expect(screen.queryByText('Prestidigitation')).not.toBeInTheDocument();
     expect(screen.queryByText('Sleep')).not.toBeInTheDocument();
   });
+
+  it('shows a "No spells prepared" hint when the character has spells but none are prepared', () => {
+    const unpreparedSpell = makeSpell({
+      id: 'sleep',
+      name: 'Sleep',
+      level: 1,
+      isPrepared: false,
+    });
+    seedCharacter({ spells: [unpreparedSpell] });
+
+    renderDock();
+
+    expect(screen.getByText('No spells prepared')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Prepare spells in the Spellcasting tab/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', { name: /search spells/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Sleep')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/ui/campaign/player-vtt/__tests__/SpellPlacementController.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/SpellPlacementController.test.tsx
@@ -134,4 +134,22 @@ describe('SpellPlacementController', () => {
     });
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
+
+  it('Escape defers to an open dialog (closes it first, does not cancel)', () => {
+    const { onCancel } = setup(makePending());
+    act(() => {});
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('data-state', 'open');
+    document.body.appendChild(dialog);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onCancel).not.toHaveBeenCalled();
+    dialog.remove();
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/ui/campaign/player-vtt/__tests__/SpellTemplateTool.test.ts
+++ b/src/components/ui/campaign/player-vtt/__tests__/SpellTemplateTool.test.ts
@@ -22,6 +22,7 @@ function fakeCtx() {
       update: vi.fn((id: string, patch: Record<string, unknown>) => {
         updates.push({ id, patch });
       }),
+      remove: vi.fn(),
     },
     requestRender: vi.fn(),
     switchTool: vi.fn(),
@@ -150,5 +151,22 @@ describe('SpellTemplateTool', () => {
     expect(f.ctx.setCursor).toHaveBeenCalledWith('crosshair');
     tool.onDeactivate?.(f.ctx);
     expect(f.ctx.setCursor).toHaveBeenCalledWith('default');
+  });
+
+  it('deactivation mid-gesture removes the in-flight template (Escape cancel)', () => {
+    const { tool } = armed({ shape: 'circle', sizeFeet: 20 });
+    tool.onPointerDown(down(0, 0), f.ctx);
+    expect(f.added).toHaveLength(1);
+    tool.onDeactivate?.(f.ctx);
+    expect(f.ctx.store.remove).toHaveBeenCalledWith(f.added[0].id);
+  });
+
+  it('deactivation after normal completion removes nothing', () => {
+    const { tool, onPlaced } = armed({ shape: 'circle', sizeFeet: 20 });
+    tool.onPointerDown(down(0, 0), f.ctx);
+    tool.onPointerUp(down(0, 0), f.ctx);
+    tool.onDeactivate?.(f.ctx);
+    expect(f.ctx.store.remove).not.toHaveBeenCalled();
+    expect(onPlaced).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Fix-pass over the shipped player VTT (#153/#154/#155), DM VTT (#156/#157), and fieldnotes-0.48 (#158) work — 6 stability items + 5 polish items, no new features. Spec: `docs/superpowers/specs/2026-07-11-vtt-stability-polish-design.md` (untracked by policy).

### Stability
- **S1** Player tokens on hex grids now size via the shared `cellUnit()` helper (were √3 too small) — new `PlayerTokenTool` test suite
- **S2** Escape mid-gesture no longer leaves a half-placed element: `SpellTemplateTool` and `DmTokenTool` remove the in-flight element in `onDeactivate`; happy path untouched
- **S3** Both VTT screens wrapped in the existing `ErrorBoundary` with a VTT-scoped fallback + "Reload map" button (canvas state lives in relay + store, so reload is lossless)
- **S4** Roster tray distinguishes unlinked / linked-but-empty / populated encounter states (was showing the wrong prompt for linked-empty)
- **S5a** Relay drops client presence envelopes forging reserved `@`-prefixed senders (e.g. `@poke`) — monkey-patch beside the corrections precedent, real-socket tests
- **S5b** All five loose `dmAuth === 'mismatch'` rejections flipped to fail-closed `dmAuth !== 'ok'` (shared, locations ×2, battlemaps ×2)
- **S6** Placement-controller Escape listeners moved to capture phase with an open-dialog guard — Escape closes only the dialog, the next Escape cancels placement

### Polish
- **P7** Responsive DM chrome below ~1350px: Play toolbar and tool-options bar drop below the top bar, Setup pill clears the header; duplicated Live chip removed (top bar is its single home)
- **P8** Player combat rows: percent HP tinted by hp tier; neutral disposition gets its own muted bucket instead of enemy red
- **P9** Casters with zero prepared spells see a "No spells prepared" hint in the dock instead of an empty searchable list
- **P10** DM top-bar grid + mode segments bumped to ≥44px touch targets
- **P11** Studio initiative-row border precedence made explicit (`selected > active > divider`) + regression test

## ⚠️ Deploy note

**S5a changes the relay — Railway needs a redeploy of `relay/` when this merges.**

## Test plan

- [x] Unit suite: 138 files, 2635 passed (new tests for S1/S2/S4/S6/P8/P9/P11)
- [x] Relay suite: 45 passed incl. new forged-sender real-socket tests; relay `tsc --noEmit` clean
- [x] `type-check` + lint clean; `grep "=== 'mismatch'" src/app/api` empty
- [x] Final whole-branch review passed (1 finding fixed: tool-options bar offset)

### Manual checklist (post-merge / on this branch)
- [ ] Hex map: player-placed token fills one full cell
- [ ] Cast a circle spell, press Escape mid-press → nothing left on the map, toast says cancelled
- [ ] Open a dialog (e.g. AC) during placement → first Escape closes only the dialog, second cancels placement
- [ ] DM window at ~1280px: toolbar below top bar, tool-options bar below toolbar, Setup pill clear of the header — no overlaps
- [ ] Neutral-disposition combatant renders muted (not red) in the player combat panel
- [ ] Caster with all spells unprepared sees the "No spells prepared" hint in the dock
- [ ] DM top-bar grid/mode segments comfortably tappable on iPad
- [ ] After relay redeploy: initiative poke still refreshes players instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)