### PR TITLE
feat(vtt): token identity — name labels, HP bars, portraits, creature-size tokens

### DIFF
--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -21,6 +21,8 @@ import {
   type DmTokenConfig,
 } from '@/components/ui/campaign/dm-vtt/combatantToken';
 
+import type { TokenInfoMode } from '@/components/ui/campaign/token-overlay';
+
 export interface DmBattleMapCanvasProps {
   campaignCode: string;
   battleMapId: string;
@@ -32,8 +34,8 @@ export interface DmBattleMapCanvasProps {
   tokenConfigRef: React.MutableRefObject<DmTokenConfig | null>;
   /** Select-tool selection changes (element ids) — Task 8 maps to entities. */
   onSelectionChange?: (selectedIds: string[]) => void;
-  /** Show/hide state for the token decoration layer, surfaced as a toolbar toggle. */
-  tokenInfoToggle: { visible: boolean; onToggle: () => void };
+  /** Show/hide/compact state for the token decoration layer, surfaced as a toolbar toggle. */
+  tokenInfoToggle: { mode: TokenInfoMode; onCycle: () => void };
 }
 
 /** Viewport exposes historyRecorder at runtime for batched store ops. */

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -32,6 +32,8 @@ export interface DmBattleMapCanvasProps {
   tokenConfigRef: React.MutableRefObject<DmTokenConfig | null>;
   /** Select-tool selection changes (element ids) — Task 8 maps to entities. */
   onSelectionChange?: (selectedIds: string[]) => void;
+  /** Show/hide state for the token decoration layer, surfaced as a toolbar toggle. */
+  tokenInfoToggle: { visible: boolean; onToggle: () => void };
 }
 
 /** Viewport exposes historyRecorder at runtime for batched store ops. */

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -18,7 +18,7 @@ export type { DmBattleMapCanvasProps };
  * init/persistence/connection wiring.
  */
 export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
-  const { children } = props;
+  const { children, tokenInfoToggle } = props;
   const { viewport, tools, handleReady, handleClearDrawings } =
     useDmBattleMapCanvas(props);
 
@@ -32,7 +32,12 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
           className="h-full w-full"
           snapToGrid
         />
-        {viewport && <DmVttToolbar onClearDrawings={handleClearDrawings} />}
+        {viewport && (
+          <DmVttToolbar
+            onClearDrawings={handleClearDrawings}
+            tokenInfoToggle={tokenInfoToggle}
+          />
+        )}
         {viewport && (
           <div className="border-divider absolute top-[7.25rem] left-1/2 z-10 max-w-[92vw] -translate-x-1/2 overflow-hidden rounded-xl border shadow-lg min-[1350px]:top-16">
             <DmLocationToolOptions mode="battlemap" />

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
@@ -12,6 +12,7 @@ import { useDmVttGrid } from './useDmVttGrid';
 import { useDmVttInitiative } from './useDmVttInitiative';
 import { useDmVttPlacementAndSelection } from './useDmVttPlacementAndSelection';
 import { useDmVttRoster } from './useDmVttRoster';
+import { useTokenIdentityUpdate } from './useTokenIdentityUpdate';
 
 import type { Viewport } from '@fieldnotes/core';
 import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
@@ -115,6 +116,11 @@ export function useDmVttScreen({
     getViewport,
   });
 
+  const updateTokenIdentity = useTokenIdentityUpdate({
+    encounterId: encounter?.id,
+    getViewport,
+  });
+
   return {
     battleMap,
     linkedEncounterIds,
@@ -144,6 +150,7 @@ export function useDmVttScreen({
     startDrag,
     getCanvasEl,
     setGridMode,
+    updateTokenIdentity,
     toasts,
     dismissToast,
     npcDialog: {

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -118,6 +118,7 @@ export function DmVttScreen({
             collapsed={studioCollapsed}
             onToggleCollapsed={() => setStudioCollapsed(v => !v)}
             followNote={vtt.followNote}
+            onTokenIdentityChange={vtt.updateTokenIdentity}
           />
         )}
         {vtt.encounter?.isActive && (

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { TokenDecorationLayer } from '@/components/ui/campaign/token-overlay';
 import { useDmTokenDecorations } from '@/components/ui/campaign/token-overlay/useDmTokenDecorations';
-import { useTokenInfoToggle } from '@/components/ui/campaign/token-overlay/useTokenInfoToggle';
+import { useTokenInfoMode } from '@/components/ui/campaign/token-overlay/useTokenInfoToggle';
 import { ToastContainer } from '@/components/ui/feedback/Toast';
 
 import { DmBattleMapCanvas } from './DmBattleMapCanvas';
@@ -47,7 +47,7 @@ export function DmVttScreen({
   const vtt = useDmVttScreen({ campaignCode, battleMapId, dmId });
   const [rosterCollapsed, setRosterCollapsed] = useState(false);
   const [studioCollapsed, setStudioCollapsed] = useState(false);
-  const [tokenInfoVisible, toggleTokenInfo] = useTokenInfoToggle(
+  const [tokenInfoMode, cycleTokenInfo] = useTokenInfoMode(
     'rollkeeper-vtt-token-info-dm'
   );
   const decorations = useDmTokenDecorations(vtt.linkedEntities);
@@ -65,12 +65,9 @@ export function DmVttScreen({
       onViewportReady={vtt.onViewportReady}
       tokenConfigRef={vtt.tokenConfigRef}
       onSelectionChange={vtt.onSelectionChange}
-      tokenInfoToggle={{ visible: tokenInfoVisible, onToggle: toggleTokenInfo }}
+      tokenInfoToggle={{ mode: tokenInfoMode, onCycle: cycleTokenInfo }}
     >
-      <TokenDecorationLayer
-        decorations={decorations}
-        visible={tokenInfoVisible}
-      />
+      <TokenDecorationLayer decorations={decorations} mode={tokenInfoMode} />
       <TokenPlacementController
         pending={vtt.pendingPlacement}
         configRef={vtt.tokenConfigRef}

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -2,6 +2,9 @@
 
 import { useState } from 'react';
 
+import { TokenDecorationLayer } from '@/components/ui/campaign/token-overlay';
+import { useDmTokenDecorations } from '@/components/ui/campaign/token-overlay/useDmTokenDecorations';
+import { useTokenInfoToggle } from '@/components/ui/campaign/token-overlay/useTokenInfoToggle';
 import { ToastContainer } from '@/components/ui/feedback/Toast';
 
 import { DmBattleMapCanvas } from './DmBattleMapCanvas';
@@ -44,6 +47,10 @@ export function DmVttScreen({
   const vtt = useDmVttScreen({ campaignCode, battleMapId, dmId });
   const [rosterCollapsed, setRosterCollapsed] = useState(false);
   const [studioCollapsed, setStudioCollapsed] = useState(false);
+  const [tokenInfoVisible, toggleTokenInfo] = useTokenInfoToggle(
+    'rollkeeper-vtt-token-info-dm'
+  );
+  const decorations = useDmTokenDecorations(vtt.linkedEntities);
 
   const gridMode: DmVttGridMode = vtt.battleMap?.gridEnabled
     ? (vtt.battleMap.gridSettings?.gridType ?? 'hex')
@@ -58,7 +65,12 @@ export function DmVttScreen({
       onViewportReady={vtt.onViewportReady}
       tokenConfigRef={vtt.tokenConfigRef}
       onSelectionChange={vtt.onSelectionChange}
+      tokenInfoToggle={{ visible: tokenInfoVisible, onToggle: toggleTokenInfo }}
     >
+      <TokenDecorationLayer
+        decorations={decorations}
+        visible={tokenInfoVisible}
+      />
       <TokenPlacementController
         pending={vtt.pendingPlacement}
         configRef={vtt.tokenConfigRef}

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -8,9 +8,12 @@ import {
   Ruler,
   Circle,
   Eraser,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
-import { Button } from '@/components/ui/forms/button';
 import { useActiveTool } from '@fieldnotes/react';
+
+import { Button } from '@/components/ui/forms/button';
 
 const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
   { name: 'hand', label: 'Pan', Icon: Hand },
@@ -23,6 +26,7 @@ const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
 
 export interface DmVttToolbarProps {
   onClearDrawings: () => void;
+  tokenInfoToggle: { visible: boolean; onToggle: () => void };
 }
 
 /** Top-center tool pill for the DM battle-map canvas — structurally mirrors
@@ -30,7 +34,10 @@ export interface DmVttToolbarProps {
  * the roster in Task 8, never through this toolbar) plus a Clear-drawings
  * action. The connection-status chip lives solely in `DmVttTopBar` now (see
  * P7c) — this toolbar no longer duplicates it. */
-export function DmVttToolbar({ onClearDrawings }: DmVttToolbarProps) {
+export function DmVttToolbar({
+  onClearDrawings,
+  tokenInfoToggle,
+}: DmVttToolbarProps) {
   const [activeTool, setTool] = useActiveTool();
   return (
     <div className="bg-surface-raised border-divider absolute top-16 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-xl border p-1 shadow-lg min-[1350px]:top-3">
@@ -39,7 +46,7 @@ export function DmVttToolbar({ onClearDrawings }: DmVttToolbarProps) {
           key={name}
           variant={activeTool === name ? 'primary' : 'ghost'}
           onClick={() => setTool(name)}
-          className="h-8 w-8 p-0"
+          className="min-h-[44px] min-w-[44px] p-0"
           title={label}
           aria-label={label}
         >
@@ -49,11 +56,23 @@ export function DmVttToolbar({ onClearDrawings }: DmVttToolbarProps) {
       <Button
         variant="ghost"
         onClick={onClearDrawings}
-        className="h-8 w-8 p-0"
+        className="min-h-[44px] min-w-[44px] p-0"
         title="Clear drawings"
         aria-label="Clear drawings"
       >
         <Eraser size={16} />
+      </Button>
+      <Button
+        variant="ghost"
+        onClick={tokenInfoToggle.onToggle}
+        className="min-h-[44px] min-w-[44px] p-0"
+        title={tokenInfoToggle.visible ? 'Hide token info' : 'Show token info'}
+        aria-label={
+          tokenInfoToggle.visible ? 'Hide token info' : 'Show token info'
+        }
+        aria-pressed={tokenInfoToggle.visible}
+      >
+        {tokenInfoToggle.visible ? <Eye size={16} /> : <EyeOff size={16} />}
       </Button>
     </div>
   );

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -9,11 +9,14 @@ import {
   Circle,
   Eraser,
   Eye,
+  Minus,
   EyeOff,
 } from 'lucide-react';
 import { useActiveTool } from '@fieldnotes/react';
 
 import { Button } from '@/components/ui/forms/button';
+
+import type { TokenInfoMode } from '@/components/ui/campaign/token-overlay';
 
 const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
   { name: 'hand', label: 'Pan', Icon: Hand },
@@ -26,8 +29,20 @@ const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
 
 export interface DmVttToolbarProps {
   onClearDrawings: () => void;
-  tokenInfoToggle: { visible: boolean; onToggle: () => void };
+  tokenInfoToggle: { mode: TokenInfoMode; onCycle: () => void };
 }
+
+const TOKEN_INFO_ICON: Record<TokenInfoMode, typeof Eye> = {
+  full: Eye,
+  compact: Minus,
+  off: EyeOff,
+};
+
+const TOKEN_INFO_LABEL: Record<TokenInfoMode, string> = {
+  full: 'Token info: full',
+  compact: 'Token info: compact',
+  off: 'Token info: hidden',
+};
 
 /** Top-center tool pill for the DM battle-map canvas — structurally mirrors
  * `PlayerBattleMapCanvas`'s `PlayerToolbar`, minus the token tool (placed via
@@ -39,6 +54,7 @@ export function DmVttToolbar({
   tokenInfoToggle,
 }: DmVttToolbarProps) {
   const [activeTool, setTool] = useActiveTool();
+  const TokenInfoIcon = TOKEN_INFO_ICON[tokenInfoToggle.mode];
   return (
     <div className="bg-surface-raised border-divider absolute top-16 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-xl border p-1 shadow-lg min-[1350px]:top-3">
       {DM_TOOLS.map(({ name, label, Icon }) => (
@@ -64,15 +80,12 @@ export function DmVttToolbar({
       </Button>
       <Button
         variant="ghost"
-        onClick={tokenInfoToggle.onToggle}
+        onClick={tokenInfoToggle.onCycle}
         className="min-h-[44px] min-w-[44px] p-0"
-        title={tokenInfoToggle.visible ? 'Hide token info' : 'Show token info'}
-        aria-label={
-          tokenInfoToggle.visible ? 'Hide token info' : 'Show token info'
-        }
-        aria-pressed={tokenInfoToggle.visible}
+        title={TOKEN_INFO_LABEL[tokenInfoToggle.mode]}
+        aria-label={TOKEN_INFO_LABEL[tokenInfoToggle.mode]}
       >
-        {tokenInfoToggle.visible ? <Eye size={16} /> : <EyeOff size={16} />}
+        <TokenInfoIcon size={16} />
       </Button>
     </div>
   );

--- a/src/components/ui/campaign/dm-vtt/RosterDragGhost.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterDragGhost.tsx
@@ -2,6 +2,8 @@
 
 import { dispositionColor } from './combatantToken';
 
+import { tokenAvatarUrl } from '@/components/ui/campaign/location-map/PlayerTokenTool';
+
 import type { RosterDragState } from './useRosterDrag';
 
 export interface RosterDragGhostProps {
@@ -21,7 +23,7 @@ export function RosterDragGhost({ drag }: RosterDragGhostProps) {
   const { entity, x, y } = drag;
   const color = dispositionColor(entity);
   const firstName = entity.name.split(' ')[0];
-  const isImage = entity.avatarUrl?.startsWith('http') ?? false;
+  const isImage = tokenAvatarUrl(entity.avatarUrl) !== null;
   const cells = entity.tokenSize ?? 1;
 
   return (

--- a/src/components/ui/campaign/dm-vtt/RosterDragGhost.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterDragGhost.tsx
@@ -22,6 +22,7 @@ export function RosterDragGhost({ drag }: RosterDragGhostProps) {
   const color = dispositionColor(entity);
   const firstName = entity.name.split(' ')[0];
   const isImage = entity.avatarUrl?.startsWith('http') ?? false;
+  const cells = entity.tokenSize ?? 1;
 
   return (
     <div
@@ -45,6 +46,11 @@ export function RosterDragGhost({ drag }: RosterDragGhostProps) {
       </span>
       <span className="text-heading text-xs font-medium whitespace-nowrap">
         {firstName}
+        {cells > 1 && (
+          <span className="text-muted ml-1">
+            {cells}×{cells}
+          </span>
+        )}
       </span>
     </div>
   );

--- a/src/components/ui/campaign/dm-vtt/RosterRow.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterRow.tsx
@@ -2,6 +2,8 @@
 
 import { dispositionColor } from './combatantToken';
 
+import { tokenAvatarUrl } from '@/components/ui/campaign/location-map/PlayerTokenTool';
+
 import type { PointerEvent } from 'react';
 import type { EncounterEntity } from '@/types/encounter';
 
@@ -30,7 +32,7 @@ export function RosterRow({
 }: RosterRowProps) {
   const color = dispositionColor(entity);
   const firstName = entity.name.split(' ')[0];
-  const isImage = entity.avatarUrl?.startsWith('http') ?? false;
+  const isImage = tokenAvatarUrl(entity.avatarUrl) !== null;
 
   const handleClick = () => {
     if (placed) onSelectEntity(entity.id);

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/TokenSettings.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/TokenSettings.tsx
@@ -23,6 +23,7 @@ export interface TokenSettingsProps {
 export function TokenSettings({ entity, onChange }: TokenSettingsProps) {
   const [url, setUrl] = useState(entity.avatarUrl ?? '');
   const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
   const cells = entity.tokenSize ?? 1;
 
@@ -33,6 +34,7 @@ export function TokenSettings({ entity, onChange }: TokenSettingsProps) {
 
   const handleFile = async (file: File) => {
     setUploading(true);
+    setUploadError(false);
     try {
       const formData = new FormData();
       formData.append('file', file, file.name);
@@ -41,12 +43,17 @@ export function TokenSettings({ entity, onChange }: TokenSettingsProps) {
         method: 'POST',
         body: formData,
       });
-      if (!res.ok) return;
+      if (!res.ok) {
+        setUploadError(true);
+        return;
+      }
       const data = (await res.json()) as { url?: string };
       if (data.url) {
         setUrl(data.url);
         onChange({ avatarUrl: data.url });
       }
+    } catch {
+      setUploadError(true);
     } finally {
       setUploading(false);
     }
@@ -86,6 +93,11 @@ export function TokenSettings({ entity, onChange }: TokenSettingsProps) {
           }}
         />
       </div>
+      {uploadError && (
+        <p className="text-accent-red-text mt-1 text-xs">
+          Upload failed — check S3 config or try a URL.
+        </p>
+      )}
       <div
         className="flex items-center gap-1"
         role="radiogroup"

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/TokenSettings.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/TokenSettings.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/forms/button';
+import { Input } from '@/components/ui/forms/input';
+
+import type { EncounterEntity, TokenCellSize } from '@/types/encounter';
+
+const SIZES: { cells: TokenCellSize; label: string }[] = [
+  { cells: 1, label: 'M 1×1' },
+  { cells: 2, label: 'L 2×2' },
+  { cells: 3, label: 'H 3×3' },
+  { cells: 4, label: 'G 4×4' },
+];
+
+export interface TokenSettingsProps {
+  entity: EncounterEntity;
+  onChange: (updates: Pick<EncounterEntity, 'avatarUrl' | 'tokenSize'>) => void;
+}
+
+/** Studio-panel section: entity portrait (URL or upload) + token footprint. */
+export function TokenSettings({ entity, onChange }: TokenSettingsProps) {
+  const [url, setUrl] = useState(entity.avatarUrl ?? '');
+  const [uploading, setUploading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const cells = entity.tokenSize ?? 1;
+
+  const applyUrl = () => {
+    const trimmed = url.trim();
+    onChange({ avatarUrl: trimmed === '' ? undefined : trimmed });
+  };
+
+  const handleFile = async (file: File) => {
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file, file.name);
+      formData.append('assetId', `entity-portrait-${entity.id}`);
+      const res = await fetch('/api/assets/upload', {
+        method: 'POST',
+        body: formData,
+      });
+      if (!res.ok) return;
+      const data = (await res.json()) as { url?: string };
+      if (data.url) {
+        setUrl(data.url);
+        onChange({ avatarUrl: data.url });
+      }
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="border-divider border-t px-3 py-2">
+      <p className="text-muted mb-1.5 text-[11px] font-bold tracking-wider uppercase">
+        Token
+      </p>
+      <div className="mb-2 flex items-center gap-1.5">
+        <Input
+          value={url}
+          onChange={e => setUrl(e.target.value)}
+          onBlur={applyUrl}
+          placeholder="Portrait URL (https://…)"
+          className="min-h-[44px] flex-1 text-xs"
+          aria-label="Portrait URL"
+        />
+        <Button
+          variant="outline"
+          className="min-h-[44px] text-xs"
+          disabled={uploading}
+          onClick={() => fileRef.current?.click()}
+        >
+          {uploading ? 'Uploading…' : 'Upload'}
+        </Button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={e => {
+            const file = e.target.files?.[0];
+            if (file) void handleFile(file);
+            e.target.value = '';
+          }}
+        />
+      </div>
+      <div
+        className="flex items-center gap-1"
+        role="radiogroup"
+        aria-label="Token size"
+      >
+        {SIZES.map(s => (
+          <Button
+            key={s.cells}
+            variant={cells === s.cells ? 'primary' : 'ghost'}
+            className="min-h-[44px] flex-1 text-xs"
+            onClick={() => onChange({ tokenSize: s.cells })}
+            role="radio"
+            aria-checked={cells === s.cells}
+          >
+            {s.label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
@@ -123,6 +123,7 @@ export function StudioPanel({
             <CombatantDetail entity={selectedEntity} actions={actions} />
             {onTokenIdentityChange && (
               <TokenSettings
+                key={selectedEntity.id}
                 entity={selectedEntity}
                 onChange={updates =>
                   onTokenIdentityChange(selectedEntity, updates)

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
@@ -6,8 +6,9 @@ import { Button } from '@/components/ui/forms/button';
 import { CombatantDetail } from '@/components/ui/encounter/combat-screen/detail/CombatantDetail';
 
 import { InitiativeTab } from './InitiativeTab';
+import { TokenSettings } from './TokenSettings';
 
-import type { Encounter } from '@/types/encounter';
+import type { Encounter, EncounterEntity } from '@/types/encounter';
 import type { EntityActions } from '@/components/ui/encounter/combat-screen/types';
 
 export interface StudioPanelProps {
@@ -22,6 +23,11 @@ export interface StudioPanelProps {
   onToggleCollapsed: () => void;
   /** "Following: {name}" when 2+ linked encounters are active; else null. */
   followNote?: string | null;
+  /** Persist portrait/size edits + restamp placed tokens (Selected tab section). */
+  onTokenIdentityChange?: (
+    entity: EncounterEntity,
+    updates: Pick<EncounterEntity, 'avatarUrl' | 'tokenSize'>
+  ) => void;
 }
 
 const TABS: { key: 'initiative' | 'selected'; icon: string; label: string }[] =
@@ -46,6 +52,7 @@ export function StudioPanel({
   collapsed,
   onToggleCollapsed,
   followNote,
+  onTokenIdentityChange,
 }: StudioPanelProps) {
   if (collapsed) {
     return (
@@ -112,7 +119,17 @@ export function StudioPanel({
             encounterHref={encounterHref}
           />
         ) : selectedEntity ? (
-          <CombatantDetail entity={selectedEntity} actions={actions} />
+          <>
+            <CombatantDetail entity={selectedEntity} actions={actions} />
+            {onTokenIdentityChange && (
+              <TokenSettings
+                entity={selectedEntity}
+                onChange={updates =>
+                  onTokenIdentityChange(selectedEntity, updates)
+                }
+              />
+            )}
+          </>
         ) : (
           <p className="text-muted px-3 py-4 text-xs">
             Select a combatant or token.

--- a/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
@@ -269,4 +269,31 @@ describe('StudioPanel', () => {
     render(<StudioPanel {...baseProps({ followNote: null })} />);
     expect(screen.queryByText(/^Following:/)).not.toBeInTheDocument();
   });
+
+  it('renders the Token settings section on the selected tab when the prop is provided, and calls the handler with the entity + update', () => {
+    const onTokenIdentityChange = vi.fn();
+    render(
+      <StudioPanel
+        {...baseProps({
+          activeTab: 'selected',
+          selectedEntityId: 'm1',
+          onTokenIdentityChange,
+        })}
+      />
+    );
+    expect(screen.getByText('Token')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('radio', { name: 'L 2×2' }));
+    expect(onTokenIdentityChange).toHaveBeenCalledWith(goblin1, {
+      tokenSize: 2,
+    });
+  });
+
+  it('does not render the Token settings section when onTokenIdentityChange is absent', () => {
+    render(
+      <StudioPanel
+        {...baseProps({ activeTab: 'selected', selectedEntityId: 'm1' })}
+      />
+    );
+    expect(screen.queryByText('Token')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
@@ -296,4 +296,45 @@ describe('StudioPanel', () => {
     );
     expect(screen.queryByText('Token')).not.toBeInTheDocument();
   });
+
+  it('resets the portrait input when the selected entity changes (no state bleed)', () => {
+    const entityA = makeEntity({
+      id: 'm1',
+      name: 'Goblin Scout',
+      avatarUrl: 'https://example.com/goblin-a.png',
+    });
+    const entityB = makeEntity({
+      id: 'm2',
+      name: 'Goblin Boss',
+      avatarUrl: undefined,
+    });
+    const onTokenIdentityChange = vi.fn();
+    const { rerender } = render(
+      <StudioPanel
+        {...baseProps({
+          encounter: makeEncounter({ entities: [entityA, entityB] }),
+          activeTab: 'selected',
+          selectedEntityId: 'm1',
+          onTokenIdentityChange,
+        })}
+      />
+    );
+
+    expect(screen.getByLabelText('Portrait URL')).toHaveValue(
+      'https://example.com/goblin-a.png'
+    );
+
+    rerender(
+      <StudioPanel
+        {...baseProps({
+          encounter: makeEncounter({ entities: [entityA, entityB] }),
+          activeTab: 'selected',
+          selectedEntityId: 'm2',
+          onTokenIdentityChange,
+        })}
+      />
+    );
+
+    expect(screen.getByLabelText('Portrait URL')).toHaveValue('');
+  });
 });

--- a/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
@@ -115,6 +115,74 @@ describe('stampCombatantToken', () => {
     const el = added[0] as CanvasElement & { size?: { w: number } };
     expect(el.size?.w).toBeCloseTo(Math.sqrt(3) * 40, 6);
   });
+
+  it('a 1×1 token centers in the CELL (not the old four-cell intersection)', () => {
+    const { ctx, added } = fakeCtx({ snapToGrid: true });
+    stampCombatantToken(
+      { entityId: 'e4', name: 'Goblin', color: '#C0392B' },
+      { x: 55, y: 70 },
+      ctx
+    );
+    const el = added[0] as CanvasElement & {
+      position?: { x: number; y: number };
+      size?: { w: number; h: number };
+    };
+    // cell (40,40)-(80,80) center is (60,60); one-cell size is 40 → position
+    // is the center minus half the size.
+    expect(el.size).toEqual({ w: 40, h: 40 });
+    expect(el.position).toEqual({ x: 40, y: 40 });
+  });
+
+  it('a 2×2 token (tokenSize: 2) fills 80×80 and centers on the intersection', () => {
+    const { ctx, added } = fakeCtx({ snapToGrid: true });
+    stampCombatantToken(
+      { entityId: 'e5', name: 'Ogre', color: '#C0392B', tokenSize: 2 },
+      { x: 55, y: 70 },
+      ctx
+    );
+    const el = added[0] as CanvasElement & {
+      position?: { x: number; y: number };
+      size?: { w: number; h: number };
+    };
+    // intersection nearest (55,70) is (40,80); 2-cell size is 80 → position
+    // is the intersection minus half the size.
+    expect(el.size).toEqual({ w: 80, h: 80 });
+    expect(el.position).toEqual({ x: 0, y: 40 });
+  });
+
+  it('rejects a base64 data-URL avatar (strict guard) — falls back to ellipse', () => {
+    const { ctx, added } = fakeCtx();
+    stampCombatantToken(
+      {
+        entityId: 'e6',
+        name: 'Sneaky',
+        avatarUrl: 'data:image/png;base64,xyz',
+        color: '#6B7280',
+      },
+      { x: 0, y: 0 },
+      ctx
+    );
+    const el = added[0] as CanvasElement & { shape?: string };
+    expect(el.type).toBe('shape');
+    expect(el.shape).toBe('ellipse');
+  });
+
+  it('rejects a lookalike scheme like httpx:// (sharper than the old startsWith("http") guard) — falls back to ellipse', () => {
+    const { ctx, added } = fakeCtx();
+    stampCombatantToken(
+      {
+        entityId: 'e7',
+        name: 'Sneakier',
+        avatarUrl: 'httpx://evil',
+        color: '#6B7280',
+      },
+      { x: 0, y: 0 },
+      ctx
+    );
+    const el = added[0] as CanvasElement & { shape?: string };
+    expect(el.type).toBe('shape');
+    expect(el.shape).toBe('ellipse');
+  });
 });
 
 describe('isCombatantToken', () => {

--- a/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
@@ -4,15 +4,18 @@ import {
   isCombatantToken,
   dispositionColor,
   stampCombatantToken,
+  restampCombatantTokens,
   DmTokenTool,
   type DmTokenConfig,
 } from '@/components/ui/campaign/dm-vtt/combatantToken';
 
 import type {
   CanvasElement,
+  ElementStore,
   PointerState,
   ToolContext,
 } from '@fieldnotes/core';
+import type { EncounterEntity } from '@/types/encounter';
 
 function fakeCtx(overrides: Record<string, unknown> = {}) {
   const added: CanvasElement[] = [];
@@ -269,5 +272,107 @@ describe('DmTokenTool', () => {
     tool.onDeactivate?.(ctx);
     expect(ctx.store.remove).not.toHaveBeenCalled();
     expect(onPlaced).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('restampCombatantTokens', () => {
+  const ctx = {
+    gridSize: 40,
+    gridType: 'square',
+    snapToGrid: true,
+  } as unknown as ToolContext;
+
+  function fakeStore(seed: Record<string, unknown>[]) {
+    const updates: Array<{ id: string; patch: Record<string, unknown> }> = [];
+    const added: Record<string, unknown>[] = [];
+    const removed: string[] = [];
+    return {
+      store: {
+        getAll: () => seed,
+        update: (id: string, patch: Record<string, unknown>) =>
+          updates.push({ id, patch }),
+        add: (el: Record<string, unknown>) => added.push(el),
+        remove: (id: string) => removed.push(id),
+      } as unknown as ElementStore,
+      updates,
+      added,
+      removed,
+    };
+  }
+
+  const imageToken = {
+    id: 'tok-1',
+    type: 'image',
+    position: { x: 40, y: 40 },
+    size: { w: 40, h: 40 },
+    layerId: 'l1',
+    src: 'https://x/old.png',
+    entityId: 'ent-1',
+    tokenKind: 'combatant',
+  };
+
+  const entity = (o: Partial<EncounterEntity>): EncounterEntity =>
+    ({
+      id: 'ent-1',
+      type: 'monster',
+      name: 'Ogre',
+      currentHp: 30,
+      maxHp: 60,
+      tempHp: 0,
+      armorClass: 11,
+      initiative: null,
+      initiativeModifier: 0,
+      conditions: [],
+      ...o,
+    }) as EncounterEntity;
+
+  it('updates src, size, and re-snapped position in place for same-type', () => {
+    const f = fakeStore([imageToken]);
+    restampCombatantTokens(
+      f.store,
+      entity({ avatarUrl: 'https://x/new.png', tokenSize: 2 }),
+      ctx
+    );
+    expect(f.removed).toHaveLength(0);
+    expect(f.added).toHaveLength(0);
+    expect(f.updates).toHaveLength(1);
+    expect(f.updates[0].id).toBe('tok-1');
+    // old center {60,60}; even footprint snaps to the nearest intersection:
+    // Math.round(60/40)*40 = 80 → center {80,80}, size 80 → position {40,40}
+    expect(f.updates[0].patch).toEqual({
+      src: 'https://x/new.png',
+      size: { w: 80, h: 80 },
+      position: { x: 40, y: 40 },
+    });
+  });
+
+  it('removes + re-adds preserving keys/layer when ellipse gains a portrait', () => {
+    const ellipse = {
+      ...imageToken,
+      type: 'shape',
+      shape: 'ellipse',
+      src: undefined,
+    };
+    const f = fakeStore([ellipse]);
+    restampCombatantTokens(
+      f.store,
+      entity({ avatarUrl: 'https://x/new.png' }),
+      ctx
+    );
+    expect(f.removed).toEqual(['tok-1']);
+    expect(f.added).toHaveLength(1);
+    const el = f.added[0] as Record<string, unknown>;
+    expect(el.type).toBe('image');
+    expect(el.entityId).toBe('ent-1');
+    expect(el.tokenKind).toBe('combatant');
+    expect(el.layerId).toBe('l1');
+  });
+
+  it('ignores tokens of other entities', () => {
+    const f = fakeStore([{ ...imageToken, entityId: 'other' }]);
+    restampCombatantTokens(f.store, entity({ tokenSize: 2 }), ctx);
+    expect(f.updates).toHaveLength(0);
+    expect(f.added).toHaveLength(0);
+    expect(f.removed).toHaveLength(0);
   });
 });

--- a/src/components/ui/campaign/dm-vtt/combatantToken.ts
+++ b/src/components/ui/campaign/dm-vtt/combatantToken.ts
@@ -1,6 +1,8 @@
-import { createImage, createShape, smartSnap } from '@fieldnotes/core';
+import { createImage, createShape } from '@fieldnotes/core';
 
 import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
+import { tokenAvatarUrl } from '@/components/ui/campaign/location-map/PlayerTokenTool';
+import { snapTokenCenter } from '@/components/ui/campaign/location-map/tokenSnap';
 
 import type {
   CanvasElement,
@@ -9,7 +11,7 @@ import type {
   Tool,
   ToolContext,
 } from '@fieldnotes/core';
-import type { EncounterEntity } from '@/types/encounter';
+import type { EncounterEntity, TokenCellSize } from '@/types/encounter';
 
 export const COMBATANT_TOKEN_KIND = 'combatant';
 
@@ -46,38 +48,41 @@ export interface DmTokenConfig {
   name: string;
   avatarUrl?: string;
   color: string;
+  /** Footprint in cells (Large=2 …); absent = 1. */
+  tokenSize?: TokenCellSize;
   /** Fired once after placement (tool has handed back to select). */
   onPlaced: () => void;
 }
 
-/** Stamps a grid-snapped one-cell combatant token and adds it to the store. */
+/** Stamps a grid-snapped, creature-size-aware combatant token and adds it to the store. */
 export function stampCombatantToken(
   config: Omit<DmTokenConfig, 'onPlaced'>,
   world: Point,
   ctx: ToolContext
 ): CanvasElement {
-  const center = smartSnap(world, ctx);
-  const size = cellUnit(ctx);
+  const cells = config.tokenSize ?? 1;
+  const center = snapTokenCenter(world, cells, ctx);
+  const size = cells * cellUnit(ctx);
   const position = { x: center.x - size / 2, y: center.y - size / 2 };
   const layerId = ctx.activeLayerId ?? '';
+  const src = tokenAvatarUrl(config.avatarUrl);
 
-  const base =
-    config.avatarUrl && config.avatarUrl.startsWith('http')
-      ? createImage({
-          position,
-          size: { w: size, h: size },
-          src: config.avatarUrl,
-          layerId,
-        })
-      : createShape({
-          position,
-          size: { w: size, h: size },
-          shape: 'ellipse',
-          fillColor: config.color,
-          strokeColor: '#1e293b',
-          strokeWidth: 2,
-          layerId,
-        });
+  const base = src
+    ? createImage({
+        position,
+        size: { w: size, h: size },
+        src,
+        layerId,
+      })
+    : createShape({
+        position,
+        size: { w: size, h: size },
+        shape: 'ellipse',
+        fillColor: config.color,
+        strokeColor: '#1e293b',
+        strokeWidth: 2,
+        layerId,
+      });
 
   const token: CanvasElement & CombatantTokenKeys = {
     ...base,

--- a/src/components/ui/campaign/dm-vtt/combatantToken.ts
+++ b/src/components/ui/campaign/dm-vtt/combatantToken.ts
@@ -6,6 +6,7 @@ import { snapTokenCenter } from '@/components/ui/campaign/location-map/tokenSnap
 
 import type {
   CanvasElement,
+  ElementStore,
   Point,
   PointerState,
   Tool,
@@ -138,5 +139,78 @@ export class DmTokenTool implements Tool {
       ctx.requestRender();
     }
     ctx.setCursor?.('default');
+  }
+}
+
+/**
+ * Re-applies an entity's portrait/size to its already-placed tokens.
+ * Same element type → narrow store.update (NEVER spread a captured element
+ * into the patch — update() shallow-merges and stale fields would resurrect).
+ * Ellipse↔image transitions → remove + re-add preserving keys/layer/center.
+ */
+export function restampCombatantTokens(
+  store: ElementStore,
+  entity: EncounterEntity,
+  ctx: ToolContext
+): void {
+  const cells = entity.tokenSize ?? 1;
+  const size = cells * cellUnit(ctx);
+  const src = tokenAvatarUrl(entity.avatarUrl);
+  for (const el of store.getAll()) {
+    if (!isCombatantToken(el) || el.entityId !== entity.id) continue;
+    const rect = el as unknown as {
+      id: string;
+      type: string;
+      layerId?: string;
+      position: Point;
+      size?: { w: number; h: number };
+    };
+    const oldSize = rect.size ?? { w: size, h: size };
+    const oldCenter = {
+      x: rect.position.x + oldSize.w / 2,
+      y: rect.position.y + oldSize.h / 2,
+    };
+    const center = snapTokenCenter(oldCenter, cells, ctx);
+    const position = { x: center.x - size / 2, y: center.y - size / 2 };
+    const wantsImage = src !== null;
+    const isImage = rect.type === 'image';
+
+    if (wantsImage === isImage) {
+      store.update(
+        rect.id,
+        wantsImage
+          ? { src: src as string, size: { w: size, h: size }, position }
+          : {
+              fillColor: dispositionColor(entity),
+              size: { w: size, h: size },
+              position,
+            }
+      );
+    } else {
+      const layerId = rect.layerId ?? '';
+      const base = wantsImage
+        ? createImage({
+            position,
+            size: { w: size, h: size },
+            src: src as string,
+            layerId,
+          })
+        : createShape({
+            position,
+            size: { w: size, h: size },
+            shape: 'ellipse',
+            fillColor: dispositionColor(entity),
+            strokeColor: '#1e293b',
+            strokeWidth: 2,
+            layerId,
+          });
+      const token: CanvasElement & CombatantTokenKeys = {
+        ...base,
+        entityId: entity.id,
+        tokenKind: COMBATANT_TOKEN_KIND,
+      };
+      store.remove(rect.id);
+      store.add(token);
+    }
   }
 }

--- a/src/components/ui/campaign/dm-vtt/useDmVttPlacementAndSelection.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttPlacementAndSelection.ts
@@ -65,6 +65,7 @@ export function useDmVttPlacementAndSelection({
         name: entity.name,
         avatarUrl: entity.avatarUrl,
         color: dispositionColor(entity),
+        tokenSize: entity.tokenSize,
         onPlaced: () => {
           setPendingPlacement(null); // SYNCHRONOUS — see comment above.
           selectEntity(entity.id);

--- a/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
+++ b/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
@@ -71,6 +71,7 @@ export function stampAtScreenPoint(
     name: entity.name,
     avatarUrl: entity.avatarUrl,
     color: dispositionColor(entity),
+    tokenSize: entity.tokenSize,
   };
   stampCombatantToken(config, world, vp.toolContext);
 }

--- a/src/components/ui/campaign/dm-vtt/useTokenIdentityUpdate.ts
+++ b/src/components/ui/campaign/dm-vtt/useTokenIdentityUpdate.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { useEncounterStore } from '@/store/encounterStore';
+
+import { restampCombatantTokens } from './combatantToken';
+
+import type { Viewport } from '@fieldnotes/core';
+import type { EncounterEntity } from '@/types/encounter';
+
+interface UseTokenIdentityUpdateOptions {
+  encounterId: string | undefined;
+  getViewport: () => Viewport | null;
+}
+
+/** Persists portrait/size edits to the encounter store and restamps placed tokens. */
+export function useTokenIdentityUpdate({
+  encounterId,
+  getViewport,
+}: UseTokenIdentityUpdateOptions) {
+  const { updateEntity } = useEncounterStore();
+  return useCallback(
+    (
+      entity: EncounterEntity,
+      updates: Pick<EncounterEntity, 'avatarUrl' | 'tokenSize'>
+    ) => {
+      if (!encounterId) return;
+      updateEntity(encounterId, entity.id, updates);
+      const vp = getViewport();
+      if (vp) {
+        restampCombatantTokens(
+          vp.store,
+          { ...entity, ...updates },
+          vp.toolContext
+        );
+      }
+    },
+    [encounterId, getViewport, updateEntity]
+  );
+}

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -162,6 +162,9 @@ export function PlayerBattleMapCanvas({
   // Read by the (single, canvas-retained) token tool at placement time;
   // starts as the square avatar and upgrades to the circular render async.
   const tokenSrcRef = useRef<string | null>(tokenAvatarUrl(characterAvatar));
+  // Read at placement time by the (single, canvas-retained) token tool.
+  const characterIdRef = useRef<string | null>(characterId);
+  characterIdRef.current = characterId;
 
   useEffect(() => {
     const avatar = tokenAvatarUrl(characterAvatar);
@@ -188,7 +191,7 @@ export function PlayerBattleMapCanvas({
     return [
       new PlayerHandTool(selectTool),
       selectTool,
-      new PlayerTokenTool(color, tokenSrcRef),
+      new PlayerTokenTool(color, tokenSrcRef, characterIdRef),
       new PencilTool({ color, width: 3 }),
       new ArrowTool({ color, width: 2 }),
       new MeasureTool({ feetPerCell: 5 }),

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -18,6 +18,8 @@ import {
   Ruler,
   Circle,
   Trash2,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import {
@@ -69,6 +71,8 @@ interface PlayerBattleMapCanvasProps {
   spellTemplateConfigRef?: React.MutableRefObject<SpellTemplateConfig | null>;
   /** Hide the built-in back-button (the VTT screen renders its own top-left chrome). */
   hideBackButton?: boolean;
+  /** Show/hide toggle for the token decoration overlay (optional — non-VTT routes render no toggle). */
+  tokenInfoToggle?: { visible: boolean; onToggle: () => void };
 }
 
 /** Viewport exposes historyRecorder at runtime for batched store ops. */
@@ -94,10 +98,12 @@ function PlayerToolbar({
   status,
   hasSelection,
   onDeleteSelected,
+  tokenInfoToggle,
 }: {
   status: BattleMapConnectionStatus;
   hasSelection: boolean;
   onDeleteSelected: () => void;
+  tokenInfoToggle?: { visible: boolean; onToggle: () => void };
 }) {
   const [activeTool, setTool] = useActiveTool();
   return (
@@ -107,7 +113,7 @@ function PlayerToolbar({
           key={name}
           variant={activeTool === name ? 'primary' : 'ghost'}
           onClick={() => setTool(name)}
-          className="h-8 w-8 p-0"
+          className="min-h-[44px] min-w-[44px] p-0"
           title={label}
           aria-label={label}
         >
@@ -118,11 +124,27 @@ function PlayerToolbar({
         <Button
           variant="danger"
           onClick={onDeleteSelected}
-          className="h-8 w-8 p-0"
+          className="min-h-[44px] min-w-[44px] p-0"
           title="Delete selected"
           aria-label="Delete selected"
         >
           <Trash2 size={16} />
+        </Button>
+      )}
+      {tokenInfoToggle && (
+        <Button
+          variant="ghost"
+          onClick={tokenInfoToggle.onToggle}
+          className="min-h-[44px] min-w-[44px] p-0"
+          title={
+            tokenInfoToggle.visible ? 'Hide token info' : 'Show token info'
+          }
+          aria-label={
+            tokenInfoToggle.visible ? 'Hide token info' : 'Show token info'
+          }
+          aria-pressed={tokenInfoToggle.visible}
+        >
+          {tokenInfoToggle.visible ? <Eye size={16} /> : <EyeOff size={16} />}
         </Button>
       )}
       <span
@@ -154,6 +176,7 @@ export function PlayerBattleMapCanvas({
   onPoke,
   spellTemplateConfigRef,
   hideBackButton = false,
+  tokenInfoToggle,
 }: PlayerBattleMapCanvasProps) {
   const [viewport, setViewport] = useState<Viewport | null>(null);
   const [status, setStatus] = useState<BattleMapConnectionStatus>('connecting');
@@ -306,6 +329,7 @@ export function PlayerBattleMapCanvas({
             status={status}
             hasSelection={hasSelection}
             onDeleteSelected={handleDeleteSelected}
+            tokenInfoToggle={tokenInfoToggle}
           />
         )}
         {viewport && (

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -19,9 +19,11 @@ import {
   Circle,
   Trash2,
   Eye,
+  Minus,
   EyeOff,
 } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
+import type { TokenInfoMode } from '@/components/ui/campaign/token-overlay';
 import {
   FieldNotesCanvas,
   ViewportContext,
@@ -71,8 +73,8 @@ interface PlayerBattleMapCanvasProps {
   spellTemplateConfigRef?: React.MutableRefObject<SpellTemplateConfig | null>;
   /** Hide the built-in back-button (the VTT screen renders its own top-left chrome). */
   hideBackButton?: boolean;
-  /** Show/hide toggle for the token decoration overlay (optional — non-VTT routes render no toggle). */
-  tokenInfoToggle?: { visible: boolean; onToggle: () => void };
+  /** Show/hide/compact toggle for the token decoration overlay (optional — non-VTT routes render no toggle). */
+  tokenInfoToggle?: { mode: TokenInfoMode; onCycle: () => void };
 }
 
 /** Viewport exposes historyRecorder at runtime for batched store ops. */
@@ -94,6 +96,18 @@ const PLAYER_TOOLS: {
   { name: 'template', label: 'Spell template', Icon: Circle },
 ];
 
+const TOKEN_INFO_ICON: Record<TokenInfoMode, typeof Eye> = {
+  full: Eye,
+  compact: Minus,
+  off: EyeOff,
+};
+
+const TOKEN_INFO_LABEL: Record<TokenInfoMode, string> = {
+  full: 'Token info: full',
+  compact: 'Token info: compact',
+  off: 'Token info: hidden',
+};
+
 function PlayerToolbar({
   status,
   hasSelection,
@@ -103,9 +117,12 @@ function PlayerToolbar({
   status: BattleMapConnectionStatus;
   hasSelection: boolean;
   onDeleteSelected: () => void;
-  tokenInfoToggle?: { visible: boolean; onToggle: () => void };
+  tokenInfoToggle?: { mode: TokenInfoMode; onCycle: () => void };
 }) {
   const [activeTool, setTool] = useActiveTool();
+  const TokenInfoIcon = tokenInfoToggle
+    ? TOKEN_INFO_ICON[tokenInfoToggle.mode]
+    : null;
   return (
     <div className="bg-surface-raised border-divider absolute top-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-xl border p-1 shadow-lg">
       {PLAYER_TOOLS.map(({ name, label, Icon }) => (
@@ -131,20 +148,15 @@ function PlayerToolbar({
           <Trash2 size={16} />
         </Button>
       )}
-      {tokenInfoToggle && (
+      {tokenInfoToggle && TokenInfoIcon && (
         <Button
           variant="ghost"
-          onClick={tokenInfoToggle.onToggle}
+          onClick={tokenInfoToggle.onCycle}
           className="min-h-[44px] min-w-[44px] p-0"
-          title={
-            tokenInfoToggle.visible ? 'Hide token info' : 'Show token info'
-          }
-          aria-label={
-            tokenInfoToggle.visible ? 'Hide token info' : 'Show token info'
-          }
-          aria-pressed={tokenInfoToggle.visible}
+          title={TOKEN_INFO_LABEL[tokenInfoToggle.mode]}
+          aria-label={TOKEN_INFO_LABEL[tokenInfoToggle.mode]}
         >
-          {tokenInfoToggle.visible ? <Eye size={16} /> : <EyeOff size={16} />}
+          <TokenInfoIcon size={16} />
         </Button>
       )}
       <span

--- a/src/components/ui/campaign/location-map/PlayerTokenTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerTokenTool.ts
@@ -143,7 +143,9 @@ export class PlayerTokenTool implements Tool {
 
   constructor(
     private readonly color: string,
-    private readonly srcRef: { current: string | null }
+    private readonly srcRef: { current: string | null },
+    /** Read at placement time (canvas keeps the first tool instance). */
+    private readonly characterIdRef: { current: string | null }
   ) {}
 
   onPointerDown(state: PointerState, ctx: ToolContext): void {
@@ -152,18 +154,14 @@ export class PlayerTokenTool implements Tool {
     const size = cellUnit(ctx);
     const src = this.srcRef.current;
 
-    if (src) {
-      ctx.store.add(
-        createImage({
+    const base = src
+      ? createImage({
           position: { x: center.x - size / 2, y: center.y - size / 2 },
           size: { w: size, h: size },
           src,
           layerId: ctx.activeLayerId ?? '',
         })
-      );
-    } else {
-      ctx.store.add(
-        createShape({
+      : createShape({
           position: { x: center.x - size / 2, y: center.y - size / 2 },
           size: { w: size, h: size },
           shape: 'ellipse',
@@ -171,9 +169,18 @@ export class PlayerTokenTool implements Tool {
           strokeColor: '#1e293b',
           strokeWidth: 2,
           layerId: ctx.activeLayerId ?? '',
-        })
-      );
-    }
+        });
+
+    const characterId = this.characterIdRef.current;
+    ctx.store.add(
+      characterId
+        ? ({
+            ...base,
+            characterId,
+            tokenKind: PLAYER_TOKEN_KIND,
+          } as unknown as typeof base)
+        : base
+    );
     ctx.requestRender();
   }
 

--- a/src/components/ui/campaign/location-map/PlayerTokenTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerTokenTool.ts
@@ -9,6 +9,15 @@ import {
 } from '@fieldnotes/core';
 import { cellUnit } from './cellUnit';
 
+export const PLAYER_TOKEN_KIND = 'player';
+
+/** Extra top-level keys stamped on player self-placed tokens (Task 2 stamps
+ * them) — like CombatantTokenKeys, they survive store/export/sync round-trips. */
+export interface PlayerTokenKeys {
+  characterId: string;
+  tokenKind: typeof PLAYER_TOKEN_KIND;
+}
+
 const TOKEN_COLORS = [
   '#ef4444',
   '#3b82f6',

--- a/src/components/ui/campaign/location-map/PlayerTokenTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerTokenTool.ts
@@ -172,15 +172,16 @@ export class PlayerTokenTool implements Tool {
         });
 
     const characterId = this.characterIdRef.current;
-    ctx.store.add(
-      characterId
-        ? ({
-            ...base,
-            characterId,
-            tokenKind: PLAYER_TOKEN_KIND,
-          } as unknown as typeof base)
-        : base
-    );
+    if (characterId) {
+      const stamped: typeof base & PlayerTokenKeys = {
+        ...base,
+        characterId,
+        tokenKind: PLAYER_TOKEN_KIND,
+      };
+      ctx.store.add(stamped);
+    } else {
+      ctx.store.add(base);
+    }
     ctx.requestRender();
   }
 

--- a/src/components/ui/campaign/location-map/PlayerTokenTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerTokenTool.ts
@@ -1,13 +1,13 @@
 import {
   createImage,
   createShape,
-  smartSnap,
   TemplateTool,
   type Tool,
   type ToolContext,
   type PointerState,
 } from '@fieldnotes/core';
 import { cellUnit } from './cellUnit';
+import { snapTokenCenter } from './tokenSnap';
 
 export const PLAYER_TOKEN_KIND = 'player';
 
@@ -150,7 +150,7 @@ export class PlayerTokenTool implements Tool {
 
   onPointerDown(state: PointerState, ctx: ToolContext): void {
     const world = ctx.camera.screenToWorld({ x: state.x, y: state.y });
-    const center = smartSnap(world, ctx);
+    const center = snapTokenCenter(world, 1, ctx);
     const size = cellUnit(ctx);
     const src = this.srcRef.current;
 

--- a/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
@@ -104,6 +104,24 @@ describe('PlayerTokenTool sizing', () => {
     expect(el.tokenKind).toBe('player');
   });
 
+  it('centers the token in the CELL on square grids (not the old four-cell intersection)', () => {
+    const { ctx, added } = fakeCtx({ snapToGrid: true });
+    const tool = new PlayerTokenTool(
+      '#12855C',
+      { current: null },
+      { current: 'char-1' }
+    );
+    tool.onPointerDown(down(55, 70), ctx);
+    const el = added[0] as CanvasElement & {
+      position?: { x: number; y: number };
+      size?: { w: number; h: number };
+    };
+    // cell (40,40)-(80,80) center is (60,60); one-cell size is 40 → position
+    // is the center minus half the size.
+    expect(el.size).toEqual({ w: 40, h: 40 });
+    expect(el.position).toEqual({ x: 40, y: 40 });
+  });
+
   it('places an unstamped token when no characterId is known', () => {
     const { ctx, added } = fakeCtx();
     const tool = new PlayerTokenTool(

--- a/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
@@ -32,7 +32,11 @@ const down = (x: number, y: number) => ({ x, y }) as PointerState;
 describe('PlayerTokenTool sizing', () => {
   it('square grids: token fills one cell (gridSize px)', () => {
     const { ctx, added } = fakeCtx();
-    const tool = new PlayerTokenTool('#12855C', { current: null });
+    const tool = new PlayerTokenTool(
+      '#12855C',
+      { current: null },
+      { current: 'char-1' }
+    );
     tool.onPointerDown(down(100, 100), ctx);
     const el = added[0] as CanvasElement & { size?: { w: number } };
     expect(el.size?.w).toBe(40);
@@ -40,7 +44,11 @@ describe('PlayerTokenTool sizing', () => {
 
   it('hex grids: token fills one cell = √3 × gridSize (SDK cell unit)', () => {
     const { ctx, added } = fakeCtx({ gridType: 'hex' });
-    const tool = new PlayerTokenTool('#12855C', { current: null });
+    const tool = new PlayerTokenTool(
+      '#12855C',
+      { current: null },
+      { current: 'char-1' }
+    );
     tool.onPointerDown(down(0, 0), ctx);
     const el = added[0] as CanvasElement & { size?: { w: number } };
     expect(el.size?.w).toBeCloseTo(Math.sqrt(3) * 40, 6);
@@ -48,9 +56,13 @@ describe('PlayerTokenTool sizing', () => {
 
   it('avatar tokens size identically (image branch)', () => {
     const { ctx, added } = fakeCtx({ gridType: 'hex' });
-    const tool = new PlayerTokenTool('#12855C', {
-      current: 'https://x/avatar.png',
-    });
+    const tool = new PlayerTokenTool(
+      '#12855C',
+      {
+        current: 'https://x/avatar.png',
+      },
+      { current: 'char-1' }
+    );
     tool.onPointerDown(down(0, 0), ctx);
     const el = added[0] as CanvasElement & {
       size?: { w: number };
@@ -58,5 +70,53 @@ describe('PlayerTokenTool sizing', () => {
     };
     expect(el.type).toBe('image');
     expect(el.size?.w).toBeCloseTo(Math.sqrt(3) * 40, 6);
+  });
+
+  it('stamps characterId + tokenKind player on image tokens', () => {
+    const { ctx, added } = fakeCtx();
+    const tool = new PlayerTokenTool(
+      '#ef4444',
+      { current: 'https://x/a.png' },
+      { current: 'char-1' }
+    );
+    tool.onPointerDown(down(0, 0), ctx);
+    const el = added[0] as unknown as {
+      characterId?: string;
+      tokenKind?: string;
+    };
+    expect(el.characterId).toBe('char-1');
+    expect(el.tokenKind).toBe('player');
+  });
+
+  it('stamps the keys on the ellipse fallback too', () => {
+    const { ctx, added } = fakeCtx();
+    const tool = new PlayerTokenTool(
+      '#ef4444',
+      { current: null },
+      { current: 'char-1' }
+    );
+    tool.onPointerDown(down(0, 0), ctx);
+    const el = added[0] as unknown as {
+      characterId?: string;
+      tokenKind?: string;
+    };
+    expect(el.characterId).toBe('char-1');
+    expect(el.tokenKind).toBe('player');
+  });
+
+  it('places an unstamped token when no characterId is known', () => {
+    const { ctx, added } = fakeCtx();
+    const tool = new PlayerTokenTool(
+      '#ef4444',
+      { current: null },
+      { current: null }
+    );
+    tool.onPointerDown(down(0, 0), ctx);
+    const el = added[0] as unknown as {
+      characterId?: string;
+      tokenKind?: string;
+    };
+    expect(el.characterId).toBeUndefined();
+    expect(el.tokenKind).toBeUndefined();
   });
 });

--- a/src/components/ui/campaign/location-map/__tests__/tokenSnap.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/tokenSnap.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+import { snapTokenCenter } from '@/components/ui/campaign/location-map/tokenSnap';
+
+import type { ToolContext } from '@fieldnotes/core';
+
+const squareCtx = {
+  gridSize: 40,
+  gridType: 'square',
+  snapToGrid: true,
+} as unknown as ToolContext;
+
+describe('snapTokenCenter', () => {
+  it('odd sizes snap the center to a CELL CENTER on square grids', () => {
+    // click near the middle of the cell spanning (40,40)-(80,80)
+    expect(snapTokenCenter({ x: 55, y: 70 }, 1, squareCtx)).toEqual({
+      x: 60,
+      y: 60,
+    });
+    expect(snapTokenCenter({ x: 55, y: 70 }, 3, squareCtx)).toEqual({
+      x: 60,
+      y: 60,
+    });
+  });
+
+  it('even sizes snap the center to a grid INTERSECTION (fills cells exactly)', () => {
+    expect(snapTokenCenter({ x: 55, y: 70 }, 2, squareCtx)).toEqual({
+      x: 40,
+      y: 80,
+    });
+    expect(snapTokenCenter({ x: 55, y: 70 }, 4, squareCtx)).toEqual({
+      x: 40,
+      y: 80,
+    });
+  });
+
+  it('hex grids defer to smartSnap regardless of size', () => {
+    const hexCtx = {
+      gridSize: 40,
+      gridType: 'hex',
+      hexOrientation: 'pointy',
+      snapToGrid: true,
+    } as unknown as ToolContext;
+    const one = snapTokenCenter({ x: 55, y: 70 }, 1, hexCtx);
+    const two = snapTokenCenter({ x: 55, y: 70 }, 2, hexCtx);
+    expect(one).toEqual(two); // same smartSnap result — no parity math on hex
+  });
+
+  it('is the identity when snapping is off', () => {
+    const offCtx = { snapToGrid: false } as unknown as ToolContext;
+    expect(snapTokenCenter({ x: 55, y: 70 }, 1, offCtx)).toEqual({
+      x: 55,
+      y: 70,
+    });
+  });
+});

--- a/src/components/ui/campaign/location-map/tokenSnap.ts
+++ b/src/components/ui/campaign/location-map/tokenSnap.ts
@@ -1,0 +1,34 @@
+import { smartSnap } from '@fieldnotes/core';
+
+import type { Point, ToolContext } from '@fieldnotes/core';
+
+/**
+ * Grid-aware token CENTER snap for an N×N-cell footprint.
+ *
+ * Square grids: odd N centers in a cell (a 1×1 fills one cell — the old
+ * smartSnap-only path put every token on an intersection, straddling four);
+ * even N centers on an intersection so the footprint fills cells exactly.
+ * Hex grids and snapping-off defer to smartSnap unchanged (snapToHexCenter
+ * already centers in cells; identity when snapping is disabled).
+ */
+export function snapTokenCenter(
+  world: Point,
+  cells: number,
+  ctx: ToolContext
+): Point {
+  const gridSize = ctx.gridSize;
+  // Mirror smartSnap's own routing: only square-grid snapping gets parity math.
+  if (!ctx.snapToGrid || !gridSize || ctx.gridType === 'hex') {
+    return smartSnap(world, ctx);
+  }
+  if (cells % 2 === 0) {
+    return {
+      x: Math.round(world.x / gridSize) * gridSize,
+      y: Math.round(world.y / gridSize) * gridSize,
+    };
+  }
+  return {
+    x: (Math.round((world.x - gridSize / 2) / gridSize) + 0.5) * gridSize,
+    y: (Math.round((world.y - gridSize / 2) / gridSize) + 0.5) * gridSize,
+  };
+}

--- a/src/components/ui/campaign/player-vtt/PlayerVttScreen.tsx
+++ b/src/components/ui/campaign/player-vtt/PlayerVttScreen.tsx
@@ -6,6 +6,9 @@ import { ArrowLeft } from 'lucide-react';
 
 import { Button } from '@/components/ui/forms/button';
 import { PlayerBattleMapCanvas } from '@/components/ui/campaign/location-map/PlayerBattleMapCanvas';
+import { TokenDecorationLayer } from '@/components/ui/campaign/token-overlay';
+import { usePlayerTokenDecorations } from '@/components/ui/campaign/token-overlay/usePlayerTokenDecorations';
+import { useTokenInfoToggle } from '@/components/ui/campaign/token-overlay/useTokenInfoToggle';
 import { ToastContainer } from '@/components/ui/feedback/Toast';
 
 import { CastingBanner } from './CastingBanner';
@@ -54,6 +57,12 @@ export function PlayerVttScreen({
 
   const [combatCollapsed, setCombatCollapsed] = useState(defaultCollapsed);
   const [dockCollapsed, setDockCollapsed] = useState(defaultCollapsed);
+  const [tokenInfoVisible, toggleTokenInfo] = useTokenInfoToggle(
+    'rollkeeper-vtt-token-info-player'
+  );
+  const decorations = usePlayerTokenDecorations(
+    sharedState?.initiative ?? null
+  );
 
   const handlePoke = useCallback(
     (feature: string) => {
@@ -73,7 +82,12 @@ export function PlayerVttScreen({
       onStatus={setConnectionStatus}
       onPoke={handlePoke}
       spellTemplateConfigRef={spellTemplateConfigRef}
+      tokenInfoToggle={{ visible: tokenInfoVisible, onToggle: toggleTokenInfo }}
     >
+      <TokenDecorationLayer
+        decorations={decorations}
+        visible={tokenInfoVisible}
+      />
       <SpellPlacementController
         pending={pendingPlacement}
         configRef={spellTemplateConfigRef}

--- a/src/components/ui/campaign/player-vtt/PlayerVttScreen.tsx
+++ b/src/components/ui/campaign/player-vtt/PlayerVttScreen.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/forms/button';
 import { PlayerBattleMapCanvas } from '@/components/ui/campaign/location-map/PlayerBattleMapCanvas';
 import { TokenDecorationLayer } from '@/components/ui/campaign/token-overlay';
 import { usePlayerTokenDecorations } from '@/components/ui/campaign/token-overlay/usePlayerTokenDecorations';
-import { useTokenInfoToggle } from '@/components/ui/campaign/token-overlay/useTokenInfoToggle';
+import { useTokenInfoMode } from '@/components/ui/campaign/token-overlay/useTokenInfoToggle';
 import { ToastContainer } from '@/components/ui/feedback/Toast';
 
 import { CastingBanner } from './CastingBanner';
@@ -57,7 +57,7 @@ export function PlayerVttScreen({
 
   const [combatCollapsed, setCombatCollapsed] = useState(defaultCollapsed);
   const [dockCollapsed, setDockCollapsed] = useState(defaultCollapsed);
-  const [tokenInfoVisible, toggleTokenInfo] = useTokenInfoToggle(
+  const [tokenInfoMode, cycleTokenInfo] = useTokenInfoMode(
     'rollkeeper-vtt-token-info-player'
   );
   const decorations = usePlayerTokenDecorations(
@@ -82,12 +82,9 @@ export function PlayerVttScreen({
       onStatus={setConnectionStatus}
       onPoke={handlePoke}
       spellTemplateConfigRef={spellTemplateConfigRef}
-      tokenInfoToggle={{ visible: tokenInfoVisible, onToggle: toggleTokenInfo }}
+      tokenInfoToggle={{ mode: tokenInfoMode, onCycle: cycleTokenInfo }}
     >
-      <TokenDecorationLayer
-        decorations={decorations}
-        visible={tokenInfoVisible}
-      />
+      <TokenDecorationLayer decorations={decorations} mode={tokenInfoMode} />
       <SpellPlacementController
         pending={pendingPlacement}
         configRef={spellTemplateConfigRef}

--- a/src/components/ui/campaign/token-overlay/DecorationItem.tsx
+++ b/src/components/ui/campaign/token-overlay/DecorationItem.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { getHpTierBarColor, getHpTierTextColor } from '@/utils/hpColor';
+
+import type { DecoratedTokenRect } from './TokenDecorationLayer.hooks';
+import type {
+  TokenDecoration,
+  TokenHpView,
+  TokenInfoMode,
+} from './TokenDecorationLayer.types';
+
+interface DecorationItemProps {
+  rect: DecoratedTokenRect;
+  deco: TokenDecoration;
+  mode: TokenInfoMode;
+  cell: number;
+}
+
+type BarLikeHp = Extract<TokenHpView, { kind: 'bar' | 'exact' }>;
+
+/** HP bar rendered INSIDE the token, flush to its bottom edge. */
+function InTokenBar({
+  rect,
+  cell,
+  hp,
+}: {
+  rect: DecoratedTokenRect;
+  cell: number;
+  hp: BarLikeHp;
+}) {
+  const inset = Math.max(2, 0.05 * cell);
+  const barHeight = 0.12 * cell;
+  return (
+    <span
+      role="progressbar"
+      aria-valuenow={Math.round(hp.percent)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className="bg-surface-secondary/90 border-divider absolute block overflow-hidden rounded-full border"
+      style={{
+        left: rect.x + inset,
+        top: rect.y + rect.h - barHeight - inset,
+        width: rect.w - 2 * inset,
+        height: barHeight,
+      }}
+    >
+      <span
+        className={`block h-full ${getHpTierBarColor(hp.tier)}`}
+        style={{ width: `${hp.percent}%` }}
+      />
+    </span>
+  );
+}
+
+/** Skull glyph centered inside the token rect for a dead entity. */
+function DeadGlyph({ rect, cell }: { rect: DecoratedTokenRect; cell: number }) {
+  return (
+    <span
+      className="absolute flex items-center justify-center"
+      style={{
+        left: rect.x,
+        top: rect.y,
+        width: rect.w,
+        height: rect.h,
+        fontSize: cell * 0.3,
+        lineHeight: 1,
+      }}
+    >
+      ☠️
+    </span>
+  );
+}
+
+/** One chip row centered below the token: name + exact numbers/label chip. */
+function ChipRow({
+  rect,
+  cell,
+  deco,
+}: {
+  rect: DecoratedTokenRect;
+  cell: number;
+  deco: TokenDecoration;
+}) {
+  // Min-width clamp keeps chips legible on 1×1 tokens.
+  const width = Math.max(rect.w, 0.9 * cell);
+  const showHpChip = !deco.isDead && deco.hp;
+  return (
+    <div
+      className="absolute flex flex-row flex-wrap items-center justify-center"
+      style={{
+        left: rect.x + rect.w / 2 - width / 2,
+        top: rect.y + rect.h + cell * 0.06,
+        width,
+        gap: cell * 0.05,
+      }}
+    >
+      {deco.name && (
+        <span
+          className="bg-surface-raised/90 border-divider text-heading overflow-hidden rounded-full border font-semibold text-ellipsis whitespace-nowrap"
+          style={{
+            fontSize: cell * 0.24,
+            padding: `0 ${cell * 0.15}px`,
+            maxWidth: 3 * cell,
+          }}
+        >
+          {deco.name}
+        </span>
+      )}
+      {showHpChip && deco.hp?.kind === 'exact' && (
+        <span
+          className="bg-surface-raised/90 text-heading rounded-full font-semibold whitespace-nowrap"
+          style={{ fontSize: cell * 0.2, padding: `0 ${cell * 0.12}px` }}
+        >
+          {deco.hp.current}/{deco.hp.max}
+        </span>
+      )}
+      {showHpChip && deco.hp?.kind === 'label' && (
+        <span
+          className={`bg-surface-raised/90 border-divider rounded-full border font-semibold whitespace-nowrap ${getHpTierTextColor(deco.hp.tier)}`}
+          style={{ fontSize: cell * 0.22, padding: `0 ${cell * 0.15}px` }}
+        >
+          {deco.hp.text}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * One token's decoration: an in-token HP bar (full/compact, bar/exact kinds),
+ * a centered skull when dead, and — full mode only — a single chip row below
+ * the token with the name plus an exact-numbers or label-state chip.
+ */
+export function DecorationItem({
+  rect,
+  deco,
+  mode,
+  cell,
+}: DecorationItemProps) {
+  const showBar =
+    !deco.isDead &&
+    deco.hp &&
+    (deco.hp.kind === 'bar' || deco.hp.kind === 'exact');
+  return (
+    <div style={{ opacity: deco.isDead ? 0.75 : 1 }}>
+      {deco.isDead && <DeadGlyph rect={rect} cell={cell} />}
+      {showBar && (
+        <InTokenBar rect={rect} cell={cell} hp={deco.hp as BarLikeHp} />
+      )}
+      {mode === 'full' && <ChipRow rect={rect} cell={cell} deco={deco} />}
+    </div>
+  );
+}

--- a/src/components/ui/campaign/token-overlay/DecorationItem.tsx
+++ b/src/components/ui/campaign/token-overlay/DecorationItem.tsx
@@ -14,6 +14,8 @@ interface DecorationItemProps {
   deco: TokenDecoration;
   mode: TokenInfoMode;
   cell: number;
+  /** Compact mode only: render the chip row for this rect (hovered/revealed). */
+  showChipRow?: boolean;
 }
 
 type BarLikeHp = Extract<TokenHpView, { kind: 'bar' | 'exact' }>;
@@ -71,7 +73,13 @@ function DeadGlyph({ rect, cell }: { rect: DecoratedTokenRect; cell: number }) {
   );
 }
 
-/** One chip row centered below the token: name + exact numbers/label chip. */
+/**
+ * One chip row centered below the token: name + exact numbers/label chip.
+ * The row is sized to its content (`width: max-content`) rather than clamped
+ * to the token width, so short-to-medium names render unclipped; it's capped
+ * at 4 cells so it never runs away, and each chip keeps its own
+ * overflow/ellipsis as a safety net for a truly huge name.
+ */
 function ChipRow({
   rect,
   cell,
@@ -81,16 +89,16 @@ function ChipRow({
   cell: number;
   deco: TokenDecoration;
 }) {
-  // Min-width clamp keeps chips legible on 1×1 tokens.
-  const width = Math.max(rect.w, 0.9 * cell);
   const showHpChip = !deco.isDead && deco.hp;
   return (
     <div
       className="absolute flex flex-row flex-wrap items-center justify-center"
       style={{
-        left: rect.x + rect.w / 2 - width / 2,
+        left: rect.x + rect.w / 2,
         top: rect.y + rect.h + cell * 0.06,
-        width,
+        transform: 'translateX(-50%)',
+        width: 'max-content',
+        maxWidth: 4 * cell,
         gap: cell * 0.05,
       }}
     >
@@ -100,7 +108,7 @@ function ChipRow({
           style={{
             fontSize: cell * 0.24,
             padding: `0 ${cell * 0.15}px`,
-            maxWidth: 3 * cell,
+            maxWidth: 4 * cell,
           }}
         >
           {deco.name}
@@ -128,26 +136,30 @@ function ChipRow({
 
 /**
  * One token's decoration: an in-token HP bar (full/compact, bar/exact kinds),
- * a centered skull when dead, and — full mode only — a single chip row below
- * the token with the name plus an exact-numbers or label-state chip.
+ * a centered skull when dead, and a chip row below the token with the name
+ * plus an exact-numbers or label-state chip. In full mode the chip row is
+ * always shown; in compact mode it only appears when `showChipRow` is set
+ * (the token is hovered or tap-revealed — see `useCompactReveal`).
  */
 export function DecorationItem({
   rect,
   deco,
   mode,
   cell,
+  showChipRow,
 }: DecorationItemProps) {
   const showBar =
     !deco.isDead &&
     deco.hp &&
     (deco.hp.kind === 'bar' || deco.hp.kind === 'exact');
+  const shouldShowChipRow = mode === 'full' || showChipRow === true;
   return (
     <div style={{ opacity: deco.isDead ? 0.75 : 1 }}>
       {deco.isDead && <DeadGlyph rect={rect} cell={cell} />}
       {showBar && (
         <InTokenBar rect={rect} cell={cell} hp={deco.hp as BarLikeHp} />
       )}
-      {mode === 'full' && <ChipRow rect={rect} cell={cell} deco={deco} />}
+      {shouldShowChipRow && <ChipRow rect={rect} cell={cell} deco={deco} />}
     </div>
   );
 }

--- a/src/components/ui/campaign/token-overlay/TokenDecorationLayer.hooks.ts
+++ b/src/components/ui/campaign/token-overlay/TokenDecorationLayer.hooks.ts
@@ -1,11 +1,15 @@
 'use client';
 
-import { useElements } from '@fieldnotes/react';
+import { useEffect, useRef, useState } from 'react';
+
+import { useCamera, useElements } from '@fieldnotes/react';
 
 import { COMBATANT_TOKEN_KIND } from '@/components/ui/campaign/dm-vtt/combatantToken';
 import { PLAYER_TOKEN_KIND } from '@/components/ui/campaign/location-map/PlayerTokenTool';
 
 import type { CanvasElement } from '@fieldnotes/core';
+import type { RefObject } from 'react';
+import type { TokenInfoMode } from './TokenDecorationLayer.types';
 
 /** World-space rect of a decorated token plus its decoration lookup key. */
 export interface DecoratedTokenRect {
@@ -89,4 +93,100 @@ function rectsEqual(a: DecoratedTokenRect[], b: DecoratedTokenRect[]): boolean {
  */
 export function useDecoratedTokenRects(): DecoratedTokenRect[] {
   return useElements(selectRects, rectsEqual);
+}
+
+function hitTestRects(
+  rects: DecoratedTokenRect[],
+  worldX: number,
+  worldY: number
+): string | null {
+  // Later elements render on top, so the LAST match wins.
+  let hitId: string | null = null;
+  for (const rect of rects) {
+    if (
+      worldX >= rect.x &&
+      worldX <= rect.x + rect.w &&
+      worldY >= rect.y &&
+      worldY <= rect.y + rect.h
+    ) {
+      hitId = rect.id;
+    }
+  }
+  return hitId;
+}
+
+export interface UseCompactRevealResult {
+  containerRef: RefObject<HTMLDivElement | null>;
+  activeId: string | null;
+}
+
+/**
+ * Compact-mode-only name reveal: since the layer is `pointer-events-none`
+ * (it must never intercept clicks meant for the SDK canvas below it) and SDK
+ * selection isn't available to players on locked/mirrored layers, this does
+ * its own hit-testing off raw window pointer events. Hovering a token (desktop)
+ * or tapping it (iPad — pointer events unify mouse/touch) reveals its chip
+ * row; tapping empty space clears the tap-reveal. Both ids reset when mode
+ * leaves 'compact'.
+ */
+export function useCompactReveal(
+  mode: TokenInfoMode,
+  rects: DecoratedTokenRect[]
+): UseCompactRevealResult {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [revealedId, setRevealedId] = useState<string | null>(null);
+  const camera = useCamera();
+
+  // Kept fresh via refs so the pointer listeners (added once per mode change)
+  // always read current rects/camera without needing to re-subscribe.
+  const rectsRef = useRef(rects);
+  rectsRef.current = rects;
+  const cameraRef = useRef(camera);
+  cameraRef.current = camera;
+
+  useEffect(() => {
+    if (mode !== 'compact') {
+      setHoveredId(null);
+      setRevealedId(null);
+      return;
+    }
+
+    function toWorldPoint(clientX: number, clientY: number) {
+      const containerRect = containerRef.current?.getBoundingClientRect();
+      const screenX = clientX - (containerRect?.left ?? 0);
+      const screenY = clientY - (containerRect?.top ?? 0);
+      const cam = cameraRef.current;
+      return {
+        x: (screenX - cam.x) / cam.zoom,
+        y: (screenY - cam.y) / cam.zoom,
+      };
+    }
+
+    let framePending = false;
+
+    function handlePointerMove(e: PointerEvent) {
+      if (framePending) return;
+      framePending = true;
+      requestAnimationFrame(() => {
+        framePending = false;
+        const world = toWorldPoint(e.clientX, e.clientY);
+        setHoveredId(hitTestRects(rectsRef.current, world.x, world.y));
+      });
+    }
+
+    function handlePointerDown(e: PointerEvent) {
+      const world = toWorldPoint(e.clientX, e.clientY);
+      setRevealedId(hitTestRects(rectsRef.current, world.x, world.y));
+    }
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerdown', handlePointerDown);
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, [mode]);
+
+  return { containerRef, activeId: hoveredId ?? revealedId };
 }

--- a/src/components/ui/campaign/token-overlay/TokenDecorationLayer.hooks.ts
+++ b/src/components/ui/campaign/token-overlay/TokenDecorationLayer.hooks.ts
@@ -163,13 +163,12 @@ export function useCompactReveal(
       };
     }
 
-    let framePending = false;
+    let frameId: number | null = null;
 
     function handlePointerMove(e: PointerEvent) {
-      if (framePending) return;
-      framePending = true;
-      requestAnimationFrame(() => {
-        framePending = false;
+      if (frameId !== null) return;
+      frameId = requestAnimationFrame(() => {
+        frameId = null;
         const world = toWorldPoint(e.clientX, e.clientY);
         setHoveredId(hitTestRects(rectsRef.current, world.x, world.y));
       });
@@ -185,6 +184,9 @@ export function useCompactReveal(
     return () => {
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerdown', handlePointerDown);
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
     };
   }, [mode]);
 

--- a/src/components/ui/campaign/token-overlay/TokenDecorationLayer.hooks.ts
+++ b/src/components/ui/campaign/token-overlay/TokenDecorationLayer.hooks.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useElements } from '@fieldnotes/react';
+
+import { COMBATANT_TOKEN_KIND } from '@/components/ui/campaign/dm-vtt/combatantToken';
+import { PLAYER_TOKEN_KIND } from '@/components/ui/campaign/location-map/PlayerTokenTool';
+
+import type { CanvasElement } from '@fieldnotes/core';
+
+/** World-space rect of a decorated token plus its decoration lookup key. */
+export interface DecoratedTokenRect {
+  id: string;
+  /** entityId (combatant tokens) or characterId (player self-tokens). */
+  key: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** The decoration-map key a store element resolves to, if it is a token. */
+export function decorationKey(el: CanvasElement): string | null {
+  const rec = el as Partial<{
+    tokenKind: unknown;
+    entityId: unknown;
+    characterId: unknown;
+  }>;
+  if (
+    rec.tokenKind === COMBATANT_TOKEN_KIND &&
+    typeof rec.entityId === 'string'
+  ) {
+    return rec.entityId;
+  }
+  if (
+    rec.tokenKind === PLAYER_TOKEN_KIND &&
+    typeof rec.characterId === 'string'
+  ) {
+    return rec.characterId;
+  }
+  return null;
+}
+
+function selectRects(elements: CanvasElement[]): DecoratedTokenRect[] {
+  const rects: DecoratedTokenRect[] = [];
+  for (const el of elements) {
+    const key = decorationKey(el);
+    if (!key) continue;
+    // Tokens are image/shape elements — both carry size; skip anything without.
+    const size = (el as { size?: { w: number; h: number } }).size;
+    if (!size) continue;
+    rects.push({
+      id: el.id,
+      key,
+      x: el.position.x,
+      y: el.position.y,
+      w: size.w,
+      h: size.h,
+    });
+  }
+  return rects;
+}
+
+// useElements' default isEqual is one-level shallow: the selector returns
+// fresh objects each run, so a custom per-field comparator is required or
+// the layer re-renders on EVERY store mutation.
+function rectsEqual(a: DecoratedTokenRect[], b: DecoratedTokenRect[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const p = a[i];
+    const q = b[i];
+    if (
+      p.id !== q.id ||
+      p.key !== q.key ||
+      p.x !== q.x ||
+      p.y !== q.y ||
+      p.w !== q.w ||
+      p.h !== q.h
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Live rects of every decorated token. Re-renders on position/size changes
+ * from BOTH local drags and remote sync (unlike useCombatantTokens, which
+ * deliberately skips update events — do not reuse it here).
+ */
+export function useDecoratedTokenRects(): DecoratedTokenRect[] {
+  return useElements(selectRects, rectsEqual);
+}

--- a/src/components/ui/campaign/token-overlay/TokenDecorationLayer.types.ts
+++ b/src/components/ui/campaign/token-overlay/TokenDecorationLayer.types.ts
@@ -1,5 +1,8 @@
 import type { HpTier } from '@/utils/hpState';
 
+/** Token decoration visibility: full (bar + chips), compact (bar only), off (nothing). */
+export type TokenInfoMode = 'full' | 'compact' | 'off';
+
 /** How a token's HP renders: bar-only, bar+numbers, or a state chip ("Bloodied"). */
 export type TokenHpView =
   | { kind: 'bar'; percent: number; tier: HpTier }

--- a/src/components/ui/campaign/token-overlay/TokenDecorationLayer.types.ts
+++ b/src/components/ui/campaign/token-overlay/TokenDecorationLayer.types.ts
@@ -1,0 +1,22 @@
+import type { HpTier } from '@/utils/hpState';
+
+/** How a token's HP renders: bar-only, bar+numbers, or a state chip ("Bloodied"). */
+export type TokenHpView =
+  | { kind: 'bar'; percent: number; tier: HpTier }
+  | {
+      kind: 'exact';
+      percent: number;
+      tier: HpTier;
+      current: number;
+      max: number;
+    }
+  | { kind: 'label'; text: string; tier: HpTier };
+
+export interface TokenDecoration {
+  /** Omit → no name row. Player screens receive the policy-filtered displayName. */
+  name?: string;
+  /** Omit → no HP row (e.g. enemyHpDisplay 'off'). */
+  hp?: TokenHpView;
+  /** Dim the decoration and replace the HP row with a skull glyph. */
+  isDead?: boolean;
+}

--- a/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
+++ b/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
@@ -276,18 +276,77 @@ describe('TokenDecorationLayer compact-mode reveal', () => {
   });
 
   it('reveals the name chip on hover (pointermove), throttled via rAF', () => {
+    let pending: FrameRequestCallback | null = null;
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-      cb(0);
-      return 0;
+      pending = cb;
+      return 99;
     });
+
     render(<TokenDecorationLayer decorations={deco()} mode="compact" />);
     expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
 
+    // First pointermove schedules a frame
     firePointer('pointermove', 120, 220);
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument(); // callback not run yet
+
+    // Execute the pending callback
+    act(() => {
+      if (pending) pending(0);
+    });
     expect(screen.getByText('Ogre')).toBeInTheDocument();
 
+    // Second pointermove to different location schedules another frame
+    pending = null;
     firePointer('pointermove', 10, 10);
+
+    // Execute the pending callback
+    act(() => {
+      if (pending) pending(0);
+    });
     expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('cancels pending rAF on hover when mode leaves compact', () => {
+    let pendingCallback: FrameRequestCallback | null = null;
+    const cancelSpy = vi.fn();
+
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      pendingCallback = cb;
+      return 42;
+    });
+    vi.stubGlobal('cancelAnimationFrame', cancelSpy);
+
+    const { rerender } = render(
+      <TokenDecorationLayer decorations={deco()} mode="compact" />
+    );
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+
+    // Dispatch pointermove — schedules rAF with id 42, callback stored in pendingCallback.
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointermove', { clientX: 120, clientY: 220 })
+      );
+    });
+    expect(pendingCallback).not.toBeNull();
+
+    // Switch to full mode — cleanup should cancel the pending frame.
+    rerender(<TokenDecorationLayer decorations={deco()} mode="full" />);
+    expect(cancelSpy).toHaveBeenCalledWith(42);
+
+    // Simulate the pending callback running anyway (e.g. due to timing).
+    // It should no longer surface the chip because the effect cleanup
+    // has also cleared hover/revealed state.
+    act(() => {
+      if (pendingCallback) pendingCallback(0);
+    });
+    // In full mode, the name should show (not due to the stale callback,
+    // but because full mode always renders it). If the callback had been
+    // allowed to run without cancellation, it would have re-set hoveredId
+    // after cleanup cleared it. Verify that doesn't happen by checking
+    // the current state is consistent with full mode.
+    expect(screen.getByText('Ogre')).toBeInTheDocument();
 
     vi.unstubAllGlobals();
   });

--- a/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
+++ b/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { TokenDecorationLayer } from '@/components/ui/campaign/token-overlay';
+import {
+  decorationKey,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  useDecoratedTokenRects,
+} from '@/components/ui/campaign/token-overlay/TokenDecorationLayer.hooks';
+
+import type { CanvasElement } from '@fieldnotes/core';
+import type { TokenDecoration } from '@/components/ui/campaign/token-overlay';
+
+let mockElements: CanvasElement[] = [];
+let mockCamera = { x: 0, y: 0, zoom: 1 };
+
+vi.mock('@fieldnotes/react', () => ({
+  useCamera: () => mockCamera,
+  useViewport: () => ({ toolContext: { gridSize: 40, gridType: 'square' } }),
+  useElements: (selector: (els: CanvasElement[]) => unknown) =>
+    selector(mockElements),
+}));
+
+function tokenEl(overrides: Record<string, unknown> = {}): CanvasElement {
+  return {
+    id: 'el-1',
+    type: 'shape',
+    position: { x: 100, y: 200 },
+    size: { w: 40, h: 40 },
+    zIndex: 0,
+    locked: false,
+    layerId: 'l1',
+    entityId: 'ent-1',
+    tokenKind: 'combatant',
+    ...overrides,
+  } as unknown as CanvasElement;
+}
+
+const deco = (d: Partial<TokenDecoration> = {}): Map<string, TokenDecoration> =>
+  new Map([['ent-1', { name: 'Ogre', ...d }]]);
+
+describe('decorationKey', () => {
+  it('maps combatant tokens to entityId and player tokens to characterId', () => {
+    expect(decorationKey(tokenEl())).toBe('ent-1');
+    expect(
+      decorationKey(
+        tokenEl({
+          tokenKind: 'player',
+          characterId: 'char-9',
+          entityId: undefined,
+        })
+      )
+    ).toBe('char-9');
+    expect(decorationKey(tokenEl({ tokenKind: undefined }))).toBeNull();
+  });
+});
+
+describe('TokenDecorationLayer', () => {
+  beforeEach(() => {
+    cleanup();
+    mockElements = [tokenEl()];
+    mockCamera = { x: 0, y: 0, zoom: 1 };
+  });
+
+  it('renders the name chip positioned under the token rect', () => {
+    const { container } = render(
+      <TokenDecorationLayer decorations={deco()} visible />
+    );
+    expect(screen.getByText('Ogre')).toBeInTheDocument();
+    const item = screen.getByText('Ogre').parentElement as HTMLElement;
+    // top = y + h + 0.06*cell = 200 + 40 + 2.4
+    expect(item.style.top).toBe('242.4px');
+    // camera transform applied once at the layer root
+    const transformed = container.querySelector(
+      '[style*="translate3d"]'
+    ) as HTMLElement;
+    expect(transformed.style.transform).toContain('scale(1)');
+  });
+
+  it('renders nothing when hidden or when the key has no decoration', () => {
+    const hidden = render(
+      <TokenDecorationLayer decorations={deco()} visible={false} />
+    );
+    expect(hidden.container).toBeEmptyDOMElement();
+    cleanup();
+    render(<TokenDecorationLayer decorations={new Map()} visible />);
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+  });
+
+  it('renders an exact bar with numbers, and a label chip for label mode', () => {
+    const { rerender } = render(
+      <TokenDecorationLayer
+        decorations={deco({
+          hp: { kind: 'exact', percent: 50, tier: 'mid', current: 30, max: 60 },
+        })}
+        visible
+      />
+    );
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '50'
+    );
+    expect(screen.getByText('30/60')).toBeInTheDocument();
+    rerender(
+      <TokenDecorationLayer
+        decorations={deco({
+          hp: { kind: 'label', text: 'Bloodied', tier: 'low' },
+        })}
+        visible
+      />
+    );
+    expect(screen.getByText('Bloodied')).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('dead tokens show a skull instead of the HP row', () => {
+    render(
+      <TokenDecorationLayer
+        decorations={deco({
+          isDead: true,
+          hp: { kind: 'bar', percent: 0, tier: 'critical' },
+        })}
+        visible
+      />
+    );
+    expect(screen.getByText('☠️')).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('clamps decoration width to 0.9×cell on small tokens', () => {
+    mockElements = [tokenEl({ size: { w: 20, h: 20 } })];
+    render(<TokenDecorationLayer decorations={deco()} visible />);
+    const item = screen.getByText('Ogre').parentElement as HTMLElement;
+    expect(item.style.width).toBe('36px'); // 0.9 × 40 > 20
+  });
+});

--- a/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
+++ b/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, act } from '@testing-library/react';
 
 import { TokenDecorationLayer } from '@/components/ui/campaign/token-overlay';
 import { decorationKey } from '@/components/ui/campaign/token-overlay/TokenDecorationLayer.hooks';
@@ -92,6 +92,25 @@ describe('TokenDecorationLayer', () => {
       '[style*="translate3d"]'
     ) as HTMLElement;
     expect(transformed.style.transform).toContain('scale(1)');
+  });
+
+  it('sizes the chip row to its content and centers it under the token, unclipped', () => {
+    render(<TokenDecorationLayer decorations={deco()} mode="full" />);
+    const item = screen.getByText('Ogre').parentElement as HTMLElement;
+    expect(item.style.width).toBe('max-content');
+    expect(item.style.maxWidth).toBe('160px'); // 4 * 40
+    expect(item.style.transform).toBe('translateX(-50%)');
+    expect(item.style.left).toBe('120px'); // rect.x + rect.w / 2
+  });
+
+  it('renders a long name in full without clipping the text content', () => {
+    render(
+      <TokenDecorationLayer
+        decorations={deco({ name: 'Vecna the Archlich Supreme' })}
+        mode="full"
+      />
+    );
+    expect(screen.getByText('Vecna the Archlich Supreme')).toBeInTheDocument();
   });
 
   it('renders nothing when off, or when the key has no decoration', () => {
@@ -205,10 +224,85 @@ describe('TokenDecorationLayer', () => {
     expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
   });
 
-  it('clamps the chip row width to 0.9×cell on small tokens', () => {
+  it('keeps the chip row content-sized (not clamped to token width) on small tokens', () => {
     mockElements = [tokenEl({ size: { w: 20, h: 20 } })];
     render(<TokenDecorationLayer decorations={deco()} mode="full" />);
     const item = screen.getByText('Ogre').parentElement as HTMLElement;
-    expect(item.style.width).toBe('36px'); // 0.9 × 40 > 20
+    expect(item.style.width).toBe('max-content');
+    expect(item.style.maxWidth).toBe('160px'); // 4 * cell, independent of token size
+  });
+});
+
+function firePointer(type: string, clientX: number, clientY: number) {
+  act(() => {
+    window.dispatchEvent(new PointerEvent(type, { clientX, clientY }));
+  });
+}
+
+describe('TokenDecorationLayer compact-mode reveal', () => {
+  beforeEach(() => {
+    mockElements = [tokenEl()];
+    mockCamera = { x: 0, y: 0, zoom: 1 };
+  });
+
+  afterEach(() => cleanup());
+
+  it('shows no chip row initially in compact mode', () => {
+    render(<TokenDecorationLayer decorations={deco()} mode="compact" />);
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+  });
+
+  it('reveals the name chip on pointerdown inside the token, and hides it again on pointerdown outside', () => {
+    render(<TokenDecorationLayer decorations={deco()} mode="compact" />);
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+
+    // Token at (100, 200), size 40x40, camera {x:0,y:0,zoom:1} — (120, 220) is inside.
+    firePointer('pointerdown', 120, 220);
+    expect(screen.getByText('Ogre')).toBeInTheDocument();
+
+    // (10, 10) is well outside the token — clears the reveal.
+    firePointer('pointerdown', 10, 10);
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+  });
+
+  it('accounts for camera pan/zoom when hit-testing pointerdown', () => {
+    mockCamera = { x: 50, y: 0, zoom: 2 };
+    render(<TokenDecorationLayer decorations={deco()} mode="compact" />);
+
+    // World (120, 220) is inside the 40x40 token at (100,200).
+    // screen = world*zoom + camera => clientX = 120*2+50 = 290, clientY = 220*2+0 = 440.
+    firePointer('pointerdown', 290, 440);
+    expect(screen.getByText('Ogre')).toBeInTheDocument();
+  });
+
+  it('reveals the name chip on hover (pointermove), throttled via rAF', () => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    render(<TokenDecorationLayer decorations={deco()} mode="compact" />);
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+
+    firePointer('pointermove', 120, 220);
+    expect(screen.getByText('Ogre')).toBeInTheDocument();
+
+    firePointer('pointermove', 10, 10);
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('clears both hover and tap reveal state when leaving compact mode', () => {
+    const { rerender } = render(
+      <TokenDecorationLayer decorations={deco()} mode="compact" />
+    );
+    firePointer('pointerdown', 120, 220);
+    expect(screen.getByText('Ogre')).toBeInTheDocument();
+
+    rerender(<TokenDecorationLayer decorations={deco()} mode="full" />);
+    expect(screen.getByText('Ogre')).toBeInTheDocument(); // full mode always shows it
+
+    rerender(<TokenDecorationLayer decorations={deco()} mode="compact" />);
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
   });
 });

--- a/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
+++ b/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
@@ -1,12 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 
 import { TokenDecorationLayer } from '@/components/ui/campaign/token-overlay';
-import {
-  decorationKey,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  useDecoratedTokenRects,
-} from '@/components/ui/campaign/token-overlay/TokenDecorationLayer.hooks';
+import { decorationKey } from '@/components/ui/campaign/token-overlay/TokenDecorationLayer.hooks';
 
 import type { CanvasElement } from '@fieldnotes/core';
 import type { TokenDecoration } from '@/components/ui/campaign/token-overlay';
@@ -57,10 +53,11 @@ describe('decorationKey', () => {
 
 describe('TokenDecorationLayer', () => {
   beforeEach(() => {
-    cleanup();
     mockElements = [tokenEl()];
     mockCamera = { x: 0, y: 0, zoom: 1 };
   });
+
+  afterEach(() => cleanup());
 
   it('renders the name chip positioned under the token rect', () => {
     const { container } = render(
@@ -96,7 +93,7 @@ describe('TokenDecorationLayer', () => {
         visible
       />
     );
-    expect(screen.getByRole('progressbar')).toHaveAttribute(
+    expect(screen.getByRole('progressbar', { hidden: true })).toHaveAttribute(
       'aria-valuenow',
       '50'
     );
@@ -110,7 +107,9 @@ describe('TokenDecorationLayer', () => {
       />
     );
     expect(screen.getByText('Bloodied')).toBeInTheDocument();
-    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('progressbar', { hidden: true })
+    ).not.toBeInTheDocument();
   });
 
   it('dead tokens show a skull instead of the HP row', () => {
@@ -124,7 +123,9 @@ describe('TokenDecorationLayer', () => {
       />
     );
     expect(screen.getByText('☠️')).toBeInTheDocument();
-    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('progressbar', { hidden: true })
+    ).not.toBeInTheDocument();
   });
 
   it('clamps decoration width to 0.9×cell on small tokens', () => {

--- a/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
+++ b/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
@@ -59,9 +59,29 @@ describe('TokenDecorationLayer', () => {
 
   afterEach(() => cleanup());
 
-  it('renders the name chip positioned under the token rect', () => {
+  it('positions the HP bar inside the token rect, flush to its bottom edge', () => {
+    render(
+      <TokenDecorationLayer
+        decorations={deco({
+          hp: { kind: 'bar', percent: 50, tier: 'mid' },
+        })}
+        mode="full"
+      />
+    );
+    // 40px token at (100, 200): inset = max(2, 0.05*40) = 2,
+    // barHeight = 0.12*40 = 4.8.
+    // left = 100 + 2 = 102, width = 40 - 2*2 = 36,
+    // top = 200 + 40 - 4.8 - 2 = 233.2
+    const bar = screen.getByRole('progressbar', { hidden: true });
+    expect(bar.style.left).toBe('102px');
+    expect(bar.style.width).toBe('36px');
+    expect(bar.style.top).toBe('233.2px');
+    expect(bar.style.height).toBe('4.8px');
+  });
+
+  it('renders the name chip centered below the token in full mode', () => {
     const { container } = render(
-      <TokenDecorationLayer decorations={deco()} visible />
+      <TokenDecorationLayer decorations={deco()} mode="full" />
     );
     expect(screen.getByText('Ogre')).toBeInTheDocument();
     const item = screen.getByText('Ogre').parentElement as HTMLElement;
@@ -74,63 +94,120 @@ describe('TokenDecorationLayer', () => {
     expect(transformed.style.transform).toContain('scale(1)');
   });
 
-  it('renders nothing when hidden or when the key has no decoration', () => {
+  it('renders nothing when off, or when the key has no decoration', () => {
     const hidden = render(
-      <TokenDecorationLayer decorations={deco()} visible={false} />
+      <TokenDecorationLayer decorations={deco()} mode="off" />
     );
     expect(hidden.container).toBeEmptyDOMElement();
     cleanup();
-    render(<TokenDecorationLayer decorations={new Map()} visible />);
+    render(<TokenDecorationLayer decorations={new Map()} mode="full" />);
     expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
   });
 
-  it('renders an exact bar with numbers, and a label chip for label mode', () => {
+  it('full mode shows the bar plus name + exact-numbers chip side by side', () => {
     const { rerender } = render(
       <TokenDecorationLayer
         decorations={deco({
           hp: { kind: 'exact', percent: 50, tier: 'mid', current: 30, max: 60 },
         })}
-        visible
+        mode="full"
       />
     );
     expect(screen.getByRole('progressbar', { hidden: true })).toHaveAttribute(
       'aria-valuenow',
       '50'
     );
+    expect(screen.getByText('Ogre')).toBeInTheDocument();
     expect(screen.getByText('30/60')).toBeInTheDocument();
+
     rerender(
       <TokenDecorationLayer
         decorations={deco({
           hp: { kind: 'label', text: 'Bloodied', tier: 'low' },
         })}
-        visible
+        mode="full"
       />
     );
     expect(screen.getByText('Bloodied')).toBeInTheDocument();
+    // label kind has no percent to draw a bar with.
     expect(
       screen.queryByRole('progressbar', { hidden: true })
     ).not.toBeInTheDocument();
   });
 
-  it('dead tokens show a skull instead of the HP row', () => {
+  it('compact mode keeps the in-token bar but renders no chips', () => {
+    render(
+      <TokenDecorationLayer
+        decorations={deco({
+          hp: { kind: 'exact', percent: 50, tier: 'mid', current: 30, max: 60 },
+        })}
+        mode="compact"
+      />
+    );
+    expect(
+      screen.getByRole('progressbar', { hidden: true })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+    expect(screen.queryByText('30/60')).not.toBeInTheDocument();
+  });
+
+  it('compact mode renders nothing for label-kind hp (no percent to draw)', () => {
+    const { container } = render(
+      <TokenDecorationLayer
+        decorations={deco({
+          hp: { kind: 'label', text: 'Bloodied', tier: 'low' },
+        })}
+        mode="compact"
+      />
+    );
+    expect(screen.queryByText('Bloodied')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('progressbar', { hidden: true })
+    ).not.toBeInTheDocument();
+    // Only the (empty, opacity-wrapped) item div renders — no visible content.
+    expect(container.querySelector('span')).not.toBeInTheDocument();
+  });
+
+  it('dead tokens show a skull centered inside the token, no bar, and in full mode still show the name chip below', () => {
     render(
       <TokenDecorationLayer
         decorations={deco({
           isDead: true,
           hp: { kind: 'bar', percent: 0, tier: 'critical' },
         })}
-        visible
+        mode="full"
       />
     );
-    expect(screen.getByText('☠️')).toBeInTheDocument();
+    const skull = screen.getByText('☠️');
+    expect(skull).toBeInTheDocument();
+    // Centered inside the 40px token at (100, 200).
+    expect(skull.style.left).toBe('100px');
+    expect(skull.style.top).toBe('200px');
+    expect(skull.style.width).toBe('40px');
+    expect(skull.style.height).toBe('40px');
     expect(
       screen.queryByRole('progressbar', { hidden: true })
     ).not.toBeInTheDocument();
+    expect(screen.getByText('Ogre')).toBeInTheDocument();
   });
 
-  it('clamps decoration width to 0.9×cell on small tokens', () => {
+  it('dead tokens show the skull in compact mode too, with no chip row', () => {
+    render(
+      <TokenDecorationLayer
+        decorations={deco({
+          isDead: true,
+          hp: { kind: 'bar', percent: 0, tier: 'critical' },
+        })}
+        mode="compact"
+      />
+    );
+    expect(screen.getByText('☠️')).toBeInTheDocument();
+    expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+  });
+
+  it('clamps the chip row width to 0.9×cell on small tokens', () => {
     mockElements = [tokenEl({ size: { w: 20, h: 20 } })];
-    render(<TokenDecorationLayer decorations={deco()} visible />);
+    render(<TokenDecorationLayer decorations={deco()} mode="full" />);
     const item = screen.getByText('Ogre').parentElement as HTMLElement;
     expect(item.style.width).toBe('36px'); // 0.9 × 40 > 20
   });

--- a/src/components/ui/campaign/token-overlay/__tests__/useDmTokenDecorations.test.ts
+++ b/src/components/ui/campaign/token-overlay/__tests__/useDmTokenDecorations.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useDmTokenDecorations } from '@/components/ui/campaign/token-overlay/useDmTokenDecorations';
+
+import type { EncounterEntity } from '@/types/encounter';
+
+const entity = (o: Partial<EncounterEntity>): EncounterEntity =>
+  ({
+    id: 'e1',
+    type: 'monster',
+    name: 'Ogre',
+    initiative: null,
+    initiativeModifier: 0,
+    currentHp: 36,
+    maxHp: 60,
+    tempHp: 0,
+    armorClass: 11,
+    conditions: [],
+    ...o,
+  }) as EncounterEntity;
+
+describe('useDmTokenDecorations', () => {
+  it('maps exact HP with tier and real name', () => {
+    const { result } = renderHook(() => useDmTokenDecorations([entity({})]));
+    const d = result.current.get('e1');
+    expect(d?.name).toBe('Ogre');
+    expect(d?.hp).toEqual({
+      kind: 'exact',
+      current: 36,
+      max: 60,
+      percent: 60,
+      tier: 'mid',
+    });
+    expect(d?.isDead).toBe(false);
+  });
+
+  it('flags dead at 0 HP', () => {
+    const { result } = renderHook(() =>
+      useDmTokenDecorations([entity({ currentHp: 0 })])
+    );
+    expect(result.current.get('e1')?.isDead).toBe(true);
+  });
+
+  it('double-keys player entities under playerCharacterId', () => {
+    const { result } = renderHook(() =>
+      useDmTokenDecorations([
+        entity({ type: 'player', playerCharacterId: 'char-9' }),
+      ])
+    );
+    expect(result.current.get('char-9')).toBe(result.current.get('e1'));
+  });
+
+  it('skips lair entities', () => {
+    const { result } = renderHook(() =>
+      useDmTokenDecorations([entity({ type: 'lair', maxHp: 0 })])
+    );
+    expect(result.current.size).toBe(0);
+  });
+});

--- a/src/components/ui/campaign/token-overlay/__tests__/usePlayerTokenDecorations.test.ts
+++ b/src/components/ui/campaign/token-overlay/__tests__/usePlayerTokenDecorations.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { usePlayerTokenDecorations } from '@/components/ui/campaign/token-overlay/usePlayerTokenDecorations';
+
+import type {
+  SharedInitiativeState,
+  SharedTurnEntry,
+} from '@/types/sharedState';
+
+const enemy = (o: Partial<SharedTurnEntry> = {}): SharedTurnEntry => ({
+  entityId: 'e1',
+  displayName: 'Enemy',
+  type: 'monster',
+  ...o,
+});
+
+const state = (
+  enemyHpMode: SharedInitiativeState['enemyHpMode'],
+  entries: SharedTurnEntry[]
+): SharedInitiativeState =>
+  ({
+    encounterId: 'enc',
+    isActive: true,
+    round: 1,
+    currentEntityId: null,
+    turnOrder: entries,
+    enemyHpMode,
+  }) as SharedInitiativeState;
+
+describe('usePlayerTokenDecorations', () => {
+  it('returns an empty map without shared initiative', () => {
+    const { result } = renderHook(() => usePlayerTokenDecorations(null));
+    expect(result.current.size).toBe(0);
+  });
+
+  it("mode 'off': name only, no hp", () => {
+    const { result } = renderHook(() =>
+      usePlayerTokenDecorations(state('off', [enemy({ hpTier: 'mid' })]))
+    );
+    expect(result.current.get('e1')).toEqual({
+      name: 'Enemy',
+      hp: undefined,
+      isDead: false,
+    });
+  });
+
+  it("mode 'label': tier-colored state chip", () => {
+    const { result } = renderHook(() =>
+      usePlayerTokenDecorations(
+        state('label', [enemy({ hpState: 'Bloodied', hpTier: 'low' })])
+      )
+    );
+    expect(result.current.get('e1')?.hp).toEqual({
+      kind: 'label',
+      text: 'Bloodied',
+      tier: 'low',
+    });
+  });
+
+  it("modes 'bar' and 'percent': percent bar from hpPercent", () => {
+    for (const mode of ['bar', 'percent'] as const) {
+      const { result } = renderHook(() =>
+        usePlayerTokenDecorations(
+          state(mode, [enemy({ hpPercent: 40, hpTier: 'mid' })])
+        )
+      );
+      expect(result.current.get('e1')?.hp).toEqual({
+        kind: 'bar',
+        percent: 40,
+        tier: 'mid',
+      });
+    }
+  });
+
+  it("mode 'exact': bar + numbers", () => {
+    const { result } = renderHook(() =>
+      usePlayerTokenDecorations(
+        state('exact', [
+          enemy({ currentHp: 12, maxHp: 48, hpTier: 'critical' }),
+        ])
+      )
+    );
+    expect(result.current.get('e1')?.hp).toEqual({
+      kind: 'exact',
+      current: 12,
+      max: 48,
+      percent: 25,
+      tier: 'critical',
+    });
+  });
+
+  it('players always get exact HP regardless of mode, and double-key', () => {
+    const { result } = renderHook(() =>
+      usePlayerTokenDecorations(
+        state('off', [
+          enemy({
+            entityId: 'p1',
+            type: 'player',
+            displayName: 'Fjord',
+            playerCharacterId: 'char-9',
+            currentHp: 24,
+            maxHp: 40,
+          }),
+        ])
+      )
+    );
+    const d = result.current.get('p1');
+    expect(d?.hp).toEqual({
+      kind: 'exact',
+      current: 24,
+      max: 40,
+      percent: 60,
+      tier: 'mid',
+    });
+    expect(result.current.get('char-9')).toBe(d);
+  });
+
+  it('omits the hp row when the mode’s field is missing (stale share)', () => {
+    const { result } = renderHook(() =>
+      usePlayerTokenDecorations(state('label', [enemy({ hpTier: 'mid' })]))
+    );
+    expect(result.current.get('e1')?.hp).toBeUndefined();
+  });
+
+  it('carries isDead through', () => {
+    const { result } = renderHook(() =>
+      usePlayerTokenDecorations(state('off', [enemy({ isDead: true })]))
+    );
+    expect(result.current.get('e1')?.isDead).toBe(true);
+  });
+});

--- a/src/components/ui/campaign/token-overlay/__tests__/useTokenInfoToggle.test.ts
+++ b/src/components/ui/campaign/token-overlay/__tests__/useTokenInfoToggle.test.ts
@@ -1,22 +1,44 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-import { useTokenInfoToggle } from '@/components/ui/campaign/token-overlay/useTokenInfoToggle';
+import { useTokenInfoMode } from '@/components/ui/campaign/token-overlay/useTokenInfoToggle';
 
-describe('useTokenInfoToggle', () => {
+describe('useTokenInfoMode', () => {
   beforeEach(() => localStorage.clear());
 
-  it('defaults ON and persists toggles', () => {
-    const { result } = renderHook(() => useTokenInfoToggle('test-key'));
-    expect(result.current[0]).toBe(true);
+  it('defaults to full and cycles full -> compact -> off -> full', () => {
+    const { result } = renderHook(() => useTokenInfoMode('test-key'));
+    expect(result.current[0]).toBe('full');
     act(() => result.current[1]());
-    expect(result.current[0]).toBe(false);
-    expect(localStorage.getItem('test-key')).toBe('false');
+    expect(result.current[0]).toBe('compact');
+    expect(localStorage.getItem('test-key')).toBe('compact');
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe('off');
+    expect(localStorage.getItem('test-key')).toBe('off');
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe('full');
+    expect(localStorage.getItem('test-key')).toBe('full');
   });
 
-  it('restores a persisted OFF state', () => {
+  it('migrates legacy boolean strings to modes', () => {
     localStorage.setItem('test-key', 'false');
-    const { result } = renderHook(() => useTokenInfoToggle('test-key'));
-    expect(result.current[0]).toBe(false);
+    const offResult = renderHook(() => useTokenInfoMode('test-key'));
+    expect(offResult.result.current[0]).toBe('off');
+
+    localStorage.setItem('test-key-2', 'true');
+    const onResult = renderHook(() => useTokenInfoMode('test-key-2'));
+    expect(onResult.result.current[0]).toBe('full');
+  });
+
+  it('passes already-valid mode strings through unchanged', () => {
+    localStorage.setItem('test-key', 'compact');
+    const { result } = renderHook(() => useTokenInfoMode('test-key'));
+    expect(result.current[0]).toBe('compact');
+  });
+
+  it('falls back to full for corrupt/unknown stored values', () => {
+    localStorage.setItem('test-key', 'garbage');
+    const { result } = renderHook(() => useTokenInfoMode('test-key'));
+    expect(result.current[0]).toBe('full');
   });
 });

--- a/src/components/ui/campaign/token-overlay/__tests__/useTokenInfoToggle.test.ts
+++ b/src/components/ui/campaign/token-overlay/__tests__/useTokenInfoToggle.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useTokenInfoToggle } from '@/components/ui/campaign/token-overlay/useTokenInfoToggle';
+
+describe('useTokenInfoToggle', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('defaults ON and persists toggles', () => {
+    const { result } = renderHook(() => useTokenInfoToggle('test-key'));
+    expect(result.current[0]).toBe(true);
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe(false);
+    expect(localStorage.getItem('test-key')).toBe('false');
+  });
+
+  it('restores a persisted OFF state', () => {
+    localStorage.setItem('test-key', 'false');
+    const { result } = renderHook(() => useTokenInfoToggle('test-key'));
+    expect(result.current[0]).toBe(false);
+  });
+});

--- a/src/components/ui/campaign/token-overlay/index.tsx
+++ b/src/components/ui/campaign/token-overlay/index.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useCamera, useViewport } from '@fieldnotes/react';
+
+import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
+import { getHpTierBarColor, getHpTierTextColor } from '@/utils/hpColor';
+
+import { useDecoratedTokenRects } from './TokenDecorationLayer.hooks';
+
+import type {
+  TokenDecoration,
+  TokenHpView,
+} from './TokenDecorationLayer.types';
+
+export type {
+  TokenDecoration,
+  TokenHpView,
+} from './TokenDecorationLayer.types';
+
+export interface TokenDecorationLayerProps {
+  /** Keyed by entityId AND/OR characterId — resolvers double-key player entries. */
+  decorations: ReadonlyMap<string, TokenDecoration>;
+  visible: boolean;
+}
+
+function HpRow({ hp, cell }: { hp: TokenHpView; cell: number }) {
+  if (hp.kind === 'label') {
+    return (
+      <span
+        className={`bg-surface-raised/90 border-divider rounded-full border font-semibold whitespace-nowrap ${getHpTierTextColor(hp.tier)}`}
+        style={{ fontSize: cell * 0.22, padding: `0 ${cell * 0.15}px` }}
+      >
+        {hp.text}
+      </span>
+    );
+  }
+  return (
+    <span
+      className="flex w-full flex-col items-center"
+      style={{ gap: cell * 0.05 }}
+    >
+      <span
+        role="progressbar"
+        aria-valuenow={Math.round(hp.percent)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className="bg-surface-secondary/90 border-divider block w-full overflow-hidden rounded-full border"
+        style={{ height: cell * 0.14 }}
+      >
+        <span
+          className={`block h-full ${getHpTierBarColor(hp.tier)}`}
+          style={{ width: `${hp.percent}%` }}
+        />
+      </span>
+      {hp.kind === 'exact' && (
+        <span
+          className="bg-surface-raised/90 text-heading rounded-full font-semibold whitespace-nowrap"
+          style={{ fontSize: cell * 0.2, padding: `0 ${cell * 0.12}px` }}
+        >
+          {hp.current}/{hp.max}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * Pure-local decoration overlay: name labels + HP bars under tokens. Renders
+ * as a canvas child (inside ViewportContext), positions each decoration in
+ * WORLD units, and lets one camera CSS transform (the SDK's own domLayer
+ * technique, transform-origin 0 0) handle pan and zoom for all of them.
+ * Nothing here enters the element store or the sync channel.
+ */
+export function TokenDecorationLayer({
+  decorations,
+  visible,
+}: TokenDecorationLayerProps) {
+  const camera = useCamera();
+  const viewport = useViewport();
+  const rects = useDecoratedTokenRects();
+  if (!visible) return null;
+  const cell = cellUnit(viewport.toolContext);
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden select-none">
+      <div
+        style={{
+          transform: `translate3d(${camera.x}px, ${camera.y}px, 0) scale(${camera.zoom})`,
+          transformOrigin: '0 0',
+        }}
+      >
+        {rects.map(rect => {
+          const deco = decorations.get(rect.key);
+          if (!deco) return null;
+          // Min-width clamp keeps bars legible on 1×1 tokens.
+          const width = Math.max(rect.w, 0.9 * cell);
+          return (
+            <div
+              key={rect.id}
+              className="absolute flex flex-col items-center"
+              style={{
+                left: rect.x + rect.w / 2 - width / 2,
+                top: rect.y + rect.h + cell * 0.06,
+                width,
+                gap: cell * 0.05,
+                opacity: deco.isDead ? 0.75 : 1,
+              }}
+            >
+              {deco.name && (
+                <span
+                  className="bg-surface-raised/90 border-divider text-heading overflow-hidden rounded-full border font-semibold text-ellipsis whitespace-nowrap"
+                  style={{
+                    fontSize: cell * 0.24,
+                    padding: `0 ${cell * 0.15}px`,
+                    maxWidth: 3 * cell,
+                  }}
+                >
+                  {deco.name}
+                </span>
+              )}
+              {deco.isDead ? (
+                <span style={{ fontSize: cell * 0.3, lineHeight: 1 }}>☠️</span>
+              ) : (
+                deco.hp && <HpRow hp={deco.hp} cell={cell} />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/token-overlay/index.tsx
+++ b/src/components/ui/campaign/token-overlay/index.tsx
@@ -81,7 +81,10 @@ export function TokenDecorationLayer({
   if (!visible) return null;
   const cell = cellUnit(viewport.toolContext);
   return (
-    <div className="pointer-events-none absolute inset-0 overflow-hidden select-none">
+    <div
+      className="pointer-events-none absolute inset-0 overflow-hidden select-none"
+      aria-hidden
+    >
       <div
         style={{
           transform: `translate3d(${camera.x}px, ${camera.y}px, 0) scale(${camera.zoom})`,

--- a/src/components/ui/campaign/token-overlay/index.tsx
+++ b/src/components/ui/campaign/token-overlay/index.tsx
@@ -3,82 +3,43 @@
 import { useCamera, useViewport } from '@fieldnotes/react';
 
 import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
-import { getHpTierBarColor, getHpTierTextColor } from '@/utils/hpColor';
 
+import { DecorationItem } from './DecorationItem';
 import { useDecoratedTokenRects } from './TokenDecorationLayer.hooks';
 
 import type {
   TokenDecoration,
-  TokenHpView,
+  TokenInfoMode,
 } from './TokenDecorationLayer.types';
 
 export type {
   TokenDecoration,
   TokenHpView,
+  TokenInfoMode,
 } from './TokenDecorationLayer.types';
 
 export interface TokenDecorationLayerProps {
   /** Keyed by entityId AND/OR characterId — resolvers double-key player entries. */
   decorations: ReadonlyMap<string, TokenDecoration>;
-  visible: boolean;
-}
-
-function HpRow({ hp, cell }: { hp: TokenHpView; cell: number }) {
-  if (hp.kind === 'label') {
-    return (
-      <span
-        className={`bg-surface-raised/90 border-divider rounded-full border font-semibold whitespace-nowrap ${getHpTierTextColor(hp.tier)}`}
-        style={{ fontSize: cell * 0.22, padding: `0 ${cell * 0.15}px` }}
-      >
-        {hp.text}
-      </span>
-    );
-  }
-  return (
-    <span
-      className="flex w-full flex-col items-center"
-      style={{ gap: cell * 0.05 }}
-    >
-      <span
-        role="progressbar"
-        aria-valuenow={Math.round(hp.percent)}
-        aria-valuemin={0}
-        aria-valuemax={100}
-        className="bg-surface-secondary/90 border-divider block w-full overflow-hidden rounded-full border"
-        style={{ height: cell * 0.14 }}
-      >
-        <span
-          className={`block h-full ${getHpTierBarColor(hp.tier)}`}
-          style={{ width: `${hp.percent}%` }}
-        />
-      </span>
-      {hp.kind === 'exact' && (
-        <span
-          className="bg-surface-raised/90 text-heading rounded-full font-semibold whitespace-nowrap"
-          style={{ fontSize: cell * 0.2, padding: `0 ${cell * 0.12}px` }}
-        >
-          {hp.current}/{hp.max}
-        </span>
-      )}
-    </span>
-  );
+  mode: TokenInfoMode;
 }
 
 /**
- * Pure-local decoration overlay: name labels + HP bars under tokens. Renders
- * as a canvas child (inside ViewportContext), positions each decoration in
- * WORLD units, and lets one camera CSS transform (the SDK's own domLayer
- * technique, transform-origin 0 0) handle pan and zoom for all of them.
- * Nothing here enters the element store or the sync channel.
+ * Pure-local decoration overlay: an in-token HP bar plus (in full mode) a
+ * name/state chip row under each token. Renders as a canvas child (inside
+ * ViewportContext), positions each decoration in WORLD units, and lets one
+ * camera CSS transform (the SDK's own domLayer technique, transform-origin
+ * 0 0) handle pan and zoom for all of them. Nothing here enters the element
+ * store or the sync channel.
  */
 export function TokenDecorationLayer({
   decorations,
-  visible,
+  mode,
 }: TokenDecorationLayerProps) {
   const camera = useCamera();
   const viewport = useViewport();
   const rects = useDecoratedTokenRects();
-  if (!visible) return null;
+  if (mode === 'off') return null;
   const cell = cellUnit(viewport.toolContext);
   return (
     <div
@@ -94,38 +55,14 @@ export function TokenDecorationLayer({
         {rects.map(rect => {
           const deco = decorations.get(rect.key);
           if (!deco) return null;
-          // Min-width clamp keeps bars legible on 1×1 tokens.
-          const width = Math.max(rect.w, 0.9 * cell);
           return (
-            <div
+            <DecorationItem
               key={rect.id}
-              className="absolute flex flex-col items-center"
-              style={{
-                left: rect.x + rect.w / 2 - width / 2,
-                top: rect.y + rect.h + cell * 0.06,
-                width,
-                gap: cell * 0.05,
-                opacity: deco.isDead ? 0.75 : 1,
-              }}
-            >
-              {deco.name && (
-                <span
-                  className="bg-surface-raised/90 border-divider text-heading overflow-hidden rounded-full border font-semibold text-ellipsis whitespace-nowrap"
-                  style={{
-                    fontSize: cell * 0.24,
-                    padding: `0 ${cell * 0.15}px`,
-                    maxWidth: 3 * cell,
-                  }}
-                >
-                  {deco.name}
-                </span>
-              )}
-              {deco.isDead ? (
-                <span style={{ fontSize: cell * 0.3, lineHeight: 1 }}>☠️</span>
-              ) : (
-                deco.hp && <HpRow hp={deco.hp} cell={cell} />
-              )}
-            </div>
+              rect={rect}
+              deco={deco}
+              mode={mode}
+              cell={cell}
+            />
           );
         })}
       </div>

--- a/src/components/ui/campaign/token-overlay/index.tsx
+++ b/src/components/ui/campaign/token-overlay/index.tsx
@@ -5,7 +5,10 @@ import { useCamera, useViewport } from '@fieldnotes/react';
 import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
 
 import { DecorationItem } from './DecorationItem';
-import { useDecoratedTokenRects } from './TokenDecorationLayer.hooks';
+import {
+  useCompactReveal,
+  useDecoratedTokenRects,
+} from './TokenDecorationLayer.hooks';
 
 import type {
   TokenDecoration,
@@ -39,10 +42,12 @@ export function TokenDecorationLayer({
   const camera = useCamera();
   const viewport = useViewport();
   const rects = useDecoratedTokenRects();
+  const { containerRef, activeId } = useCompactReveal(mode, rects);
   if (mode === 'off') return null;
   const cell = cellUnit(viewport.toolContext);
   return (
     <div
+      ref={containerRef}
       className="pointer-events-none absolute inset-0 overflow-hidden select-none"
       aria-hidden
     >
@@ -62,6 +67,7 @@ export function TokenDecorationLayer({
               deco={deco}
               mode={mode}
               cell={cell}
+              showChipRow={mode === 'compact' && rect.id === activeId}
             />
           );
         })}

--- a/src/components/ui/campaign/token-overlay/useDmTokenDecorations.ts
+++ b/src/components/ui/campaign/token-overlay/useDmTokenDecorations.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { hpPercent, hpTier } from '@/utils/hpState';
+
+import type { EncounterEntity } from '@/types/encounter';
+import type { TokenDecoration } from './TokenDecorationLayer.types';
+
+/** DM-side decorations: full fidelity, always — real names, exact HP. */
+export function useDmTokenDecorations(
+  entities: EncounterEntity[]
+): ReadonlyMap<string, TokenDecoration> {
+  return useMemo(() => {
+    const map = new Map<string, TokenDecoration>();
+    for (const e of entities) {
+      if (e.type === 'lair') continue; // no token presence
+      const percent = hpPercent(e.currentHp, e.maxHp);
+      const deco: TokenDecoration = {
+        name: e.name,
+        hp: {
+          kind: 'exact',
+          current: e.currentHp,
+          max: e.maxHp,
+          percent,
+          tier: hpTier(percent),
+        },
+        isDead: e.currentHp <= 0,
+      };
+      map.set(e.id, deco);
+      if (e.playerCharacterId) map.set(e.playerCharacterId, deco);
+    }
+    return map;
+  }, [entities]);
+}

--- a/src/components/ui/campaign/token-overlay/usePlayerTokenDecorations.ts
+++ b/src/components/ui/campaign/token-overlay/usePlayerTokenDecorations.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { hpPercent, hpTier } from '@/utils/hpState';
+
+import type { EnemyHpDisplay } from '@/types/encounter';
+import type {
+  SharedInitiativeState,
+  SharedTurnEntry,
+} from '@/types/sharedState';
+import type {
+  TokenDecoration,
+  TokenHpView,
+} from './TokenDecorationLayer.types';
+
+function hpViewFor(
+  entry: SharedTurnEntry,
+  mode: EnemyHpDisplay
+): TokenHpView | undefined {
+  if (entry.type === 'player') {
+    if (entry.currentHp === undefined || entry.maxHp === undefined)
+      return undefined;
+    const percent = hpPercent(entry.currentHp, entry.maxHp);
+    return {
+      kind: 'exact',
+      current: entry.currentHp,
+      max: entry.maxHp,
+      percent,
+      tier: hpTier(percent),
+    };
+  }
+  // Non-players: exactly what the DM's enemyHpDisplay policy shares — a
+  // missing field for the mode (stale share) omits the row, never breaks it.
+  switch (mode) {
+    case 'off':
+      return undefined;
+    case 'label':
+      return entry.hpState && entry.hpTier
+        ? { kind: 'label', text: entry.hpState, tier: entry.hpTier }
+        : undefined;
+    case 'bar':
+    case 'percent':
+      return entry.hpPercent !== undefined && entry.hpTier
+        ? { kind: 'bar', percent: entry.hpPercent, tier: entry.hpTier }
+        : undefined;
+    case 'exact': {
+      if (entry.currentHp === undefined || entry.maxHp === undefined)
+        return undefined;
+      const percent = hpPercent(entry.currentHp, entry.maxHp);
+      return {
+        kind: 'exact',
+        current: entry.currentHp,
+        max: entry.maxHp,
+        percent,
+        tier: entry.hpTier ?? hpTier(percent),
+      };
+    }
+  }
+}
+
+/** Player-side decorations from the policy-filtered shared initiative. */
+export function usePlayerTokenDecorations(
+  initiative: SharedInitiativeState | null
+): ReadonlyMap<string, TokenDecoration> {
+  return useMemo(() => {
+    const map = new Map<string, TokenDecoration>();
+    if (!initiative) return map;
+    for (const entry of initiative.turnOrder) {
+      const deco: TokenDecoration = {
+        name: entry.displayName,
+        hp: hpViewFor(entry, initiative.enemyHpMode),
+        isDead: entry.isDead ?? false,
+      };
+      map.set(entry.entityId, deco);
+      if (entry.playerCharacterId) map.set(entry.playerCharacterId, deco);
+    }
+    return map;
+  }, [initiative]);
+}

--- a/src/components/ui/campaign/token-overlay/useTokenInfoToggle.ts
+++ b/src/components/ui/campaign/token-overlay/useTokenInfoToggle.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+/** Persisted show/hide state for token decorations. Defaults ON. */
+export function useTokenInfoToggle(storageKey: string): [boolean, () => void] {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(storageKey) === 'false') setVisible(false);
+    } catch {
+      // Ignore localStorage errors
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(storageKey, String(visible));
+    } catch {
+      // Ignore localStorage errors
+    }
+  }, [storageKey, visible]);
+
+  const toggle = useCallback(() => setVisible(v => !v), []);
+  return [visible, toggle];
+}

--- a/src/components/ui/campaign/token-overlay/useTokenInfoToggle.ts
+++ b/src/components/ui/campaign/token-overlay/useTokenInfoToggle.ts
@@ -2,13 +2,33 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-/** Persisted show/hide state for token decorations. Defaults ON. */
-export function useTokenInfoToggle(storageKey: string): [boolean, () => void] {
-  const [visible, setVisible] = useState(true);
+import type { TokenInfoMode } from './TokenDecorationLayer.types';
+
+/** Cycle order for the toolbar eye button. */
+const CYCLE_ORDER: readonly TokenInfoMode[] = ['full', 'compact', 'off'];
+
+/**
+ * Maps a raw localStorage value to a mode. Handles the pre-mode boolean
+ * strings ('true'/'false') from before this feature, passes through already-
+ * valid mode strings, and falls back to the default for anything else
+ * (missing key, corrupt value).
+ */
+function migrateStoredValue(raw: string | null): TokenInfoMode {
+  if (raw === 'true') return 'full';
+  if (raw === 'false') return 'off';
+  if (raw === 'full' || raw === 'compact' || raw === 'off') return raw;
+  return 'full';
+}
+
+/** Persisted show/hide/compact mode for token decorations. Defaults 'full'. */
+export function useTokenInfoMode(
+  storageKey: string
+): [TokenInfoMode, () => void] {
+  const [mode, setMode] = useState<TokenInfoMode>('full');
 
   useEffect(() => {
     try {
-      if (localStorage.getItem(storageKey) === 'false') setVisible(false);
+      setMode(migrateStoredValue(localStorage.getItem(storageKey)));
     } catch {
       // Ignore localStorage errors
     }
@@ -16,12 +36,18 @@ export function useTokenInfoToggle(storageKey: string): [boolean, () => void] {
 
   useEffect(() => {
     try {
-      localStorage.setItem(storageKey, String(visible));
+      localStorage.setItem(storageKey, mode);
     } catch {
       // Ignore localStorage errors
     }
-  }, [storageKey, visible]);
+  }, [storageKey, mode]);
 
-  const toggle = useCallback(() => setVisible(v => !v), []);
-  return [visible, toggle];
+  const cycle = useCallback(() => {
+    setMode(
+      current =>
+        CYCLE_ORDER[(CYCLE_ORDER.indexOf(current) + 1) % CYCLE_ORDER.length]
+    );
+  }, []);
+
+  return [mode, cycle];
 }

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -106,6 +106,9 @@ export type ChessPiece =
 // disguised as an ally until the DM reveals the twist).
 export type PlayerDisposition = 'ally' | 'enemy' | 'neutral';
 
+/** Token side length in grid cells: Tiny/Small/Medium 1, Large 2, Huge 3, Gargantuan 4. */
+export type TokenCellSize = 1 | 2 | 3 | 4;
+
 export interface EncounterEntity {
   id: string;
   type: EntityType;
@@ -166,6 +169,7 @@ export interface EncounterEntity {
   playerAlias?: string; // Optional name players see instead (DM-controlled entities); takes precedence over the hidden generic label
   playerDisposition?: PlayerDisposition; // Allegiance players see (disguise); defaults to enemy for non-players
   chessPiece?: ChessPiece; // Chess piece icon for map correlation
+  tokenSize?: TokenCellSize; // Battle-map token footprint; absent = 1 (no migration needed)
 
   // Player sync reference
   playerCharacterId?: string; // Link to playerStore character

--- a/src/utils/__tests__/encounterConverter.tokenSize.test.ts
+++ b/src/utils/__tests__/encounterConverter.tokenSize.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  monsterToEncounterEntity,
+  sizeCodeToTokenCells,
+} from '@/utils/encounterConverter';
+
+import type { ProcessedMonster } from '@/types/bestiary';
+
+/** Minimal ProcessedMonster fixture — only fields monsterToEncounterEntity
+ * and its helpers actually read are filled in with realistic values. */
+function buildMonster(
+  overrides: Partial<ProcessedMonster> = {}
+): ProcessedMonster {
+  return {
+    id: 'goblin',
+    name: 'Goblin',
+    size: ['S'],
+    type: 'Humanoid',
+    alignment: 'Neutral Evil',
+    ac: '15',
+    hp: '7 (2d6)',
+    speed: '30 ft.',
+    str: 8,
+    dex: 14,
+    con: 10,
+    int: 10,
+    wis: 8,
+    cha: 8,
+    saves: '',
+    skills: '',
+    resistances: '',
+    immunities: '',
+    vulnerabilities: '',
+    senses: '',
+    passivePerception: 9,
+    languages: 'Common, Goblin',
+    cr: '1/4',
+    source: 'MM',
+    page: 166,
+    acValue: 15,
+    hpAverage: 7,
+    hpFormula: '2d6',
+    legendaryActionCount: 0,
+    conditionImmunities: [],
+    ...overrides,
+  };
+}
+
+describe('sizeCodeToTokenCells', () => {
+  it.each([
+    ['T', 1],
+    ['S', 1],
+    ['M', 1],
+    ['L', 2],
+    ['H', 3],
+    ['G', 4],
+    [undefined, 1],
+    ['X', 1],
+  ] as const)('%s → %i', (code, cells) => {
+    expect(sizeCodeToTokenCells(code)).toBe(cells);
+  });
+});
+
+describe('monsterToEncounterEntity tokenSize', () => {
+  it('derives tokenSize from monster.size[0]', () => {
+    expect(
+      monsterToEncounterEntity(buildMonster({ size: ['M'] })).tokenSize
+    ).toBe(1);
+    expect(
+      monsterToEncounterEntity(buildMonster({ size: ['L'] })).tokenSize
+    ).toBe(2);
+    expect(
+      monsterToEncounterEntity(buildMonster({ size: ['H'] })).tokenSize
+    ).toBe(3);
+    expect(
+      monsterToEncounterEntity(buildMonster({ size: ['G'] })).tokenSize
+    ).toBe(4);
+  });
+});

--- a/src/utils/__tests__/encounterSync.test.ts
+++ b/src/utils/__tests__/encounterSync.test.ts
@@ -315,6 +315,25 @@ describe('mergePlayerSyncData', () => {
     const result = mergePlayerSyncData(entity, playerData)!;
     expect(result.deathSaves).toBeUndefined();
   });
+
+  it('copies http(s) avatars into avatarUrl and rejects base64', () => {
+    const entity = createMockEncounterEntity({ type: 'player' });
+    const httpData = createMockPlayerData({
+      characterData: createMockCharacterState({
+        avatar: 'https://s3.amazonaws.com/x/a.png',
+      }),
+    });
+    expect(mergePlayerSyncData(entity, httpData)!.avatarUrl).toBe(
+      'https://s3.amazonaws.com/x/a.png'
+    );
+
+    const b64Data = createMockPlayerData({
+      characterData: createMockCharacterState({
+        avatar: 'data:image/png;base64,xyz',
+      }),
+    });
+    expect(mergePlayerSyncData(entity, b64Data)!.avatarUrl).toBeUndefined();
+  });
 });
 
 describe('hasPlayerDataChanged', () => {
@@ -400,6 +419,51 @@ describe('hasPlayerDataChanged', () => {
         armorClass: 15,
         concentrationSpell: undefined,
         conditions: [...conditions],
+      })
+    ).toBe(false);
+  });
+
+  it('returns true when the avatar changed', () => {
+    const entity = createMockEncounterEntity({
+      avatarUrl: undefined,
+      currentHp: 20,
+      maxHp: 20,
+      tempHp: 0,
+      armorClass: 15,
+      concentrationSpell: undefined,
+      conditions: [],
+    });
+    expect(
+      hasPlayerDataChanged(entity, {
+        currentHp: 20,
+        maxHp: 20,
+        tempHp: 0,
+        armorClass: 15,
+        concentrationSpell: undefined,
+        conditions: [],
+        avatarUrl: 'https://s3.amazonaws.com/x/a.png',
+      })
+    ).toBe(true);
+  });
+
+  it('does not flag unchanged when avatarUrl is absent from updates', () => {
+    const entity = createMockEncounterEntity({
+      avatarUrl: 'https://s3.amazonaws.com/x/a.png',
+      currentHp: 20,
+      maxHp: 20,
+      tempHp: 0,
+      armorClass: 15,
+      concentrationSpell: undefined,
+      conditions: [],
+    });
+    expect(
+      hasPlayerDataChanged(entity, {
+        currentHp: 20,
+        maxHp: 20,
+        tempHp: 0,
+        armorClass: 15,
+        concentrationSpell: undefined,
+        conditions: [],
       })
     ).toBe(false);
   });

--- a/src/utils/__tests__/encounterSync.test.ts
+++ b/src/utils/__tests__/encounterSync.test.ts
@@ -334,6 +334,30 @@ describe('mergePlayerSyncData', () => {
     });
     expect(mergePlayerSyncData(entity, b64Data)!.avatarUrl).toBeUndefined();
   });
+
+  it('omits the avatarUrl key entirely for base64/absent avatars (no clobber of DM-set portraits)', () => {
+    const entityWithDmPortrait = createMockEncounterEntity({
+      type: 'player',
+      avatarUrl: 'https://s3.amazonaws.com/dm/set.png',
+    });
+    const b64Data = createMockPlayerData({
+      characterData: createMockCharacterState({
+        avatar: 'data:image/png;base64,xyz',
+      }),
+    });
+
+    const result = mergePlayerSyncData(entityWithDmPortrait, b64Data);
+    expect(result).not.toBeNull();
+    expect('avatarUrl' in (result as object)).toBe(false); // key OMITTED, not undefined
+
+    const entity = createMockEncounterEntity({ type: 'player' });
+    const noAvatarData = createMockPlayerData({
+      characterData: createMockCharacterState({ avatar: undefined }),
+    });
+    const result2 = mergePlayerSyncData(entity, noAvatarData);
+    expect(result2).not.toBeNull();
+    expect('avatarUrl' in (result2 as object)).toBe(false);
+  });
 });
 
 describe('hasPlayerDataChanged', () => {

--- a/src/utils/__tests__/hpColor.test.ts
+++ b/src/utils/__tests__/hpColor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getHpBarColor } from '../hpColor';
+import { getHpBarColor, getHpTierBarColor } from '../hpColor';
 
 describe('getHpBarColor', () => {
   it('is green above 50%', () => {
@@ -16,5 +16,16 @@ describe('getHpBarColor', () => {
 
   it('falls back to a neutral token when max is 0', () => {
     expect(getHpBarColor(0, 0)).toBe('bg-surface-secondary');
+  });
+});
+
+describe('getHpTierBarColor', () => {
+  it('maps each tier to a distinct bar fill', () => {
+    const classes = (['high', 'mid', 'low', 'critical'] as const).map(
+      getHpTierBarColor
+    );
+    expect(new Set(classes).size).toBe(4);
+    expect(classes[0]).toContain('green');
+    expect(classes[3]).toContain('red');
   });
 });

--- a/src/utils/encounterConverter.ts
+++ b/src/utils/encounterConverter.ts
@@ -5,6 +5,7 @@ import {
   MonsterStatBlock,
   LegendaryActionPool,
   MonsterSpellcasting,
+  TokenCellSize,
 } from '@/types/encounter';
 
 function generateId(): string {
@@ -214,6 +215,20 @@ function abilityModifier(score: number): number {
   return Math.floor((score - 10) / 2);
 }
 
+/** 5eTools size code → token cells: T/S/M 1, L 2, H 3, G 4 (unknown → 1). */
+export function sizeCodeToTokenCells(code: string | undefined): TokenCellSize {
+  switch (code) {
+    case 'L':
+      return 2;
+    case 'H':
+      return 3;
+    case 'G':
+      return 4;
+    default:
+      return 1;
+  }
+}
+
 /**
  * Build a full stat block from a ProcessedMonster for display in the encounter tracker.
  */
@@ -298,6 +313,7 @@ export function monsterToEncounterEntity(
     spellcasting: buildMonsterSpellcasting(monster),
     color: options?.color,
     isHidden: false,
+    tokenSize: sizeCodeToTokenCells(monster.size[0]),
   };
 }
 

--- a/src/utils/encounterSync.ts
+++ b/src/utils/encounterSync.ts
@@ -85,6 +85,12 @@ export function mergePlayerSyncData(
     source: s.source,
   }));
 
+  // Only http(s) avatars — a base64 data-URL must never reach a synced
+  // ImageElement src (it would ride every sync upsert). Same guard as
+  // tokenAvatarUrl; kept inline to keep this util canvas-agnostic.
+  const avatarUrl =
+    char.avatar && /^https?:\/\//.test(char.avatar) ? char.avatar : undefined;
+
   return {
     currentHp,
     maxHp,
@@ -95,6 +101,7 @@ export function mergePlayerSyncData(
     inspirationCount,
     hasUsedReaction,
     deathSaves,
+    avatarUrl,
     conditions: mergedConditions,
     suppressedConditions:
       updatedSuppressed.length > 0 ? updatedSuppressed : undefined,
@@ -127,6 +134,8 @@ export function hasPlayerDataChanged(
   if (updates.concentrationSpell !== entity.concentrationSpell) return true;
   if (updates.inspirationCount !== entity.inspirationCount) return true;
   if (updates.hasUsedReaction !== entity.hasUsedReaction) return true;
+  if (updates.avatarUrl !== undefined && updates.avatarUrl !== entity.avatarUrl)
+    return true;
 
   // Compare death saves
   if (updates.deathSaves !== undefined || entity.deathSaves !== undefined) {

--- a/src/utils/encounterSync.ts
+++ b/src/utils/encounterSync.ts
@@ -101,7 +101,7 @@ export function mergePlayerSyncData(
     inspirationCount,
     hasUsedReaction,
     deathSaves,
-    avatarUrl,
+    ...(avatarUrl !== undefined ? { avatarUrl } : {}),
     conditions: mergedConditions,
     suppressedConditions:
       updatedSuppressed.length > 0 ? updatedSuppressed : undefined,

--- a/src/utils/encounterSync.ts
+++ b/src/utils/encounterSync.ts
@@ -88,6 +88,10 @@ export function mergePlayerSyncData(
   // Only http(s) avatars — a base64 data-URL must never reach a synced
   // ImageElement src (it would ride every sync upsert). Same guard as
   // tokenAvatarUrl; kept inline to keep this util canvas-agnostic.
+  // Precedence consequence: a player's own http(s) avatar wins over a
+  // DM-set portrait on the next poll; base64/absent avatars omit the key
+  // so DM-set portraits survive. Sync updates never restamp already-placed
+  // tokens — only studio edits do.
   const avatarUrl =
     char.avatar && /^https?:\/\//.test(char.avatar) ? char.avatar : undefined;
 

--- a/src/utils/hpColor.ts
+++ b/src/utils/hpColor.ts
@@ -26,3 +26,21 @@ export function getHpTierTextColor(tier: HpTier): string {
       return 'text-accent-red-text';
   }
 }
+
+/**
+ * Bar-fill class for a coarse health tier. Raw Tailwind colors are the
+ * established precedent for HP-bar fills (see getHpBarColor above) — these
+ * are canvas-adjacent paint, not themed UI chrome.
+ */
+export function getHpTierBarColor(tier: HpTier): string {
+  switch (tier) {
+    case 'high':
+      return 'bg-green-600 dark:bg-green-500';
+    case 'mid':
+      return 'bg-amber-500 dark:bg-amber-400';
+    case 'low':
+      return 'bg-orange-500 dark:bg-orange-400';
+    case 'critical':
+      return 'bg-red-600 dark:bg-red-500';
+  }
+}


### PR DESCRIPTION
## Summary

Combatant tokens on both VTT battle maps are now visually identifiable. Spec: `docs/superpowers/specs/2026-07-12-token-identity-design.md` (untracked by policy).

### How it works
- **`token-overlay/TokenDecorationLayer`** — a pure-local DOM layer over each canvas (the SDK has no decoration seam): one camera CSS transform (the SDK's own domLayer technique) handles pan/zoom for every decoration; a `useElements` selector with a custom comparator tracks token rects live through local **and remote** drags. Nothing enters the element store or the sync channel — visibility policy is applied at render time on each viewer's client.
- **DM screen**: real names + exact HP bars (tier-colored) for every linked-encounter combatant.
- **Player screen**: built from the policy-filtered `SharedTurnEntry` — `displayName` respects hidden/alias, and HP follows `enemyHpDisplay` (off / "Bloodied" chip / tier bar / exact numbers). Players always see full HP on player tokens. Changing the mode mid-session updates token bars on the next poll with zero map writes.
- **Player self-placed tokens** now stamp `characterId`, so they get the same label + HP treatment everywhere.
- **Portraits**: player avatars flow into `avatarUrl` via campaign sync (strict `https?://` only — base64 never rides the sync channel; key omitted so DM-set portraits survive polls); the studio panel gets a portrait URL/upload field + token size picker that restamp placed tokens in place.
- **Creature sizes**: `tokenSize` derives from the monster statblock (L→2×2, H→3×3, G→4×4) with a DM override. **Snapping behavior change:** odd-size tokens now center IN a cell (previously every token straddled four cells on square grids — latent misalignment, now fixed); even sizes center on intersections so footprints fill cells exactly. Hex unchanged.
- **Per-screen eye toggle** (persisted) hides all decorations; both map toolbars bumped to 44px touch targets.
- Dead combatants show a dimmed skull instead of a bar.

## Test plan
- [x] 144 files / 2687 unit tests pass; type-check + lint clean
- [x] New suites: decoration layer (positioning, modes, dead state, clamp), both resolvers (every `enemyHpDisplay` mode, double-keying, stale-share fallbacks), snap math (odd/even/hex/off, hand-derived), restamp (narrow patches, type-switch key preservation), merge guards (key omission regression), stamp keys, TokenSettings keyed-state regression
- [x] Final whole-branch review passed (1 finding fixed: keyed TokenSettings per entity)

### Manual checklist
- [x] Square grid: Medium token lands centered in one cell (not straddling four); Large fills exactly 2×2
- [x] DM sees name + exact HP; damage updates the bar live
- [x] Player enemy bars follow `enemyHpDisplay`; mode change applies on next poll
- [x] Hidden enemy: generic label on player map, real name on DM map
- [x] Player with an **S3-hosted** avatar gets a portrait token via sync (base64 stays an ellipse by design)
- [x] Studio → Selected: portrait upload + size picker restamp the placed token in place
- [x] Self-placed player token shows own name + HP on both screens
- [x] Eye toggles hide everything and survive reload
- [x] Decorations track the other screen's drags live; glued through pan/zoom
- [x] Dead combatant: dimmed skull
- [x] Both themes; iPad-comfortable toolbar buttons

### Known follow-ups (deliberately deferred)
Footprint-matched drag ghost (currently an N×N text hint), toggle one-frame flash when persisted OFF, restamp minting a new element id on ellipse↔image switch, 12px gap between grown toolbar and options strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)