### PR TITLE
feat(player-vtt): onboarding hints — template placement instruction + pulsing place-token button

### DIFF
--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -23,6 +23,7 @@ import {
   EyeOff,
 } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
+import { cn } from '@/utils/cn';
 import type { TokenInfoMode } from '@/components/ui/campaign/token-overlay';
 import {
   FieldNotesCanvas,
@@ -109,7 +110,7 @@ const TOKEN_INFO_LABEL: Record<TokenInfoMode, string> = {
   off: 'Token info: hidden',
 };
 
-function PlayerToolbar({
+export function PlayerToolbar({
   status,
   hasSelection,
   onDeleteSelected,
@@ -138,11 +139,11 @@ function PlayerToolbar({
             key={name}
             variant={activeTool === name ? 'primary' : 'ghost'}
             onClick={() => setTool(name)}
-            className={`min-h-[44px] min-w-[44px] p-0${
-              isTokenHint
-                ? 'bg-accent-emerald-bg text-accent-emerald-text animate-pulse'
-                : ''
-            }`}
+            className={cn(
+              'min-h-[44px] min-w-[44px] p-0',
+              isTokenHint &&
+                'bg-accent-emerald-bg text-accent-emerald-text animate-pulse'
+            )}
             title={isTokenHint ? 'Place your token on the map' : label}
             aria-label={isTokenHint ? 'Place your token on the map' : label}
           >

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -51,6 +51,7 @@ import {
   tokenAvatarUrl,
   buildCircularTokenUrl,
 } from './PlayerTokenTool';
+import { useOwnTokenPresent } from './useOwnTokenPresent';
 import {
   SpellTemplateTool,
   type SpellTemplateConfig,
@@ -113,30 +114,42 @@ function PlayerToolbar({
   hasSelection,
   onDeleteSelected,
   tokenInfoToggle,
+  characterId,
 }: {
   status: BattleMapConnectionStatus;
   hasSelection: boolean;
   onDeleteSelected: () => void;
   tokenInfoToggle?: { mode: TokenInfoMode; onCycle: () => void };
+  characterId: string;
 }) {
   const [activeTool, setTool] = useActiveTool();
   const TokenInfoIcon = tokenInfoToggle
     ? TOKEN_INFO_ICON[tokenInfoToggle.mode]
     : null;
+  const hasOwnToken = useOwnTokenPresent(characterId);
+  const needsTokenHint =
+    status === 'live' && !hasOwnToken && activeTool !== 'token';
   return (
     <div className="bg-surface-raised border-divider absolute top-3 left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-xl border p-1 shadow-lg">
-      {PLAYER_TOOLS.map(({ name, label, Icon }) => (
-        <Button
-          key={name}
-          variant={activeTool === name ? 'primary' : 'ghost'}
-          onClick={() => setTool(name)}
-          className="min-h-[44px] min-w-[44px] p-0"
-          title={label}
-          aria-label={label}
-        >
-          <Icon size={16} />
-        </Button>
-      ))}
+      {PLAYER_TOOLS.map(({ name, label, Icon }) => {
+        const isTokenHint = name === 'token' && needsTokenHint;
+        return (
+          <Button
+            key={name}
+            variant={activeTool === name ? 'primary' : 'ghost'}
+            onClick={() => setTool(name)}
+            className={`min-h-[44px] min-w-[44px] p-0${
+              isTokenHint
+                ? 'bg-accent-emerald-bg text-accent-emerald-text animate-pulse'
+                : ''
+            }`}
+            title={isTokenHint ? 'Place your token on the map' : label}
+            aria-label={isTokenHint ? 'Place your token on the map' : label}
+          >
+            <Icon size={16} />
+          </Button>
+        );
+      })}
       {hasSelection && (
         <Button
           variant="danger"
@@ -342,6 +355,7 @@ export function PlayerBattleMapCanvas({
             hasSelection={hasSelection}
             onDeleteSelected={handleDeleteSelected}
             tokenInfoToggle={tokenInfoToggle}
+            characterId={characterId}
           />
         )}
         {viewport && (

--- a/src/components/ui/campaign/location-map/__tests__/PlayerToolbar.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerToolbar.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { PlayerToolbar } from '@/components/ui/campaign/location-map/PlayerBattleMapCanvas';
+import { PLAYER_TOKEN_KIND } from '@/components/ui/campaign/location-map/PlayerTokenTool';
+
+import type { CanvasElement } from '@fieldnotes/core';
+
+let mockElements: CanvasElement[] = [];
+
+vi.mock('@fieldnotes/react', () => ({
+  useActiveTool: () => ['select', vi.fn()] as const,
+  useElements: (
+    selector: (els: CanvasElement[]) => unknown,
+    isEqual?: (a: unknown, b: unknown) => boolean
+  ) => {
+    void isEqual;
+    return selector(mockElements);
+  },
+}));
+
+function ownTokenEl(characterId: string): CanvasElement {
+  return {
+    id: 'tok-1',
+    type: 'shape',
+    position: { x: 0, y: 0 },
+    size: { w: 40, h: 40 },
+    zIndex: 0,
+    locked: false,
+    layerId: 'l1',
+    tokenKind: PLAYER_TOKEN_KIND,
+    characterId,
+  } as unknown as CanvasElement;
+}
+
+describe('PlayerToolbar', () => {
+  beforeEach(() => {
+    mockElements = [];
+  });
+
+  afterEach(() => cleanup());
+
+  it('pulses the token button with an intact class list when the player has no own token yet', () => {
+    render(
+      <PlayerToolbar
+        status="live"
+        hasSelection={false}
+        onDeleteSelected={vi.fn()}
+        characterId="char-1"
+      />
+    );
+    const btn = screen.getByTitle('Place your token on the map');
+    expect(btn.className.split(/\s+/)).toEqual(
+      expect.arrayContaining(['p-0', 'animate-pulse', 'bg-accent-emerald-bg'])
+    );
+  });
+
+  it('shows the plain label with no pulse once the player has placed their own token', () => {
+    mockElements = [ownTokenEl('char-1')];
+    render(
+      <PlayerToolbar
+        status="live"
+        hasSelection={false}
+        onDeleteSelected={vi.fn()}
+        characterId="char-1"
+      />
+    );
+    expect(
+      screen.queryByTitle('Place your token on the map')
+    ).not.toBeInTheDocument();
+    const btn = screen.getByTitle('Place token');
+    expect(btn.className).not.toContain('animate-pulse');
+  });
+
+  it('does not pulse the token button while still connecting', () => {
+    render(
+      <PlayerToolbar
+        status="connecting"
+        hasSelection={false}
+        onDeleteSelected={vi.fn()}
+        characterId="char-1"
+      />
+    );
+    expect(
+      screen.queryByTitle('Place your token on the map')
+    ).not.toBeInTheDocument();
+    const btn = screen.getByTitle('Place token');
+    expect(btn.className).not.toContain('animate-pulse');
+  });
+});

--- a/src/components/ui/campaign/location-map/__tests__/useOwnTokenPresent.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/useOwnTokenPresent.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useOwnTokenPresent } from '@/components/ui/campaign/location-map/useOwnTokenPresent';
+
+import type { CanvasElement } from '@fieldnotes/core';
+
+let mockElements: CanvasElement[] = [];
+
+vi.mock('@fieldnotes/react', () => ({
+  useElements: (
+    selector: (els: CanvasElement[]) => unknown,
+    isEqual?: (a: unknown, b: unknown) => boolean
+  ) => {
+    void isEqual;
+    return selector(mockElements);
+  },
+}));
+
+function tokenEl(overrides: Record<string, unknown> = {}): CanvasElement {
+  return {
+    id: 'el-1',
+    type: 'shape',
+    position: { x: 0, y: 0 },
+    size: { w: 40, h: 40 },
+    zIndex: 0,
+    locked: false,
+    layerId: 'l1',
+    ...overrides,
+  } as unknown as CanvasElement;
+}
+
+describe('useOwnTokenPresent', () => {
+  beforeEach(() => {
+    mockElements = [];
+  });
+
+  it('returns true when the store has a stamped own player token', () => {
+    mockElements = [tokenEl({ tokenKind: 'player', characterId: 'char-1' })];
+    const { result } = renderHook(() => useOwnTokenPresent('char-1'));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when the only player token belongs to another character', () => {
+    mockElements = [tokenEl({ tokenKind: 'player', characterId: 'char-2' })];
+    const { result } = renderHook(() => useOwnTokenPresent('char-1'));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false for an unstamped image element', () => {
+    mockElements = [tokenEl({ type: 'image', src: 'https://x/a.png' })];
+    const { result } = renderHook(() => useOwnTokenPresent('char-1'));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when the store is empty', () => {
+    mockElements = [];
+    const { result } = renderHook(() => useOwnTokenPresent('char-1'));
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/components/ui/campaign/location-map/useOwnTokenPresent.ts
+++ b/src/components/ui/campaign/location-map/useOwnTokenPresent.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { useElements } from '@fieldnotes/react';
+
+import { PLAYER_TOKEN_KIND } from './PlayerTokenTool';
+
+import type { CanvasElement } from '@fieldnotes/core';
+
+function isOwnPlayerToken(el: CanvasElement, characterId: string): boolean {
+  const rec = el as Partial<{ tokenKind: unknown; characterId: unknown }>;
+  return rec.tokenKind === PLAYER_TOKEN_KIND && rec.characterId === characterId;
+}
+
+function isEqual(a: boolean, b: boolean): boolean {
+  return a === b;
+}
+
+/**
+ * True once the player has placed their own (stamped) token on the map.
+ * Tokens placed before the ownership-stamping feature shipped lack the
+ * stamp — this returns false for those, so the "place your token" hint
+ * keeps pulsing until the player places a fresh (stamped) one.
+ */
+export function useOwnTokenPresent(characterId: string): boolean {
+  const selectHasOwnToken = useCallback(
+    (elements: CanvasElement[]) =>
+      elements.some(el => isOwnPlayerToken(el, characterId)),
+    [characterId]
+  );
+  return useElements(selectHasOwnToken, isEqual);
+}

--- a/src/components/ui/campaign/player-vtt/CastingBanner.tsx
+++ b/src/components/ui/campaign/player-vtt/CastingBanner.tsx
@@ -15,15 +15,23 @@ export function CastingBanner({
   aoe,
   onCancel,
 }: CastingBannerProps) {
+  const instruction =
+    aoe.shape === 'cone' || aoe.shape === 'line'
+      ? 'Tap the map, then drag to aim'
+      : 'Tap the map to place the template';
+
   return (
-    <div className="bg-accent-purple-bg border-accent-purple-border text-accent-purple-text pointer-events-auto fixed top-[64px] left-1/2 z-20 flex -translate-x-1/2 items-center gap-3 rounded-full border px-4 py-2 shadow-xl">
-      <span className="text-sm font-medium">
-        ✨ Placing {spellName} — tap the map to drop the {aoe.shape} ·{' '}
-        {aoe.sizeFeet} ft
-      </span>
-      <Button variant="ghost" size="lg" onClick={onCancel}>
-        Cancel
-      </Button>
+    <div className="bg-accent-purple-bg border-accent-purple-border text-accent-purple-text pointer-events-auto fixed top-[64px] left-1/2 z-20 flex -translate-x-1/2 flex-col items-center gap-1 rounded-full border px-4 py-2 shadow-xl">
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-medium">
+          ✨ Placing {spellName} — tap the map to drop the {aoe.shape} ·{' '}
+          {aoe.sizeFeet} ft
+        </span>
+        <Button variant="ghost" size="lg" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+      <span className="text-muted text-xs">{instruction}</span>
     </div>
   );
 }

--- a/src/components/ui/campaign/player-vtt/__tests__/CastingBanner.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/CastingBanner.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { CastingBanner } from '@/components/ui/campaign/player-vtt/CastingBanner';
+import type { SpellAoe } from '@/types/spellAoe';
+
+describe('CastingBanner', () => {
+  afterEach(() => cleanup());
+
+  it('shows the tap-to-place instruction for a circle spell', () => {
+    const aoe: SpellAoe = { shape: 'circle', sizeFeet: 20 };
+    render(<CastingBanner spellName="Fireball" aoe={aoe} onCancel={vi.fn()} />);
+
+    expect(
+      screen.getByText('Tap the map to place the template')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the tap-then-drag aim instruction for a cone spell', () => {
+    const aoe: SpellAoe = { shape: 'cone', sizeFeet: 15 };
+    render(
+      <CastingBanner spellName="Burning Hands" aoe={aoe} onCancel={vi.fn()} />
+    );
+
+    expect(
+      screen.getByText('Tap the map, then drag to aim')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the tap-then-drag aim instruction for a line spell', () => {
+    const aoe: SpellAoe = { shape: 'line', sizeFeet: 60, widthFeet: 5 };
+    render(
+      <CastingBanner spellName="Lightning Bolt" aoe={aoe} onCancel={vi.fn()} />
+    );
+
+    expect(
+      screen.getByText('Tap the map, then drag to aim')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the tap-to-place instruction for a square spell', () => {
+    const aoe: SpellAoe = { shape: 'square', sizeFeet: 15 };
+    render(
+      <CastingBanner spellName="Storm Sphere" aoe={aoe} onCancel={vi.fn()} />
+    );
+
+    expect(
+      screen.getByText('Tap the map to place the template')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Two small discoverability hints on the player VTT (post-token-identity playtest feedback):

1. **Casting banner now says what to do** — while a spell template placement is pending, the banner shows "Tap the map to place the template" (cone/line spells: "Tap the map, then drag to aim").
2. **Pulsing place-token onboarding** — when a player opens a battle map with a live connection and has no token of their own on the map (detected via the `characterId` stamp from #160), the toolbar's Place-token button pulses with an emerald tint and its label becomes "Place your token on the map". It settles the moment they select the tool or a token of theirs exists (including from a previous session's snapshot).

Known accepted limitation: self-tokens placed before #160 lack the stamp, so the pulse can show once for those maps — placing once clears it permanently.

## Test plan
- [x] 147 files / 2712 unit tests pass; type-check + lint clean
- [x] New: CastingBanner copy per shape; `useOwnTokenPresent` (stamped/other/unstamped/empty); PlayerToolbar guard tests (pulse gating incl. class-token separation — catches the class-merge regression found in review)
- [x] Manual: open a fresh map as a player → token button pulses; place token → pulse stops; cast Fireball → banner instructs tap; cast a cone spell → banner instructs tap-then-drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)