### PR TITLE
fix+feat(vtt): visible tokens everywhere, compact default, chess piece & color identity

### DIFF
--- a/src/components/ui/campaign/dm-vtt/StudioPanel/TokenAppearanceRow.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/TokenAppearanceRow.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import {
+  CHESS_PIECES,
+  PIECE_COLORS,
+} from '@/components/ui/encounter/combat-screen/TokenChip';
+
+import type { EncounterEntity } from '@/types/encounter';
+
+export interface TokenAppearanceRowProps {
+  entity: EncounterEntity;
+  onChange: (updates: Pick<EncounterEntity, 'chessPiece' | 'color'>) => void;
+}
+
+/**
+ * Studio-panel controls: chess piece + color swatches for map-correlation
+ * identity (mirrors the encounter page's `TokenChip` picker). Both rows are
+ * radiogroups with a "none"/"clear" option to unset.
+ */
+export function TokenAppearanceRow({
+  entity,
+  onChange,
+}: TokenAppearanceRowProps) {
+  const piece = entity.chessPiece;
+  const color = entity.color;
+
+  return (
+    <div className="mb-2 flex flex-col gap-1.5">
+      <div
+        className="flex items-center gap-1"
+        role="radiogroup"
+        aria-label="Chess piece"
+      >
+        {CHESS_PIECES.map(({ piece: p, Icon }) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() =>
+              onChange({ chessPiece: p === piece ? undefined : p })
+            }
+            className={`flex min-h-[44px] min-w-[44px] flex-1 items-center justify-center rounded transition-colors ${
+              p === piece
+                ? 'bg-accent-amber-bg-strong text-heading'
+                : 'text-muted hover:bg-surface-secondary hover:text-heading'
+            }`}
+            role="radio"
+            aria-checked={p === piece}
+            title={p.charAt(0).toUpperCase() + p.slice(1)}
+          >
+            <Icon size={18} />
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => onChange({ chessPiece: undefined })}
+          className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-[10px] font-semibold transition-colors ${
+            piece === undefined
+              ? 'bg-accent-amber-bg-strong text-heading'
+              : 'text-muted hover:bg-surface-secondary hover:text-heading'
+          }`}
+          role="radio"
+          aria-checked={piece === undefined}
+          title="No piece"
+        >
+          None
+        </button>
+      </div>
+      <div
+        className="flex items-center gap-1"
+        role="radiogroup"
+        aria-label="Token color"
+      >
+        {PIECE_COLORS.map(c => (
+          <button
+            key={c.value}
+            type="button"
+            onClick={() =>
+              onChange({ color: c.value === color ? undefined : c.value })
+            }
+            className={`flex min-h-[44px] min-w-[44px] flex-1 items-center justify-center rounded transition-colors ${
+              c.value === color
+                ? 'ring-heading ring-2'
+                : 'hover:bg-surface-secondary'
+            }`}
+            role="radio"
+            aria-checked={c.value === color}
+            title={c.name}
+          >
+            <span
+              className="border-divider h-4 w-4 rounded-full border"
+              style={{ backgroundColor: c.value }}
+            />
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => onChange({ color: undefined })}
+          className="text-faint hover:text-accent-red-text flex min-h-[44px] min-w-[44px] items-center justify-center rounded text-[10px] font-semibold transition-colors"
+          role="radio"
+          aria-checked={color === undefined}
+          title="Clear color"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/TokenSettings.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/TokenSettings.tsx
@@ -5,6 +5,8 @@ import { useRef, useState } from 'react';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
 
+import { TokenAppearanceRow } from './TokenAppearanceRow';
+
 import type { EncounterEntity, TokenCellSize } from '@/types/encounter';
 
 const SIZES: { cells: TokenCellSize; label: string }[] = [
@@ -16,7 +18,12 @@ const SIZES: { cells: TokenCellSize; label: string }[] = [
 
 export interface TokenSettingsProps {
   entity: EncounterEntity;
-  onChange: (updates: Pick<EncounterEntity, 'avatarUrl' | 'tokenSize'>) => void;
+  onChange: (
+    updates: Pick<
+      EncounterEntity,
+      'avatarUrl' | 'tokenSize' | 'chessPiece' | 'color'
+    >
+  ) => void;
 }
 
 /** Studio-panel section: entity portrait (URL or upload) + token footprint. */
@@ -98,6 +105,7 @@ export function TokenSettings({ entity, onChange }: TokenSettingsProps) {
           Upload failed — check S3 config or try a URL.
         </p>
       )}
+      <TokenAppearanceRow entity={entity} onChange={onChange} />
       <div
         className="flex items-center gap-1"
         role="radiogroup"

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
@@ -26,7 +26,10 @@ export interface StudioPanelProps {
   /** Persist portrait/size edits + restamp placed tokens (Selected tab section). */
   onTokenIdentityChange?: (
     entity: EncounterEntity,
-    updates: Pick<EncounterEntity, 'avatarUrl' | 'tokenSize'>
+    updates: Pick<
+      EncounterEntity,
+      'avatarUrl' | 'tokenSize' | 'chessPiece' | 'color'
+    >
   ) => void;
 }
 

--- a/src/components/ui/campaign/dm-vtt/__tests__/DmVttScreen.hooks.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/DmVttScreen.hooks.test.ts
@@ -152,6 +152,29 @@ describe('useDmVttScreen', () => {
     });
   });
 
+  it('armPlacement uses entity.color over the disposition color when set', () => {
+    seed();
+    const { result } = renderHook(() =>
+      useDmVttScreen({ campaignCode: 'ABC', battleMapId: 'bm-1', dmId: 'dm-1' })
+    );
+
+    act(() => result.current.onStatus('live'));
+    act(() =>
+      result.current.armPlacement(
+        createMockEncounterEntity({
+          id: 'known-1',
+          name: 'Aria',
+          type: 'player',
+          color: '#a855f7',
+        })
+      )
+    );
+
+    expect(result.current.pendingPlacement?.config).toMatchObject({
+      color: '#a855f7',
+    });
+  });
+
   it('config.onPlaced clears pending SYNCHRONOUSLY and selects the entity', () => {
     seed();
     const { result } = renderHook(() =>

--- a/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
@@ -288,6 +288,103 @@ describe('StudioPanel', () => {
     });
   });
 
+  it('clicking a chess piece calls the handler with { chessPiece }', () => {
+    const onTokenIdentityChange = vi.fn();
+    render(
+      <StudioPanel
+        {...baseProps({
+          activeTab: 'selected',
+          selectedEntityId: 'm1',
+          onTokenIdentityChange,
+        })}
+      />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Rook' }));
+    expect(onTokenIdentityChange).toHaveBeenCalledWith(goblin1, {
+      chessPiece: 'rook',
+    });
+  });
+
+  it('clicking the selected chess piece again clears it ({ chessPiece: undefined })', () => {
+    const onTokenIdentityChange = vi.fn();
+    render(
+      <StudioPanel
+        {...baseProps({
+          encounter: makeEncounter({
+            entities: [aria, { ...goblin1, chessPiece: 'rook' }, goblin2],
+          }),
+          activeTab: 'selected',
+          selectedEntityId: 'm1',
+          onTokenIdentityChange,
+        })}
+      />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Rook' }));
+    expect(onTokenIdentityChange).toHaveBeenCalledWith(
+      { ...goblin1, chessPiece: 'rook' },
+      { chessPiece: undefined }
+    );
+  });
+
+  it('clicking "None" clears the chess piece ({ chessPiece: undefined })', () => {
+    const onTokenIdentityChange = vi.fn();
+    render(
+      <StudioPanel
+        {...baseProps({
+          encounter: makeEncounter({
+            entities: [aria, { ...goblin1, chessPiece: 'rook' }, goblin2],
+          }),
+          activeTab: 'selected',
+          selectedEntityId: 'm1',
+          onTokenIdentityChange,
+        })}
+      />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'None' }));
+    expect(onTokenIdentityChange).toHaveBeenCalledWith(
+      { ...goblin1, chessPiece: 'rook' },
+      { chessPiece: undefined }
+    );
+  });
+
+  it('clicking a color swatch calls the handler with { color }', () => {
+    const onTokenIdentityChange = vi.fn();
+    render(
+      <StudioPanel
+        {...baseProps({
+          activeTab: 'selected',
+          selectedEntityId: 'm1',
+          onTokenIdentityChange,
+        })}
+      />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Red' }));
+    expect(onTokenIdentityChange).toHaveBeenCalledWith(goblin1, {
+      color: '#ef4444',
+    });
+  });
+
+  it('clicking "Clear" on colors sends { color: undefined }', () => {
+    const onTokenIdentityChange = vi.fn();
+    render(
+      <StudioPanel
+        {...baseProps({
+          encounter: makeEncounter({
+            entities: [aria, { ...goblin1, color: '#ef4444' }, goblin2],
+          }),
+          activeTab: 'selected',
+          selectedEntityId: 'm1',
+          onTokenIdentityChange,
+        })}
+      />
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Clear' }));
+    expect(onTokenIdentityChange).toHaveBeenCalledWith(
+      { ...goblin1, color: '#ef4444' },
+      { color: undefined }
+    );
+  });
+
   it('does not render the Token settings section when onTokenIdentityChange is absent', () => {
     render(
       <StudioPanel

--- a/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   COMBATANT_TOKEN_KIND,
+  COMBATANT_TOKEN_ZINDEX,
   isCombatantToken,
   dispositionColor,
   stampCombatantToken,
@@ -83,11 +84,13 @@ describe('stampCombatantToken', () => {
       entityId?: string;
       tokenKind?: string;
       size?: { w: number };
+      zIndex?: number;
     };
     expect(el.type).toBe('image');
     expect(el.entityId).toBe('e1');
     expect(el.tokenKind).toBe(COMBATANT_TOKEN_KIND);
     expect(el.size?.w).toBe(40); // one square cell
+    expect(el.zIndex).toBe(COMBATANT_TOKEN_ZINDEX);
     expect(isCombatantToken(el)).toBe(true);
   });
 
@@ -101,10 +104,12 @@ describe('stampCombatantToken', () => {
     const el = added[0] as unknown as CanvasElement & {
       shape?: string;
       fillColor?: string;
+      zIndex?: number;
     };
     expect(el.type).toBe('shape');
     expect(el.shape).toBe('ellipse');
     expect(el.fillColor).toBe('#6B7280');
+    expect(el.zIndex).toBe(COMBATANT_TOKEN_ZINDEX);
     expect(isCombatantToken(el as CanvasElement)).toBe(true);
   });
 
@@ -343,6 +348,7 @@ describe('restampCombatantTokens', () => {
       src: 'https://x/new.png',
       size: { w: 80, h: 80 },
       position: { x: 40, y: 40 },
+      zIndex: COMBATANT_TOKEN_ZINDEX,
     });
   });
 
@@ -366,6 +372,7 @@ describe('restampCombatantTokens', () => {
     expect(el.entityId).toBe('ent-1');
     expect(el.tokenKind).toBe('combatant');
     expect(el.layerId).toBe('l1');
+    expect(el.zIndex).toBe(COMBATANT_TOKEN_ZINDEX);
   });
 
   it('ignores tokens of other entities', () => {

--- a/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts
@@ -375,6 +375,48 @@ describe('restampCombatantTokens', () => {
     expect(el.zIndex).toBe(COMBATANT_TOKEN_ZINDEX);
   });
 
+  it('uses entity.color for the fill (in place update) when set, overriding disposition color', () => {
+    const ellipse = {
+      ...imageToken,
+      type: 'shape',
+      shape: 'ellipse',
+      src: undefined,
+    };
+    const f = fakeStore([ellipse]);
+    restampCombatantTokens(
+      f.store,
+      entity({ color: '#a855f7', avatarUrl: undefined }),
+      ctx
+    );
+    expect(f.updates).toHaveLength(1);
+    expect(f.updates[0].patch).toMatchObject({ fillColor: '#a855f7' });
+  });
+
+  it('uses entity.color for the fill on remove+re-add (type transition)', () => {
+    const f = fakeStore([imageToken]); // image -> ellipse transition (no avatarUrl)
+    restampCombatantTokens(
+      f.store,
+      entity({ color: '#a855f7', avatarUrl: undefined }),
+      ctx
+    );
+    expect(f.added).toHaveLength(1);
+    expect(f.added[0]).toMatchObject({ fillColor: '#a855f7' });
+  });
+
+  it('falls back to dispositionColor when entity.color is unset', () => {
+    const ellipse = {
+      ...imageToken,
+      type: 'shape',
+      shape: 'ellipse',
+      src: undefined,
+    };
+    const f = fakeStore([ellipse]);
+    restampCombatantTokens(f.store, entity({ tokenSize: 2 }), ctx);
+    expect(f.updates).toHaveLength(1);
+    // entity() defaults to type: 'monster' with no legendaryActions/disposition -> red
+    expect(f.updates[0].patch).toMatchObject({ fillColor: '#C0392B' });
+  });
+
   it('ignores tokens of other entities', () => {
     const f = fakeStore([{ ...imageToken, entityId: 'other' }]);
     restampCombatantTokens(f.store, entity({ tokenSize: 2 }), ctx);

--- a/src/components/ui/campaign/dm-vtt/__tests__/useRosterDrag.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useRosterDrag.test.ts
@@ -85,6 +85,19 @@ describe('stampAtScreenPoint', () => {
     expect(added).toHaveLength(1);
     expect(added[0].position).toEqual({ x: 30, y: 20 }); // world (50,40) - half cell (20,20)
   });
+
+  it('uses entity.color over the disposition color when set', () => {
+    const { vp, added } = fakeViewport();
+    const canvasEl = fakeCanvasEl({ left: 0, top: 0 });
+    const entity = makeEntity({ color: '#a855f7', avatarUrl: undefined });
+
+    stampAtScreenPoint(vp, canvasEl, entity, { x: 10, y: 10 });
+
+    expect(added).toHaveLength(1);
+    expect((added[0] as unknown as { fillColor?: string }).fillColor).toBe(
+      '#a855f7'
+    );
+  });
 });
 
 describe('useRosterDrag', () => {

--- a/src/components/ui/campaign/dm-vtt/combatantToken.ts
+++ b/src/components/ui/campaign/dm-vtt/combatantToken.ts
@@ -196,7 +196,7 @@ export function restampCombatantTokens(
               zIndex: COMBATANT_TOKEN_ZINDEX,
             }
           : {
-              fillColor: dispositionColor(entity),
+              fillColor: entity.color ?? dispositionColor(entity),
               size: { w: size, h: size },
               position,
               zIndex: COMBATANT_TOKEN_ZINDEX,
@@ -216,7 +216,7 @@ export function restampCombatantTokens(
             position,
             size: { w: size, h: size },
             shape: 'ellipse',
-            fillColor: dispositionColor(entity),
+            fillColor: entity.color ?? dispositionColor(entity),
             strokeColor: '#1e293b',
             strokeWidth: 2,
             layerId,

--- a/src/components/ui/campaign/dm-vtt/combatantToken.ts
+++ b/src/components/ui/campaign/dm-vtt/combatantToken.ts
@@ -2,7 +2,10 @@ import { createImage, createShape } from '@fieldnotes/core';
 
 import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
 import { tokenAvatarUrl } from '@/components/ui/campaign/location-map/PlayerTokenTool';
-import { snapTokenCenter } from '@/components/ui/campaign/location-map/tokenSnap';
+import {
+  snapTokenCenter,
+  TOKEN_ELEMENT_ZINDEX,
+} from '@/components/ui/campaign/location-map/tokenSnap';
 
 import type {
   CanvasElement,
@@ -15,6 +18,11 @@ import type {
 import type { EncounterEntity, TokenCellSize } from '@/types/encounter';
 
 export const COMBATANT_TOKEN_KIND = 'combatant';
+
+/** Re-exported from tokenSnap.ts (single source of truth — location-map
+ * must not import from dm-vtt, so the constant lives there and this file
+ * imports it, not the reverse). */
+export const COMBATANT_TOKEN_ZINDEX = TOKEN_ELEMENT_ZINDEX;
 
 /** Extra top-level keys carried on token elements — they survive the
  * FieldNotes store, export, and sync round-trips (verified in the spec). */
@@ -74,6 +82,7 @@ export function stampCombatantToken(
         size: { w: size, h: size },
         src,
         layerId,
+        zIndex: COMBATANT_TOKEN_ZINDEX,
       })
     : createShape({
         position,
@@ -83,6 +92,7 @@ export function stampCombatantToken(
         strokeColor: '#1e293b',
         strokeWidth: 2,
         layerId,
+        zIndex: COMBATANT_TOKEN_ZINDEX,
       });
 
   const token: CanvasElement & CombatantTokenKeys = {
@@ -179,11 +189,17 @@ export function restampCombatantTokens(
       store.update(
         rect.id,
         wantsImage
-          ? { src: src as string, size: { w: size, h: size }, position }
+          ? {
+              src: src as string,
+              size: { w: size, h: size },
+              position,
+              zIndex: COMBATANT_TOKEN_ZINDEX,
+            }
           : {
               fillColor: dispositionColor(entity),
               size: { w: size, h: size },
               position,
+              zIndex: COMBATANT_TOKEN_ZINDEX,
             }
       );
     } else {
@@ -194,6 +210,7 @@ export function restampCombatantTokens(
             size: { w: size, h: size },
             src: src as string,
             layerId,
+            zIndex: COMBATANT_TOKEN_ZINDEX,
           })
         : createShape({
             position,
@@ -203,6 +220,7 @@ export function restampCombatantTokens(
             strokeColor: '#1e293b',
             strokeWidth: 2,
             layerId,
+            zIndex: COMBATANT_TOKEN_ZINDEX,
           });
       const token: CanvasElement & CombatantTokenKeys = {
         ...base,

--- a/src/components/ui/campaign/dm-vtt/useDmVttPlacementAndSelection.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttPlacementAndSelection.ts
@@ -64,7 +64,7 @@ export function useDmVttPlacementAndSelection({
         entityId: entity.id,
         name: entity.name,
         avatarUrl: entity.avatarUrl,
-        color: dispositionColor(entity),
+        color: entity.color ?? dispositionColor(entity),
         tokenSize: entity.tokenSize,
         onPlaced: () => {
           setPendingPlacement(null); // SYNCHRONOUS — see comment above.

--- a/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
+++ b/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
@@ -70,7 +70,7 @@ export function stampAtScreenPoint(
     entityId: entity.id,
     name: entity.name,
     avatarUrl: entity.avatarUrl,
-    color: dispositionColor(entity),
+    color: entity.color ?? dispositionColor(entity),
     tokenSize: entity.tokenSize,
   };
   stampCombatantToken(config, world, vp.toolContext);

--- a/src/components/ui/campaign/dm-vtt/useTokenIdentityUpdate.ts
+++ b/src/components/ui/campaign/dm-vtt/useTokenIdentityUpdate.ts
@@ -23,7 +23,10 @@ export function useTokenIdentityUpdate({
   return useCallback(
     (
       entity: EncounterEntity,
-      updates: Pick<EncounterEntity, 'avatarUrl' | 'tokenSize'>
+      updates: Pick<
+        EncounterEntity,
+        'avatarUrl' | 'tokenSize' | 'chessPiece' | 'color'
+      >
     ) => {
       if (!encounterId) return;
       updateEntity(encounterId, entity.id, updates);

--- a/src/components/ui/campaign/location-map/PlayerTokenTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerTokenTool.ts
@@ -7,7 +7,11 @@ import {
   type PointerState,
 } from '@fieldnotes/core';
 import { cellUnit } from './cellUnit';
-import { snapTokenCenter, TOKEN_ELEMENT_ZINDEX } from './tokenSnap';
+import {
+  snapTokenCenter,
+  TOKEN_ELEMENT_ZINDEX,
+  TEMPLATE_ELEMENT_ZINDEX,
+} from './tokenSnap';
 
 export const PLAYER_TOKEN_KIND = 'player';
 
@@ -200,6 +204,21 @@ export class PlayerTokenTool implements Tool {
  * so a follow-up drag adjusts/moves instead of stamping another template.
  */
 export class PlayerTemplateTool extends TemplateTool {
+  onPointerDown(state: PointerState, ctx: ToolContext): void {
+    // The base class's createTemplate call has no zIndex option, so a
+    // manually drag-sized template lands at the default (0) and can paint
+    // under the map image on remote screens — the same tie-break bug
+    // documented at tokenSnap.ts's TOKEN_ELEMENT_ZINDEX. Elevate any newly
+    // created template element after the base handler runs.
+    const existingIds = new Set(ctx.store.getAll().map(el => el.id));
+    super.onPointerDown(state, ctx);
+    for (const el of ctx.store.getAll()) {
+      if (!existingIds.has(el.id) && el.type === 'template') {
+        ctx.store.update(el.id, { zIndex: TEMPLATE_ELEMENT_ZINDEX });
+      }
+    }
+  }
+
   onPointerUp(state: PointerState, ctx: ToolContext): void {
     super.onPointerUp(state, ctx);
     ctx.switchTool?.('select');

--- a/src/components/ui/campaign/location-map/PlayerTokenTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerTokenTool.ts
@@ -7,7 +7,7 @@ import {
   type PointerState,
 } from '@fieldnotes/core';
 import { cellUnit } from './cellUnit';
-import { snapTokenCenter } from './tokenSnap';
+import { snapTokenCenter, TOKEN_ELEMENT_ZINDEX } from './tokenSnap';
 
 export const PLAYER_TOKEN_KIND = 'player';
 
@@ -160,6 +160,7 @@ export class PlayerTokenTool implements Tool {
           size: { w: size, h: size },
           src,
           layerId: ctx.activeLayerId ?? '',
+          zIndex: TOKEN_ELEMENT_ZINDEX,
         })
       : createShape({
           position: { x: center.x - size / 2, y: center.y - size / 2 },
@@ -169,6 +170,7 @@ export class PlayerTokenTool implements Tool {
           strokeColor: '#1e293b',
           strokeWidth: 2,
           layerId: ctx.activeLayerId ?? '',
+          zIndex: TOKEN_ELEMENT_ZINDEX,
         });
 
     const characterId = this.characterIdRef.current;

--- a/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { PlayerTokenTool } from '@/components/ui/campaign/location-map/PlayerTokenTool';
+import { TOKEN_ELEMENT_ZINDEX } from '@/components/ui/campaign/location-map/tokenSnap';
 
 import type {
   CanvasElement,
@@ -120,6 +121,30 @@ describe('PlayerTokenTool sizing', () => {
     // is the center minus half the size.
     expect(el.size).toEqual({ w: 40, h: 40 });
     expect(el.position).toEqual({ x: 40, y: 40 });
+  });
+
+  it('stamps TOKEN_ELEMENT_ZINDEX on the ellipse fallback (guarantees paint above the map background)', () => {
+    const { ctx, added } = fakeCtx();
+    const tool = new PlayerTokenTool(
+      '#12855C',
+      { current: null },
+      { current: 'char-1' }
+    );
+    tool.onPointerDown(down(0, 0), ctx);
+    const el = added[0] as CanvasElement & { zIndex?: number };
+    expect(el.zIndex).toBe(TOKEN_ELEMENT_ZINDEX);
+  });
+
+  it('stamps TOKEN_ELEMENT_ZINDEX on avatar image tokens too', () => {
+    const { ctx, added } = fakeCtx();
+    const tool = new PlayerTokenTool(
+      '#12855C',
+      { current: 'https://x/a.png' },
+      { current: 'char-1' }
+    );
+    tool.onPointerDown(down(0, 0), ctx);
+    const el = added[0] as CanvasElement & { zIndex?: number };
+    expect(el.zIndex).toBe(TOKEN_ELEMENT_ZINDEX);
   });
 
   it('places an unstamped token when no characterId is known', () => {

--- a/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
-import { PlayerTokenTool } from '@/components/ui/campaign/location-map/PlayerTokenTool';
-import { TOKEN_ELEMENT_ZINDEX } from '@/components/ui/campaign/location-map/tokenSnap';
+import { TemplateTool } from '@fieldnotes/core';
+import {
+  PlayerTokenTool,
+  PlayerTemplateTool,
+} from '@/components/ui/campaign/location-map/PlayerTokenTool';
+import {
+  TOKEN_ELEMENT_ZINDEX,
+  TEMPLATE_ELEMENT_ZINDEX,
+} from '@/components/ui/campaign/location-map/tokenSnap';
 
 import type {
   CanvasElement,
@@ -10,11 +17,18 @@ import type {
 
 function fakeCtx(overrides: Record<string, unknown> = {}) {
   const added: CanvasElement[] = [];
+  const elements: CanvasElement[] = [];
+  const updates: Array<{ id: string; patch: Record<string, unknown> }> = [];
   const ctx = {
     camera: { screenToWorld: (p: { x: number; y: number }) => p },
     store: {
       add: vi.fn((el: CanvasElement) => {
         added.push(el);
+        elements.push(el);
+      }),
+      getAll: vi.fn(() => elements),
+      update: vi.fn((id: string, patch: Record<string, unknown>) => {
+        updates.push({ id, patch });
       }),
     },
     requestRender: vi.fn(),
@@ -25,7 +39,7 @@ function fakeCtx(overrides: Record<string, unknown> = {}) {
     snapToGrid: false,
     ...overrides,
   } as unknown as ToolContext;
-  return { ctx, added };
+  return { ctx, added, elements, updates };
 }
 
 const down = (x: number, y: number) => ({ x, y }) as PointerState;
@@ -161,5 +175,36 @@ describe('PlayerTokenTool sizing', () => {
     };
     expect(el.characterId).toBeUndefined();
     expect(el.tokenKind).toBeUndefined();
+  });
+});
+
+describe('PlayerTemplateTool zIndex stamping', () => {
+  it('stamps TEMPLATE_ELEMENT_ZINDEX on the newly created template, leaving pre-existing elements untouched', () => {
+    const { ctx, elements, updates } = fakeCtx();
+    const preExisting = {
+      id: 'existing-1',
+      type: 'template',
+    } as unknown as CanvasElement;
+    elements.push(preExisting);
+
+    // The SDK base class has no zIndex option; simulate it creating a new
+    // template element via the store, the way the real onPointerDown does.
+    const spy = vi
+      .spyOn(TemplateTool.prototype, 'onPointerDown')
+      .mockImplementation((_state, c) => {
+        c.store.add({
+          id: 'new-template-1',
+          type: 'template',
+        } as unknown as CanvasElement);
+      });
+
+    const tool = new PlayerTemplateTool();
+    tool.onPointerDown(down(10, 10), ctx);
+
+    expect(updates).toEqual([
+      { id: 'new-template-1', patch: { zIndex: TEMPLATE_ELEMENT_ZINDEX } },
+    ]);
+
+    spy.mockRestore();
   });
 });

--- a/src/components/ui/campaign/location-map/tokenSnap.ts
+++ b/src/components/ui/campaign/location-map/tokenSnap.ts
@@ -3,6 +3,18 @@ import { smartSnap } from '@fieldnotes/core';
 import type { Point, ToolContext } from '@fieldnotes/core';
 
 /**
+ * zIndex stamped on every token element (DM combatant tokens and player
+ * self-tokens). Players mirror unknown remote layers at `order: -1`
+ * (PlayerBattleMapCanvas), and the SDK breaks (layerOrder, zIndex) ties by
+ * element-arrival order — after a resync, a token can land beneath the map
+ * background (zIndex 0). Elevating tokens above every map-background
+ * element guarantees they always paint on top, regardless of arrival order.
+ * Single source of truth: dm-vtt/combatantToken.ts re-exports this value as
+ * COMBATANT_TOKEN_ZINDEX (location-map must not import from dm-vtt).
+ */
+export const TOKEN_ELEMENT_ZINDEX = 1000;
+
+/**
  * Grid-aware token CENTER snap for an N×N-cell footprint.
  *
  * Square grids: odd N centers in a cell (a 1×1 fills one cell — the old

--- a/src/components/ui/campaign/location-map/tokenSnap.ts
+++ b/src/components/ui/campaign/location-map/tokenSnap.ts
@@ -14,6 +14,9 @@ import type { Point, ToolContext } from '@fieldnotes/core';
  */
 export const TOKEN_ELEMENT_ZINDEX = 1000;
 
+/** Templates paint above the map background, below tokens. */
+export const TEMPLATE_ELEMENT_ZINDEX = 900;
+
 /**
  * Grid-aware token CENTER snap for an N×N-cell footprint.
  *

--- a/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
+++ b/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
@@ -1,6 +1,7 @@
 import { createTemplate, smartSnap } from '@fieldnotes/core';
 
 import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
+import { TEMPLATE_ELEMENT_ZINDEX } from '@/components/ui/campaign/location-map/tokenSnap';
 
 import type { Point, PointerState, Tool, ToolContext } from '@fieldnotes/core';
 import type { AoeShape } from '@/types/spellAoe';
@@ -18,11 +19,6 @@ export interface SpellTemplateConfig {
 
 const FEET_PER_CELL = 5;
 const SPELL_FILL = '#7C3AB7';
-/** Below tokens (COMBATANT_TOKEN_ZINDEX / TOKEN_ELEMENT_ZINDEX = 1000 in
- * dm-vtt/combatantToken.ts and location-map/tokenSnap.ts), above the map
- * background and drawings (zIndex 0) — see the tie-break bug documented at
- * tokenSnap.ts's TOKEN_ELEMENT_ZINDEX. */
-const TEMPLATE_ZINDEX = 900;
 
 /**
  * One-shot fixed-size AoE placement, armed by the casting flow via the
@@ -76,7 +72,7 @@ export class SpellTemplateTool implements Tool {
       radiusFeet: config.sizeFeet,
       renderStyle: 'geometric',
       layerId: ctx.activeLayerId ?? '',
-      zIndex: TEMPLATE_ZINDEX,
+      zIndex: TEMPLATE_ELEMENT_ZINDEX,
     });
     ctx.store.add(el);
     this.placedId = el.id;

--- a/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
+++ b/src/components/ui/campaign/player-vtt/SpellTemplateTool.ts
@@ -18,6 +18,11 @@ export interface SpellTemplateConfig {
 
 const FEET_PER_CELL = 5;
 const SPELL_FILL = '#7C3AB7';
+/** Below tokens (COMBATANT_TOKEN_ZINDEX / TOKEN_ELEMENT_ZINDEX = 1000 in
+ * dm-vtt/combatantToken.ts and location-map/tokenSnap.ts), above the map
+ * background and drawings (zIndex 0) — see the tie-break bug documented at
+ * tokenSnap.ts's TOKEN_ELEMENT_ZINDEX. */
+const TEMPLATE_ZINDEX = 900;
 
 /**
  * One-shot fixed-size AoE placement, armed by the casting flow via the
@@ -71,6 +76,7 @@ export class SpellTemplateTool implements Tool {
       radiusFeet: config.sizeFeet,
       renderStyle: 'geometric',
       layerId: ctx.activeLayerId ?? '',
+      zIndex: TEMPLATE_ZINDEX,
     });
     ctx.store.add(el);
     this.placedId = el.id;

--- a/src/components/ui/campaign/player-vtt/__tests__/SpellTemplateTool.test.ts
+++ b/src/components/ui/campaign/player-vtt/__tests__/SpellTemplateTool.test.ts
@@ -65,6 +65,10 @@ describe('SpellTemplateTool', () => {
     expect(el.radiusFeet).toBe(20);
     expect(el.feetPerCell).toBe(5);
     expect(el.position).toEqual({ x: 100, y: 200 });
+    // Below tokens (zIndex 1000), above map background (zIndex 0) — see the
+    // layer-tie paint-order bug documented at tokenSnap.ts's
+    // TOKEN_ELEMENT_ZINDEX.
+    expect(el.zIndex).toBe(900);
     tool.onPointerUp(down(100, 200), f.ctx);
     expect(f.ctx.switchTool).toHaveBeenCalledWith('select');
     expect(onPlaced).toHaveBeenCalledTimes(1);

--- a/src/components/ui/campaign/token-overlay/DecorationItem.tsx
+++ b/src/components/ui/campaign/token-overlay/DecorationItem.tsx
@@ -2,6 +2,8 @@
 
 import { getHpTierBarColor, getHpTierTextColor } from '@/utils/hpColor';
 
+import { DeadGlyph, PieceGlyph } from './TokenGlyphs';
+
 import type { DecoratedTokenRect } from './TokenDecorationLayer.hooks';
 import type {
   TokenDecoration,
@@ -50,25 +52,6 @@ function InTokenBar({
         className={`block h-full ${getHpTierBarColor(hp.tier)}`}
         style={{ width: `${hp.percent}%` }}
       />
-    </span>
-  );
-}
-
-/** Skull glyph centered inside the token rect for a dead entity. */
-function DeadGlyph({ rect, cell }: { rect: DecoratedTokenRect; cell: number }) {
-  return (
-    <span
-      className="absolute flex items-center justify-center"
-      style={{
-        left: rect.x,
-        top: rect.y,
-        width: rect.w,
-        height: rect.h,
-        fontSize: cell * 0.3,
-        lineHeight: 1,
-      }}
-    >
-      ☠️
     </span>
   );
 }
@@ -158,6 +141,9 @@ export function DecorationItem({
       {deco.isDead && <DeadGlyph rect={rect} cell={cell} />}
       {showBar && (
         <InTokenBar rect={rect} cell={cell} hp={deco.hp as BarLikeHp} />
+      )}
+      {!deco.isDead && deco.chessPiece && (
+        <PieceGlyph rect={rect} deco={deco} />
       )}
       {shouldShowChipRow && <ChipRow rect={rect} cell={cell} deco={deco} />}
     </div>

--- a/src/components/ui/campaign/token-overlay/TokenDecorationLayer.types.ts
+++ b/src/components/ui/campaign/token-overlay/TokenDecorationLayer.types.ts
@@ -1,3 +1,4 @@
+import type { ChessPiece } from '@/types/encounter';
 import type { HpTier } from '@/utils/hpState';
 
 /** Token decoration visibility: full (bar + chips), compact (bar only), off (nothing). */
@@ -22,4 +23,8 @@ export interface TokenDecoration {
   hp?: TokenHpView;
   /** Dim the decoration and replace the HP row with a skull glyph. */
   isDead?: boolean;
+  /** Chess piece icon for map correlation — omit → no piece glyph. */
+  chessPiece?: ChessPiece;
+  /** Piece tint; falls back to a neutral color when omitted. */
+  pieceColor?: string;
 }

--- a/src/components/ui/campaign/token-overlay/TokenGlyphs.tsx
+++ b/src/components/ui/campaign/token-overlay/TokenGlyphs.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { CHESS_PIECES } from '@/components/ui/encounter/combat-screen/TokenChip';
+
+import type { DecoratedTokenRect } from './TokenDecorationLayer.hooks';
+import type { TokenDecoration } from './TokenDecorationLayer.types';
+
+/** Skull glyph centered inside the token rect for a dead entity. */
+export function DeadGlyph({
+  rect,
+  cell,
+}: {
+  rect: DecoratedTokenRect;
+  cell: number;
+}) {
+  return (
+    <span
+      className="absolute flex items-center justify-center"
+      style={{
+        left: rect.x,
+        top: rect.y,
+        width: rect.w,
+        height: rect.h,
+        fontSize: cell * 0.3,
+        lineHeight: 1,
+      }}
+    >
+      ☠️
+    </span>
+  );
+}
+
+/** Chess piece icon centered inside the token rect — identity, not status. */
+export function PieceGlyph({
+  rect,
+  deco,
+}: {
+  rect: DecoratedTokenRect;
+  deco: TokenDecoration;
+}) {
+  const Icon = CHESS_PIECES.find(p => p.piece === deco.chessPiece)?.Icon;
+  if (!Icon) return null;
+  const size = 0.55 * Math.min(rect.w, rect.h);
+  return (
+    <span
+      className="absolute flex items-center justify-center"
+      style={{ left: rect.x, top: rect.y, width: rect.w, height: rect.h }}
+    >
+      <Icon
+        size={size}
+        style={{
+          color: deco.pieceColor ?? '#e2e8f0',
+          filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.7))',
+        }}
+      />
+    </span>
+  );
+}

--- a/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
+++ b/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
@@ -231,6 +231,67 @@ describe('TokenDecorationLayer', () => {
     expect(item.style.width).toBe('max-content');
     expect(item.style.maxWidth).toBe('160px'); // 4 * cell, independent of token size
   });
+
+  it('renders the chess piece icon centered in the token rect with its color, in full mode', () => {
+    const { container } = render(
+      <TokenDecorationLayer
+        decorations={deco({ chessPiece: 'rook', pieceColor: '#a855f7' })}
+        mode="full"
+      />
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg?.style.color).toBe('rgb(168, 85, 247)');
+    // Centering wrapper matches the token rect at (100, 200), 40x40.
+    const wrapper = svg?.parentElement as HTMLElement;
+    expect(wrapper.style.left).toBe('100px');
+    expect(wrapper.style.top).toBe('200px');
+    expect(wrapper.style.width).toBe('40px');
+    expect(wrapper.style.height).toBe('40px');
+  });
+
+  it('renders the chess piece in compact mode too', () => {
+    const { container } = render(
+      <TokenDecorationLayer
+        decorations={deco({ chessPiece: 'pawn' })}
+        mode="compact"
+      />
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('defaults the piece color to a neutral tone when pieceColor is absent', () => {
+    const { container } = render(
+      <TokenDecorationLayer
+        decorations={deco({ chessPiece: 'pawn' })}
+        mode="full"
+      />
+    );
+    const svg = container.querySelector('svg');
+    expect(svg?.style.color).toBe('rgb(226, 232, 240)'); // #e2e8f0
+  });
+
+  it('renders no piece icon when chessPiece is absent', () => {
+    const { container } = render(
+      <TokenDecorationLayer decorations={deco()} mode="full" />
+    );
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('hides the piece icon (skull takes precedence) when the token is dead', () => {
+    const { container } = render(
+      <TokenDecorationLayer
+        decorations={deco({
+          chessPiece: 'king',
+          isDead: true,
+          hp: { kind: 'bar', percent: 0, tier: 'critical' },
+        })}
+        mode="full"
+      />
+    );
+    expect(screen.getByText('☠️')).toBeInTheDocument();
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
 });
 
 function firePointer(type: string, clientX: number, clientY: number) {

--- a/src/components/ui/campaign/token-overlay/__tests__/useDmTokenDecorations.test.ts
+++ b/src/components/ui/campaign/token-overlay/__tests__/useDmTokenDecorations.test.ts
@@ -57,4 +57,20 @@ describe('useDmTokenDecorations', () => {
     );
     expect(result.current.size).toBe(0);
   });
+
+  it('carries chessPiece and color through as chessPiece/pieceColor', () => {
+    const { result } = renderHook(() =>
+      useDmTokenDecorations([entity({ chessPiece: 'rook', color: '#a855f7' })])
+    );
+    const d = result.current.get('e1');
+    expect(d?.chessPiece).toBe('rook');
+    expect(d?.pieceColor).toBe('#a855f7');
+  });
+
+  it('leaves chessPiece/pieceColor undefined when unset', () => {
+    const { result } = renderHook(() => useDmTokenDecorations([entity({})]));
+    const d = result.current.get('e1');
+    expect(d?.chessPiece).toBeUndefined();
+    expect(d?.pieceColor).toBeUndefined();
+  });
 });

--- a/src/components/ui/campaign/token-overlay/__tests__/usePlayerTokenDecorations.test.ts
+++ b/src/components/ui/campaign/token-overlay/__tests__/usePlayerTokenDecorations.test.ts
@@ -129,4 +129,24 @@ describe('usePlayerTokenDecorations', () => {
     );
     expect(result.current.get('e1')?.isDead).toBe(true);
   });
+
+  it('maps chessPiece and tokenColor to chessPiece/pieceColor', () => {
+    const { result } = renderHook(() =>
+      usePlayerTokenDecorations(
+        state('off', [enemy({ chessPiece: 'bishop', tokenColor: '#22c55e' })])
+      )
+    );
+    const d = result.current.get('e1');
+    expect(d?.chessPiece).toBe('bishop');
+    expect(d?.pieceColor).toBe('#22c55e');
+  });
+
+  it('leaves chessPiece/pieceColor undefined when absent', () => {
+    const { result } = renderHook(() =>
+      usePlayerTokenDecorations(state('off', [enemy({})]))
+    );
+    const d = result.current.get('e1');
+    expect(d?.chessPiece).toBeUndefined();
+    expect(d?.pieceColor).toBeUndefined();
+  });
 });

--- a/src/components/ui/campaign/token-overlay/__tests__/useTokenInfoToggle.test.ts
+++ b/src/components/ui/campaign/token-overlay/__tests__/useTokenInfoToggle.test.ts
@@ -6,18 +6,18 @@ import { useTokenInfoMode } from '@/components/ui/campaign/token-overlay/useToke
 describe('useTokenInfoMode', () => {
   beforeEach(() => localStorage.clear());
 
-  it('defaults to full and cycles full -> compact -> off -> full', () => {
+  it('defaults to compact and cycles compact -> off -> full -> compact', () => {
     const { result } = renderHook(() => useTokenInfoMode('test-key'));
-    expect(result.current[0]).toBe('full');
-    act(() => result.current[1]());
     expect(result.current[0]).toBe('compact');
-    expect(localStorage.getItem('test-key')).toBe('compact');
     act(() => result.current[1]());
     expect(result.current[0]).toBe('off');
     expect(localStorage.getItem('test-key')).toBe('off');
     act(() => result.current[1]());
     expect(result.current[0]).toBe('full');
     expect(localStorage.getItem('test-key')).toBe('full');
+    act(() => result.current[1]());
+    expect(result.current[0]).toBe('compact');
+    expect(localStorage.getItem('test-key')).toBe('compact');
   });
 
   it('migrates legacy boolean strings to modes', () => {
@@ -36,9 +36,9 @@ describe('useTokenInfoMode', () => {
     expect(result.current[0]).toBe('compact');
   });
 
-  it('falls back to full for corrupt/unknown stored values', () => {
+  it('falls back to compact for corrupt/unknown stored values', () => {
     localStorage.setItem('test-key', 'garbage');
     const { result } = renderHook(() => useTokenInfoMode('test-key'));
-    expect(result.current[0]).toBe('full');
+    expect(result.current[0]).toBe('compact');
   });
 });

--- a/src/components/ui/campaign/token-overlay/useDmTokenDecorations.ts
+++ b/src/components/ui/campaign/token-overlay/useDmTokenDecorations.ts
@@ -26,6 +26,8 @@ export function useDmTokenDecorations(
           tier: hpTier(percent),
         },
         isDead: e.currentHp <= 0,
+        chessPiece: e.chessPiece,
+        pieceColor: e.color,
       };
       map.set(e.id, deco);
       if (e.playerCharacterId) map.set(e.playerCharacterId, deco);

--- a/src/components/ui/campaign/token-overlay/usePlayerTokenDecorations.ts
+++ b/src/components/ui/campaign/token-overlay/usePlayerTokenDecorations.ts
@@ -71,6 +71,8 @@ export function usePlayerTokenDecorations(
         name: entry.displayName,
         hp: hpViewFor(entry, initiative.enemyHpMode),
         isDead: entry.isDead ?? false,
+        chessPiece: entry.chessPiece,
+        pieceColor: entry.tokenColor,
       };
       map.set(entry.entityId, deco);
       if (entry.playerCharacterId) map.set(entry.playerCharacterId, deco);

--- a/src/components/ui/campaign/token-overlay/useTokenInfoToggle.ts
+++ b/src/components/ui/campaign/token-overlay/useTokenInfoToggle.ts
@@ -17,14 +17,14 @@ function migrateStoredValue(raw: string | null): TokenInfoMode {
   if (raw === 'true') return 'full';
   if (raw === 'false') return 'off';
   if (raw === 'full' || raw === 'compact' || raw === 'off') return raw;
-  return 'full';
+  return 'compact';
 }
 
-/** Persisted show/hide/compact mode for token decorations. Defaults 'full'. */
+/** Persisted show/hide/compact mode for token decorations. Defaults 'compact'. */
 export function useTokenInfoMode(
   storageKey: string
 ): [TokenInfoMode, () => void] {
-  const [mode, setMode] = useState<TokenInfoMode>('full');
+  const [mode, setMode] = useState<TokenInfoMode>('compact');
 
   useEffect(() => {
     try {

--- a/src/types/sharedState.ts
+++ b/src/types/sharedState.ts
@@ -1,6 +1,6 @@
 import type { CalendarConfig, WeatherType } from './calendar';
 import type { InventoryItem } from './character';
-import type { EnemyHpDisplay } from './encounter';
+import type { ChessPiece, EnemyHpDisplay } from './encounter';
 
 // Stored in Redis — DM's calendar data (events stay local, not synced)
 export interface SharedCalendar {
@@ -71,6 +71,11 @@ export interface SharedTurnEntry {
   hpTier?: 'high' | 'mid' | 'low' | 'critical';
   isDead?: boolean; // current HP <= 0 (players always; enemies when HP is shared)
   disposition?: 'ally' | 'enemy' | 'neutral'; // player-facing allegiance (non-players)
+  // DM-assigned map-correlation identity — lets players match a token on the
+  // battle map to its initiative row even when the entity is a hidden enemy;
+  // that correlation is the whole purpose, so it's safe to always share.
+  chessPiece?: ChessPiece;
+  tokenColor?: string;
 }
 
 // Initiative/turn state pushed by the DM, read by players

--- a/src/utils/__tests__/buildSharedInitiative.test.ts
+++ b/src/utils/__tests__/buildSharedInitiative.test.ts
@@ -194,6 +194,43 @@ describe('buildSharedInitiative', () => {
     expect(buildSharedInitiative(enc).turnOrder[0].displayName).toBe('Aragorn');
   });
 
+  it('includes chessPiece and tokenColor when set, for players and non-players alike', () => {
+    const enc = encounter([
+      entity({
+        id: 'p',
+        name: 'Aragorn',
+        type: 'player',
+        initiative: 20,
+        playerCharacterId: 'char-a',
+        chessPiece: 'king',
+        color: '#a855f7',
+      }),
+      entity({
+        id: 'm',
+        name: 'Goblin',
+        initiative: 5,
+        isHidden: true,
+        chessPiece: 'pawn',
+        color: '#ef4444',
+      }),
+    ]);
+    const rows = buildSharedInitiative(enc).turnOrder;
+    const player = rows.find(r => r.entityId === 'p')!;
+    const monster = rows.find(r => r.entityId === 'm')!;
+    expect(player.chessPiece).toBe('king');
+    expect(player.tokenColor).toBe('#a855f7');
+    expect(monster.chessPiece).toBe('pawn');
+    expect(monster.tokenColor).toBe('#ef4444');
+    expect(monster.displayName).toBe('Enemy'); // still hidden — identity is separate
+  });
+
+  it('omits chessPiece/tokenColor when unset', () => {
+    const enc = encounter([entity({ id: 'm', name: 'Goblin', initiative: 5 })]);
+    const row = buildSharedInitiative(enc).turnOrder[0];
+    expect(row.chessPiece).toBeUndefined();
+    expect(row.tokenColor).toBeUndefined();
+  });
+
   it('includes HP for player entities only', () => {
     const enc = encounter([
       entity({

--- a/src/utils/buildSharedInitiative.ts
+++ b/src/utils/buildSharedInitiative.ts
@@ -44,6 +44,11 @@ function toEntry(
     type: entity.type as SharedTurnEntry['type'],
   };
 
+  // DM-assigned map-correlation identity — shared for every entity type,
+  // hidden enemies included (that correlation is its whole purpose).
+  if (entity.chessPiece !== undefined) entry.chessPiece = entity.chessPiece;
+  if (entity.color !== undefined) entry.tokenColor = entity.color;
+
   // Players always expose identity + exact HP (their own sheet is authoritative).
   if (isPlayer) {
     entry.playerCharacterId = entity.playerCharacterId;


### PR DESCRIPTION
## Summary

Three playtest items:

### 1. Fix: enemy tokens invisible on player screens (root-caused)
Players mirror every unknown remote layer at the same order (-1) because layers aren't synced — so the DM's map-background layer and token layer tie, and the SDK's stable sort falls back to element **arrival order**. After a resync, tokens could paint *underneath* the map image while their DOM decorations (name/HP) still showed. Fix: tokens stamp `zIndex: 1000` and spell/drag templates `zIndex: 900` (map background is structurally locked to zIndex 0 by the SDK's `addImage` API), making paint order deterministic on every screen. Covers DM combatant tokens, player self-tokens, cast templates, AND drag-sized templates (the SDK base class needed an override — caught in review). Restamping an old token heals its zIndex.

### 2. Compact (HP-bar-only) is now the default token-info mode
Fresh users get the bar-only view; anyone who explicitly picked a mode keeps it (`'true'`→full, `'false'`→off migrations preserved).

### 3. Chess piece + color identity from the encounter page
- Entity **color** (the encounter-page TokenChip palette) now paints the token ellipse on the map (falls back to disposition color); syncs natively as canvas paint.
- Entity **chess piece** renders as a colored lucide glyph centered on the token via the decoration overlay — both screens, full and compact modes. It rides the shared initiative payload (`chessPiece`/`tokenColor` on `SharedTurnEntry`), and deliberately works for hidden enemies — map correlation without leaking names ("focus the black rook").
- The battle-map studio panel gets the same piece picker + color swatches as the encounter page (with none/clear), restamping placed tokens live.

## Test plan
- [x] 144 files / 2725 unit tests; type-check + lint clean
- [x] New: zIndex assertions on every stamp/restamp/template path; toggle migration truth table; piece glyph render (centered/colored/compact/dead-precedence); resolver + buildSharedInitiative passthrough (incl. hidden enemy keeps piece); TokenSettings piece/color/clear payloads; undefined-clear semantics vs the store's spread-merge
- [x] Manual: reload a player map with DM tokens → tokens always visible above the map; fresh browser → compact by default; assign piece+color on the encounter page → token shows colored piece on both screens; change color in the battle-map studio → placed token recolors

🤖 Generated with [Claude Code](https://claude.com/claude-code)