### PR TITLE
feat(vtt): condition icons and concentration ring on battle-map tokens

### DIFF
--- a/src/components/ui/campaign/__tests__/InitiativePanel.test.tsx
+++ b/src/components/ui/campaign/__tests__/InitiativePanel.test.tsx
@@ -9,6 +9,7 @@ const base: SharedInitiativeState = {
   round: 3,
   currentEntityId: 'a',
   enemyHpMode: 'off',
+  enemyConditionsMode: 'off',
   turnOrder: [
     {
       entityId: 'a',

--- a/src/components/ui/campaign/__tests__/useInitiativePrompt.test.ts
+++ b/src/components/ui/campaign/__tests__/useInitiativePrompt.test.ts
@@ -56,6 +56,7 @@ describe('useInitiativePrompt', () => {
             currentEntityId: null,
             turnOrder: [],
             enemyHpMode: 'off',
+            enemyConditionsMode: 'off',
             updatedAt: '2026-01-01T00:00:00.000Z',
           },
         },

--- a/src/components/ui/campaign/player-vtt/__tests__/CombatPanel.test.tsx
+++ b/src/components/ui/campaign/player-vtt/__tests__/CombatPanel.test.tsx
@@ -49,6 +49,7 @@ function buildState(
     currentEntityId: 'goblin-1',
     turnOrder: [enemyEntry, playerEntry, defeatedEntry],
     enemyHpMode: 'label',
+    enemyConditionsMode: 'off',
     updatedAt: '2026-07-08T12:00:00.000Z',
     ...overrides,
   };

--- a/src/components/ui/campaign/token-overlay/ChipRow.tsx
+++ b/src/components/ui/campaign/token-overlay/ChipRow.tsx
@@ -16,10 +16,13 @@ export function ChipRow({
   rect,
   cell,
   deco,
+  conditionNames,
 }: {
   rect: DecoratedTokenRect;
   cell: number;
   deco: TokenDecoration;
+  /** Compact-reveal only: joined condition names shown as one chip. */
+  conditionNames?: string[];
 }) {
   const showHpChip = !deco.isDead && deco.hp;
   return (
@@ -60,6 +63,14 @@ export function ChipRow({
           style={{ fontSize: cell * 0.22, padding: `0 ${cell * 0.15}px` }}
         >
           {deco.hp.text}
+        </span>
+      )}
+      {conditionNames && conditionNames.length > 0 && (
+        <span
+          className="bg-surface-raised/90 border-divider text-body rounded-full border whitespace-nowrap"
+          style={{ fontSize: cell * 0.2, padding: `0 ${cell * 0.12}px` }}
+        >
+          {conditionNames.join(' · ')}
         </span>
       )}
     </div>

--- a/src/components/ui/campaign/token-overlay/ChipRow.tsx
+++ b/src/components/ui/campaign/token-overlay/ChipRow.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { getHpTierTextColor } from '@/utils/hpColor';
+
+import type { DecoratedTokenRect } from './TokenDecorationLayer.hooks';
+import type { TokenDecoration } from './TokenDecorationLayer.types';
+
+/**
+ * One chip row centered below the token: name + exact numbers/label chip.
+ * The row is sized to its content (`width: max-content`) rather than clamped
+ * to the token width, so short-to-medium names render unclipped; it's capped
+ * at 4 cells so it never runs away, and each chip keeps its own
+ * overflow/ellipsis as a safety net for a truly huge name.
+ */
+export function ChipRow({
+  rect,
+  cell,
+  deco,
+}: {
+  rect: DecoratedTokenRect;
+  cell: number;
+  deco: TokenDecoration;
+}) {
+  const showHpChip = !deco.isDead && deco.hp;
+  return (
+    <div
+      className="absolute flex flex-row flex-wrap items-center justify-center"
+      style={{
+        left: rect.x + rect.w / 2,
+        top: rect.y + rect.h + cell * 0.06,
+        transform: 'translateX(-50%)',
+        width: 'max-content',
+        maxWidth: 4 * cell,
+        gap: cell * 0.05,
+      }}
+    >
+      {deco.name && (
+        <span
+          className="bg-surface-raised/90 border-divider text-heading overflow-hidden rounded-full border font-semibold text-ellipsis whitespace-nowrap"
+          style={{
+            fontSize: cell * 0.24,
+            padding: `0 ${cell * 0.15}px`,
+            maxWidth: 4 * cell,
+          }}
+        >
+          {deco.name}
+        </span>
+      )}
+      {showHpChip && deco.hp?.kind === 'exact' && (
+        <span
+          className="bg-surface-raised/90 text-heading rounded-full font-semibold whitespace-nowrap"
+          style={{ fontSize: cell * 0.2, padding: `0 ${cell * 0.12}px` }}
+        >
+          {deco.hp.current}/{deco.hp.max}
+        </span>
+      )}
+      {showHpChip && deco.hp?.kind === 'label' && (
+        <span
+          className={`bg-surface-raised/90 border-divider rounded-full border font-semibold whitespace-nowrap ${getHpTierTextColor(deco.hp.tier)}`}
+          style={{ fontSize: cell * 0.22, padding: `0 ${cell * 0.15}px` }}
+        >
+          {deco.hp.text}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/campaign/token-overlay/ConcentrationRing.tsx
+++ b/src/components/ui/campaign/token-overlay/ConcentrationRing.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { DecoratedTokenRect } from './TokenDecorationLayer.hooks';
+
+/**
+ * Purple ring around a concentrating entity's token — spatial-tactical info
+ * (who to hit to break it). Pulses; static under prefers-reduced-motion.
+ */
+export function ConcentrationRing({ rect }: { rect: DecoratedTokenRect }) {
+  const outset = Math.max(2, rect.w * 0.04);
+  return (
+    <span
+      data-testid="concentration-ring"
+      className="border-accent-purple-border absolute block rounded-full border-2 motion-safe:animate-pulse"
+      style={{
+        left: rect.x - outset,
+        top: rect.y - outset,
+        width: rect.w + 2 * outset,
+        height: rect.h + 2 * outset,
+      }}
+    />
+  );
+}

--- a/src/components/ui/campaign/token-overlay/ConditionStrip.tsx
+++ b/src/components/ui/campaign/token-overlay/ConditionStrip.tsx
@@ -36,11 +36,11 @@ export function ConditionStrip({
         maxWidth: rect.w - 2 * inset,
       }}
     >
-      {shown.map(c => {
+      {shown.map((c, i) => {
         const Icon = getConditionIcon(c.name, c.kind);
         return (
           <span
-            key={c.name}
+            key={`${c.name}-${i}`}
             className="bg-surface-raised/90 border-divider text-body relative flex items-center justify-center rounded-full border"
             style={{ width: size, height: size }}
           >

--- a/src/components/ui/campaign/token-overlay/ConditionStrip.tsx
+++ b/src/components/ui/campaign/token-overlay/ConditionStrip.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { getConditionIcon } from '@/utils/conditionIcons';
+
+import type { DecoratedTokenRect } from './TokenDecorationLayer.hooks';
+import type { SharedCondition } from '@/types/sharedState';
+
+const MAX_ICONS = 4;
+
+interface ConditionStripProps {
+  rect: DecoratedTokenRect;
+  cell: number;
+  conditions: SharedCondition[];
+}
+
+/**
+ * Row of condition icon bubbles inside the token's top edge (mirroring the
+ * HP bar inside the bottom edge). Caps at 4 icons + a "+N" overflow chip.
+ */
+export function ConditionStrip({
+  rect,
+  cell,
+  conditions,
+}: ConditionStripProps) {
+  const inset = Math.max(2, 0.05 * cell);
+  const size = 0.26 * cell;
+  const shown = conditions.slice(0, MAX_ICONS);
+  const overflow = conditions.length - shown.length;
+  return (
+    <span
+      className="absolute flex flex-row items-center"
+      style={{
+        left: rect.x + inset,
+        top: rect.y + inset,
+        gap: 0.03 * cell,
+        maxWidth: rect.w - 2 * inset,
+      }}
+    >
+      {shown.map(c => {
+        const Icon = getConditionIcon(c.name, c.kind);
+        return (
+          <span
+            key={c.name}
+            className="bg-surface-raised/90 border-divider text-body relative flex items-center justify-center rounded-full border"
+            style={{ width: size, height: size }}
+          >
+            <Icon style={{ width: size * 0.7, height: size * 0.7 }} />
+            {c.stackCount !== undefined && c.stackCount > 1 && (
+              <span
+                className="bg-surface-raised text-heading absolute rounded-full leading-none font-semibold"
+                style={{
+                  fontSize: size * 0.5,
+                  right: -size * 0.2,
+                  top: -size * 0.2,
+                  padding: size * 0.08,
+                }}
+              >
+                {c.stackCount}
+              </span>
+            )}
+          </span>
+        );
+      })}
+      {overflow > 0 && (
+        <span
+          className="bg-surface-raised/90 border-divider text-body flex items-center justify-center rounded-full border font-semibold"
+          style={{
+            height: size,
+            fontSize: size * 0.55,
+            padding: `0 ${size * 0.25}px`,
+          }}
+        >
+          +{overflow}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/ui/campaign/token-overlay/DecorationItem.tsx
+++ b/src/components/ui/campaign/token-overlay/DecorationItem.tsx
@@ -3,6 +3,8 @@
 import { getHpTierBarColor } from '@/utils/hpColor';
 
 import { ChipRow } from './ChipRow';
+import { ConcentrationRing } from './ConcentrationRing';
+import { ConditionStrip } from './ConditionStrip';
 import { DeadGlyph, PieceGlyph } from './TokenGlyphs';
 
 import type { DecoratedTokenRect } from './TokenDecorationLayer.hooks';
@@ -59,10 +61,14 @@ function InTokenBar({
 
 /**
  * One token's decoration: an in-token HP bar (full/compact, bar/exact kinds),
- * a centered skull when dead, and a chip row below the token with the name
- * plus an exact-numbers or label-state chip. In full mode the chip row is
- * always shown; in compact mode it only appears when `showChipRow` is set
- * (the token is hovered or tap-revealed — see `useCompactReveal`).
+ * a centered skull when dead, a condition icon strip inside the top edge, a
+ * concentration ring around the token, and a chip row below the token with
+ * the name plus an exact-numbers or label-state chip. In full mode the chip
+ * row and condition strip are always shown; in compact mode they only appear
+ * when `showChipRow` is set (the token is hovered or tap-revealed — see
+ * `useCompactReveal`), where the chip row instead lists condition names. The
+ * concentration ring shows in both full and compact modes. Dead entities keep
+ * skull precedence: no strip, no ring, no piece glyph.
  */
 export function DecorationItem({
   rect,
@@ -76,8 +82,13 @@ export function DecorationItem({
     deco.hp &&
     (deco.hp.kind === 'bar' || deco.hp.kind === 'exact');
   const shouldShowChipRow = mode === 'full' || showChipRow === true;
+  const conditions = deco.isDead ? undefined : deco.conditions;
+  const hasConditions = conditions !== undefined && conditions.length > 0;
   return (
     <div style={{ opacity: deco.isDead ? 0.75 : 1 }}>
+      {!deco.isDead && deco.isConcentrating && (
+        <ConcentrationRing rect={rect} />
+      )}
       {deco.isDead && <DeadGlyph rect={rect} cell={cell} />}
       {showBar && (
         <InTokenBar rect={rect} cell={cell} hp={deco.hp as BarLikeHp} />
@@ -85,7 +96,21 @@ export function DecorationItem({
       {!deco.isDead && deco.chessPiece && (
         <PieceGlyph rect={rect} deco={deco} />
       )}
-      {shouldShowChipRow && <ChipRow rect={rect} cell={cell} deco={deco} />}
+      {hasConditions && shouldShowChipRow && (
+        <ConditionStrip rect={rect} cell={cell} conditions={conditions} />
+      )}
+      {shouldShowChipRow && (
+        <ChipRow
+          rect={rect}
+          cell={cell}
+          deco={deco}
+          conditionNames={
+            mode === 'compact' && hasConditions
+              ? conditions.map(c => c.name)
+              : undefined
+          }
+        />
+      )}
     </div>
   );
 }

--- a/src/components/ui/campaign/token-overlay/DecorationItem.tsx
+++ b/src/components/ui/campaign/token-overlay/DecorationItem.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { getHpTierBarColor, getHpTierTextColor } from '@/utils/hpColor';
+import { getHpTierBarColor } from '@/utils/hpColor';
 
+import { ChipRow } from './ChipRow';
 import { DeadGlyph, PieceGlyph } from './TokenGlyphs';
 
 import type { DecoratedTokenRect } from './TokenDecorationLayer.hooks';
@@ -53,67 +54,6 @@ function InTokenBar({
         style={{ width: `${hp.percent}%` }}
       />
     </span>
-  );
-}
-
-/**
- * One chip row centered below the token: name + exact numbers/label chip.
- * The row is sized to its content (`width: max-content`) rather than clamped
- * to the token width, so short-to-medium names render unclipped; it's capped
- * at 4 cells so it never runs away, and each chip keeps its own
- * overflow/ellipsis as a safety net for a truly huge name.
- */
-function ChipRow({
-  rect,
-  cell,
-  deco,
-}: {
-  rect: DecoratedTokenRect;
-  cell: number;
-  deco: TokenDecoration;
-}) {
-  const showHpChip = !deco.isDead && deco.hp;
-  return (
-    <div
-      className="absolute flex flex-row flex-wrap items-center justify-center"
-      style={{
-        left: rect.x + rect.w / 2,
-        top: rect.y + rect.h + cell * 0.06,
-        transform: 'translateX(-50%)',
-        width: 'max-content',
-        maxWidth: 4 * cell,
-        gap: cell * 0.05,
-      }}
-    >
-      {deco.name && (
-        <span
-          className="bg-surface-raised/90 border-divider text-heading overflow-hidden rounded-full border font-semibold text-ellipsis whitespace-nowrap"
-          style={{
-            fontSize: cell * 0.24,
-            padding: `0 ${cell * 0.15}px`,
-            maxWidth: 4 * cell,
-          }}
-        >
-          {deco.name}
-        </span>
-      )}
-      {showHpChip && deco.hp?.kind === 'exact' && (
-        <span
-          className="bg-surface-raised/90 text-heading rounded-full font-semibold whitespace-nowrap"
-          style={{ fontSize: cell * 0.2, padding: `0 ${cell * 0.12}px` }}
-        >
-          {deco.hp.current}/{deco.hp.max}
-        </span>
-      )}
-      {showHpChip && deco.hp?.kind === 'label' && (
-        <span
-          className={`bg-surface-raised/90 border-divider rounded-full border font-semibold whitespace-nowrap ${getHpTierTextColor(deco.hp.tier)}`}
-          style={{ fontSize: cell * 0.22, padding: `0 ${cell * 0.15}px` }}
-        >
-          {deco.hp.text}
-        </span>
-      )}
-    </div>
   );
 }
 

--- a/src/components/ui/campaign/token-overlay/TokenDecorationLayer.types.ts
+++ b/src/components/ui/campaign/token-overlay/TokenDecorationLayer.types.ts
@@ -1,4 +1,5 @@
 import type { ChessPiece } from '@/types/encounter';
+import type { SharedCondition } from '@/types/sharedState';
 import type { HpTier } from '@/utils/hpState';
 
 /** Token decoration visibility: full (bar + chips), compact (bar only), off (nothing). */
@@ -27,4 +28,8 @@ export interface TokenDecoration {
   chessPiece?: ChessPiece;
   /** Piece tint; falls back to a neutral color when omitted. */
   pieceColor?: string;
+  /** Active conditions, already policy-filtered. Omit/empty → no strip. */
+  conditions?: SharedCondition[];
+  /** Entity is concentrating → purple ring around the token. */
+  isConcentrating?: boolean;
 }

--- a/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
+++ b/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
@@ -292,6 +292,85 @@ describe('TokenDecorationLayer', () => {
     expect(screen.getByText('☠️')).toBeInTheDocument();
     expect(container.querySelector('svg')).not.toBeInTheDocument();
   });
+
+  it('renders condition icons inside the token top edge in full mode, capped at 4 with overflow', () => {
+    const { container } = render(
+      <TokenDecorationLayer
+        decorations={deco({
+          conditions: [
+            { name: 'Poisoned' },
+            { name: 'Prone' },
+            { name: 'Stunned' },
+            { name: 'Blinded' },
+            { name: 'Charmed' },
+            { name: 'Deafened' },
+          ],
+        })}
+        mode="full"
+      />
+    );
+    // 4 icon bubbles + one "+2" overflow chip
+    expect(screen.getByText('+2')).toBeInTheDocument();
+    const strip = screen.getByText('+2').parentElement as HTMLElement;
+    // inset = max(2, 0.05*40) = 2 → strip anchored at rect.x+2 / rect.y+2
+    expect(strip.style.left).toBe('102px');
+    expect(strip.style.top).toBe('202px');
+    expect(container.querySelectorAll('svg').length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('shows a stack count on stacked conditions', () => {
+    render(
+      <TokenDecorationLayer
+        decorations={deco({
+          conditions: [{ name: 'Exhaustion', stackCount: 3 }],
+        })}
+        mode="full"
+      />
+    );
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('hides the condition strip in compact mode until revealed, and lists names in the reveal', () => {
+    render(
+      <TokenDecorationLayer
+        decorations={deco({
+          conditions: [{ name: 'Poisoned' }, { name: 'Prone' }],
+        })}
+        mode="compact"
+      />
+    );
+    // Nothing revealed: no name chip row, no condition names
+    expect(screen.queryByText('Poisoned · Prone')).not.toBeInTheDocument();
+  });
+
+  it('renders a concentration ring in full and compact modes, but not when dead', () => {
+    const ringSelector = '[data-testid="concentration-ring"]';
+    const full = render(
+      <TokenDecorationLayer
+        decorations={deco({ isConcentrating: true })}
+        mode="full"
+      />
+    );
+    expect(full.container.querySelector(ringSelector)).toBeInTheDocument();
+    cleanup();
+
+    const compact = render(
+      <TokenDecorationLayer
+        decorations={deco({ isConcentrating: true })}
+        mode="compact"
+      />
+    );
+    expect(compact.container.querySelector(ringSelector)).toBeInTheDocument();
+    cleanup();
+
+    const dead = render(
+      <TokenDecorationLayer
+        decorations={deco({ isConcentrating: true, isDead: true })}
+        mode="full"
+      />
+    );
+    expect(dead.container.querySelector(ringSelector)).not.toBeInTheDocument();
+  });
 });
 
 function firePointer(type: string, clientX: number, clientY: number) {
@@ -424,5 +503,20 @@ describe('TokenDecorationLayer compact-mode reveal', () => {
 
     rerender(<TokenDecorationLayer decorations={deco()} mode="compact" />);
     expect(screen.queryByText('Ogre')).not.toBeInTheDocument();
+  });
+
+  it('lists condition names in the chip row once the token is revealed', () => {
+    render(
+      <TokenDecorationLayer
+        decorations={deco({
+          conditions: [{ name: 'Poisoned' }, { name: 'Prone' }],
+        })}
+        mode="compact"
+      />
+    );
+    expect(screen.queryByText('Poisoned · Prone')).not.toBeInTheDocument();
+
+    firePointer('pointerdown', 120, 220);
+    expect(screen.getByText('Poisoned · Prone')).toBeInTheDocument();
   });
 });

--- a/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
+++ b/src/components/ui/campaign/token-overlay/__tests__/TokenDecorationLayer.test.tsx
@@ -318,6 +318,19 @@ describe('TokenDecorationLayer', () => {
     expect(container.querySelectorAll('svg').length).toBeGreaterThanOrEqual(4);
   });
 
+  it('renders both bubbles when duplicate same-name conditions are present (no key collision)', () => {
+    const { container } = render(
+      <TokenDecorationLayer
+        decorations={deco({
+          conditions: [{ name: 'Marked' }, { name: 'Marked' }],
+        })}
+        mode="full"
+      />
+    );
+    // Two condition icon bubbles should render distinctly despite sharing a name.
+    expect(container.querySelectorAll('svg').length).toBe(2);
+  });
+
   it('shows a stack count on stacked conditions', () => {
     render(
       <TokenDecorationLayer

--- a/src/components/ui/campaign/token-overlay/__tests__/useDmTokenDecorations.test.ts
+++ b/src/components/ui/campaign/token-overlay/__tests__/useDmTokenDecorations.test.ts
@@ -73,4 +73,30 @@ describe('useDmTokenDecorations', () => {
     expect(d?.chessPiece).toBeUndefined();
     expect(d?.pieceColor).toBeUndefined();
   });
+
+  it('carries projected conditions and concentration from the entity', () => {
+    const { result } = renderHook(() =>
+      useDmTokenDecorations([
+        entity({
+          conditions: [
+            { id: 'c1', name: 'Poisoned', kind: 'debuff', source: 'dm' },
+          ],
+          concentrationSpell: 'Hold Person',
+        }),
+      ])
+    );
+    expect(result.current.get('e1')?.conditions).toEqual([
+      { name: 'Poisoned', kind: 'debuff' },
+    ]);
+    expect(result.current.get('e1')?.isConcentrating).toBe(true);
+  });
+
+  it('omits conditions when empty and isConcentrating when not concentrating', () => {
+    const { result } = renderHook(() =>
+      useDmTokenDecorations([entity({ conditions: [] })])
+    );
+    const d = result.current.get('e1');
+    expect(d?.conditions).toBeUndefined();
+    expect(d?.isConcentrating).toBeUndefined();
+  });
 });

--- a/src/components/ui/campaign/token-overlay/__tests__/usePlayerTokenDecorations.test.ts
+++ b/src/components/ui/campaign/token-overlay/__tests__/usePlayerTokenDecorations.test.ts
@@ -149,4 +149,29 @@ describe('usePlayerTokenDecorations', () => {
     expect(d?.chessPiece).toBeUndefined();
     expect(d?.pieceColor).toBeUndefined();
   });
+
+  it('passes through shared conditions and concentration from the entry', () => {
+    const { result } = renderHook(() =>
+      usePlayerTokenDecorations(
+        state('off', [
+          enemy({
+            conditions: [{ name: 'Prone' }],
+            isConcentrating: true,
+          }),
+        ])
+      )
+    );
+    const d = result.current.get('e1');
+    expect(d?.conditions).toEqual([{ name: 'Prone' }]);
+    expect(d?.isConcentrating).toBe(true);
+  });
+
+  it('leaves conditions/isConcentrating undefined when the share omits them', () => {
+    const { result } = renderHook(() =>
+      usePlayerTokenDecorations(state('off', [enemy({})]))
+    );
+    const d = result.current.get('e1');
+    expect(d?.conditions).toBeUndefined();
+    expect(d?.isConcentrating).toBeUndefined();
+  });
 });

--- a/src/components/ui/campaign/token-overlay/useDmTokenDecorations.ts
+++ b/src/components/ui/campaign/token-overlay/useDmTokenDecorations.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 
+import { toSharedConditions } from '@/utils/buildSharedInitiative';
 import { hpPercent, hpTier } from '@/utils/hpState';
 
 import type { EncounterEntity } from '@/types/encounter';
@@ -29,6 +30,9 @@ export function useDmTokenDecorations(
         chessPiece: e.chessPiece,
         pieceColor: e.color,
       };
+      if (e.conditions.length > 0)
+        deco.conditions = toSharedConditions(e.conditions);
+      if (e.concentrationSpell) deco.isConcentrating = true;
       map.set(e.id, deco);
       if (e.playerCharacterId) map.set(e.playerCharacterId, deco);
     }

--- a/src/components/ui/campaign/token-overlay/usePlayerTokenDecorations.ts
+++ b/src/components/ui/campaign/token-overlay/usePlayerTokenDecorations.ts
@@ -73,6 +73,8 @@ export function usePlayerTokenDecorations(
         isDead: entry.isDead ?? false,
         chessPiece: entry.chessPiece,
         pieceColor: entry.tokenColor,
+        conditions: entry.conditions,
+        isConcentrating: entry.isConcentrating,
       };
       map.set(entry.entityId, deco);
       if (entry.playerCharacterId) map.set(entry.playerCharacterId, deco);

--- a/src/components/ui/encounter/CombatConfigDialog.tsx
+++ b/src/components/ui/encounter/CombatConfigDialog.tsx
@@ -242,22 +242,15 @@ export function CombatConfigDialog({
           )}
 
           {/* Enemy conditions sharing */}
-          <div className="border-divider flex items-center justify-between gap-4 border-t pt-4">
-            <div>
-              <span className="text-heading block text-sm font-medium">
-                Share enemy conditions with players
-              </span>
-              <span className="text-muted text-xs">
-                Players see condition icons and concentration on enemy tokens.
-                Your own party&apos;s conditions are always visible to them.
-              </span>
-            </div>
+          <div className="border-divider border-t pt-4">
             <Switch
               checked={conditionsDisplay === 'on'}
               onCheckedChange={checked =>
                 setConditionsDisplay(checked ? 'on' : 'off')
               }
-              aria-label="Share enemy conditions with players"
+              label="Share enemy conditions with players"
+              description="Players see condition icons and concentration on enemy tokens. Your own party's conditions are always visible to them."
+              wrapperClassName="gap-4"
             />
           </div>
         </DialogBody>

--- a/src/components/ui/encounter/CombatConfigDialog.tsx
+++ b/src/components/ui/encounter/CombatConfigDialog.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/feedback/dialog';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
+import { Switch } from '@/components/ui/forms/switch';
 import {
   RadioGroupField,
   RadioGroupItem,
@@ -20,6 +21,7 @@ import {
 import { useEncounterStore } from '@/store/encounterStore';
 import {
   type EnemyHpDisplay,
+  type EnemyConditionsDisplay,
   type HpStateBand,
   DEFAULT_HP_STATE_BANDS,
 } from '@/types/encounter';
@@ -73,12 +75,17 @@ export function CombatConfigDialog({
   const [hpDisplay, setHpDisplay] = useState<EnemyHpDisplay>(
     combatConfig.enemyHpDisplay
   );
+  const [conditionsDisplay, setConditionsDisplay] =
+    useState<EnemyConditionsDisplay>(
+      combatConfig.enemyConditionsDisplay ?? 'off'
+    );
   const [bands, setBands] = useState<HpStateBand[]>(combatConfig.hpStateBands);
 
   // Re-sync local state when dialog opens or store changes
   useEffect(() => {
     if (open) {
       setHpDisplay(combatConfig.enemyHpDisplay);
+      setConditionsDisplay(combatConfig.enemyConditionsDisplay ?? 'off');
       setBands(combatConfig.hpStateBands);
     }
   }, [open, combatConfig]);
@@ -120,7 +127,11 @@ export function CombatConfigDialog({
       .filter(b => b.label.trim() !== '')
       .sort((a, b) => b.minPercent - a.minPercent);
 
-    setCombatConfig({ enemyHpDisplay: hpDisplay, hpStateBands: cleaned });
+    setCombatConfig({
+      enemyHpDisplay: hpDisplay,
+      hpStateBands: cleaned,
+      enemyConditionsDisplay: conditionsDisplay,
+    });
     onOpenChange(false);
   };
 
@@ -134,7 +145,7 @@ export function CombatConfigDialog({
         <DialogHeader>
           <DialogTitle>Combat Configuration</DialogTitle>
           <DialogDescription>
-            Controls what players see for enemy HP during combat.
+            Controls what players see for enemy HP and conditions during combat.
           </DialogDescription>
         </DialogHeader>
 
@@ -229,6 +240,26 @@ export function CombatConfigDialog({
               </Button>
             </div>
           )}
+
+          {/* Enemy conditions sharing */}
+          <div className="border-divider flex items-center justify-between gap-4 border-t pt-4">
+            <div>
+              <span className="text-heading block text-sm font-medium">
+                Share enemy conditions with players
+              </span>
+              <span className="text-muted text-xs">
+                Players see condition icons and concentration on enemy tokens.
+                Your own party&apos;s conditions are always visible to them.
+              </span>
+            </div>
+            <Switch
+              checked={conditionsDisplay === 'on'}
+              onCheckedChange={checked =>
+                setConditionsDisplay(checked ? 'on' : 'off')
+              }
+              aria-label="Share enemy conditions with players"
+            />
+          </div>
         </DialogBody>
 
         <DialogFooter>

--- a/src/hooks/__tests__/useDmInitiativeSync.test.ts
+++ b/src/hooks/__tests__/useDmInitiativeSync.test.ts
@@ -12,6 +12,7 @@ const state: SharedInitiativeState = {
   round: 1,
   currentEntityId: 'a',
   enemyHpMode: 'off',
+  enemyConditionsMode: 'off',
   turnOrder: [],
   updatedAt: '',
 };

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -206,6 +206,9 @@ export interface Encounter {
 // How much of an enemy's (non-player) HP players may see during combat.
 export type EnemyHpDisplay = 'off' | 'label' | 'bar' | 'percent' | 'exact';
 
+// Whether players may see non-player conditions and concentration status.
+export type EnemyConditionsDisplay = 'on' | 'off';
+
 // A named HP band shown to players when enemyHpDisplay is 'label'. `minPercent`
 // is the lowest HP percentage (inclusive) at which this label applies.
 export interface HpStateBand {
@@ -217,6 +220,7 @@ export interface HpStateBand {
 export interface CombatConfig {
   enemyHpDisplay: EnemyHpDisplay;
   hpStateBands: HpStateBand[];
+  enemyConditionsDisplay: EnemyConditionsDisplay;
 }
 
 export const DEFAULT_HP_STATE_BANDS: HpStateBand[] = [
@@ -231,6 +235,7 @@ export const DEFAULT_HP_STATE_BANDS: HpStateBand[] = [
 export const DEFAULT_COMBAT_CONFIG: CombatConfig = {
   enemyHpDisplay: 'off',
   hpStateBands: DEFAULT_HP_STATE_BANDS,
+  enemyConditionsDisplay: 'off',
 };
 
 export interface NPCInventoryItem {

--- a/src/types/sharedState.ts
+++ b/src/types/sharedState.ts
@@ -1,6 +1,10 @@
 import type { CalendarConfig, WeatherType } from './calendar';
 import type { InventoryItem } from './character';
-import type { ChessPiece, EnemyHpDisplay } from './encounter';
+import type {
+  ChessPiece,
+  EnemyConditionsDisplay,
+  EnemyHpDisplay,
+} from './encounter';
 
 // Stored in Redis — DM's calendar data (events stay local, not synced)
 export interface SharedCalendar {
@@ -55,6 +59,15 @@ export interface SharedCustomCounter {
   updatedAt: string; // ISO timestamp
 }
 
+// Display-only projection of an EncounterCondition. Deliberately excludes
+// id, duration, rounds, sourceEntity, sourceSpell, and source — none of
+// that leaves the DM.
+export interface SharedCondition {
+  name: string;
+  kind?: 'buff' | 'debuff' | 'neutral';
+  stackCount?: number;
+}
+
 // A single combatant row shown to players during combat
 export interface SharedTurnEntry {
   entityId: string;
@@ -76,6 +89,12 @@ export interface SharedTurnEntry {
   // that correlation is the whole purpose, so it's safe to always share.
   chessPiece?: ChessPiece;
   tokenColor?: string;
+  // Active conditions. Players always; non-players only when the DM's
+  // enemyConditionsDisplay is 'on' (hidden enemies included — a visible
+  // "prone" marker is fiction-visible information).
+  conditions?: SharedCondition[];
+  // Boolean only — the concentrated spell's name never leaves the DM.
+  isConcentrating?: boolean;
 }
 
 // Initiative/turn state pushed by the DM, read by players
@@ -88,6 +107,8 @@ export interface SharedInitiativeState {
   // How non-player HP is presented to players; tells the panel how to render
   // hpState / hpPercent / currentHp on enemy rows. Defaults to 'off'.
   enemyHpMode: EnemyHpDisplay;
+  // Whether non-player conditions/concentration are being shared.
+  enemyConditionsMode: EnemyConditionsDisplay;
   updatedAt: string; // ISO timestamp
 }
 

--- a/src/utils/__tests__/buildSharedInitiative.test.ts
+++ b/src/utils/__tests__/buildSharedInitiative.test.ts
@@ -260,6 +260,113 @@ describe('buildSharedInitiative', () => {
     expect(monster.maxHp).toBeUndefined();
     expect(monster.playerCharacterId).toBeUndefined();
   });
+
+  it('always shares player conditions and concentration, projected to name/kind/stackCount', () => {
+    const shared = buildSharedInitiative(
+      encounter([
+        entity({
+          id: 'p1',
+          type: 'player',
+          playerCharacterId: 'char-1',
+          conditions: [
+            {
+              id: 'c1',
+              name: 'Poisoned',
+              kind: 'debuff',
+              duration: '1 minute',
+              sourceEntity: 'Spider',
+              sourceSpell: 'Venom',
+              source: 'dm',
+              rounds: 3,
+              stackCount: 2,
+            },
+          ],
+          concentrationSpell: 'Bless',
+        }),
+      ])
+      // no config arg — DEFAULT_COMBAT_CONFIG has enemyConditionsDisplay 'off'
+    );
+    const entry = shared.turnOrder[0];
+    expect(entry.conditions).toEqual([
+      { name: 'Poisoned', kind: 'debuff', stackCount: 2 },
+    ]);
+    expect(entry.isConcentrating).toBe(true);
+  });
+
+  it('omits non-player conditions/concentration when enemyConditionsDisplay is off', () => {
+    const shared = buildSharedInitiative(
+      encounter([
+        entity({
+          id: 'm1',
+          conditions: [{ id: 'c1', name: 'Prone' }],
+          concentrationSpell: 'Hold Person',
+        }),
+      ])
+    );
+    const entry = shared.turnOrder[0];
+    expect('conditions' in entry).toBe(false);
+    expect('isConcentrating' in entry).toBe(false);
+    expect(shared.enemyConditionsMode).toBe('off');
+  });
+
+  it('shares non-player (and hidden-enemy) conditions/concentration when mode is on', () => {
+    const shared = buildSharedInitiative(
+      encounter([
+        entity({
+          id: 'm1',
+          isHidden: true,
+          conditions: [{ id: 'c1', name: 'Prone' }],
+          concentrationSpell: 'Hold Person',
+        }),
+      ]),
+      {
+        enemyHpDisplay: 'off',
+        hpStateBands: [],
+        enemyConditionsDisplay: 'on',
+      }
+    );
+    const entry = shared.turnOrder[0];
+    expect(entry.conditions).toEqual([{ name: 'Prone' }]);
+    expect(entry.isConcentrating).toBe(true);
+    expect(shared.enemyConditionsMode).toBe('on');
+  });
+
+  it('omits empty conditions, stackCount <= 1, and isConcentrating when not concentrating', () => {
+    const shared = buildSharedInitiative(
+      encounter([
+        entity({
+          id: 'p1',
+          type: 'player',
+          playerCharacterId: 'char-1',
+          conditions: [{ id: 'c1', name: 'Blessed', stackCount: 1 }],
+        }),
+        entity({
+          id: 'p2',
+          type: 'player',
+          playerCharacterId: 'char-2',
+          conditions: [],
+        }),
+      ])
+    );
+    expect(shared.turnOrder[0].conditions).toEqual([{ name: 'Blessed' }]);
+    expect(shared.turnOrder[0].isConcentrating).toBeUndefined();
+    expect('conditions' in shared.turnOrder[1]).toBe(false);
+  });
+
+  it('defaults enemyConditionsMode to off for legacy persisted configs missing the field', () => {
+    const legacyConfig = {
+      enemyHpDisplay: 'off',
+      hpStateBands: [],
+    } as unknown as import('@/types/encounter').CombatConfig;
+    const shared = buildSharedInitiative(
+      encounter([
+        entity({ id: 'm1', conditions: [{ id: 'c1', name: 'Prone' }] }),
+      ]),
+      legacyConfig
+    );
+    expect(shared.enemyConditionsMode).toBe('off');
+    expect('conditions' in shared.turnOrder[0]).toBe(false);
+  });
 });
 
 describe('buildSharedInitiative — enemy HP config', () => {
@@ -301,6 +408,7 @@ describe('buildSharedInitiative — enemy HP config', () => {
     const result = buildSharedInitiative(enc(), {
       enemyHpDisplay: 'label',
       hpStateBands: bands,
+      enemyConditionsDisplay: 'off',
     });
     expect(result.enemyHpMode).toBe('label');
     expect(result.turnOrder.find(r => r.entityId === 'm')!.hpState).toBe(
@@ -316,6 +424,7 @@ describe('buildSharedInitiative — enemy HP config', () => {
       const result = buildSharedInitiative(enc(), {
         enemyHpDisplay: mode,
         hpStateBands: bands,
+        enemyConditionsDisplay: 'off',
       });
       const monster = result.turnOrder.find(r => r.entityId === 'm')!;
       expect(monster.hpPercent).toBe(25);
@@ -328,6 +437,7 @@ describe('buildSharedInitiative — enemy HP config', () => {
     const result = buildSharedInitiative(enc(), {
       enemyHpDisplay: 'exact',
       hpStateBands: bands,
+      enemyConditionsDisplay: 'off',
     });
     const monster = result.turnOrder.find(r => r.entityId === 'm')!;
     expect(monster.currentHp).toBe(5);
@@ -338,6 +448,7 @@ describe('buildSharedInitiative — enemy HP config', () => {
     const result = buildSharedInitiative(enc(), {
       enemyHpDisplay: 'label',
       hpStateBands: bands,
+      enemyConditionsDisplay: 'off',
     });
     // 5/20 = 25% -> 'critical'
     expect(result.turnOrder.find(r => r.entityId === 'm')!.hpTier).toBe(
@@ -358,6 +469,7 @@ describe('buildSharedInitiative — enemy HP config', () => {
     const monster = buildSharedInitiative(e, {
       enemyHpDisplay: 'label',
       hpStateBands: bands,
+      enemyConditionsDisplay: 'off',
     }).turnOrder[0];
     expect(monster.isDead).toBe(true);
     expect(monster.hpTier).toBeUndefined();

--- a/src/utils/__tests__/conditionIcons.test.ts
+++ b/src/utils/__tests__/conditionIcons.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Biohazard,
+  ChevronsDown,
+  CircleDot,
+  TrendingDown,
+  TrendingUp,
+} from 'lucide-react';
+import { getConditionIcon } from '../conditionIcons';
+
+describe('getConditionIcon', () => {
+  it('resolves canonical 5e condition names case-insensitively', () => {
+    expect(getConditionIcon('Poisoned')).toBe(Biohazard);
+    expect(getConditionIcon('poisoned')).toBe(Biohazard);
+    expect(getConditionIcon('  PRONE  ')).toBe(ChevronsDown);
+  });
+
+  it('strips a trailing parenthetical (e.g. exhaustion levels)', () => {
+    expect(getConditionIcon('Exhaustion (3)')).toBe(
+      getConditionIcon('Exhaustion')
+    );
+  });
+
+  it('falls back by kind for unknown names', () => {
+    expect(getConditionIcon("Hunter's Mark", 'debuff')).toBe(TrendingDown);
+    expect(getConditionIcon('Heroism', 'buff')).toBe(TrendingUp);
+    expect(getConditionIcon('Marked', 'neutral')).toBe(CircleDot);
+  });
+
+  it('defaults unknown names with no kind to the neutral glyph', () => {
+    expect(getConditionIcon('Totally Homebrew')).toBe(CircleDot);
+  });
+});

--- a/src/utils/buildSharedInitiative.ts
+++ b/src/utils/buildSharedInitiative.ts
@@ -3,10 +3,12 @@ import {
   DEFAULT_COMBAT_CONFIG,
   type CombatConfig,
   type Encounter,
+  type EncounterCondition,
   type EncounterEntity,
 } from '@/types/encounter';
 import { hpPercent, hpStateLabel, hpTier } from '@/utils/hpState';
 import type {
+  SharedCondition,
   SharedInitiativeState,
   SharedTurnEntry,
 } from '@/types/sharedState';
@@ -31,6 +33,19 @@ function playerFacingName(entity: EncounterEntity): string {
   return entity.name;
 }
 
+/** Display-only projection of encounter conditions — see SharedCondition. */
+export function toSharedConditions(
+  conditions: EncounterCondition[]
+): SharedCondition[] {
+  return conditions.map(c => {
+    const shared: SharedCondition = { name: c.name };
+    if (c.kind !== undefined) shared.kind = c.kind;
+    if (c.stackCount !== undefined && c.stackCount > 1)
+      shared.stackCount = c.stackCount;
+    return shared;
+  });
+}
+
 function toEntry(
   entity: EncounterEntity,
   config: CombatConfig
@@ -48,6 +63,17 @@ function toEntry(
   // hidden enemies included (that correlation is its whole purpose).
   if (entity.chessPiece !== undefined) entry.chessPiece = entity.chessPiece;
   if (entity.color !== undefined) entry.tokenColor = entity.color;
+
+  // Conditions & concentration: players always; non-players only when the
+  // DM has turned sharing on. Legacy persisted configs lack the field →
+  // default off.
+  const shareConditions =
+    isPlayer || (config.enemyConditionsDisplay ?? 'off') === 'on';
+  if (shareConditions) {
+    if (entity.conditions.length > 0)
+      entry.conditions = toSharedConditions(entity.conditions);
+    if (entity.concentrationSpell) entry.isConcentrating = true;
+  }
 
   // Players always expose identity + exact HP (their own sheet is authoritative).
   if (isPlayer) {
@@ -107,6 +133,7 @@ export function buildSharedInitiative(
     currentEntityId: current ? current.id : null,
     turnOrder: sorted.map(e => toEntry(e, config)),
     enemyHpMode: config.enemyHpDisplay,
+    enemyConditionsMode: config.enemyConditionsDisplay ?? 'off',
     updatedAt: new Date().toISOString(),
   };
 }

--- a/src/utils/conditionIcons.ts
+++ b/src/utils/conditionIcons.ts
@@ -1,0 +1,66 @@
+import {
+  Ban,
+  BatteryLow,
+  Biohazard,
+  ChevronsDown,
+  CircleDashed,
+  CircleDot,
+  EarOff,
+  EyeOff,
+  Ghost,
+  Grab,
+  Heart,
+  Link,
+  Moon,
+  Mountain,
+  Sparkles,
+  TrendingDown,
+  TrendingUp,
+  Zap,
+} from 'lucide-react';
+
+import type { LucideIcon } from 'lucide-react';
+
+export type ConditionKind = 'buff' | 'debuff' | 'neutral';
+
+// Canonical 5e conditions, keyed lowercase.
+const CONDITION_ICONS: Record<string, LucideIcon> = {
+  blinded: EyeOff,
+  charmed: Heart,
+  deafened: EarOff,
+  exhaustion: BatteryLow,
+  frightened: Ghost,
+  grappled: Grab,
+  incapacitated: Ban,
+  invisible: CircleDashed,
+  paralyzed: Zap,
+  petrified: Mountain,
+  poisoned: Biohazard,
+  prone: ChevronsDown,
+  restrained: Link,
+  stunned: Sparkles,
+  unconscious: Moon,
+};
+
+const KIND_FALLBACK: Record<ConditionKind, LucideIcon> = {
+  buff: TrendingUp,
+  debuff: TrendingDown,
+  neutral: CircleDot,
+};
+
+/**
+ * Icon for a condition name. Lookup is case-insensitive and ignores a
+ * trailing parenthetical ("Exhaustion (3)" → "exhaustion"). Unknown names
+ * fall back by kind; no kind → neutral glyph. Compact-mode reveal shows the
+ * full name, so a generic fallback icon loses nothing.
+ */
+export function getConditionIcon(
+  name: string,
+  kind: ConditionKind = 'neutral'
+): LucideIcon {
+  const key = name
+    .trim()
+    .toLowerCase()
+    .replace(/\s*\([^)]*\)$/, '');
+  return CONDITION_ICONS[key] ?? KIND_FALLBACK[kind];
+}


### PR DESCRIPTION
## Summary

Surfaces combat conditions and concentration on VTT battle-map tokens:

- **Condition icon strip** along the token's top edge (HP bar stays at the bottom) — canonical 5e conditions map to distinct icons, unknown/homebrew names fall back by kind (buff/debuff/neutral). Caps at 4 icons with a `+N` overflow chip; stacked conditions show a count.
- **Concentration ring** — purple pulsing ring around a concentrating entity's token (static under reduced motion). Spell name never leaves the DM for non-players; only a boolean is shared.
- **DM setting: "Share enemy conditions with players"** (`enemyConditionsDisplay`, default off) in the Combat Configuration dialog, following the `enemyHpDisplay` pattern. Player-entity conditions are always visible to players; non-player (hidden enemies included) conditions/concentration only when the toggle is on.
- Respects the existing `TokenInfoMode`: full = strip always visible; compact = strip + condition names in the hover/tap reveal; off = nothing. Dead entities keep skull precedence (no strip, no ring).

## Privacy contract

`SharedCondition` is a deliberate projection — only `name`, `kind`, `stackCount` cross the sync boundary. `id`, `duration`, `rounds`, `sourceEntity`, `sourceSpell`, and `source` never leave the DM. Legacy persisted combat configs (missing the new field) default to off at every read site.

## Changes

- `src/types/encounter.ts`, `src/types/sharedState.ts` — `EnemyConditionsDisplay`, `SharedCondition`, `SharedTurnEntry.conditions`/`isConcentrating`, `SharedInitiativeState.enemyConditionsMode`
- `src/utils/buildSharedInitiative.ts` — share-shaping gate + exported `toSharedConditions` projection
- `src/utils/conditionIcons.ts` (new) — name→icon mapper with kind fallback
- `src/components/ui/campaign/token-overlay/` — `ConditionStrip` + `ConcentrationRing` (new), `ChipRow` extracted from `DecorationItem`, both resolver hooks carry the new fields
- `src/components/ui/encounter/CombatConfigDialog.tsx` — toggle via design-system Switch (label-associated, full-row click target)

## Testing

- Unit suite: 2792 passed / 1 skipped (156 files), including new coverage for share-shaping gating and projection, icon fallback contract, per-mode visibility matrix, dead-entity precedence, duplicate-condition rendering, and legacy-config defaulting
- Type-check and lint clean on branch files
- Manual smoke (both themes, DM + player over Redis) in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)