### PR TITLE
feat(encounter): battle map launcher from the encounter view

### DIFF
--- a/src/components/ui/campaign/battle-map/BattleMapPickerDialog.tsx
+++ b/src/components/ui/campaign/battle-map/BattleMapPickerDialog.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Plus } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogBody,
+} from '@/components/ui/feedback/dialog';
+import { Button } from '@/components/ui/forms/button';
+import { Input } from '@/components/ui/forms/input';
+
+import { modeStorageKey } from '@/components/ui/campaign/dm-vtt/useBattleMapMode';
+import { generateBattleMapId, useBattleMapStore } from '@/store/battleMapStore';
+import { findLinkedBattleMap, planMapLinkSwitch } from '@/utils/battleMapLinks';
+
+import { BattleMapPickerRow } from './BattleMapPickerRow';
+
+interface BattleMapPickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  campaignCode: string;
+  encounterId: string;
+}
+
+/**
+ * Pick, switch, unlink, or create the battle map linked to an encounter,
+ * then jump straight to it. Same lock as the map editor's
+ * EncounterLinkingPanel — this is just the door on the encounter side.
+ */
+export function BattleMapPickerDialog({
+  open,
+  onOpenChange,
+  campaignCode,
+  encounterId,
+}: BattleMapPickerDialogProps) {
+  const router = useRouter();
+  const { getBattleMaps, addBattleMap, linkEncounter, unlinkEncounter } =
+    useBattleMapStore();
+  const [newName, setNewName] = useState('');
+
+  const battleMaps = getBattleMaps(campaignCode);
+  const current = findLinkedBattleMap(battleMaps, encounterId);
+
+  function applyAndGo(mapId: string) {
+    const plan = planMapLinkSwitch(current?.id ?? null, mapId);
+    if (plan.unlinkFrom)
+      unlinkEncounter(campaignCode, plan.unlinkFrom, encounterId);
+    if (plan.linkTo) linkEncounter(campaignCode, plan.linkTo, encounterId);
+    onOpenChange(false);
+    router.push(`/dm/campaign/${campaignCode}/battlemaps/${mapId}`);
+  }
+
+  function handleCreate() {
+    const name = newName.trim();
+    if (!name) return;
+    const id = generateBattleMapId();
+    const now = new Date().toISOString();
+    addBattleMap(campaignCode, {
+      id,
+      campaignCode,
+      name,
+      mapImageUrl: '',
+      mapImageSize: { w: 0, h: 0 },
+      canvasState: '',
+      dmOnlyElements: {},
+      gridEnabled: false,
+      linkedEncounterIds: [],
+      createdAt: now,
+      updatedAt: now,
+    });
+    try {
+      // Fresh map with a linked encounter would auto-resolve to play mode —
+      // a blank canvas in play mode is wrong. Land the DM in setup.
+      window.localStorage.setItem(modeStorageKey(id), 'setup');
+    } catch {
+      // Ignore localStorage errors
+    }
+    setNewName('');
+    applyAndGo(id);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Battle Map</DialogTitle>
+          <DialogDescription>
+            Link this encounter to a battle map and jump straight to it.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody className="space-y-4">
+          {battleMaps.length === 0 ? (
+            <p className="text-muted text-sm">
+              No battle maps in this campaign yet — create one below.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {battleMaps.map(bm => (
+                <BattleMapPickerRow
+                  key={bm.id}
+                  battleMap={bm}
+                  isCurrent={bm.id === current?.id}
+                  hasCurrent={!!current}
+                  onUnlink={() =>
+                    unlinkEncounter(campaignCode, bm.id, encounterId)
+                  }
+                  onOpen={() => applyAndGo(bm.id)}
+                />
+              ))}
+            </div>
+          )}
+          <div className="border-divider flex items-center gap-2 border-t pt-4">
+            <Input
+              value={newName}
+              onChange={e => setNewName(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') handleCreate();
+              }}
+              placeholder="New map name..."
+              wrapperClassName="flex-1"
+              aria-label="New battle map name"
+            />
+            <Button
+              variant="primary"
+              size="md"
+              onClick={handleCreate}
+              disabled={!newName.trim()}
+              leftIcon={<Plus size={16} />}
+            >
+              Create & open
+            </Button>
+          </div>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/campaign/battle-map/BattleMapPickerRow.tsx
+++ b/src/components/ui/campaign/battle-map/BattleMapPickerRow.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Button } from '@/components/ui/forms/button';
+import { Badge } from '@/components/ui/layout/badge';
+
+import type { BattleMap } from '@/types/battlemap';
+
+interface BattleMapPickerRowProps {
+  battleMap: BattleMap;
+  isCurrent: boolean;
+  hasCurrent: boolean;
+  onUnlink: () => void;
+  onOpen: () => void;
+}
+
+/** Single battle map row in the picker: name, status badges, and its action. */
+export function BattleMapPickerRow({
+  battleMap,
+  isCurrent,
+  hasCurrent,
+  onUnlink,
+  onOpen,
+}: BattleMapPickerRowProps) {
+  const inUse = !isCurrent && battleMap.linkedEncounterIds.length > 0;
+
+  return (
+    <div className="border-divider bg-surface-secondary flex items-center justify-between gap-3 rounded-lg border px-3 py-2">
+      <div className="min-w-0">
+        <span className="text-heading block truncate text-sm font-medium">
+          {battleMap.name}
+        </span>
+        <span className="text-muted text-xs">
+          Updated {new Date(battleMap.updatedAt).toLocaleDateString()}
+        </span>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {isCurrent && <Badge variant="success">Current</Badge>}
+        {inUse && <Badge variant="neutral">In use</Badge>}
+        {isCurrent ? (
+          <>
+            <Button variant="ghost" size="sm" onClick={onUnlink}>
+              Unlink
+            </Button>
+            <Button variant="primary" size="sm" onClick={onOpen}>
+              Open
+            </Button>
+          </>
+        ) : (
+          <Button variant="secondary" size="sm" onClick={onOpen}>
+            {hasCurrent ? 'Switch & open' : 'Link & open'}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/battle-map/__tests__/BattleMapPickerDialog.test.tsx
+++ b/src/components/ui/campaign/battle-map/__tests__/BattleMapPickerDialog.test.tsx
@@ -106,4 +106,42 @@ describe('BattleMapPickerDialog', () => {
       `/dm/campaign/ABC123/battlemaps/${created?.id}`
     );
   });
+
+  it('creates the map when Enter is pressed in the name input', () => {
+    renderDialog();
+    const input = screen.getByLabelText('New battle map name');
+    fireEvent.change(input, { target: { value: 'Goblin Ambush' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    const created = useBattleMapStore
+      .getState()
+      .getBattleMaps('ABC123')
+      .find(m => m.name === 'Goblin Ambush');
+    expect(created).toBeDefined();
+    expect(created?.linkedEncounterIds).toContain('e1');
+    expect(pushMock).toHaveBeenCalledWith(
+      `/dm/campaign/ABC123/battlemaps/${created?.id}`
+    );
+  });
+
+  it('disables the create button when the name is empty or whitespace', () => {
+    renderDialog();
+    const input = screen.getByLabelText('New battle map name');
+    const createButton = screen.getByRole('button', { name: /create & open/i });
+    expect(createButton).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '   ' } });
+    expect(createButton).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: 'Goblin Ambush' } });
+    expect(createButton).not.toBeDisabled();
+  });
+
+  it('shows an empty-state message when the campaign has no battle maps', () => {
+    renderDialog();
+    expect(
+      screen.getByText(
+        'No battle maps in this campaign yet — create one below.'
+      )
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/ui/campaign/battle-map/__tests__/BattleMapPickerDialog.test.tsx
+++ b/src/components/ui/campaign/battle-map/__tests__/BattleMapPickerDialog.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+import { BattleMapPickerDialog } from '../BattleMapPickerDialog';
+import { useBattleMapStore } from '@/store/battleMapStore';
+
+import type { BattleMap } from '@/types/battlemap';
+
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+function map(id: string, linked: string[] = []): BattleMap {
+  return {
+    id,
+    campaignCode: 'ABC123',
+    name: `Map ${id}`,
+    mapImageUrl: '',
+    mapImageSize: { w: 0, h: 0 },
+    canvasState: '',
+    dmOnlyElements: {},
+    gridEnabled: false,
+    linkedEncounterIds: linked,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function seed(maps: BattleMap[]) {
+  for (const m of maps) {
+    useBattleMapStore.getState().addBattleMap('ABC123', m);
+  }
+}
+
+function renderDialog() {
+  return render(
+    <BattleMapPickerDialog
+      open
+      onOpenChange={() => {}}
+      campaignCode="ABC123"
+      encounterId="e1"
+    />
+  );
+}
+
+describe('BattleMapPickerDialog', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    pushMock.mockClear();
+    // Reset the persisted store between tests: remove every seeded map.
+    const state = useBattleMapStore.getState();
+    for (const m of state.getBattleMaps('ABC123')) {
+      state.removeBattleMap('ABC123', m.id);
+    }
+  });
+
+  afterEach(() => cleanup());
+
+  it('lists maps with a Current badge on the linked one', () => {
+    seed([map('m1'), map('m2', ['e1'])]);
+    renderDialog();
+    expect(screen.getByText('Map m1')).toBeInTheDocument();
+    expect(screen.getByText('Map m2')).toBeInTheDocument();
+    expect(screen.getByText('Current')).toBeInTheDocument();
+  });
+
+  it('links the selected map, unlinks the previous, and navigates', () => {
+    seed([map('m1', ['e1']), map('m2')]);
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /switch & open/i }));
+    const maps = useBattleMapStore.getState().getBattleMaps('ABC123');
+    expect(maps.find(m => m.id === 'm2')?.linkedEncounterIds).toContain('e1');
+    expect(maps.find(m => m.id === 'm1')?.linkedEncounterIds).not.toContain(
+      'e1'
+    );
+    expect(pushMock).toHaveBeenCalledWith('/dm/campaign/ABC123/battlemaps/m2');
+  });
+
+  it('unlinks the current map without navigating', () => {
+    seed([map('m1', ['e1'])]);
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /unlink/i }));
+    const maps = useBattleMapStore.getState().getBattleMaps('ABC123');
+    expect(maps.find(m => m.id === 'm1')?.linkedEncounterIds).toEqual([]);
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('creates a named blank map, links it, stamps setup mode, navigates', () => {
+    renderDialog();
+    fireEvent.change(screen.getByLabelText('New battle map name'), {
+      target: { value: 'Cave of Chaos' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create & open/i }));
+    const created = useBattleMapStore
+      .getState()
+      .getBattleMaps('ABC123')
+      .find(m => m.name === 'Cave of Chaos');
+    expect(created).toBeDefined();
+    expect(created?.linkedEncounterIds).toContain('e1');
+    expect(created?.mapImageUrl).toBe('');
+    expect(
+      localStorage.getItem(`rollkeeper-battlemap-mode:${created?.id}`)
+    ).toBe('setup');
+    expect(pushMock).toHaveBeenCalledWith(
+      `/dm/campaign/ABC123/battlemaps/${created?.id}`
+    );
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/useBattleMapMode.ts
+++ b/src/components/ui/campaign/dm-vtt/useBattleMapMode.ts
@@ -6,7 +6,8 @@ import type { BattleMap } from '@/types/battlemap';
 
 export type BattleMapPageMode = 'setup' | 'play';
 
-function modeStorageKey(battleMapId: string): string {
+/** localStorage key for a map's persisted Setup|Play mode. */
+export function modeStorageKey(battleMapId: string): string {
   return `rollkeeper-battlemap-mode:${battleMapId}`;
 }
 

--- a/src/components/ui/encounter/EncounterBattleMapButton.tsx
+++ b/src/components/ui/encounter/EncounterBattleMapButton.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { ChevronDown, Map as MapIcon } from 'lucide-react';
+
+import { Button } from '@/components/ui/forms/button';
+
+import { BattleMapPickerDialog } from '@/components/ui/campaign/battle-map/BattleMapPickerDialog';
+import { useBattleMapStore } from '@/store/battleMapStore';
+import { findLinkedBattleMap } from '@/utils/battleMapLinks';
+
+interface EncounterBattleMapButtonProps {
+  campaignCode: string;
+  encounterId: string;
+}
+
+/**
+ * Combat-header entry to the encounter's battle map. Linked → one-click
+ * open (hot path mid-session) with a chevron for switching; unlinked →
+ * opens the picker.
+ */
+export function EncounterBattleMapButton({
+  campaignCode,
+  encounterId,
+}: EncounterBattleMapButtonProps) {
+  const { getBattleMaps } = useBattleMapStore();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const linked = findLinkedBattleMap(getBattleMaps(campaignCode), encounterId);
+
+  return (
+    <>
+      {linked ? (
+        <div className="flex items-center gap-0.5">
+          <Link href={`/dm/campaign/${campaignCode}/battlemaps/${linked.id}`}>
+            <Button
+              variant="secondary"
+              size="sm"
+              leftIcon={<MapIcon size={16} />}
+            >
+              Open Battle Map
+            </Button>
+          </Link>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setPickerOpen(true)}
+            aria-label="Change battle map"
+            title="Change battle map"
+          >
+            <ChevronDown size={16} />
+          </Button>
+        </div>
+      ) : (
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => setPickerOpen(true)}
+          leftIcon={<MapIcon size={16} />}
+        >
+          Battle Map
+        </Button>
+      )}
+      <BattleMapPickerDialog
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        campaignCode={campaignCode}
+        encounterId={encounterId}
+      />
+    </>
+  );
+}

--- a/src/components/ui/encounter/EncounterBattleMapButton.tsx
+++ b/src/components/ui/encounter/EncounterBattleMapButton.tsx
@@ -34,12 +34,9 @@ export function EncounterBattleMapButton({
       {linked ? (
         <div className="flex items-center gap-0.5">
           <Link href={`/dm/campaign/${campaignCode}/battlemaps/${linked.id}`}>
-            <Button
-              variant="secondary"
-              size="sm"
-              leftIcon={<MapIcon size={16} />}
-            >
-              Open Battle Map
+            <Button variant="secondary" size="sm" aria-label="Open battle map">
+              <MapIcon size={16} aria-hidden="true" />
+              <span className="hidden sm:inline">Open Battle Map</span>
             </Button>
           </Link>
           <Button
@@ -57,9 +54,10 @@ export function EncounterBattleMapButton({
           variant="secondary"
           size="sm"
           onClick={() => setPickerOpen(true)}
-          leftIcon={<MapIcon size={16} />}
+          aria-label="Battle map"
         >
-          Battle Map
+          <MapIcon size={16} aria-hidden="true" />
+          <span className="hidden sm:inline">Battle Map</span>
         </Button>
       )}
       <BattleMapPickerDialog

--- a/src/components/ui/encounter/EncounterList.tsx
+++ b/src/components/ui/encounter/EncounterList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import {
   Plus,
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
 import { Badge } from '@/components/ui/layout/badge';
 import { CombatConfigDialog } from '@/components/ui/encounter/CombatConfigDialog';
+import { findLinkedBattleMap } from '@/utils/battleMapLinks';
 import { Encounter } from '@/types/encounter';
 import type { BattleMap } from '@/types/battlemap';
 
@@ -29,15 +30,6 @@ interface EncounterListProps {
 export function EncounterList({ campaignCode }: EncounterListProps) {
   const { encounters, createEncounter, deleteEncounter } = useEncounterStore();
   const battleMaps = useBattleMapStore(s => s.getBattleMaps)(campaignCode);
-  const encounterToMap = React.useMemo(() => {
-    const map = new globalThis.Map<string, BattleMap>();
-    for (const bm of battleMaps) {
-      for (const eid of bm.linkedEncounterIds) {
-        map.set(eid, bm);
-      }
-    }
-    return map;
-  }, [battleMaps]);
   const [newName, setNewName] = useState('');
   const [isCreating, setIsCreating] = useState(false);
   const [configOpen, setConfigOpen] = useState(false);
@@ -129,7 +121,7 @@ export function EncounterList({ campaignCode }: EncounterListProps) {
               key={encounter.id}
               encounter={encounter}
               campaignCode={campaignCode}
-              linkedBattleMap={encounterToMap.get(encounter.id)}
+              linkedBattleMap={findLinkedBattleMap(battleMaps, encounter.id)}
               onDelete={() => {
                 if (
                   confirm(`Delete "${encounter.name}"? This cannot be undone.`)

--- a/src/components/ui/encounter/EncounterView.tsx
+++ b/src/components/ui/encounter/EncounterView.tsx
@@ -26,6 +26,7 @@ import { useInitiativeSubmissionSync } from '@/hooks/useInitiativeSubmissionSync
 import { buildSharedInitiative } from '@/utils/buildSharedInitiative';
 import { Button } from '@/components/ui/forms/button';
 import { CombatScreen } from './combat-screen/CombatScreen';
+import { EncounterBattleMapButton } from './EncounterBattleMapButton';
 import type { EntityActions } from './combat-screen/types';
 import { buildEntityActions } from './combat-screen/buildEntityActions';
 import { AddCombatantDialog } from './combat-screen/AddCombatantDialog';
@@ -337,6 +338,12 @@ export function EncounterView({
         onOpenAdd={() => setAddDialogOpen(true)}
         onOpenConfig={() => setConfigOpen(true)}
         backHref={`/dm/campaign/${campaignCode}/encounters`}
+        mapAction={
+          <EncounterBattleMapButton
+            campaignCode={campaignCode}
+            encounterId={encounterId}
+          />
+        }
       />
 
       {/* Add combatant dialog */}

--- a/src/components/ui/encounter/__tests__/EncounterBattleMapButton.test.tsx
+++ b/src/components/ui/encounter/__tests__/EncounterBattleMapButton.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { EncounterBattleMapButton } from '../EncounterBattleMapButton';
+import { useBattleMapStore } from '@/store/battleMapStore';
+
+import type { BattleMap } from '@/types/battlemap';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+function map(id: string, linked: string[] = []): BattleMap {
+  return {
+    id,
+    campaignCode: 'ABC123',
+    name: `Map ${id}`,
+    mapImageUrl: '',
+    mapImageSize: { w: 0, h: 0 },
+    canvasState: '',
+    dmOnlyElements: {},
+    gridEnabled: false,
+    linkedEncounterIds: linked,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('EncounterBattleMapButton', () => {
+  beforeEach(() => {
+    const state = useBattleMapStore.getState();
+    for (const m of state.getBattleMaps('ABC123')) {
+      state.removeBattleMap('ABC123', m.id);
+    }
+  });
+
+  afterEach(() => cleanup());
+
+  it('shows the picker-opening button when unlinked', () => {
+    render(<EncounterBattleMapButton campaignCode="ABC123" encounterId="e1" />);
+    expect(
+      screen.getByRole('button', { name: /battle map/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/open battle map/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a direct open link plus change chevron when linked', () => {
+    useBattleMapStore.getState().addBattleMap('ABC123', map('m1', ['e1']));
+    render(<EncounterBattleMapButton campaignCode="ABC123" encounterId="e1" />);
+    const link = screen.getByRole('link', { name: /open battle map/i });
+    expect(link).toHaveAttribute('href', '/dm/campaign/ABC123/battlemaps/m1');
+    expect(
+      screen.getByRole('button', { name: /change battle map/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/encounter/combat-screen/CombatAppBar.tsx
+++ b/src/components/ui/encounter/combat-screen/CombatAppBar.tsx
@@ -11,6 +11,8 @@ export interface CombatAppBarProps {
   onRename: (name: string) => void;
   onOpenAdd: () => void;
   onOpenConfig: () => void;
+  /** Optional battle-map action rendered before the Add button. */
+  mapAction?: React.ReactNode;
 }
 
 export function CombatAppBar({
@@ -19,6 +21,7 @@ export function CombatAppBar({
   onRename,
   onOpenAdd,
   onOpenConfig,
+  mapAction,
 }: CombatAppBarProps): React.JSX.Element {
   const [editing, setEditing] = useState(false);
   const [nameInput, setNameInput] = useState('');
@@ -85,6 +88,7 @@ export function CombatAppBar({
       </div>
 
       <div className="flex shrink-0 items-center gap-2">
+        {mapAction}
         <Button
           variant="primary"
           size="sm"

--- a/src/components/ui/encounter/combat-screen/CombatScreen.tsx
+++ b/src/components/ui/encounter/combat-screen/CombatScreen.tsx
@@ -30,6 +30,8 @@ export interface CombatScreenProps {
   onOpenAdd: () => void;
   onOpenConfig: () => void;
   backHref: string;
+  /** Optional battle-map action rendered in the header before the Add button. */
+  mapAction?: React.ReactNode;
 }
 
 export function CombatScreen({
@@ -51,6 +53,7 @@ export function CombatScreen({
   onOpenAdd,
   onOpenConfig,
   backHref,
+  mapAction,
 }: CombatScreenProps): React.JSX.Element {
   const isRail = useMediaQuery('(min-width: 1024px)');
   const [railSelectionId, setRailSelectionId] = useState<string | null>(null);
@@ -84,6 +87,7 @@ export function CombatScreen({
       onRename={onRename}
       onOpenAdd={onOpenAdd}
       onOpenConfig={onOpenConfig}
+      mapAction={mapAction}
     />
   );
 

--- a/src/utils/__tests__/battleMapLinks.test.ts
+++ b/src/utils/__tests__/battleMapLinks.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { findLinkedBattleMap, planMapLinkSwitch } from '../battleMapLinks';
+
+import type { BattleMap } from '@/types/battlemap';
+
+function map(id: string, linked: string[]): BattleMap {
+  return {
+    id,
+    campaignCode: 'ABC123',
+    name: `Map ${id}`,
+    mapImageUrl: '',
+    mapImageSize: { w: 0, h: 0 },
+    canvasState: '',
+    dmOnlyElements: {},
+    gridEnabled: false,
+    linkedEncounterIds: linked,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('findLinkedBattleMap', () => {
+  it('returns the first map containing the encounter id', () => {
+    const maps = [map('m1', ['other']), map('m2', ['e1']), map('m3', ['e1'])];
+    expect(findLinkedBattleMap(maps, 'e1')?.id).toBe('m2');
+  });
+
+  it('returns undefined when no map links the encounter', () => {
+    expect(findLinkedBattleMap([map('m1', [])], 'e1')).toBeUndefined();
+  });
+});
+
+describe('planMapLinkSwitch', () => {
+  it('links only, when the encounter has no current map', () => {
+    expect(planMapLinkSwitch(null, 'm2')).toEqual({
+      linkTo: 'm2',
+      unlinkFrom: null,
+    });
+  });
+
+  it('links the new and unlinks the old on a switch', () => {
+    expect(planMapLinkSwitch('m1', 'm2')).toEqual({
+      linkTo: 'm2',
+      unlinkFrom: 'm1',
+    });
+  });
+
+  it('plans no writes when selecting the current map', () => {
+    expect(planMapLinkSwitch('m1', 'm1')).toEqual({
+      linkTo: null,
+      unlinkFrom: null,
+    });
+  });
+});

--- a/src/utils/battleMapLinks.ts
+++ b/src/utils/battleMapLinks.ts
@@ -1,9 +1,11 @@
 import type { BattleMap } from '@/types/battlemap';
 
 /**
- * The battle map an encounter is linked to: first map whose
- * linkedEncounterIds contains the encounter — the same first-wins rule
- * EncounterList has always used for its "Map: X" chip.
+ * First map whose linkedEncounterIds contains the encounter.
+ * Deliberately first-wins: the old EncounterList memo was incidentally
+ * last-wins when an encounter was linked from several maps, a degenerate
+ * state the picker's switch flow (link new + unlink old) prevents;
+ * first-wins makes the resolution deterministic by list order.
  */
 export function findLinkedBattleMap(
   battleMaps: BattleMap[],

--- a/src/utils/battleMapLinks.ts
+++ b/src/utils/battleMapLinks.ts
@@ -1,0 +1,27 @@
+import type { BattleMap } from '@/types/battlemap';
+
+/**
+ * The battle map an encounter is linked to: first map whose
+ * linkedEncounterIds contains the encounter — the same first-wins rule
+ * EncounterList has always used for its "Map: X" chip.
+ */
+export function findLinkedBattleMap(
+  battleMaps: BattleMap[],
+  encounterId: string
+): BattleMap | undefined {
+  return battleMaps.find(bm => bm.linkedEncounterIds.includes(encounterId));
+}
+
+/**
+ * Store writes needed to make nextMapId the encounter's linked map.
+ * Selecting the already-current map plans no writes (plain navigation).
+ * From the encounter's side the relationship is 1:1 — switching unlinks
+ * the previous map; a map's multi-encounter array is otherwise untouched.
+ */
+export function planMapLinkSwitch(
+  currentMapId: string | null,
+  nextMapId: string
+): { linkTo: string | null; unlinkFrom: string | null } {
+  if (currentMapId === nextMapId) return { linkTo: null, unlinkFrom: null };
+  return { linkTo: nextMapId, unlinkFrom: currentMapId };
+}


### PR DESCRIPTION
## Summary

Removes the tab-hopping between encounters and battle maps. The combat header gains a **Battle Map** button:

- **Unlinked encounter** → opens a picker dialog listing the campaign's battle maps (with "Current" / "In use" badges), plus an inline **create new map** row: name it, and a blank map is created, linked, and opened — landing in **setup mode** (a localStorage mode stamp overrides the play-when-linked auto-resolution, so the DM gets a drawable blank canvas, not an empty play screen).
- **Linked encounter** → the button becomes **Open Battle Map** (one click straight to the map, hot path mid-session) with a chevron to switch or unlink.
- Switching maps links the new one and unlinks the old — the encounter↔map relationship stays effectively 1:1 from the encounter's side.

The map editor's existing `EncounterLinkingPanel` is untouched — two doors, same lock. No sync/transport changes; linking remains DM-local Zustand state.

## Implementation notes

- New pure helpers `findLinkedBattleMap` / `planMapLinkSwitch` (`src/utils/battleMapLinks.ts`); `EncounterList` refactored onto the shared lookup.
- **Deliberate micro-behavior change:** an encounter linked from multiple maps (a degenerate state only reachable by using the editor panel on two different maps) now resolves to the *first* map in list order — the old list code was incidentally last-wins. The picker's switch flow prevents that state going forward.
- `BattleMapPickerDialog` + `BattleMapPickerRow`; `modeStorageKey` exported from `useBattleMapMode`.
- `EncounterBattleMapButton` mounts via a new optional `mapAction` slot threaded `EncounterView → CombatScreen → CombatAppBar` — all other call sites untouched.
- Blank maps (`mapImageUrl: ''`) verified safe in every consumer (editor background init early-returns, list cards have fallbacks, VTT screens consume canvas state only).
- Button labels are responsive (`hidden sm:inline`) so the combat header fits phone viewports; icon-only state keeps accessible names via aria-labels.

## Testing

- Unit suite: 2816 passed / 1 skipped (161 files) — link lookup/switch planner, picker behaviors against the real Zustand store (switch writes, unlink without navigation, create + setup-mode stamp + navigation, Enter-key create, empty-name disabled state, empty-campaign message), button states.
- Type-check and lint clean on branch files.
- Manual pass pending: create-and-land-in-setup flow, one-click open, switch/unlink, mobile header, both themes.

## Known follow-ups (not in this PR)

- `size="sm"` buttons are 36px against the 44px touch-target guideline — house-style decision to make once at the design-system level.
- Codebase-wide `<Link><Button>` nesting → `asChild` cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)