### PR TITLE
feat: monster search relevance ranking + load more

### DIFF
--- a/src/app/api/bestiary/search/route.ts
+++ b/src/app/api/bestiary/search/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { loadAllBestiary } from '@/utils/bestiaryDataLoader';
-import { filterMonsters } from '@/utils/bestiaryFilters';
+import {
+  filterMonsters,
+  rankMonstersByRelevance,
+} from '@/utils/bestiaryFilters';
 import { BestiaryFilters } from '@/types/bestiary';
 
 export async function GET(request: NextRequest) {
@@ -55,17 +58,20 @@ export async function GET(request: NextRequest) {
       };
     }
 
-    // Load and filter monsters
+    // Load, filter, and rank monsters
     const allMonsters = await loadAllBestiary();
     const filteredMonsters = filterMonsters(allMonsters, filters);
+    const rankedMonsters = query
+      ? rankMonstersByRelevance(filteredMonsters, query)
+      : filteredMonsters;
 
     // Apply pagination
-    const paginatedMonsters = filteredMonsters.slice(offset, offset + limit);
+    const paginatedMonsters = rankedMonsters.slice(offset, offset + limit);
 
     return NextResponse.json({
       monsters: paginatedMonsters,
-      total: filteredMonsters.length,
-      hasMore: offset + limit < filteredMonsters.length,
+      total: rankedMonsters.length,
+      hasMore: offset + limit < rankedMonsters.length,
       filters: filters,
     });
   } catch (error) {

--- a/src/app/api/bestiary/search/route.ts
+++ b/src/app/api/bestiary/search/route.ts
@@ -9,7 +9,7 @@ import { BestiaryFilters } from '@/types/bestiary';
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
-    const query = searchParams.get('q') || '';
+    const query = (searchParams.get('q') || '').trim();
     const limit = parseInt(searchParams.get('limit') || '20', 10);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
 

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/MonsterSearch.stories.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/MonsterSearch.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, fn } from 'storybook/test';
+import { MonsterSearch } from './MonsterSearch';
+import { createMockProcessedMonster } from '@/test/helpers';
+
+const results = [
+  createMockProcessedMonster({ id: 'guard', name: 'Guard', cr: '1/8' }),
+  createMockProcessedMonster({
+    id: 'guard-drake',
+    name: 'Guard Drake',
+    cr: '2',
+  }),
+  createMockProcessedMonster({
+    id: 'guardian-naga',
+    name: 'Guardian Naga',
+    cr: '10',
+  }),
+];
+
+const meta: Meta<typeof MonsterSearch> = {
+  title: 'Encounter/AddCombatantDialog/MonsterSearch',
+  component: MonsterSearch,
+  args: {
+    query: 'guard',
+    onQueryChange: fn(),
+    results,
+    total: 63,
+    hasMore: true,
+    loading: false,
+    loadingMore: false,
+    onSelect: fn(),
+    onLoadMore: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MonsterSearch>;
+
+export const Truncated: Story = {
+  name: 'Truncated results show count and Load more',
+  play: async ({ canvas, args }) => {
+    await expect(canvas.getByText('Showing 3 of 63')).toBeInTheDocument();
+    const button = canvas.getByRole('button', { name: /load more/i });
+    button.click();
+    await expect(args.onLoadMore).toHaveBeenCalled();
+  },
+};
+
+export const LoadingMore: Story = {
+  name: 'Load more disabled while loading',
+  args: { loadingMore: true },
+  play: async ({ canvas }) => {
+    const button = canvas.getByRole('button', { name: /loading/i });
+    await expect(button).toBeDisabled();
+  },
+};
+
+export const Complete: Story = {
+  name: 'No footer when all results shown',
+  args: { total: 3, hasMore: false },
+  play: async ({ canvas }) => {
+    await expect(canvas.queryByText(/showing/i)).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: /load more/i })
+    ).not.toBeInTheDocument();
+  },
+};

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/MonsterSearch.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/MonsterSearch.tsx
@@ -2,22 +2,31 @@
 
 import React from 'react';
 import { Search } from 'lucide-react';
+import { Button } from '@/components/ui/forms/button';
 import type { ProcessedMonster } from '@/types/bestiary';
 
 interface MonsterSearchProps {
   query: string;
   onQueryChange: (q: string) => void;
   results: ProcessedMonster[];
+  total: number;
+  hasMore: boolean;
   loading: boolean;
+  loadingMore: boolean;
   onSelect: (m: ProcessedMonster) => void;
+  onLoadMore: () => void;
 }
 
 export function MonsterSearch({
   query,
   onQueryChange,
   results,
+  total,
+  hasMore,
   loading,
+  loadingMore,
   onSelect,
+  onLoadMore,
 }: MonsterSearchProps) {
   return (
     <div className="space-y-3 pb-4">
@@ -67,6 +76,22 @@ export function MonsterSearch({
           );
         })}
       </div>
+
+      {!loading && hasMore && (
+        <div className="flex flex-col items-center gap-1 pt-1">
+          <p className="text-muted text-xs font-medium">
+            Showing {results.length} of {total}
+          </p>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+          >
+            {loadingMore ? 'Loading…' : 'Load more'}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/MonsterTab.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/MonsterTab.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React from 'react';
 import type { ProcessedMonster } from '@/types/bestiary';
 import type { PlayerDisposition } from '@/types/encounter';
 import { MonsterSearch } from './MonsterSearch';
 import { MonsterDetail } from './MonsterDetail';
+import { useMonsterSearch } from '@/hooks/useMonsterSearch';
 
 interface MonsterTabProps {
   selected: ProcessedMonster | null;
@@ -39,35 +40,16 @@ export function MonsterTab({
   disposition,
   onDispositionChange,
 }: MonsterTabProps) {
-  const [query, setQuery] = useState('');
-  const [results, setResults] = useState<ProcessedMonster[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  const search = useCallback(async (q: string) => {
-    if (q.length < 2) {
-      setResults([]);
-      return;
-    }
-    setLoading(true);
-    try {
-      const res = await fetch(
-        `/api/bestiary/search?q=${encodeURIComponent(q)}&limit=20`
-      );
-      if (res.ok) {
-        const data = await res.json();
-        setResults(data.monsters ?? []);
-      }
-    } catch {
-      // silently fail
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    const t = setTimeout(() => search(query), 300);
-    return () => clearTimeout(t);
-  }, [query, search]);
+  const {
+    query,
+    setQuery,
+    results,
+    total,
+    hasMore,
+    loading,
+    loadingMore,
+    loadMore,
+  } = useMonsterSearch();
 
   const handleSelect = (m: ProcessedMonster) => {
     onSelect(m);
@@ -102,8 +84,12 @@ export function MonsterTab({
       query={query}
       onQueryChange={setQuery}
       results={results}
+      total={total}
+      hasMore={hasMore}
       loading={loading}
+      loadingMore={loadingMore}
       onSelect={handleSelect}
+      onLoadMore={loadMore}
     />
   );
 }

--- a/src/hooks/__tests__/useMonsterSearch.test.ts
+++ b/src/hooks/__tests__/useMonsterSearch.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useMonsterSearch } from '@/hooks/useMonsterSearch';
+import {
+  mockFetchResponse,
+  mockFetchSequence,
+  resetFetch,
+} from '@/test/mocks/fetch';
+import { createMockProcessedMonster } from '@/test/helpers';
+
+const guard = createMockProcessedMonster({ id: 'guard', name: 'Guard' });
+const drake = createMockProcessedMonster({
+  id: 'guard-drake',
+  name: 'Guard Drake',
+});
+
+describe('useMonsterSearch', () => {
+  beforeEach(() => {
+    resetFetch();
+  });
+
+  it('does not search for queries shorter than 2 characters', async () => {
+    const fetchFn = mockFetchResponse(200, {
+      monsters: [],
+      total: 0,
+      hasMore: false,
+    });
+    const { result } = renderHook(() => useMonsterSearch());
+    act(() => result.current.setQuery('g'));
+    // debounce is 300ms; wait past it and confirm no fetch happened
+    await new Promise(r => setTimeout(r, 400));
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(result.current.results).toEqual([]);
+  });
+
+  it('searches after debounce and exposes results, total, hasMore', async () => {
+    const fetchFn = mockFetchResponse(200, {
+      monsters: [guard],
+      total: 63,
+      hasMore: true,
+    });
+    const { result } = renderHook(() => useMonsterSearch());
+    act(() => result.current.setQuery('guard'));
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/bestiary/search?q=guard&limit=20'
+    );
+    expect(result.current.total).toBe(63);
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('loadMore fetches with offset and appends results', async () => {
+    const fetchFn = mockFetchSequence([
+      { status: 200, body: { monsters: [guard], total: 2, hasMore: true } },
+      { status: 200, body: { monsters: [drake], total: 2, hasMore: false } },
+    ]);
+    const { result } = renderHook(() => useMonsterSearch());
+    act(() => result.current.setQuery('guard'));
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+    await waitFor(() => expect(result.current.results).toHaveLength(2));
+    expect(fetchFn).toHaveBeenLastCalledWith(
+      '/api/bestiary/search?q=guard&limit=20&offset=1'
+    );
+    expect(result.current.results.map(m => m.name)).toEqual([
+      'Guard',
+      'Guard Drake',
+    ]);
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.loadingMore).toBe(false);
+  });
+
+  it('loadMore is a no-op when hasMore is false', async () => {
+    const fetchFn = mockFetchResponse(200, {
+      monsters: [guard],
+      total: 1,
+      hasMore: false,
+    });
+    const { result } = renderHook(() => useMonsterSearch());
+    act(() => result.current.setQuery('guard'));
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+    await new Promise(r => setTimeout(r, 50));
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('a new query resets results and pagination', async () => {
+    mockFetchSequence([
+      {
+        status: 200,
+        body: { monsters: [guard, drake], total: 63, hasMore: true },
+      },
+      { status: 200, body: { monsters: [drake], total: 1, hasMore: false } },
+    ]);
+    const { result } = renderHook(() => useMonsterSearch());
+    act(() => result.current.setQuery('guard'));
+    await waitFor(() => expect(result.current.results).toHaveLength(2));
+
+    act(() => result.current.setQuery('drake'));
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+    expect(result.current.results[0].name).toBe('Guard Drake');
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('fails silently on fetch error', async () => {
+    mockFetchResponse(500, { error: 'boom' });
+    const { result } = renderHook(() => useMonsterSearch());
+    act(() => result.current.setQuery('guard'));
+    await waitFor(() => expect(result.current.loading).toBe(false), {
+      timeout: 2000,
+    });
+    expect(result.current.results).toEqual([]);
+  });
+});

--- a/src/hooks/__tests__/useMonsterSearch.test.ts
+++ b/src/hooks/__tests__/useMonsterSearch.test.ts
@@ -164,6 +164,62 @@ describe('useMonsterSearch', () => {
     expect(result.current.loadingMore).toBe(false);
   });
 
+  it('ignores a stale response whose body parses after a newer search settles', async () => {
+    // Two-level deferred: resolve the response object (headers) and the
+    // json() body independently, so the guard-vs-parse ordering is pinned.
+    interface DeferredCall {
+      resolveResponse: () => void;
+      resolveBody: (body: unknown) => void;
+    }
+    const calls: DeferredCall[] = [];
+    const fetchFn = vi.fn(() => {
+      let resolveRes!: (value: unknown) => void;
+      let resolveBody!: (value: unknown) => void;
+      const bodyPromise = new Promise(r => {
+        resolveBody = r;
+      });
+      const resPromise = new Promise(r => {
+        resolveRes = r;
+      });
+      calls.push({
+        resolveResponse: () =>
+          resolveRes({ ok: true, status: 200, json: () => bodyPromise }),
+        resolveBody,
+      });
+      return resPromise;
+    });
+    global.fetch = fetchFn as unknown as typeof global.fetch;
+
+    const { result } = renderHook(() => useMonsterSearch());
+
+    // Search A: headers arrive while A is still current; body keeps parsing
+    act(() => result.current.setQuery('guard'));
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      calls[0].resolveResponse();
+    });
+
+    // Search B fires and fully settles
+    act(() => result.current.setQuery('drake'));
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      calls[1].resolveResponse();
+      calls[1].resolveBody({ monsters: [drake], total: 1, hasMore: false });
+    });
+    await waitFor(() =>
+      expect(result.current.results[0]?.name).toBe('Guard Drake')
+    );
+
+    // A's body finally finishes parsing — its data must be ignored
+    await act(async () => {
+      calls[0].resolveBody({ monsters: [guard], total: 3, hasMore: true });
+    });
+
+    expect(result.current.results.map(m => m.name)).toEqual(['Guard Drake']);
+    expect(result.current.total).toBe(1);
+    expect(result.current.hasMore).toBe(false);
+  });
+
   it('fails silently on fetch error', async () => {
     mockFetchResponse(500, { error: 'boom' });
     const { result } = renderHook(() => useMonsterSearch());

--- a/src/hooks/__tests__/useMonsterSearch.test.ts
+++ b/src/hooks/__tests__/useMonsterSearch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useMonsterSearch } from '@/hooks/useMonsterSearch';
 import {
@@ -107,6 +107,61 @@ describe('useMonsterSearch', () => {
     await waitFor(() => expect(result.current.results).toHaveLength(1));
     expect(result.current.results[0].name).toBe('Guard Drake');
     expect(result.current.hasMore).toBe(false);
+  });
+
+  it('query change while loadMore is in flight does not stick loadingMore', async () => {
+    const extra = createMockProcessedMonster({ id: 'extra', name: 'Extra' });
+    const ok = (body: unknown) => ({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    });
+    // Deferred promises so each fetch response is resolved manually.
+    const resolvers: Array<(value: unknown) => void> = [];
+    const fetchFn = vi.fn(
+      () =>
+        new Promise(resolve => {
+          resolvers.push(resolve);
+        })
+    );
+    global.fetch = fetchFn as unknown as typeof global.fetch;
+
+    const { result } = renderHook(() => useMonsterSearch());
+
+    // 1. initial search resolves with hasMore: true
+    act(() => result.current.setQuery('guard'));
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      resolvers[0](ok({ monsters: [guard], total: 3, hasMore: true }));
+    });
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+
+    // 2. loadMore starts; its response stays pending
+    act(() => {
+      void result.current.loadMore();
+    });
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(2));
+    expect(result.current.loadingMore).toBe(true);
+
+    // 3. new query supersedes the in-flight loadMore
+    act(() => result.current.setQuery('drake'));
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(3));
+    await act(async () => {
+      resolvers[2](ok({ monsters: [drake], total: 1, hasMore: false }));
+    });
+    await waitFor(() =>
+      expect(result.current.results[0]?.name).toBe('Guard Drake')
+    );
+
+    // 4. the stale loadMore response finally settles
+    await act(async () => {
+      resolvers[1](ok({ monsters: [extra], total: 3, hasMore: true }));
+    });
+
+    // 5. stale data ignored, and loadingMore is unstuck (the regression)
+    expect(result.current.results.map(m => m.name)).toEqual(['Guard Drake']);
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.loadingMore).toBe(false);
   });
 
   it('fails silently on fetch error', async () => {

--- a/src/hooks/useMonsterSearch.ts
+++ b/src/hooks/useMonsterSearch.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { ProcessedMonster } from '@/types/bestiary';
+
+const PAGE_SIZE = 20;
+const MIN_QUERY_LENGTH = 2;
+const DEBOUNCE_MS = 300;
+
+interface SearchResponse {
+  monsters?: ProcessedMonster[];
+  total?: number;
+  hasMore?: boolean;
+}
+
+/**
+ * Debounced bestiary search with load-more pagination for the
+ * Add Combatant monster tab. Results come back relevance-ranked
+ * from /api/bestiary/search.
+ */
+export function useMonsterSearch() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<ProcessedMonster[]>([]);
+  const [total, setTotal] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  // Incremented per new search so stale responses are ignored.
+  const searchIdRef = useRef(0);
+
+  const search = useCallback(async (q: string) => {
+    const searchId = ++searchIdRef.current;
+    if (q.length < MIN_QUERY_LENGTH) {
+      setResults([]);
+      setTotal(0);
+      setHasMore(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/bestiary/search?q=${encodeURIComponent(q)}&limit=${PAGE_SIZE}`
+      );
+      if (res.ok && searchId === searchIdRef.current) {
+        const data: SearchResponse = await res.json();
+        setResults(data.monsters ?? []);
+        setTotal(data.total ?? 0);
+        setHasMore(data.hasMore ?? false);
+      }
+    } catch {
+      // silently fail
+    } finally {
+      if (searchId === searchIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  const loadMore = useCallback(async () => {
+    if (loading || loadingMore || !hasMore) return;
+    const searchId = searchIdRef.current;
+    setLoadingMore(true);
+    try {
+      const res = await fetch(
+        `/api/bestiary/search?q=${encodeURIComponent(query)}&limit=${PAGE_SIZE}&offset=${results.length}`
+      );
+      if (res.ok && searchId === searchIdRef.current) {
+        const data: SearchResponse = await res.json();
+        setResults(prev => [...prev, ...(data.monsters ?? [])]);
+        setTotal(data.total ?? 0);
+        setHasMore(data.hasMore ?? false);
+      }
+    } catch {
+      // silently fail
+    } finally {
+      if (searchId === searchIdRef.current) {
+        setLoadingMore(false);
+      }
+    }
+  }, [query, results.length, hasMore, loading, loadingMore]);
+
+  useEffect(() => {
+    const t = setTimeout(() => search(query), DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [query, search]);
+
+  return {
+    query,
+    setQuery,
+    results,
+    total,
+    hasMore,
+    loading,
+    loadingMore,
+    loadMore,
+  };
+}

--- a/src/hooks/useMonsterSearch.ts
+++ b/src/hooks/useMonsterSearch.ts
@@ -13,12 +13,25 @@ interface SearchResponse {
   hasMore?: boolean;
 }
 
+export interface UseMonsterSearchResult {
+  query: string;
+  setQuery: (q: string) => void;
+  results: ProcessedMonster[];
+  total: number;
+  hasMore: boolean;
+  /** Initial search in flight. */
+  loading: boolean;
+  /** Load-more request in flight. */
+  loadingMore: boolean;
+  loadMore: () => void;
+}
+
 /**
  * Debounced bestiary search with load-more pagination for the
  * Add Combatant monster tab. Results come back relevance-ranked
  * from /api/bestiary/search.
  */
-export function useMonsterSearch() {
+export function useMonsterSearch(): UseMonsterSearchResult {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<ProcessedMonster[]>([]);
   const [total, setTotal] = useState(0);
@@ -50,9 +63,9 @@ export function useMonsterSearch() {
     } catch {
       // silently fail
     } finally {
-      if (searchId === searchIdRef.current) {
-        setLoading(false);
-      }
+      // Unconditional: a superseded search must never leave the flag
+      // stuck (the stale-response guard above still protects the data).
+      setLoading(false);
     }
   }, []);
 
@@ -73,9 +86,10 @@ export function useMonsterSearch() {
     } catch {
       // silently fail
     } finally {
-      if (searchId === searchIdRef.current) {
-        setLoadingMore(false);
-      }
+      // Unconditional: if a new query superseded this request, the
+      // searchId guard above already ignored its data, but the flag
+      // must still clear or loadMore would be blocked forever.
+      setLoadingMore(false);
     }
   }, [query, results.length, hasMore, loading, loadingMore]);
 

--- a/src/hooks/useMonsterSearch.ts
+++ b/src/hooks/useMonsterSearch.ts
@@ -54,11 +54,15 @@ export function useMonsterSearch(): UseMonsterSearchResult {
       const res = await fetch(
         `/api/bestiary/search?q=${encodeURIComponent(q)}&limit=${PAGE_SIZE}`
       );
-      if (res.ok && searchId === searchIdRef.current) {
+      if (res.ok) {
+        // Parse first, then guard: json() awaits the body, and a newer
+        // search may supersede this one while it is still parsing.
         const data: SearchResponse = await res.json();
-        setResults(data.monsters ?? []);
-        setTotal(data.total ?? 0);
-        setHasMore(data.hasMore ?? false);
+        if (searchId === searchIdRef.current) {
+          setResults(data.monsters ?? []);
+          setTotal(data.total ?? 0);
+          setHasMore(data.hasMore ?? false);
+        }
       }
     } catch {
       // silently fail
@@ -77,11 +81,15 @@ export function useMonsterSearch(): UseMonsterSearchResult {
       const res = await fetch(
         `/api/bestiary/search?q=${encodeURIComponent(query)}&limit=${PAGE_SIZE}&offset=${results.length}`
       );
-      if (res.ok && searchId === searchIdRef.current) {
+      if (res.ok) {
+        // Parse first, then guard: json() awaits the body, and a newer
+        // search may supersede this request while it is still parsing.
         const data: SearchResponse = await res.json();
-        setResults(prev => [...prev, ...(data.monsters ?? [])]);
-        setTotal(data.total ?? 0);
-        setHasMore(data.hasMore ?? false);
+        if (searchId === searchIdRef.current) {
+          setResults(prev => [...prev, ...(data.monsters ?? [])]);
+          setTotal(data.total ?? 0);
+          setHasMore(data.hasMore ?? false);
+        }
       }
     } catch {
       // silently fail

--- a/src/utils/__tests__/bestiaryFilters.test.ts
+++ b/src/utils/__tests__/bestiaryFilters.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { rankMonstersByRelevance } from '@/utils/bestiaryFilters';
+import { createMockProcessedMonster } from '@/test/helpers';
+
+// Input arrays are alphabetical by name, matching how loadAllBestiary()
+// pre-sorts the bestiary before filtering.
+const names = (result: { name: string }[]) => result.map(m => m.name);
+
+describe('rankMonstersByRelevance', () => {
+  it('puts the exact name match first for "guard"', () => {
+    const monsters = [
+      createMockProcessedMonster({ id: 'blackguard', name: 'Blackguard' }),
+      createMockProcessedMonster({ id: 'drow-guard', name: 'Drow Guard' }),
+      createMockProcessedMonster({ id: 'guard', name: 'Guard' }),
+      createMockProcessedMonster({
+        id: 'guardian-naga',
+        name: 'Guardian Naga',
+      }),
+    ];
+    const ranked = rankMonstersByRelevance(monsters, 'guard');
+    expect(ranked[0].name).toBe('Guard');
+  });
+
+  it('orders by tier: exact, prefix, word boundary, substring, metadata-only', () => {
+    const monsters = [
+      createMockProcessedMonster({ id: 'blackguard', name: 'Blackguard' }),
+      createMockProcessedMonster({
+        id: 'city-watch',
+        name: 'City Watch',
+        type: 'humanoid (guard)',
+      }),
+      createMockProcessedMonster({ id: 'drow-guard', name: 'Drow Guard' }),
+      createMockProcessedMonster({ id: 'guard', name: 'Guard' }),
+      createMockProcessedMonster({
+        id: 'guardian-naga',
+        name: 'Guardian Naga',
+      }),
+    ];
+    const ranked = rankMonstersByRelevance(monsters, 'guard');
+    expect(names(ranked)).toEqual([
+      'Guard', // tier 0: exact
+      'Guardian Naga', // tier 1: prefix
+      'Drow Guard', // tier 2: word boundary
+      'Blackguard', // tier 3: substring
+      'City Watch', // tier 4: metadata-only
+    ]);
+  });
+
+  it('preserves alphabetical input order within a tier', () => {
+    const monsters = [
+      createMockProcessedMonster({ id: 'ashari', name: 'Ashari Stoneguard' }),
+      createMockProcessedMonster({ id: 'blackguard', name: 'Blackguard' }),
+      createMockProcessedMonster({
+        id: 'doomguard',
+        name: 'Doomguard Rot Blade',
+      }),
+    ];
+    const ranked = rankMonstersByRelevance(monsters, 'guard');
+    // Ashari Stoneguard and Blackguard are both tier 3 (substring, no word
+    // boundary); Doomguard Rot Blade is also tier 3. Order must be unchanged.
+    expect(names(ranked)).toEqual([
+      'Ashari Stoneguard',
+      'Blackguard',
+      'Doomguard Rot Blade',
+    ]);
+  });
+
+  it('is case-insensitive and trims the query', () => {
+    const monsters = [
+      createMockProcessedMonster({ id: 'blackguard', name: 'Blackguard' }),
+      createMockProcessedMonster({ id: 'guard', name: 'Guard' }),
+    ];
+    const ranked = rankMonstersByRelevance(monsters, '  GUARD ');
+    expect(ranked[0].name).toBe('Guard');
+  });
+
+  it('does not throw on regex-special characters in the query', () => {
+    const monsters = [
+      createMockProcessedMonster({ id: 'guard', name: 'Guard (Veteran)' }),
+    ];
+    expect(() => rankMonstersByRelevance(monsters, 'guard (')).not.toThrow();
+    const ranked = rankMonstersByRelevance(monsters, 'guard (vet');
+    expect(ranked[0].name).toBe('Guard (Veteran)');
+  });
+
+  it('returns input order unchanged for an empty/whitespace query', () => {
+    const monsters = [
+      createMockProcessedMonster({ id: 'b', name: 'Bandit' }),
+      createMockProcessedMonster({ id: 'a', name: 'Aboleth' }),
+    ];
+    expect(names(rankMonstersByRelevance(monsters, '  '))).toEqual([
+      'Bandit',
+      'Aboleth',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const monsters = [
+      createMockProcessedMonster({ id: 'blackguard', name: 'Blackguard' }),
+      createMockProcessedMonster({ id: 'guard', name: 'Guard' }),
+    ];
+    const before = names(monsters);
+    rankMonstersByRelevance(monsters, 'guard');
+    expect(names(monsters)).toEqual(before);
+  });
+});

--- a/src/utils/bestiaryFilters.ts
+++ b/src/utils/bestiaryFilters.ts
@@ -161,3 +161,49 @@ export function filterMonsters(
     return true;
   });
 }
+
+/**
+ * Escape regex-special characters so a user query can be embedded in a RegExp.
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Relevance tier for a monster name against a search query (lower = better):
+ * 0 exact name match, 1 name prefix, 2 query at a word boundary in the name,
+ * 3 substring anywhere in the name, 4 no name match (matched via other fields).
+ */
+function relevanceTier(
+  name: string,
+  queryLower: string,
+  wordBoundary: RegExp
+): number {
+  const nameLower = name.toLowerCase();
+  if (nameLower === queryLower) return 0;
+  if (nameLower.startsWith(queryLower)) return 1;
+  if (wordBoundary.test(nameLower)) return 2;
+  if (nameLower.includes(queryLower)) return 3;
+  return 4;
+}
+
+/**
+ * Order monsters by name-match relevance to the query. Stable: monsters in
+ * the same tier keep their input (alphabetical) order. Returns a new array.
+ */
+export function rankMonstersByRelevance(
+  monsters: ProcessedMonster[],
+  query: string
+): ProcessedMonster[] {
+  const queryLower = query.trim().toLowerCase();
+  if (!queryLower) return [...monsters];
+
+  const wordBoundary = new RegExp(`\\b${escapeRegExp(queryLower)}`);
+  return monsters
+    .map(monster => ({
+      monster,
+      tier: relevanceTier(monster.name, queryLower, wordBoundary),
+    }))
+    .sort((a, b) => a.tier - b.tier)
+    .map(entry => entry.monster);
+}


### PR DESCRIPTION
## Problem

Searching "guard" in the Add Combatant dialog never surfaced the plain **Guard** monster: results were alphabetical, matched as substrings across all fields, and capped at 20 — the exact match sat past the cutoff.

## Solution

- **Relevance ranking** (`rankMonstersByRelevance` in `bestiaryFilters.ts`): 5 tiers — exact name → prefix → word boundary → substring → metadata-only match; stable (alphabetical within tier). Applied in `/api/bestiary/search` after filtering, before pagination, so all consumers benefit (the NPC form's monster picker had the same bug and is fixed for free).
- **Truncation visibility**: `useMonsterSearch` hook (debounced search + load-more pagination) and a "Showing X of N" + Load more footer in `MonsterSearch`.
- Route now trims the query once, so `" guard"` also finds Guard.

## Race bugs fixed along the way (both regression-tested with deferred-promise mocks)

- Stuck `loadingMore` flag when the query changed while a load-more request was in flight — permanently disabled pagination for that dialog instance.
- Stale-response guard ran before `await res.json()`: a slow body could overwrite a newer query's results after settling.

## Testing

- 7 unit tests for ranking (tiers, stability, case/trim, regex-special chars, immutability)
- 8 unit tests for the hook (debounce, pagination, no-op guards, query reset, silent failure, 2 race regressions)
- 3 Storybook play-tests for the footer (visible when truncated, disabled while loading, hidden when complete)
- Full unit suite: 2817 passed / 1 skipped; type-check and lint clean
- Live API verified: `q=guard` → Guard first (total 51); no-query behavior byte-identical

## Manual checklist

- [x] Add Combatant → Monster tab → "guard": Guard first, footer count, Load more appends
- [x] Footer looks right in both themes

## Out of scope (noted for follow-up)

- Bestiary data quirks: duplicate `Duergar Stone Guard` (PHB vs phb source casing), leading-quote names (`"The Demogorgon"`) sorting first alphabetically
- `limit`/`offset` `parseInt` lacks a NaN clamp (pre-existing)

Spec: `docs/superpowers/specs/2026-07-15-monster-search-relevance-design.md` (not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)