### PR TITLE
feat: DM can remove a player from the campaign

### DIFF
--- a/src/app/api/campaign/[code]/__tests__/join.test.ts
+++ b/src/app/api/campaign/[code]/__tests__/join.test.ts
@@ -84,4 +84,28 @@ describe('POST /api/campaign/[code]/join', () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it('clears the removal marker so a kicked player can rejoin', async () => {
+    seedRedis('campaign:ABC123', createMockCampaignData());
+    seedRedis('campaign:ABC123:removed:player-1', '1');
+
+    const req = createNextRequest('/api/campaign/ABC123/join', {
+      method: 'POST',
+      body: {
+        playerId: 'player-1',
+        playerName: 'Alice',
+        characterId: 'char-1',
+        characterName: 'Thorn',
+        characterData: createMockCharacterState(),
+      },
+    });
+
+    const res = await POST(
+      req as NextRequest,
+      createRouteParams({ code: 'ABC123' })
+    );
+
+    expect(res.status).toBe(200);
+    expect(getRedisStore().has('campaign:ABC123:removed:player-1')).toBe(false);
+  });
 });

--- a/src/app/api/campaign/[code]/__tests__/remove-player.test.ts
+++ b/src/app/api/campaign/[code]/__tests__/remove-player.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  resetRedis,
+  seedRedis,
+  seedRedisSet,
+  getRedisStore,
+  getRedisSet,
+} from '@/test/mocks/redis';
+import {
+  createNextRequest,
+  createRouteParams,
+  createMockCampaignData,
+  createMockPlayerData,
+} from '@/test/helpers';
+import { DELETE } from '../players/[playerId]/route';
+import { NextRequest } from 'next/server';
+
+function seedCampaignWithPlayers() {
+  // createMockCampaignData() has dmId: 'dm-test-123'
+  seedRedis('campaign:ABC123', createMockCampaignData());
+  seedRedisSet('campaign:ABC123:players', ['player-1', 'player-2']);
+  seedRedis('campaign:ABC123:player:player-1', createMockPlayerData());
+  seedRedis('campaign:ABC123:messages:player-1', '[]');
+  seedRedis('campaign:ABC123:effects:player-1', '[]');
+  seedRedis('campaign:ABC123:transfers:player-1', '[]');
+}
+
+function removeRequest(body: unknown) {
+  return createNextRequest('/api/campaign/ABC123/players/player-1', {
+    method: 'DELETE',
+    body,
+  }) as NextRequest;
+}
+
+const routeParams = () =>
+  createRouteParams({ code: 'ABC123', playerId: 'player-1' });
+
+describe('DELETE /api/campaign/[code]/players/[playerId]', () => {
+  beforeEach(() => {
+    resetRedis();
+  });
+
+  it('DM removes a player: deletes all per-player keys and sets removal marker', async () => {
+    seedCampaignWithPlayers();
+
+    const res = await DELETE(
+      removeRequest({ dmId: 'dm-test-123' }),
+      routeParams()
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+
+    expect(getRedisSet('campaign:ABC123:players').has('player-1')).toBe(false);
+    expect(getRedisSet('campaign:ABC123:players').has('player-2')).toBe(true);
+    expect(getRedisStore().has('campaign:ABC123:player:player-1')).toBe(false);
+    expect(getRedisStore().has('campaign:ABC123:messages:player-1')).toBe(
+      false
+    );
+    expect(getRedisStore().has('campaign:ABC123:effects:player-1')).toBe(false);
+    expect(getRedisStore().has('campaign:ABC123:transfers:player-1')).toBe(
+      false
+    );
+    expect(getRedisStore().has('campaign:ABC123:removed:player-1')).toBe(true);
+  });
+
+  it('player removes self when body playerId matches path', async () => {
+    seedCampaignWithPlayers();
+
+    const res = await DELETE(
+      removeRequest({ playerId: 'player-1' }),
+      routeParams()
+    );
+
+    expect(res.status).toBe(200);
+    expect(getRedisSet('campaign:ABC123:players').has('player-1')).toBe(false);
+    expect(getRedisStore().has('campaign:ABC123:removed:player-1')).toBe(true);
+  });
+
+  it('returns 403 for wrong dmId', async () => {
+    seedCampaignWithPlayers();
+
+    const res = await DELETE(
+      removeRequest({ dmId: 'dm-wrong' }),
+      routeParams()
+    );
+
+    expect(res.status).toBe(403);
+    expect(getRedisSet('campaign:ABC123:players').has('player-1')).toBe(true);
+  });
+
+  it('returns 403 when body playerId does not match path playerId', async () => {
+    seedCampaignWithPlayers();
+
+    const res = await DELETE(
+      removeRequest({ playerId: 'player-2' }),
+      routeParams()
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when campaign is missing (dm path)', async () => {
+    const res = await DELETE(
+      removeRequest({ dmId: 'dm-test-123' }),
+      routeParams()
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when campaign is missing (self path)', async () => {
+    const res = await DELETE(
+      removeRequest({ playerId: 'player-1' }),
+      routeParams()
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when body has neither dmId nor playerId', async () => {
+    seedCampaignWithPlayers();
+
+    const res = await DELETE(removeRequest({}), routeParams());
+
+    expect(res.status).toBe(400);
+  });
+
+  it('is idempotent: removing an already-removed player returns 200', async () => {
+    seedCampaignWithPlayers();
+
+    const first = await DELETE(
+      removeRequest({ dmId: 'dm-test-123' }),
+      routeParams()
+    );
+    expect(first.status).toBe(200);
+
+    const second = await DELETE(
+      removeRequest({ dmId: 'dm-test-123' }),
+      routeParams()
+    );
+    expect(second.status).toBe(200);
+  });
+});

--- a/src/app/api/campaign/[code]/__tests__/sync.test.ts
+++ b/src/app/api/campaign/[code]/__tests__/sync.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { resetRedis, getRedisStore, getRedisSet } from '@/test/mocks/redis';
+import {
+  resetRedis,
+  getRedisStore,
+  getRedisSet,
+  seedRedis,
+} from '@/test/mocks/redis';
 import {
   createNextRequest,
   createRouteParams,
@@ -102,5 +107,49 @@ describe('POST /api/campaign/[code]/sync', () => {
     const stored = getRedisStore().get('campaign:ABC123:player:player-1');
     const parsed = JSON.parse(stored!);
     expect(parsed.playerName).toBe('Unknown Player');
+  });
+
+  it('returns 410 when the player was removed from the campaign', async () => {
+    seedRedis('campaign:ABC123:removed:player-1', '1');
+
+    const req = createNextRequest('/api/campaign/ABC123/sync', {
+      method: 'POST',
+      body: {
+        playerId: 'player-1',
+        characterData: createMockCharacterState(),
+      },
+    });
+
+    const res = await POST(
+      req as NextRequest,
+      createRouteParams({ code: 'ABC123' })
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(410);
+    expect(data.error).toBe('removed');
+    // Nothing was written:
+    expect(getRedisStore().has('campaign:ABC123:player:player-1')).toBe(false);
+    expect(getRedisSet('campaign:ABC123:players').has('player-1')).toBe(false);
+  });
+
+  it('removal marker for one player does not affect another', async () => {
+    seedRedis('campaign:ABC123:removed:player-1', '1');
+
+    const req = createNextRequest('/api/campaign/ABC123/sync', {
+      method: 'POST',
+      body: {
+        playerId: 'player-2',
+        characterData: createMockCharacterState(),
+      },
+    });
+
+    const res = await POST(
+      req as NextRequest,
+      createRouteParams({ code: 'ABC123' })
+    );
+
+    expect(res.status).toBe(200);
+    expect(getRedisSet('campaign:ABC123:players').has('player-2')).toBe(true);
   });
 });

--- a/src/app/api/campaign/[code]/join/route.ts
+++ b/src/app/api/campaign/[code]/join/route.ts
@@ -4,6 +4,7 @@ import {
   campaignKey,
   campaignPlayersKey,
   campaignPlayerKey,
+  campaignRemovedKey,
   refreshCampaignTTL,
   SLIDING_TTL_SECONDS,
 } from '@/lib/redis';
@@ -56,6 +57,7 @@ export async function POST(
       redis.set(campaignPlayerKey(code, playerId), JSON.stringify(playerData), {
         ex: SLIDING_TTL_SECONDS,
       }),
+      redis.del(campaignRemovedKey(code, playerId)),
       refreshCampaignTTL(redis, code),
     ]);
 

--- a/src/app/api/campaign/[code]/players/[playerId]/route.ts
+++ b/src/app/api/campaign/[code]/players/[playerId]/route.ts
@@ -60,8 +60,12 @@ export async function DELETE(
       }
     }
 
-    // Marker first: a concurrent player sync either lands before it (its
-    // write is deleted just below) or sees it and gets 410.
+    // Marker first: this closes most of the kick-vs-sync race — a concurrent
+    // player sync either lands before it (its write is deleted just below)
+    // or sees it and gets 410. A narrow interleaving remains: a sync that
+    // passed its marker check but writes after our deletes below can briefly
+    // resurrect the entry until TTL. The client's self-DELETE on 410 cleans
+    // that up.
     await redis.set(campaignRemovedKey(code, playerId), '1', {
       ex: SLIDING_TTL_SECONDS,
     });

--- a/src/app/api/campaign/[code]/players/[playerId]/route.ts
+++ b/src/app/api/campaign/[code]/players/[playerId]/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getRedis,
+  campaignKey,
+  campaignPlayersKey,
+  campaignPlayerKey,
+  campaignMessagesKey,
+  campaignEffectsKey,
+  campaignTransfersKey,
+  campaignRemovedKey,
+  SLIDING_TTL_SECONDS,
+} from '@/lib/redis';
+import { verifyDmAuthority } from '@/lib/dmAuth';
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ code: string; playerId: string }> }
+) {
+  try {
+    const { code, playerId } = await params;
+
+    let body: { dmId?: string; playerId?: string } = {};
+    try {
+      body = await request.json();
+    } catch {
+      // missing/invalid body falls through to the 400 below
+    }
+    const { dmId, playerId: bodyPlayerId } = body;
+
+    if (!dmId && !bodyPlayerId) {
+      return NextResponse.json(
+        { error: 'dmId or playerId is required' },
+        { status: 400 }
+      );
+    }
+
+    const redis = getRedis();
+
+    if (dmId) {
+      const auth = await verifyDmAuthority(redis, code, dmId);
+      if (auth === 'missing') {
+        return NextResponse.json(
+          { error: 'Campaign not found' },
+          { status: 404 }
+        );
+      }
+      if (auth === 'mismatch') {
+        return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+      }
+    } else {
+      if (bodyPlayerId !== playerId) {
+        return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+      }
+      const exists = await redis.exists(campaignKey(code));
+      if (!exists) {
+        return NextResponse.json(
+          { error: 'Campaign not found' },
+          { status: 404 }
+        );
+      }
+    }
+
+    // Marker first: a concurrent player sync either lands before it (its
+    // write is deleted just below) or sees it and gets 410.
+    await redis.set(campaignRemovedKey(code, playerId), '1', {
+      ex: SLIDING_TTL_SECONDS,
+    });
+
+    await Promise.all([
+      redis.srem(campaignPlayersKey(code), playerId),
+      redis.del(campaignPlayerKey(code, playerId)),
+      redis.del(campaignMessagesKey(code, playerId)),
+      redis.del(campaignEffectsKey(code, playerId)),
+      redis.del(campaignTransfersKey(code, playerId)),
+    ]);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error removing player from campaign:', error);
+    return NextResponse.json(
+      { error: 'Failed to remove player' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/campaign/[code]/sync/route.ts
+++ b/src/app/api/campaign/[code]/sync/route.ts
@@ -3,6 +3,7 @@ import {
   getRedis,
   campaignPlayersKey,
   campaignPlayerKey,
+  campaignRemovedKey,
   refreshCampaignTTL,
   SLIDING_TTL_SECONDS,
 } from '@/lib/redis';
@@ -26,6 +27,11 @@ export async function POST(
     }
 
     const redis = getRedis();
+
+    const removed = await redis.exists(campaignRemovedKey(code, playerId));
+    if (removed) {
+      return NextResponse.json({ error: 'removed' }, { status: 410 });
+    }
 
     const playerData: CampaignPlayerData = {
       playerId,

--- a/src/app/dm/campaign/[code]/page.tsx
+++ b/src/app/dm/campaign/[code]/page.tsx
@@ -37,6 +37,7 @@ import { useDmCounterSync } from '@/hooks/useDmCounterSync';
 import { useDmStore } from '@/store/dmStore';
 import { BannerUpload } from '@/components/ui/campaign/BannerUpload';
 import { ToastContainer, useToast } from '@/components/ui/feedback/Toast';
+import { ConfirmationModal } from '@/components/ui/feedback/ConfirmationModal';
 import { CampaignPlayerData } from '@/types/campaign';
 import {
   SendItemDialog,
@@ -98,6 +99,8 @@ export default function CampaignViewPage() {
   const [messageTarget, setMessageTarget] = useState<
     CampaignPlayerData | null | 'all'
   >(null);
+  const [playerToRemove, setPlayerToRemove] =
+    useState<CampaignPlayerData | null>(null);
   const { toasts, addToast, dismissToast } = useToast();
   const knownPlayerIdsRef = useRef<Set<string>>(new Set());
 
@@ -191,6 +194,40 @@ export default function CampaignViewPage() {
     },
     [code, dmId, npcSendingNpcName, addToast]
   );
+
+  const handleRemovePlayer = useCallback(async () => {
+    if (!playerToRemove) return;
+    const target = playerToRemove;
+    try {
+      const res = await fetch(
+        `/api/campaign/${code}/players/${target.playerId}`,
+        {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ dmId }),
+        }
+      );
+      if (!res.ok) throw new Error('Failed to remove player');
+
+      // Prevent a "Player Joined" toast if they later rejoin legitimately,
+      // and keep the known-set consistent with the refreshed list.
+      knownPlayerIdsRef.current.delete(target.playerId);
+
+      addToast({
+        type: 'success',
+        title: 'Player Removed',
+        message: `${target.characterName} was removed from the campaign.`,
+      });
+      await refresh();
+    } catch (err) {
+      console.error('Failed to remove player:', err);
+      addToast({
+        type: 'error',
+        title: 'Failed',
+        message: 'Could not remove player. Try again.',
+      });
+    }
+  }, [playerToRemove, code, dmId, addToast, refresh]);
 
   const displayName = campaignName || localCampaign?.name || 'Campaign';
 
@@ -557,6 +594,7 @@ export default function CampaignViewPage() {
                         : undefined
                     }
                     onClick={() => setSelectedPlayer(player)}
+                    onRemove={() => setPlayerToRemove(player)}
                   />
                 ))}
               </div>
@@ -622,6 +660,16 @@ export default function CampaignViewPage() {
         targetPlayer={messageTarget === 'all' ? null : messageTarget}
         campaignCode={code}
         dmId={dmId}
+      />
+
+      <ConfirmationModal
+        isOpen={playerToRemove !== null}
+        onClose={() => setPlayerToRemove(null)}
+        onConfirm={handleRemovePlayer}
+        title="Remove Player"
+        message={`Remove ${playerToRemove?.characterName ?? 'this player'} from the campaign? Their synced data will be deleted. They can rejoin with the campaign code.`}
+        confirmText="Remove"
+        type="danger"
       />
 
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />

--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -103,6 +103,15 @@ export default function CharacterSheet() {
     addToast,
   } = useToast();
 
+  const handleRemovedFromCampaign = useCallback(() => {
+    addToast({
+      type: 'info',
+      title: 'Removed from Campaign',
+      message: 'The DM removed this character from the campaign.',
+      duration: 8000,
+    });
+  }, [addToast]);
+
   // Warn if a save fails because localStorage is full (auto-save writes here).
   useStorageQuotaListener(
     useCallback(() => {
@@ -241,7 +250,10 @@ export default function CharacterSheet() {
   const [isSendingItem, setIsSendingItem] = useState(false);
   const tabbedSheetRef = useRef<TabbedCharacterSheetRef>(null);
 
-  const playerSync = usePlayerSync({ characterId });
+  const playerSync = usePlayerSync({
+    characterId,
+    onRemovedFromCampaign: handleRemovedFromCampaign,
+  });
 
   // Location sync — used to conditionally show Map tab
   const { locations: syncedLocations } = useLocationSync(

--- a/src/components/__tests__/campaign-smoke.test.tsx
+++ b/src/components/__tests__/campaign-smoke.test.tsx
@@ -1,8 +1,16 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from '@testing-library/react';
 import { makeCharacter } from '@/utils/__tests__/test-utils';
 import type { CampaignPlayerData } from '@/types/campaign';
 import type { DmMessage } from '@/types/sharedState';
+
+afterEach(cleanup);
 
 vi.mock('next/image', () => ({
   default: (props: Record<string, unknown>) => {
@@ -92,6 +100,35 @@ describe('PlayerSummaryCard', () => {
   it('displays race', () => {
     render(<PlayerSummaryCard player={mockPlayer} />);
     expect(screen.getAllByText('Dwarf').length).toBeGreaterThan(0);
+  });
+});
+
+describe('PlayerSummaryCard remove action', () => {
+  it('renders remove button when onRemove is provided and calls it without triggering card onClick', () => {
+    const onRemove = vi.fn();
+    const onClick = vi.fn();
+    render(
+      <PlayerSummaryCard
+        player={mockPlayer}
+        onRemove={onRemove}
+        onClick={onClick}
+      />
+    );
+
+    const btn = screen.getByRole('button', {
+      name: /remove .* from campaign/i,
+    });
+    fireEvent.click(btn);
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('does not render remove button without onRemove', () => {
+    render(<PlayerSummaryCard player={mockPlayer} />);
+    expect(
+      screen.queryByRole('button', { name: /remove .* from campaign/i })
+    ).toBeNull();
   });
 });
 

--- a/src/components/ui/campaign/PlayerSummaryCard.stories.tsx
+++ b/src/components/ui/campaign/PlayerSummaryCard.stories.tsx
@@ -76,3 +76,11 @@ export const WithoutAvatarDark: Story = {
   ...WithoutAvatar,
   globals: { theme: 'dark' },
 };
+
+export const WithRemoveAction: Story = {
+  args: {
+    player: basePlayer,
+    onRemove: fn(),
+    onClick: fn(),
+  },
+};

--- a/src/components/ui/campaign/PlayerSummaryCard.tsx
+++ b/src/components/ui/campaign/PlayerSummaryCard.tsx
@@ -15,6 +15,7 @@ import {
   Eye,
   Lightbulb,
   Search,
+  UserX,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/layout/badge';
 import { CampaignPlayerData } from '@/types/campaign';
@@ -97,6 +98,7 @@ interface PlayerSummaryCardProps {
   counterValue?: number;
   onAdjustCounter?: (delta: number) => void;
   onClick?: () => void;
+  onRemove?: () => void;
 }
 
 function ensureArray<T>(value: unknown): T[] {
@@ -109,6 +111,7 @@ export function PlayerSummaryCard({
   counterValue = 0,
   onAdjustCounter,
   onClick,
+  onRemove,
 }: PlayerSummaryCardProps) {
   const { characterData: char } = player;
   const weapons = ensureArray<(typeof char.weapons)[number]>(char.weapons);
@@ -186,8 +189,24 @@ export function PlayerSummaryCard({
                   </span>
                 </div>
               </div>
-              <div className="text-muted max-w-[40%] shrink-0 truncate text-right text-[10px] leading-tight">
-                {player.playerName}
+              <div className="flex shrink-0 items-start gap-1">
+                <div className="text-muted max-w-[8rem] truncate text-right text-[10px] leading-tight">
+                  {player.playerName}
+                </div>
+                {onRemove && (
+                  <button
+                    onClick={e => {
+                      e.stopPropagation();
+                      onRemove();
+                    }}
+                    onKeyDown={e => e.stopPropagation()}
+                    className="text-muted hover:text-accent-red-text hover:bg-accent-red-bg -mt-0.5 rounded p-1 transition-colors"
+                    title="Remove from campaign"
+                    aria-label={`Remove ${char.name || player.characterName} from campaign`}
+                  >
+                    <UserX size={14} />
+                  </button>
+                )}
               </div>
             </div>
 

--- a/src/hooks/__tests__/usePlayerSync.test.ts
+++ b/src/hooks/__tests__/usePlayerSync.test.ts
@@ -1,14 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { usePlayerSync } from '@/hooks/usePlayerSync';
-import { usePlayerStore } from '@/store/playerStore';
+import { usePlayerStore, PlayerCharacter } from '@/store/playerStore';
 import {
   mockFetchResponse,
   mockFetchSequence,
   resetFetch,
 } from '@/test/mocks/fetch';
 import { createMockCharacterState } from '@/test/helpers';
-import type { CharacterState } from '@/types/character';
 
 function seedCharacter(overrides: Record<string, unknown> = {}) {
   const charData = createMockCharacterState({ id: 'char-test' });
@@ -34,6 +33,34 @@ function seedCharacter(overrides: Record<string, unknown> = {}) {
       },
     ],
   });
+}
+
+function seedLinkedCharacter() {
+  const characterData = createMockCharacterState({ id: 'char-1' });
+  usePlayerStore.setState({
+    characters: [
+      {
+        id: 'char-1',
+        name: 'Test Hero',
+        race: 'Human',
+        class: 'Fighter',
+        level: 5,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastPlayed: new Date(),
+        characterData,
+        tags: [],
+        isArchived: false,
+        campaignCode: 'ABC123',
+        campaignName: 'Test Campaign',
+        syncEnabled: true,
+        autoSync: true,
+      } as PlayerCharacter,
+    ],
+    activeCharacterId: 'char-1',
+    lastSelectedCharacterId: 'char-1',
+  });
+  return characterData;
 }
 
 describe('usePlayerSync', () => {
@@ -185,5 +212,87 @@ describe('usePlayerSync', () => {
     expect(char.campaignName).toBeUndefined();
     expect(char.syncEnabled).toBeUndefined();
     expect(result.current.syncStatus).toBe('idle');
+  });
+
+  it('on 410 clears campaign link, notifies, and does NOT attempt rejoin', async () => {
+    const characterData = seedLinkedCharacter();
+    const fetchFn = mockFetchResponse(410, { error: 'removed' });
+    const onRemoved = vi.fn();
+
+    const { result } = renderHook(() =>
+      usePlayerSync({ characterId: 'char-1', onRemovedFromCampaign: onRemoved })
+    );
+
+    await act(async () => {
+      await result.current.syncNow(characterData);
+    });
+
+    expect(onRemoved).toHaveBeenCalledTimes(1);
+    // exactly one fetch: the sync call — no /join rejoin attempt
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    const char = usePlayerStore.getState().characters[0];
+    expect(char.campaignCode).toBeUndefined();
+    expect(char.syncEnabled).toBeUndefined();
+    expect(result.current.syncStatus).toBe('idle');
+  });
+
+  it('non-410 failure still attempts rejoin (existing behavior preserved)', async () => {
+    const characterData = seedLinkedCharacter();
+    const fetchFn = mockFetchResponse(500, { error: 'boom' });
+    const onRemoved = vi.fn();
+
+    const { result } = renderHook(() =>
+      usePlayerSync({ characterId: 'char-1', onRemovedFromCampaign: onRemoved })
+    );
+
+    await act(async () => {
+      await result.current.syncNow(characterData);
+    });
+
+    expect(onRemoved).not.toHaveBeenCalled();
+    // sync call + rejoin attempt
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(usePlayerStore.getState().characters[0].campaignCode).toBe('ABC123');
+  });
+
+  it('leaveCampaign fires server-side removal and clears local link', async () => {
+    seedLinkedCharacter();
+    const fetchFn = mockFetchResponse(200, { success: true });
+
+    const { result } = renderHook(() =>
+      usePlayerSync({ characterId: 'char-1' })
+    );
+
+    act(() => {
+      result.current.leaveCampaign();
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/campaign/ABC123/players/char-1',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+    expect(
+      usePlayerStore.getState().characters[0].campaignCode
+    ).toBeUndefined();
+  });
+
+  it('leaveCampaign still clears local link when the server call fails', async () => {
+    seedLinkedCharacter();
+    global.fetch = vi.fn(() =>
+      Promise.reject(new Error('network down'))
+    ) as unknown as typeof global.fetch;
+
+    const { result } = renderHook(() =>
+      usePlayerSync({ characterId: 'char-1' })
+    );
+
+    act(() => {
+      result.current.leaveCampaign();
+    });
+
+    expect(
+      usePlayerStore.getState().characters[0].campaignCode
+    ).toBeUndefined();
   });
 });

--- a/src/hooks/__tests__/usePlayerSync.test.ts
+++ b/src/hooks/__tests__/usePlayerSync.test.ts
@@ -228,13 +228,37 @@ describe('usePlayerSync', () => {
     });
 
     expect(onRemoved).toHaveBeenCalledTimes(1);
-    // exactly one fetch: the sync call — no /join rejoin attempt
-    expect(fetchFn).toHaveBeenCalledTimes(1);
+    // two fetches: the sync call, then the self-removal DELETE
+    // (closes the kick-vs-sync resurrection race) — no /join rejoin attempt
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    const [secondUrl, secondOpts] = (fetchFn as ReturnType<typeof vi.fn>).mock
+      .calls[1];
+    expect(secondUrl).toBe('/api/campaign/ABC123/players/char-1');
+    expect(secondOpts.method).toBe('DELETE');
 
     const char = usePlayerStore.getState().characters[0];
     expect(char.campaignCode).toBeUndefined();
     expect(char.syncEnabled).toBeUndefined();
     expect(result.current.syncStatus).toBe('idle');
+  });
+
+  it('queued pending sync during a 410 does not fire the removal callback twice', async () => {
+    const characterData = seedLinkedCharacter();
+    mockFetchResponse(410, { error: 'removed' });
+    const onRemoved = vi.fn();
+
+    const { result } = renderHook(() =>
+      usePlayerSync({ characterId: 'char-1', onRemovedFromCampaign: onRemoved })
+    );
+
+    await act(async () => {
+      const first = result.current.syncNow(characterData);
+      // second call while first is in flight → queued into pendingSyncData
+      const second = result.current.syncNow(characterData);
+      await Promise.all([first, second]);
+    });
+
+    expect(onRemoved).toHaveBeenCalledTimes(1);
   });
 
   it('non-410 failure still attempts rejoin (existing behavior preserved)', async () => {

--- a/src/hooks/usePlayerSync.ts
+++ b/src/hooks/usePlayerSync.ts
@@ -4,6 +4,7 @@ import { usePlayerStore, PlayerCharacter } from '@/store/playerStore';
 
 interface UsePlayerSyncOptions {
   characterId: string;
+  onRemovedFromCampaign?: () => void;
 }
 
 interface UsePlayerSyncResult {
@@ -20,6 +21,7 @@ interface UsePlayerSyncResult {
 
 export function usePlayerSync({
   characterId,
+  onRemovedFromCampaign,
 }: UsePlayerSyncOptions): UsePlayerSyncResult {
   const { getCharacterById, updateCharacter } = usePlayerStore();
   const character = getCharacterById(characterId);
@@ -37,6 +39,17 @@ export function usePlayerSync({
   const lastSyncedAt = character?.lastSyncedAt ?? null;
 
   const rejoinInFlight = useRef(false);
+
+  const clearCampaignLink = useCallback(() => {
+    updateCharacter(characterId, {
+      campaignCode: undefined,
+      campaignName: undefined,
+      syncEnabled: undefined,
+      autoSync: undefined,
+      lastSyncedAt: undefined,
+    } as Partial<PlayerCharacter>);
+    setSyncStatus('idle');
+  }, [characterId, updateCharacter]);
 
   const attemptRejoin = useCallback(
     async (characterData: CharacterState) => {
@@ -89,6 +102,13 @@ export function usePlayerSync({
           }),
         });
 
+        if (res.status === 410) {
+          // DM removed this player. Do not rejoin; unlink locally.
+          clearCampaignLink();
+          onRemovedFromCampaign?.();
+          return;
+        }
+
         if (!res.ok) {
           const rejoined = await attemptRejoin(characterData);
           if (!rejoined) {
@@ -114,7 +134,15 @@ export function usePlayerSync({
         }
       }
     },
-    [campaignCode, syncEnabled, characterId, updateCharacter, attemptRejoin]
+    [
+      campaignCode,
+      syncEnabled,
+      characterId,
+      updateCharacter,
+      attemptRejoin,
+      clearCampaignLink,
+      onRemovedFromCampaign,
+    ]
   );
 
   const toggleAutoSync = useCallback(() => {
@@ -123,15 +151,17 @@ export function usePlayerSync({
   }, [character, characterId, autoSync, updateCharacter]);
 
   const leaveCampaign = useCallback(() => {
-    updateCharacter(characterId, {
-      campaignCode: undefined,
-      campaignName: undefined,
-      syncEnabled: undefined,
-      autoSync: undefined,
-      lastSyncedAt: undefined,
-    } as Partial<PlayerCharacter>);
-    setSyncStatus('idle');
-  }, [characterId, updateCharacter]);
+    if (campaignCode) {
+      // Best-effort server-side cleanup so the DM's list doesn't keep a
+      // stale entry for 60 days; local unlink proceeds regardless.
+      fetch(`/api/campaign/${campaignCode}/players/${characterId}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ playerId: characterId }),
+      }).catch(() => {});
+    }
+    clearCampaignLink();
+  }, [campaignCode, characterId, clearCampaignLink]);
 
   return {
     syncStatus,

--- a/src/hooks/usePlayerSync.ts
+++ b/src/hooks/usePlayerSync.ts
@@ -51,6 +51,19 @@ export function usePlayerSync({
     setSyncStatus('idle');
   }, [characterId, updateCharacter]);
 
+  const leaveCampaign = useCallback(() => {
+    if (campaignCode) {
+      // Best-effort server-side cleanup so the DM's list doesn't keep a
+      // stale entry for 60 days; local unlink proceeds regardless.
+      fetch(`/api/campaign/${campaignCode}/players/${characterId}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ playerId: characterId }),
+      }).catch(() => {});
+    }
+    clearCampaignLink();
+  }, [campaignCode, characterId, clearCampaignLink]);
+
   const attemptRejoin = useCallback(
     async (characterData: CharacterState) => {
       if (rejoinInFlight.current || !campaignCode) return false;
@@ -103,8 +116,11 @@ export function usePlayerSync({
         });
 
         if (res.status === 410) {
-          // DM removed this player. Do not rejoin; unlink locally.
-          clearCampaignLink();
+          // DM removed this player. Do not rejoin; clean up server side
+          // (closes the kick-vs-sync race that can resurrect our entry)
+          // and unlink locally.
+          pendingSyncData.current = null;
+          leaveCampaign();
           onRemovedFromCampaign?.();
           return;
         }
@@ -140,7 +156,7 @@ export function usePlayerSync({
       characterId,
       updateCharacter,
       attemptRejoin,
-      clearCampaignLink,
+      leaveCampaign,
       onRemovedFromCampaign,
     ]
   );
@@ -149,19 +165,6 @@ export function usePlayerSync({
     if (!character) return;
     updateCharacter(characterId, { autoSync: !autoSync });
   }, [character, characterId, autoSync, updateCharacter]);
-
-  const leaveCampaign = useCallback(() => {
-    if (campaignCode) {
-      // Best-effort server-side cleanup so the DM's list doesn't keep a
-      // stale entry for 60 days; local unlink proceeds regardless.
-      fetch(`/api/campaign/${campaignCode}/players/${characterId}`, {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ playerId: characterId }),
-      }).catch(() => {});
-    }
-    clearCampaignLink();
-  }, [campaignCode, characterId, clearCampaignLink]);
 
   return {
     syncStatus,

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -52,6 +52,10 @@ export function campaignTransfersKey(code: string, playerId: string): string {
   return `campaign:${code}:transfers:${playerId}`;
 }
 
+export function campaignRemovedKey(code: string, playerId: string): string {
+  return `campaign:${code}:removed:${playerId}`;
+}
+
 export function campaignLocationsKey(code: string): string {
   return `campaign:${code}:locations`;
 }

--- a/src/store/__tests__/playerStore.test.ts
+++ b/src/store/__tests__/playerStore.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { vi } from 'vitest';
+import { mockFetchResponse } from '@/test/mocks/fetch';
 import { usePlayerStore } from '@/store/playerStore';
 
 function resetStore() {
@@ -82,6 +84,42 @@ describe('playerStore', () => {
       usePlayerStore.getState().createCharacter('Hero');
       usePlayerStore.getState().deleteCharacter('non-existent-id');
       expect(usePlayerStore.getState().characters).toHaveLength(1);
+    });
+
+    it('fires server-side campaign removal when character is campaign-linked', () => {
+      const fetchFn = mockFetchResponse(200, { success: true });
+      const id = usePlayerStore.getState().createCharacter('Linked Hero');
+      usePlayerStore.getState().updateCharacter(id, { campaignCode: 'ABC123' });
+
+      usePlayerStore.getState().deleteCharacter(id);
+
+      expect(fetchFn).toHaveBeenCalledWith(
+        `/api/campaign/ABC123/players/${id}`,
+        expect.objectContaining({ method: 'DELETE' })
+      );
+      expect(usePlayerStore.getState().characters).toHaveLength(0);
+    });
+
+    it('does not call the API when character has no campaign', () => {
+      const fetchFn = mockFetchResponse(200, { success: true });
+      const id = usePlayerStore.getState().createCharacter('Loner Hero');
+
+      usePlayerStore.getState().deleteCharacter(id);
+
+      expect(fetchFn).not.toHaveBeenCalled();
+      expect(usePlayerStore.getState().characters).toHaveLength(0);
+    });
+
+    it('still deletes locally when the removal request fails', () => {
+      global.fetch = vi.fn(() =>
+        Promise.reject(new Error('network down'))
+      ) as unknown as typeof global.fetch;
+      const id = usePlayerStore.getState().createCharacter('Offline Hero');
+      usePlayerStore.getState().updateCharacter(id, { campaignCode: 'ABC123' });
+
+      usePlayerStore.getState().deleteCharacter(id);
+
+      expect(usePlayerStore.getState().characters).toHaveLength(0);
     });
   });
 

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -296,6 +296,20 @@ export const usePlayerStore = create<PlayerStoreState>()(
       },
 
       deleteCharacter: characterId => {
+        const character = get().characters.find(c => c.id === characterId);
+        if (character?.campaignCode) {
+          // Best-effort: remove this character from the campaign so the DM's
+          // player list doesn't keep a stale entry. Local delete proceeds
+          // regardless of network state.
+          fetch(
+            `/api/campaign/${character.campaignCode}/players/${characterId}`,
+            {
+              method: 'DELETE',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ playerId: characterId }),
+            }
+          ).catch(() => {});
+        }
         set(state => ({
           characters: state.characters.filter(c => c.id !== characterId),
           activeCharacterId:

--- a/src/test/mocks/redis.ts
+++ b/src/test/mocks/redis.ts
@@ -178,6 +178,8 @@ vi.mock('@/lib/redis', () => ({
     `campaign:${code}:effects:${playerId}`,
   campaignTransfersKey: (code: string, playerId: string) =>
     `campaign:${code}:transfers:${playerId}`,
+  campaignRemovedKey: (code: string, playerId: string) =>
+    `campaign:${code}:removed:${playerId}`,
   campaignLocationsKey: (code: string) => `campaign:${code}:locations`,
   campaignLocationKey: (code: string, locationId: string) =>
     `campaign:${code}:location:${locationId}`,


### PR DESCRIPTION
## Problem

No way for a DM to remove a player from a campaign. When a player deleted their character locally without leaving first, the entry stayed stuck on the DM dashboard (Redis, 60-day TTL) with no way to clean it up. Voluntary leave was also purely local — it never removed the server-side entry either.

## What this does

- **Kick endpoint** — `DELETE /api/campaign/[code]/players/[playerId]`: DM auth via `verifyDmAuthority` (or self-removal when body playerId matches path). Removes the player from the set, deletes all per-player keys (player/messages/effects/transfers), and writes a `campaign:CODE:removed:PLAYERID` marker (60d TTL) — marker written first to close the race with the player's 10s sync heartbeat.
- **Sync gate** — sync returns `410 Gone` when the removal marker exists. Gate is marker-based (not set-membership) so sync stays self-healing after Redis TTL expiry.
- **Kick ≠ ban** — join deletes the marker; a kicked player can rejoin with the campaign code.
- **Player client** — on 410: no auto-rejoin (previously any failed sync triggered rejoin), clears pending sync queue, fires self-removal DELETE (closes the narrow resurrection interleaving), unlinks locally, shows "Removed from Campaign" toast.
- **Root cause fixes** — `leaveCampaign()` and `deleteCharacter()` now fire best-effort server-side removal, so stale entries stop accumulating; local behavior never blocked by network failure.
- **DM UI** — remove (UserX) button on `PlayerSummaryCard` + `ConfirmationModal`; success/failure toasts; immediate list refresh.

## Testing

- TDD throughout: 8 endpoint tests, sync/join gate tests, 6 hook tests (incl. no-rejoin-on-410, duplicate-callback regression, fire-and-forget failure paths), 3 store tests, card smoke tests + story.
- Full unit suite 2852 passed / 1 skipped; type-check clean; touched-file lint warnings all pre-exist on base.
- Manual e2e checklist (local Redis, two browsers) pending — kick active player, rejoin, leave, delete-character, both themes.

## Follow-ups (noted in review, deferred)

- VTT screen (`PlayerVttScreen.hooks.ts`) doesn't wire `onRemovedFromCampaign` — kicked player on the battlemap unlinks silently until back on the sheet.
- Marker-first write ordering documented but not pinned by a call-order test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)