### PR TITLE
fix(sync): character revision protocol — cross-tab convergence + stale-write rejection

### DIFF
--- a/src/app/api/campaign/[code]/__tests__/join.test.ts
+++ b/src/app/api/campaign/[code]/__tests__/join.test.ts
@@ -108,4 +108,41 @@ describe('POST /api/campaign/[code]/join', () => {
     expect(res.status).toBe(200);
     expect(getRedisStore().has('campaign:ABC123:removed:player-1')).toBe(false);
   });
+
+  it('keeps the newer stored blob when a stale tab rejoins', async () => {
+    // (reuse this file's existing campaign seeding — join 404s without it)
+    const base = createMockCharacterState();
+    seedRedis(
+      'campaign:ABC123:player:player-1',
+      JSON.stringify({
+        playerId: 'player-1',
+        playerName: 'Alice',
+        characterId: 'char-1',
+        characterName: 'Thorn',
+        characterData: { ...base, revision: 5 },
+        lastSynced: '2026-07-19T00:00:00.000Z',
+      })
+    );
+
+    const req = createNextRequest('/api/campaign/ABC123/join', {
+      method: 'POST',
+      body: {
+        playerId: 'player-1',
+        playerName: 'Alice',
+        characterId: 'char-1',
+        characterName: 'Thorn',
+        characterData: { ...base, revision: 2 },
+      },
+    });
+    const res = await POST(
+      req as NextRequest,
+      createRouteParams({ code: 'ABC123' })
+    );
+    expect(res.status).toBe(200);
+
+    const stored = JSON.parse(
+      getRedisStore().get('campaign:ABC123:player:player-1')!
+    );
+    expect(stored.characterData.revision).toBe(5);
+  });
 });

--- a/src/app/api/campaign/[code]/__tests__/sync-conflict.test.ts
+++ b/src/app/api/campaign/[code]/__tests__/sync-conflict.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resetRedis, getRedisStore } from '@/test/mocks/redis';
+import {
+  createNextRequest,
+  createRouteParams,
+  createMockCharacterState,
+} from '@/test/helpers';
+import { POST } from '../sync/route';
+import { NextRequest } from 'next/server';
+
+/**
+ * Redis writes are revision-gated: a push whose characterData.revision is
+ * OLDER than the stored blob's is rejected with 409 + the current blob
+ * (the pusher was a stale tab — it must adopt, not clobber).
+ */
+
+async function push(characterData: unknown) {
+  const req = createNextRequest('/api/campaign/ABC123/sync', {
+    method: 'POST',
+    body: {
+      playerId: 'player-1',
+      playerName: 'Alice',
+      characterId: 'char-1',
+      characterName: 'Thorn',
+      characterData,
+    },
+  });
+  return POST(req as NextRequest, createRouteParams({ code: 'ABC123' }));
+}
+
+function storedCharacter() {
+  return JSON.parse(getRedisStore().get('campaign:ABC123:player:player-1')!)
+    .characterData;
+}
+
+describe('POST /api/campaign/[code]/sync — revision gating', () => {
+  beforeEach(() => {
+    resetRedis();
+  });
+
+  it('rejects a stale full-blob push with 409 and keeps the newer state', async () => {
+    const base = createMockCharacterState();
+
+    // Battlemap tab: cast a spell + took damage, pushed fresh state.
+    const fresh = {
+      ...base,
+      revision: 2,
+      spellSlots: { ...base.spellSlots, 1: { max: 2, used: 1 } },
+      hitPoints: { ...base.hitPoints, current: 30, max: 44 },
+    };
+    const freshRes = await push(fresh);
+    expect(freshRes.status).toBe(200);
+
+    // Sheet tab: pre-combat stale copy pushes after an unrelated edit.
+    const stale = {
+      ...base,
+      revision: 1,
+      spellSlots: { ...base.spellSlots, 1: { max: 2, used: 0 } },
+      hitPoints: { ...base.hitPoints, current: 44, max: 44 },
+    };
+    const staleRes = await push(stale);
+
+    expect(staleRes.status).toBe(409);
+    const body = await staleRes.json();
+    expect(body.error).toBe('stale');
+    expect(body.current.characterData.revision).toBe(2);
+
+    expect(storedCharacter().spellSlots[1].used).toBe(1);
+    expect(storedCharacter().hitPoints.current).toBe(30);
+  });
+
+  it('accepts an equal-revision re-push (idempotent retry)', async () => {
+    const base = createMockCharacterState();
+    await push({ ...base, revision: 3 });
+    const res = await push({
+      ...base,
+      revision: 3,
+      hitPoints: { ...base.hitPoints, current: 20, max: 44 },
+    });
+    expect(res.status).toBe(200);
+    expect(storedCharacter().hitPoints.current).toBe(20);
+  });
+
+  it('accepts a payload with no revision when nothing is stored', async () => {
+    const res = await push(createMockCharacterState());
+    expect(res.status).toBe(200);
+  });
+
+  it('treats a missing incoming revision as 0 against a versioned blob', async () => {
+    const base = createMockCharacterState();
+    await push({ ...base, revision: 2 });
+    const res = await push({ ...base }); // no revision → 0 < 2 → stale
+    expect(res.status).toBe(409);
+    expect(storedCharacter().revision).toBe(2);
+  });
+});

--- a/src/app/api/campaign/[code]/join/route.ts
+++ b/src/app/api/campaign/[code]/join/route.ts
@@ -52,11 +52,31 @@ export async function POST(
       lastSynced: new Date().toISOString(),
     };
 
+    // Rejoin must not clobber a newer snapshot pushed by another tab:
+    // keep whichever blob has the higher character revision.
+    const existingRaw = await redis.get<string>(
+      campaignPlayerKey(code, playerId)
+    );
+    let dataToStore = playerData;
+    if (existingRaw) {
+      const existing: CampaignPlayerData =
+        typeof existingRaw === 'string' ? JSON.parse(existingRaw) : existingRaw;
+      const storedRevision = existing.characterData?.revision ?? 0;
+      const incomingRevision = characterData.revision ?? 0;
+      if (incomingRevision < storedRevision) {
+        dataToStore = existing;
+      }
+    }
+
     await Promise.all([
       redis.sadd(campaignPlayersKey(code), playerId),
-      redis.set(campaignPlayerKey(code, playerId), JSON.stringify(playerData), {
-        ex: SLIDING_TTL_SECONDS,
-      }),
+      redis.set(
+        campaignPlayerKey(code, playerId),
+        JSON.stringify(dataToStore),
+        {
+          ex: SLIDING_TTL_SECONDS,
+        }
+      ),
       redis.del(campaignRemovedKey(code, playerId)),
       refreshCampaignTTL(redis, code),
     ]);

--- a/src/app/api/campaign/[code]/sync/route.ts
+++ b/src/app/api/campaign/[code]/sync/route.ts
@@ -33,6 +33,23 @@ export async function POST(
       return NextResponse.json({ error: 'removed' }, { status: 410 });
     }
 
+    // Revision gate: a stale tab must not clobber a newer snapshot.
+    const existingRaw = await redis.get<string>(
+      campaignPlayerKey(code, playerId)
+    );
+    if (existingRaw) {
+      const existing: CampaignPlayerData =
+        typeof existingRaw === 'string' ? JSON.parse(existingRaw) : existingRaw;
+      const storedRevision = existing.characterData?.revision ?? 0;
+      const incomingRevision = characterData.revision ?? 0;
+      if (incomingRevision < storedRevision) {
+        return NextResponse.json(
+          { error: 'stale', current: existing },
+          { status: 409 }
+        );
+      }
+    }
+
     const playerData: CampaignPlayerData = {
       playerId,
       playerName: playerName || 'Unknown Player',

--- a/src/hooks/__tests__/useCharacterRosterSync.test.ts
+++ b/src/hooks/__tests__/useCharacterRosterSync.test.ts
@@ -143,4 +143,65 @@ describe('useCharacterRosterSync', () => {
     expect(onLoad).toHaveBeenCalledTimes(1);
     expect(onLoad).toHaveBeenCalledWith(rosterData);
   });
+
+  it('does not load a stale roster blob over fresher store state', () => {
+    const rosterData = makeCharacter({ id: 'char-1', revision: 5 });
+    const liveCharacter = makeCharacter({ id: 'char-1', revision: 10 });
+    const loadCharacterState = vi.fn();
+    const onLoad = vi.fn();
+    const props = makeProps({
+      playerCharacter: { characterData: rosterData },
+      character: liveCharacter,
+      loadCharacterState,
+      onLoad,
+    });
+
+    renderHook(p => useCharacterRosterSync(p), { initialProps: props });
+
+    expect(loadCharacterState).not.toHaveBeenCalled();
+    expect(onLoad).not.toHaveBeenCalled();
+  });
+
+  it('still loads a newer roster blob', () => {
+    const rosterData = makeCharacter({ id: 'char-1', revision: 12 });
+    const liveCharacter = makeCharacter({ id: 'char-1', revision: 10 });
+    const loadCharacterState = vi.fn();
+    const props = makeProps({
+      playerCharacter: { characterData: rosterData },
+      character: liveCharacter,
+      loadCharacterState,
+    });
+
+    renderHook(p => useCharacterRosterSync(p), { initialProps: props });
+
+    expect(loadCharacterState).toHaveBeenCalledTimes(1);
+    expect(loadCharacterState).toHaveBeenCalledWith(rosterData);
+  });
+
+  it('still writes fresher store state back to the roster when a stale load is skipped', () => {
+    const rosterData = makeCharacter({ id: 'char-1', revision: 5 });
+    const liveCharacter = makeCharacter({ id: 'char-1', revision: 10 });
+    const updateCharacterData = vi.fn();
+    const props = makeProps({
+      playerCharacter: { characterData: rosterData },
+      character: liveCharacter,
+      updateCharacterData,
+    });
+
+    const { rerender } = renderHook(p => useCharacterRosterSync(p), {
+      initialProps: props,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(60);
+    });
+
+    const updatedLive = { ...liveCharacter, revision: 11 };
+    rerender({ ...props, character: updatedLive });
+
+    expect(updateCharacterData).toHaveBeenCalledWith(
+      'char-1',
+      expect.objectContaining({ revision: 11 })
+    );
+  });
 });

--- a/src/hooks/__tests__/usePlayerSync.test.ts
+++ b/src/hooks/__tests__/usePlayerSync.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { usePlayerSync } from '@/hooks/usePlayerSync';
 import { usePlayerStore, PlayerCharacter } from '@/store/playerStore';
+import { useCharacterStore } from '@/store/characterStore';
 import {
   mockFetchResponse,
   mockFetchSequence,
@@ -318,5 +319,69 @@ describe('usePlayerSync', () => {
     expect(
       usePlayerStore.getState().characters[0].campaignCode
     ).toBeUndefined();
+  });
+
+  describe('409 stale handling', () => {
+    it('adopts the server blob when it is newer, without rejoining', async () => {
+      seedLinkedCharacter();
+      const localCharacter = createMockCharacterState({
+        id: 'char-1',
+        revision: 1,
+      });
+      useCharacterStore.setState({ character: localCharacter });
+
+      const serverCharacter = createMockCharacterState({
+        id: 'char-1',
+        revision: 4,
+        armorClass: 19,
+      });
+      const fetchFn = mockFetchResponse(409, {
+        error: 'stale',
+        current: { characterData: serverCharacter },
+      });
+
+      const { result } = renderHook(() =>
+        usePlayerSync({ characterId: 'char-1' })
+      );
+      await act(async () => {
+        await result.current.syncNow(localCharacter);
+      });
+
+      expect(useCharacterStore.getState().character.revision).toBe(4);
+      expect(useCharacterStore.getState().character.armorClass).toBe(19);
+      // exactly one fetch — no /join rejoin attempt
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(result.current.syncStatus).toBe('synced');
+    });
+
+    it('keeps local state when the 409 blob is not newer', async () => {
+      seedLinkedCharacter();
+      const localCharacter = createMockCharacterState({
+        id: 'char-1',
+        revision: 6,
+      });
+      useCharacterStore.setState({ character: localCharacter });
+
+      mockFetchResponse(409, {
+        error: 'stale',
+        current: {
+          characterData: createMockCharacterState({
+            id: 'char-1',
+            revision: 6,
+            armorClass: 3,
+          }),
+        },
+      });
+
+      const { result } = renderHook(() =>
+        usePlayerSync({ characterId: 'char-1' })
+      );
+      await act(async () => {
+        await result.current.syncNow(localCharacter);
+      });
+
+      expect(useCharacterStore.getState().character.armorClass).not.toBe(3);
+      expect(useCharacterStore.getState().character.revision).toBe(6);
+    });
   });
 });

--- a/src/hooks/__tests__/usePlayerSync.test.ts
+++ b/src/hooks/__tests__/usePlayerSync.test.ts
@@ -352,6 +352,9 @@ describe('usePlayerSync', () => {
       // exactly one fetch — no /join rejoin attempt
       expect(fetchFn).toHaveBeenCalledTimes(1);
       expect(result.current.syncStatus).toBe('synced');
+      expect(usePlayerStore.getState().characters[0].lastSyncedAt).toEqual(
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/)
+      );
     });
 
     it('keeps local state when the 409 blob is not newer', async () => {

--- a/src/hooks/useCharacterRosterSync.ts
+++ b/src/hooks/useCharacterRosterSync.ts
@@ -47,19 +47,40 @@ export function useCharacterRosterSync({
   const lastSyncedCharacterRef = useRef<CharacterState | null>(null);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
 
+  // Latest-value ref for `character` — read (not reactively depended on) by
+  // the load effect below. `character` is expected to change on nearly every
+  // local mutation, and making the load effect depend on it directly would
+  // re-run it (and cancel the in-flight initial-load timer) on every one of
+  // those changes instead of only on character-switch.
+  const characterRef = useRef(character);
+  characterRef.current = character;
+
   // Load character data into store when component mounts or character changes
   useEffect(() => {
     if (playerCharacter && hasHydrated) {
       const currentCharacterId = playerCharacter.characterData.id;
+      const liveCharacter = characterRef.current;
 
       // Only load if we haven't loaded this character yet or if it's a different character
       if (lastLoadedCharacterRef.current !== currentCharacterId) {
+        // The roster blob (playerStore) has no cross-tab convergence, unlike
+        // the live characterStore state, which the storage listener keeps
+        // fresh. If the roster blob is the same character but at a stale
+        // (lower or equal) revision, adopting it here would clobber newer
+        // local state. Skip the load but still arm the write-back effect so
+        // the fresher characterStore state gets written back to the roster.
+        const isStaleRosterBlob =
+          playerCharacter.characterData.id === liveCharacter.id &&
+          (playerCharacter.characterData.revision ?? 0) <=
+            (liveCharacter.revision ?? 0);
+
         setIsInitialLoad(true);
-        loadCharacterState(playerCharacter.characterData);
+        if (!isStaleRosterBlob) {
+          loadCharacterState(playerCharacter.characterData);
+          onLoad?.(playerCharacter.characterData);
+        }
         lastLoadedCharacterRef.current = currentCharacterId;
         lastSyncedCharacterRef.current = playerCharacter.characterData;
-
-        onLoad?.(playerCharacter.characterData);
 
         // Mark initial load as complete after state has been set
         const timer = setTimeout(() => {

--- a/src/hooks/usePlayerSync.ts
+++ b/src/hooks/usePlayerSync.ts
@@ -1,6 +1,8 @@
 import { useCallback, useRef, useState } from 'react';
 import { CharacterState } from '@/types/character';
+import { CampaignPlayerData } from '@/types/campaign';
 import { usePlayerStore, PlayerCharacter } from '@/store/playerStore';
+import { useCharacterStore } from '@/store/characterStore';
 
 interface UsePlayerSyncOptions {
   characterId: string;
@@ -122,6 +124,29 @@ export function usePlayerSync({
           pendingSyncData.current = null;
           leaveCampaign();
           onRemovedFromCampaign?.();
+          return;
+        }
+
+        if (res.status === 409) {
+          // Our copy was stale (another tab pushed newer). Adopt the
+          // server's blob instead of clobbering — revision-gated, and via
+          // loadCharacterState so no bump/echo. Never rejoin on 409:
+          // rejoin would overwrite the newer blob with the stale one.
+          pendingSyncData.current = null;
+          const body = (await res.json().catch(() => null)) as {
+            current?: CampaignPlayerData;
+          } | null;
+          const serverCharacter = body?.current?.characterData;
+          const { character: localCharacter, loadCharacterState } =
+            useCharacterStore.getState();
+          if (
+            serverCharacter &&
+            serverCharacter.id === localCharacter.id &&
+            (serverCharacter.revision ?? 0) > (localCharacter.revision ?? 0)
+          ) {
+            loadCharacterState(serverCharacter);
+          }
+          setSyncStatus('synced');
           return;
         }
 

--- a/src/hooks/usePlayerSync.ts
+++ b/src/hooks/usePlayerSync.ts
@@ -146,6 +146,9 @@ export function usePlayerSync({
           ) {
             loadCharacterState(serverCharacter);
           }
+          updateCharacter(characterId, {
+            lastSyncedAt: new Date().toISOString(),
+          });
           setSyncStatus('synced');
           return;
         }

--- a/src/lib/characterRevision.ts
+++ b/src/lib/characterRevision.ts
@@ -1,0 +1,15 @@
+/** Guard flag: true while the store is applying state that originated
+ * elsewhere (another tab, the server). Mutations made under this flag
+ * must NOT bump `character.revision` — they adopt the incoming one. */
+let applyingExternal = false;
+
+export const isApplyingExternal = () => applyingExternal;
+
+export function withExternalApply<T>(fn: () => T): T {
+  applyingExternal = true;
+  try {
+    return fn();
+  } finally {
+    applyingExternal = false;
+  }
+}

--- a/src/lib/crossTabCharacterSync.ts
+++ b/src/lib/crossTabCharacterSync.ts
@@ -1,0 +1,45 @@
+import { STORAGE_KEY } from '@/utils/constants';
+import type { CharacterState } from '@/types/character';
+
+interface CharacterStoreLike {
+  getState: () => {
+    character: CharacterState;
+    loadCharacterState: (characterState: CharacterState) => void;
+  };
+}
+
+/**
+ * Cross-tab character convergence. Zustand persist already writes every
+ * mutation to localStorage; other tabs receive a `storage` event. Apply the
+ * incoming character iff it is the SAME character and a NEWER revision —
+ * `loadCharacterState` runs under withExternalApply, so the adopted
+ * revision is kept as-is (no bump, no echo loop).
+ */
+export function initCrossTabCharacterSync(
+  store: CharacterStoreLike
+): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== STORAGE_KEY || !event.newValue) return;
+
+    let incoming: CharacterState | undefined;
+    try {
+      const parsed: unknown = JSON.parse(event.newValue);
+      incoming = (parsed as { state?: { character?: CharacterState } } | null)
+        ?.state?.character;
+    } catch {
+      return;
+    }
+    if (!incoming || typeof incoming.id !== 'string') return;
+
+    const { character, loadCharacterState } = store.getState();
+    if (incoming.id !== character.id) return;
+    if ((incoming.revision ?? 0) <= (character.revision ?? 0)) return;
+
+    loadCharacterState(incoming);
+  };
+
+  window.addEventListener('storage', onStorage);
+  return () => window.removeEventListener('storage', onStorage);
+}

--- a/src/store/__tests__/characterRevision.test.ts
+++ b/src/store/__tests__/characterRevision.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCharacterStore } from '@/store/characterStore';
+import { makeCharacter } from '@/utils/__tests__/test-utils';
+
+describe('characterStore — revision bumping', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useCharacterStore.setState({
+      character: makeCharacter({ revision: 3 }),
+      hasUnsavedChanges: false,
+      saveStatus: 'saved',
+    });
+  });
+
+  it('bumps revision on a character mutation', () => {
+    useCharacterStore.getState().updateAbilityScore('strength', 18);
+    expect(useCharacterStore.getState().character.revision).toBe(4);
+  });
+
+  it('bumps revision once per mutation, not per field', () => {
+    useCharacterStore.getState().updateAbilityScore('strength', 18);
+    useCharacterStore.getState().updateAbilityScore('dexterity', 15);
+    expect(useCharacterStore.getState().character.revision).toBe(5);
+  });
+
+  it('does not bump revision on non-character state changes', () => {
+    useCharacterStore.setState({ hasUnsavedChanges: true });
+    useCharacterStore.getState().markUnsaved();
+    expect(useCharacterStore.getState().character.revision).toBe(3);
+  });
+
+  it('loadCharacterState adopts the incoming revision without bumping', () => {
+    useCharacterStore
+      .getState()
+      .loadCharacterState(makeCharacter({ revision: 7, name: 'External' }));
+    expect(useCharacterStore.getState().character.revision).toBe(7);
+    expect(useCharacterStore.getState().character.name).toBe('External');
+  });
+
+  it('defaults a missing revision to 0 then bumps to 1', () => {
+    useCharacterStore.setState({ character: makeCharacter() }); // no revision
+    useCharacterStore.getState().updateAbilityScore('strength', 18);
+    expect(useCharacterStore.getState().character.revision).toBe(1);
+  });
+});

--- a/src/store/__tests__/crossTabSync.test.ts
+++ b/src/store/__tests__/crossTabSync.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCharacterStore } from '@/store/characterStore';
+import { STORAGE_KEY } from '@/utils/constants';
+import { makeCharacter } from '@/utils/__tests__/test-utils';
+import type { CharacterState } from '@/types/character';
+
+/**
+ * Repro for the battlemap ↔ character-sheet desync: the battle map opens in
+ * a new tab (BattleMapLiveBanner target="_blank"); each tab holds an
+ * independent in-memory store. The fix: zustand-persist localStorage writes
+ * are the cross-tab transport — a `storage` event carrying a NEWER
+ * `character.revision` for the SAME character id is applied to this tab.
+ */
+
+function simulateOtherTabPersist(character: CharacterState) {
+  const persisted = JSON.stringify({
+    state: { character, lastSaved: new Date().toISOString() },
+    version: 0,
+  });
+  const oldValue = window.localStorage.getItem(STORAGE_KEY);
+  window.localStorage.setItem(STORAGE_KEY, persisted);
+  window.dispatchEvent(
+    new StorageEvent('storage', {
+      key: STORAGE_KEY,
+      oldValue,
+      newValue: persisted,
+      storageArea: window.localStorage,
+    })
+  );
+}
+
+describe('cross-tab character sync (sheet tab vs battlemap tab)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useCharacterStore.setState({
+      character: makeCharacter({
+        revision: 1,
+        spellSlots: {
+          1: { max: 2, used: 0 },
+          2: { max: 0, used: 0 },
+          3: { max: 0, used: 0 },
+          4: { max: 0, used: 0 },
+          5: { max: 0, used: 0 },
+          6: { max: 0, used: 0 },
+          7: { max: 0, used: 0 },
+          8: { max: 0, used: 0 },
+          9: { max: 0, used: 0 },
+        },
+      }),
+      hasUnsavedChanges: false,
+      saveStatus: 'saved',
+    });
+  });
+
+  it('applies a newer-revision spell-slot spend from another tab', () => {
+    simulateOtherTabPersist(
+      makeCharacter({
+        revision: 2,
+        spellSlots: {
+          ...useCharacterStore.getState().character.spellSlots,
+          1: { max: 2, used: 1 },
+        },
+      })
+    );
+    expect(useCharacterStore.getState().character.spellSlots[1].used).toBe(1);
+    expect(useCharacterStore.getState().character.revision).toBe(2);
+  });
+
+  it('applies a newer-revision HP change from another tab', () => {
+    simulateOtherTabPersist(
+      makeCharacter({
+        revision: 2,
+        hitPoints: {
+          current: 30,
+          max: 44,
+          temporary: 0,
+          calculationMode: 'auto' as const,
+        },
+      })
+    );
+    expect(useCharacterStore.getState().character.hitPoints.current).toBe(30);
+  });
+
+  it('ignores a stale (equal-or-older revision) write from another tab', () => {
+    simulateOtherTabPersist(
+      makeCharacter({
+        revision: 1,
+        hitPoints: {
+          current: 5,
+          max: 44,
+          temporary: 0,
+          calculationMode: 'auto' as const,
+        },
+      })
+    );
+    expect(useCharacterStore.getState().character.hitPoints.current).toBe(44);
+  });
+
+  it('ignores a write for a different character id', () => {
+    simulateOtherTabPersist(
+      makeCharacter({
+        id: 'someone-else',
+        revision: 99,
+        hitPoints: {
+          current: 5,
+          max: 44,
+          temporary: 0,
+          calculationMode: 'auto' as const,
+        },
+      })
+    );
+    expect(useCharacterStore.getState().character.hitPoints.current).toBe(44);
+    expect(useCharacterStore.getState().character.id).toBe('test-char-1');
+  });
+
+  it('ignores malformed persisted payloads', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'not json');
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: STORAGE_KEY,
+        newValue: 'not json',
+        storageArea: window.localStorage,
+      })
+    );
+    expect(useCharacterStore.getState().character.hitPoints.current).toBe(44);
+  });
+});

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand';
+import { create, StateCreator } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { createSafeStorage } from '@/lib/safeStorage';
 import {
@@ -60,6 +60,7 @@ import {
 } from '@/utils/hpCalculations';
 import { detectSpellAoe } from '@/utils/spellAoeDetection';
 import { usePlayerStore } from '@/store/playerStore';
+import { isApplyingExternal, withExternalApply } from '@/lib/characterRevision';
 
 // Function to migrate weapon damage from old format to new array format
 function migrateWeaponDamage(weapon: Record<string, unknown>): Weapon {
@@ -115,6 +116,10 @@ function migrateCharacterData(character: unknown): CharacterState {
     // Ensure spellSlots exist
     if (!result.spellSlots) {
       result.spellSlots = DEFAULT_CHARACTER_STATE.spellSlots;
+    }
+    // Ensure revision exists (pre-revision saves)
+    if (typeof result.revision !== 'number') {
+      result.revision = 0;
     }
     // Ensure features and traits are arrays
     if (!Array.isArray(result.features)) {
@@ -746,9 +751,44 @@ interface CharacterStore {
 const generateId = () =>
   Date.now().toString(36) + Math.random().toString(36).substr(2);
 
+type CharacterStoreCreator = StateCreator<
+  CharacterStore,
+  [],
+  [],
+  CharacterStore
+>;
+
+// Wraps the store creator's `set` so every local mutation that changes
+// `state.character` bumps `character.revision` by exactly 1. External
+// applies (loadCharacterState, cross-tab) run under withExternalApply and
+// adopt the incoming revision instead of bumping it. Implemented as a
+// middleware (rather than inline in the creator) so the creator's object
+// literal keeps its original shape/indentation.
+function withRevisionBump(
+  creator: CharacterStoreCreator
+): CharacterStoreCreator {
+  return (rawSet, get, store) => {
+    const set = ((...args: Parameters<typeof rawSet>) => {
+      const prev = get()?.character;
+      rawSet(...args);
+      if (isApplyingExternal()) return;
+      const next = get().character;
+      if (prev && next && next !== prev && next.revision === prev.revision) {
+        rawSet(state => ({
+          character: {
+            ...state.character,
+            revision: (state.character.revision ?? 0) + 1,
+          },
+        }));
+      }
+    }) as typeof rawSet;
+    return creator(set, get, store);
+  };
+}
+
 export const useCharacterStore = create<CharacterStore>()(
   persist(
-    (set, get) => ({
+    withRevisionBump((set, get) => ({
       // Initial state
       character: {
         ...DEFAULT_CHARACTER_STATE,
@@ -774,12 +814,14 @@ export const useCharacterStore = create<CharacterStore>()(
       loadCharacterState: characterState => {
         const migratedCharacter = migrateCharacterData(characterState);
         const multiclassCharacter = migrateToMulticlass(migratedCharacter);
-        set({
-          character: multiclassCharacter,
-          hasUnsavedChanges: false,
-          saveStatus: 'saved',
-          lastSaved: new Date(),
-        });
+        withExternalApply(() =>
+          set({
+            character: multiclassCharacter,
+            hasUnsavedChanges: false,
+            saveStatus: 'saved',
+            lastSaved: new Date(),
+          })
+        );
       },
 
       updateAbilityScore: (ability, value) => {
@@ -5143,7 +5185,7 @@ export const useCharacterStore = create<CharacterStore>()(
           saveStatus: 'saving',
         });
       },
-    }),
+    })),
     {
       name: STORAGE_KEY,
       storage: createJSONStorage(() => createSafeStorage()),

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -61,6 +61,7 @@ import {
 import { detectSpellAoe } from '@/utils/spellAoeDetection';
 import { usePlayerStore } from '@/store/playerStore';
 import { isApplyingExternal, withExternalApply } from '@/lib/characterRevision';
+import { initCrossTabCharacterSync } from '@/lib/crossTabCharacterSync';
 
 // Function to migrate weapon damage from old format to new array format
 function migrateWeaponDamage(weapon: Record<string, unknown>): Weapon {
@@ -5105,12 +5106,14 @@ export const useCharacterStore = create<CharacterStore>()(
       },
 
       loadCharacter: character => {
-        set({
-          character,
-          saveStatus: 'saved',
-          lastSaved: new Date(),
-          hasUnsavedChanges: false,
-        });
+        withExternalApply(() =>
+          set({
+            character,
+            saveStatus: 'saved',
+            lastSaved: new Date(),
+            hasUnsavedChanges: false,
+          })
+        );
       },
 
       resetCharacter: () => {
@@ -5207,3 +5210,7 @@ export const useCharacterStore = create<CharacterStore>()(
     }
   )
 );
+
+// Cross-tab convergence: apply newer-revision persists from other tabs
+// (battle map opens in its own tab — see BattleMapLiveBanner).
+initCrossTabCharacterSync(useCharacterStore);

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -552,6 +552,10 @@ export interface Currency {
 // Main character state interface
 export interface CharacterState {
   id: string;
+  /** Monotonic per-character mutation counter. Every consumer (other tab,
+   * Redis, DM view) accepts a snapshot only if its revision is newer.
+   * Optional for backwards compat — readers must treat missing as 0. */
+  revision?: number;
   // Basic Information
   name: string;
   race: string;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -363,6 +363,7 @@ export const BACKGROUNDS = [
 // Default character state
 export const DEFAULT_CHARACTER_STATE = {
   name: '',
+  revision: 0,
   race: '',
   class: {
     name: '',


### PR DESCRIPTION
## Problem

Two user-reported bugs after live battlemap landed:
1. Battle map opens in a second tab; each tab's zustand stores are independent in-memory copies. Spell slots spent / HP changed on the battle map never appear on the character-sheet tab.
2. Both tabs push their full character blob to Redis last-write-wins — a stale tab silently clobbers newer state on its next autosave (and on auto-rejoin).

Root cause was NOT DM writes (DM never writes the player character key) — it was the player's own two tabs racing.

## Fix — monotonic `character.revision` protocol

- **`revision?: number` on `CharacterState`** (missing = 0), bumped by a `withRevisionBump` middleware on every local characterStore mutation; `loadCharacterState`/`loadCharacter` adopt external state under `withExternalApply` without bumping.
- **Cross-tab convergence**: `storage`-event listener applies another tab's persisted write iff same character id + strictly newer revision. Echo-safe (equal revision ignored).
- **Server gates**: `POST /sync` rejects older-revision pushes with 409 `{error:'stale', current}`; `POST /join` keeps the newer stored blob on stale rejoin (still re-registers).
- **Client 409 handling**: `syncNow` adopts the server's newer blob (no rejoin, pending queue cleared, `lastSyncedAt` stamped).
- **Roster-load gate**: `useCharacterRosterSync` no longer reverts the live store to a stale roster blob on navigation.

## Tests

- New: `characterRevision.test.ts` (5), `crossTabSync.test.ts` (5), `sync-conflict.test.ts` (4), join stale-rejoin, 2×409 client tests, 3 roster-gate tests — all TDD (RED verified before each fix).
- Full unit project: 2872 passed / 1 skipped. type-check clean. Lint: only pre-existing warnings.

## Notes

- Equal-revision = last-write-wins (accepted: single player per character; concurrent same-base edits self-heal on next mutation).
- Backward compatible: pre-revision localStorage/Redis blobs read as revision 0.
- Phase 4 (relay websocket character channel replacing DM 10s polling) is a follow-up plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)