### PR TITLE
feat(sync): websocket pokes for live HP propagation + encounter tracker UX fixes

### DIFF
--- a/src/app/api/campaign/[code]/__tests__/sync-poke.test.ts
+++ b/src/app/api/campaign/[code]/__tests__/sync-poke.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { resetRedis, seedRedis } from '@/test/mocks/redis';
+import {
+  createNextRequest,
+  createRouteParams,
+  createMockCharacterState,
+} from '@/test/helpers';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/relayPoke', () => ({
+  sendBattleMapPoke: vi.fn(async () => {}),
+}));
+
+import { sendBattleMapPoke } from '@/lib/relayPoke';
+import { POST } from '../sync/route';
+
+async function push(characterData: unknown) {
+  const req = createNextRequest('/api/campaign/ABC123/sync', {
+    method: 'POST',
+    body: {
+      playerId: 'player-1',
+      playerName: 'Alice',
+      characterId: 'char-1',
+      characterName: 'Thorn',
+      characterData,
+    },
+  });
+  return POST(req as NextRequest, createRouteParams({ code: 'ABC123' }));
+}
+
+describe('POST /api/campaign/[code]/sync — players poke', () => {
+  beforeEach(() => {
+    resetRedis();
+    vi.mocked(sendBattleMapPoke).mockClear();
+  });
+
+  it('pokes feature "players" after an accepted write', async () => {
+    const res = await push({ ...createMockCharacterState(), revision: 1 });
+    expect(res.status).toBe(200);
+    expect(sendBattleMapPoke).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(sendBattleMapPoke).mock.calls[0][0]).toBe('ABC123');
+    expect(vi.mocked(sendBattleMapPoke).mock.calls[0][2]).toBe('players');
+  });
+
+  it('does not poke on a stale 409 push', async () => {
+    await push({ ...createMockCharacterState(), revision: 5 });
+    vi.mocked(sendBattleMapPoke).mockClear();
+    const res = await push({ ...createMockCharacterState(), revision: 1 });
+    expect(res.status).toBe(409);
+    expect(sendBattleMapPoke).not.toHaveBeenCalled();
+  });
+
+  it('does not poke on 410 (removed player)', async () => {
+    seedRedis('campaign:ABC123:removed:player-1', '1');
+    const res = await push(createMockCharacterState());
+    expect(res.status).toBe(410);
+    expect(sendBattleMapPoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/campaign/[code]/sync/route.ts
+++ b/src/app/api/campaign/[code]/sync/route.ts
@@ -8,6 +8,7 @@ import {
   SLIDING_TTL_SECONDS,
 } from '@/lib/redis';
 import { CampaignPlayerData } from '@/types/campaign';
+import { sendBattleMapPoke } from '@/lib/relayPoke';
 
 export async function POST(
   request: NextRequest,
@@ -67,6 +68,10 @@ export async function POST(
       }),
       refreshCampaignTTL(redis, code),
     ]);
+
+    // Latency shave: nudge battle-map clients (other players' VTTs, the DM
+    // VTT) to refetch player data now. Best-effort; polling is the fallback.
+    await sendBattleMapPoke(code, redis, 'players');
 
     return NextResponse.json({
       success: true,

--- a/src/components/__tests__/combatant-detail-vitals.test.tsx
+++ b/src/components/__tests__/combatant-detail-vitals.test.tsx
@@ -241,4 +241,79 @@ describe('DetailHeader', () => {
     expect(actions.onRemove).not.toHaveBeenCalled();
     vi.restoreAllMocks();
   });
+
+  it('non-player: Rename button swaps name for an input, commits on Enter', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailHeader entity={npcEntity} actions={actions} />);
+
+    await user.click(screen.getByRole('button', { name: 'Rename' }));
+    const input = screen.getByRole('textbox', { name: 'Combatant name' });
+    expect(input).toHaveValue('Goblin');
+
+    await user.clear(input);
+    await user.type(input, 'Goblin Boss');
+    await user.keyboard('{Enter}');
+
+    expect(actions.onUpdate).toHaveBeenCalledWith('npc-1', {
+      name: 'Goblin Boss',
+    });
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('non-player: rename commits on blur too', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailHeader entity={npcEntity} actions={actions} />);
+
+    await user.click(screen.getByRole('button', { name: 'Rename' }));
+    const input = screen.getByRole('textbox', { name: 'Combatant name' });
+    await user.clear(input);
+    await user.type(input, 'Renamed Goblin');
+    await user.tab();
+
+    expect(actions.onUpdate).toHaveBeenCalledWith('npc-1', {
+      name: 'Renamed Goblin',
+    });
+  });
+
+  it('non-player: Escape cancels the rename without committing', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailHeader entity={npcEntity} actions={actions} />);
+
+    await user.click(screen.getByRole('button', { name: 'Rename' }));
+    const input = screen.getByRole('textbox', { name: 'Combatant name' });
+    await user.clear(input);
+    await user.type(input, 'Should not save');
+    await user.keyboard('{Escape}');
+
+    expect(actions.onUpdate).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.getByText('Goblin')).toBeInTheDocument();
+  });
+
+  it('non-player: empty/whitespace name is ignored (trimmed, not committed)', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailHeader entity={npcEntity} actions={actions} />);
+
+    await user.click(screen.getByRole('button', { name: 'Rename' }));
+    const input = screen.getByRole('textbox', { name: 'Combatant name' });
+    await user.clear(input);
+    await user.type(input, '   ');
+    await user.keyboard('{Enter}');
+
+    expect(actions.onUpdate).not.toHaveBeenCalled();
+    expect(screen.getByText('Goblin')).toBeInTheDocument();
+  });
+
+  it('player entities have no rename affordance', () => {
+    const actions = makeActions();
+    render(<DetailHeader entity={playerEntity} actions={actions} />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Rename' })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/__tests__/combatant-row.test.tsx
+++ b/src/components/__tests__/combatant-row.test.tsx
@@ -236,6 +236,24 @@ describe('CombatantRow', () => {
     expect(buffBadge).not.toBeNull();
   });
 
+  it('clicking the name selects the row rather than starting a rename', () => {
+    const actions = makeMockActions();
+    const onSelect = vi.fn();
+    render(
+      <CombatantRow
+        {...defaultProps}
+        entity={mockEntity}
+        actions={actions}
+        onSelect={onSelect}
+      />
+    );
+    fireEvent.click(screen.getByText('Goblin'));
+    expect(onSelect).toHaveBeenCalled();
+    // No inline rename affordance left on the row
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(actions.onUpdate).not.toHaveBeenCalled();
+  });
+
   it('lair entity hides HP and AC', () => {
     const actions = makeMockActions();
     render(

--- a/src/components/__tests__/detail-combat-info.test.tsx
+++ b/src/components/__tests__/detail-combat-info.test.tsx
@@ -113,7 +113,7 @@ describe('DetailCombatInfo — field inventory', () => {
     expect(screen.getByLabelText('Passive Perception')).toHaveValue(13);
   });
 
-  it('editing Initiative commits via onUpdate on blur', async () => {
+  it('editing Initiative to a non-empty value commits via onSetInitiative (keeps turn order sorted)', async () => {
     const actions = makeActions();
     const user = userEvent.setup();
     render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
@@ -123,9 +123,26 @@ describe('DetailCombatInfo — field inventory', () => {
     await user.type(input, '22');
     await user.tab();
 
+    expect(actions.onSetInitiative).toHaveBeenCalledWith('monster-1', 22);
+    expect(actions.onUpdate).not.toHaveBeenCalledWith(
+      'monster-1',
+      expect.objectContaining({ initiative: expect.anything() })
+    );
+  });
+
+  it('clearing Initiative to empty commits null via onUpdate (onSetInitiative takes a number)', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Initiative');
+    await user.clear(input);
+    await user.tab();
+
     expect(actions.onUpdate).toHaveBeenCalledWith('monster-1', {
-      initiative: 22,
+      initiative: null,
     });
+    expect(actions.onSetInitiative).not.toHaveBeenCalled();
   });
 
   it('editing Proficiency Bonus commits via onUpdate on blur', async () => {

--- a/src/components/__tests__/detail-combat-info.test.tsx
+++ b/src/components/__tests__/detail-combat-info.test.tsx
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DetailCombatInfo } from '@/components/ui/encounter/combat-screen/detail/DetailCombatInfo';
+import type { EncounterEntity, MonsterStatBlock } from '@/types/encounter';
+import type { EntityActions } from '@/components/ui/encounter/combat-screen/types';
+
+afterEach(cleanup);
+
+function makeActions(): EntityActions {
+  return {
+    onUpdate: vi.fn(),
+    onRemove: vi.fn(),
+    onDamage: vi.fn(),
+    onHeal: vi.fn(),
+    onAddTempHp: vi.fn(),
+    onSetMaxHp: vi.fn(),
+    onAddCondition: vi.fn(),
+    onRemoveCondition: vi.fn(),
+    onSetConditionRounds: vi.fn(),
+    onUseAbility: vi.fn(),
+    onRestoreAbility: vi.fn(),
+    onUseLegendaryAction: vi.fn(),
+    onResetLegendaryActions: vi.fn(),
+    onSetConcentration: vi.fn(),
+    onUseLairAction: vi.fn(),
+    onSetInitiative: vi.fn(),
+    onLongRest: vi.fn(),
+  };
+}
+
+const statBlock: MonsterStatBlock = {
+  str: 16,
+  dex: 12,
+  con: 14,
+  int: 11,
+  wis: 13,
+  cha: 10,
+  saves: 'Str +5, Con +4',
+  skills: 'Athletics +5, Perception +3',
+  speed: '30 ft.',
+  resistances: 'fire',
+  immunities: 'poison',
+  vulnerabilities: 'cold',
+  conditionImmunities: ['Charmed', 'Frightened'],
+  senses: 'Darkvision 60 ft.',
+  passivePerception: 13,
+  traits: [],
+  actions: [],
+  bonusActions: [],
+  reactions: [],
+  lairActions: [],
+  cr: '3',
+  type: 'humanoid',
+  size: 'Medium',
+  languages: 'Common',
+  alignment: 'Lawful Evil',
+  hpFormula: '8d8+16',
+};
+
+const monsterEntity: EncounterEntity = {
+  id: 'monster-1',
+  type: 'monster',
+  name: 'Goblin Boss',
+  initiative: 15,
+  initiativeModifier: 1,
+  proficiencyBonus: 2,
+  currentHp: 21,
+  maxHp: 21,
+  tempHp: 0,
+  armorClass: 17,
+  conditions: [],
+  monsterStatBlock: statBlock,
+};
+
+const playerEntity: EncounterEntity = {
+  id: 'player-1',
+  type: 'player',
+  name: 'Aragorn',
+  initiative: 18,
+  initiativeModifier: 3,
+  currentHp: 40,
+  maxHp: 44,
+  tempHp: 0,
+  armorClass: 16,
+  conditions: [],
+};
+
+describe('DetailCombatInfo — field inventory', () => {
+  it('monster with a stat block: renders all fields including Initiative and Proficiency Bonus', () => {
+    const actions = makeActions();
+    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
+
+    expect(screen.getByText('Combat Details')).toBeInTheDocument();
+    expect(screen.getByLabelText('Initiative')).toHaveValue(15);
+    expect(screen.getByLabelText('Proficiency Bonus')).toHaveValue(2);
+    expect(screen.getByLabelText('Speed')).toHaveValue('30 ft.');
+    expect(screen.getByLabelText('Saving Throws')).toHaveValue(
+      'Str +5, Con +4'
+    );
+    expect(screen.getByLabelText('Skills')).toHaveValue(
+      'Athletics +5, Perception +3'
+    );
+    expect(screen.getByLabelText('Resistances')).toHaveValue('fire');
+    expect(screen.getByLabelText('Immunities')).toHaveValue('poison');
+    expect(screen.getByLabelText('Vulnerabilities')).toHaveValue('cold');
+    expect(screen.getByLabelText('Condition Immunities')).toHaveValue(
+      'Charmed, Frightened'
+    );
+    expect(screen.getByLabelText('Senses')).toHaveValue('Darkvision 60 ft.');
+    expect(screen.getByLabelText('Languages')).toHaveValue('Common');
+    expect(screen.getByLabelText('Passive Perception')).toHaveValue(13);
+  });
+
+  it('editing Initiative commits via onUpdate on blur', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Initiative');
+    await user.clear(input);
+    await user.type(input, '22');
+    await user.tab();
+
+    expect(actions.onUpdate).toHaveBeenCalledWith('monster-1', {
+      initiative: 22,
+    });
+  });
+
+  it('editing Proficiency Bonus commits via onUpdate on blur', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Proficiency Bonus');
+    await user.clear(input);
+    await user.type(input, '4');
+    await user.tab();
+
+    expect(actions.onUpdate).toHaveBeenCalledWith('monster-1', {
+      proficiencyBonus: 4,
+    });
+  });
+
+  it('editing a stat-block field (Skills) patches monsterStatBlock via onUpdate', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Skills');
+    await user.clear(input);
+    await user.type(input, 'Stealth +6');
+    await user.tab();
+
+    expect(actions.onUpdate).toHaveBeenCalledWith(
+      'monster-1',
+      expect.objectContaining({
+        monsterStatBlock: expect.objectContaining({ skills: 'Stealth +6' }),
+      })
+    );
+  });
+
+  it('editing Condition Immunities splits the comma-separated input into an array', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Condition Immunities');
+    await user.clear(input);
+    await user.type(input, 'Poisoned,  Stunned ,Charmed');
+    await user.tab();
+
+    expect(actions.onUpdate).toHaveBeenCalledWith(
+      'monster-1',
+      expect.objectContaining({
+        monsterStatBlock: expect.objectContaining({
+          conditionImmunities: ['Poisoned', 'Stunned', 'Charmed'],
+        }),
+      })
+    );
+  });
+
+  it('editing Passive Perception parses as a number', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Passive Perception');
+    await user.clear(input);
+    await user.type(input, '17');
+    await user.tab();
+
+    expect(actions.onUpdate).toHaveBeenCalledWith(
+      'monster-1',
+      expect.objectContaining({
+        monsterStatBlock: expect.objectContaining({ passivePerception: 17 }),
+      })
+    );
+  });
+});
+
+describe('DetailCombatInfo — player entities stay read-only', () => {
+  it('player with initiative only: Initiative renders as static text, Proficiency Bonus is hidden', () => {
+    const actions = makeActions();
+    render(<DetailCombatInfo entity={playerEntity} actions={actions} />);
+
+    expect(screen.getByText('Initiative')).toBeInTheDocument();
+    expect(screen.getByText('18')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Initiative')).not.toBeInTheDocument();
+    expect(screen.queryByText('Proficiency Bonus')).not.toBeInTheDocument();
+  });
+
+  it('player entity with a synced stat block never renders editable inputs', () => {
+    const actions = makeActions();
+    const syncedPlayer: EncounterEntity = {
+      ...playerEntity,
+      monsterStatBlock: statBlock,
+    };
+    render(<DetailCombatInfo entity={syncedPlayer} actions={actions} />);
+
+    expect(screen.getByText('Speed')).toBeInTheDocument();
+    expect(screen.getByText('30 ft.')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Speed')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Skills')).not.toBeInTheDocument();
+  });
+});
+
+describe('DetailCombatInfo — hidden when there is nothing to show', () => {
+  it('renders nothing for a bare entity with no combat data', () => {
+    const actions = makeActions();
+    const bareEntity: EncounterEntity = {
+      id: 'bare-1',
+      type: 'monster',
+      name: 'Mystery',
+      initiative: null,
+      initiativeModifier: 0,
+      currentHp: 1,
+      maxHp: 1,
+      tempHp: 0,
+      armorClass: 10,
+      conditions: [],
+    };
+    const { container } = render(
+      <DetailCombatInfo entity={bareEntity} actions={actions} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -30,6 +30,8 @@ export interface DmBattleMapCanvasProps {
   /** Chrome rendered inside the ViewportContext.Provider. */
   children?: React.ReactNode;
   onStatus?: (status: BattleMapConnectionStatus) => void;
+  /** Fires when the relay pokes this room (e.g. 'players' → refetch live HP). */
+  onPoke?: (feature: string) => void;
   onViewportReady?: (vp: Viewport) => void;
   tokenConfigRef: React.MutableRefObject<DmTokenConfig | null>;
   /** Select-tool selection changes (element ids) — Task 8 maps to entities. */
@@ -65,6 +67,7 @@ export function useDmBattleMapCanvas({
   battleMapId,
   dmId,
   onStatus: onStatusProp,
+  onPoke,
   onViewportReady,
   tokenConfigRef,
   onSelectionChange,
@@ -157,6 +160,7 @@ export function useDmBattleMapCanvas({
             setStatus(s);
             onStatusProp?.(s);
           },
+          onPoke,
         });
       }
 
@@ -167,6 +171,7 @@ export function useDmBattleMapCanvas({
       battleMapId,
       dmId,
       onStatusProp,
+      onPoke,
       onViewportReady,
       onSelectionChange,
     ]

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -76,6 +76,12 @@ export function useDmBattleMapCanvas({
   const [status, setStatus] = useState<BattleMapConnectionStatus>('connecting');
   const autoSaveRef = useRef<AutoSave | null>(null);
   const connectionRef = useRef<{ stop: () => void } | null>(null);
+  // The connection is created once inside the fire-once `handleReady`
+  // callback; a plain closure over `onPoke` would go stale if the prop's
+  // identity changes later (e.g. encounterId change) after the connection
+  // is already established. Read the latest value via a ref instead.
+  const onPokeRef = useRef(onPoke);
+  onPokeRef.current = onPoke;
 
   const tools = useMemo<Tool[]>(() => {
     const selectTool = new SelectTool();
@@ -160,7 +166,7 @@ export function useDmBattleMapCanvas({
             setStatus(s);
             onStatusProp?.(s);
           },
-          onPoke,
+          onPoke: feature => onPokeRef.current?.(feature),
         });
       }
 
@@ -171,7 +177,6 @@ export function useDmBattleMapCanvas({
       battleMapId,
       dmId,
       onStatusProp,
-      onPoke,
       onViewportReady,
       onSelectionChange,
     ]

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -39,7 +39,7 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
           />
         )}
         {viewport && (
-          <div className="border-divider absolute top-[7.25rem] left-1/2 z-10 max-w-[92vw] -translate-x-1/2 overflow-hidden rounded-xl border shadow-lg min-[1350px]:top-16">
+          <div className="border-divider absolute top-[7.25rem] left-1/2 z-10 max-w-[92vw] -translate-x-1/2 overflow-hidden rounded-xl border shadow-lg">
             <DmLocationToolOptions mode="battlemap" />
           </div>
         )}

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
@@ -11,6 +11,7 @@ import { useDmVttDragPlacement } from './useDmVttDragPlacement';
 import { useDmVttGrid } from './useDmVttGrid';
 import { useDmVttInitiative } from './useDmVttInitiative';
 import { useDmVttPlacementAndSelection } from './useDmVttPlacementAndSelection';
+import { useDmVttPlayersRefresh } from './useDmVttPlayersRefresh';
 import { useDmVttRoster } from './useDmVttRoster';
 import { useTokenIdentityUpdate } from './useTokenIdentityUpdate';
 
@@ -52,6 +53,17 @@ export function useDmVttScreen({
     handleNextTurn,
     handlePrevTurn,
   } = useDmVttInitiative({ campaignCode, dmId, linkedEncounterIds });
+
+  const { onPlayersPoke } = useDmVttPlayersRefresh(
+    campaignCode,
+    encounter?.id ?? null
+  );
+  const handlePoke = useCallback(
+    (feature: string) => {
+      if (feature === 'players') onPlayersPoke();
+    },
+    [onPlayersPoke]
+  );
 
   const { getNPCsForCampaign } = useNPCStore();
   const npcs = getNPCsForCampaign(campaignCode);
@@ -136,6 +148,7 @@ export function useDmVttScreen({
     status,
     onViewportReady: setViewport,
     onStatus: setStatus,
+    onPoke: handlePoke,
     onSelectionChange: handleSelectionChange,
     tokenConfigRef,
     pendingPlacement,

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -62,6 +62,7 @@ export function DmVttScreen({
       battleMapId={battleMapId}
       dmId={dmId}
       onStatus={vtt.onStatus}
+      onPoke={vtt.onPoke}
       onViewportReady={vtt.onViewportReady}
       tokenConfigRef={vtt.tokenConfigRef}
       onSelectionChange={vtt.onSelectionChange}

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -56,7 +56,7 @@ export function DmVttToolbar({
   const [activeTool, setTool] = useActiveTool();
   const TokenInfoIcon = TOKEN_INFO_ICON[tokenInfoToggle.mode ?? 'compact'];
   return (
-    <div className="bg-surface-raised border-divider absolute top-16 left-1/2 z-10 flex -translate-x-1/2 items-center gap-3 rounded-xl border p-1 shadow-lg min-[1350px]:top-3">
+    <div className="bg-surface-raised border-divider absolute top-16 left-1/2 z-10 flex -translate-x-1/2 items-center gap-3 rounded-xl border p-1 shadow-lg">
       <div className="flex items-center gap-1">
         {DM_TOOLS.map(({ name, label, Icon }) => (
           <Button

--- a/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+import { DmVttToolbar } from '@/components/ui/campaign/dm-vtt/DmVttToolbar';
+
+vi.mock('@fieldnotes/react', () => ({
+  useActiveTool: () => ['select', vi.fn()] as const,
+}));
+
+describe('DmVttToolbar', () => {
+  afterEach(() => cleanup());
+
+  it('always sits below the fixed top bar (top-16), never sharing its row', () => {
+    // Regression pin for the wide-viewport overlap bug: a `min-[1350px]:top-3`
+    // variant previously moved the toolbar into `DmVttTopBar`'s row at
+    // >=1350px, hiding the drawing tools behind the top bar's controls. The
+    // toolbar must stay at `top-16` at every width.
+    const { container } = render(
+      <DmVttToolbar
+        onClearDrawings={vi.fn()}
+        tokenInfoToggle={{ mode: 'compact', onCycle: vi.fn() }}
+      />
+    );
+    const toolbar = container.firstChild as HTMLElement;
+    const classes = toolbar.className.split(/\s+/);
+    expect(classes).toContain('top-16');
+    expect(classes).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/^min-\[1350px\]:top-3$/)])
+    );
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/useDmVttPlayersRefresh.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useDmVttPlayersRefresh.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useDmVttPlayersRefresh } from '../useDmVttPlayersRefresh';
+import { applyPlayersToEncounter } from '@/utils/encounterSync';
+import { mockFetchResponse, resetFetch } from '@/test/mocks/fetch';
+import type { CampaignPlayerData } from '@/types/campaign';
+
+vi.mock('@/utils/encounterSync', () => ({
+  applyPlayersToEncounter: vi.fn(),
+}));
+
+const CAMPAIGN_CODE = 'TEST01';
+const ENCOUNTER_ID = 'enc-1';
+
+const PLAYERS: CampaignPlayerData[] = [
+  {
+    playerId: 'p1',
+    playerName: 'Alice',
+    characterId: 'char-1',
+    characterName: 'Thorn',
+    characterData: {} as CampaignPlayerData['characterData'],
+    lastSynced: '2025-01-01T00:00:00.000Z',
+  },
+];
+
+describe('useDmVttPlayersRefresh', () => {
+  beforeEach(() => {
+    resetFetch();
+    vi.mocked(applyPlayersToEncounter).mockClear();
+  });
+
+  it('fetches players and applies them to the encounter on poke', async () => {
+    const fetchFn = mockFetchResponse(200, { players: PLAYERS });
+    const { result } = renderHook(() =>
+      useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
+    );
+
+    await act(async () => {
+      result.current.onPlayersPoke();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      `/api/campaign/${CAMPAIGN_CODE}/players`
+    );
+    expect(applyPlayersToEncounter).toHaveBeenCalledWith(ENCOUNTER_ID, PLAYERS);
+  });
+
+  it('debounces a second poke within 1s', async () => {
+    const fetchFn = mockFetchResponse(200, { players: PLAYERS });
+    const { result } = renderHook(() =>
+      useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
+    );
+
+    await act(async () => {
+      result.current.onPlayersPoke();
+      result.current.onPlayersPoke();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('never fetches when encounterId is null', async () => {
+    const fetchFn = mockFetchResponse(200, { players: PLAYERS });
+    const { result } = renderHook(() =>
+      useDmVttPlayersRefresh(CAMPAIGN_CODE, null)
+    );
+
+    await act(async () => {
+      result.current.onPlayersPoke();
+      await Promise.resolve();
+    });
+
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(applyPlayersToEncounter).not.toHaveBeenCalled();
+  });
+
+  it('silently swallows fetch errors', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.reject(new Error('network fail'))
+    ) as unknown as typeof global.fetch;
+    const { result } = renderHook(() =>
+      useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
+    );
+
+    await act(async () => {
+      expect(() => result.current.onPlayersPoke()).not.toThrow();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(applyPlayersToEncounter).not.toHaveBeenCalled();
+  });
+
+  it('silently ignores a non-OK HTTP response', async () => {
+    mockFetchResponse(500, { error: 'boom' });
+    const { result } = renderHook(() =>
+      useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
+    );
+
+    await act(async () => {
+      result.current.onPlayersPoke();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(applyPlayersToEncounter).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/useDmVttPlayersRefresh.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useDmVttPlayersRefresh.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 import { useDmVttPlayersRefresh } from '../useDmVttPlayersRefresh';
@@ -26,8 +26,13 @@ const PLAYERS: CampaignPlayerData[] = [
 
 describe('useDmVttPlayersRefresh', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     resetFetch();
     vi.mocked(applyPlayersToEncounter).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('fetches players and applies them to the encounter on poke', async () => {
@@ -38,8 +43,7 @@ describe('useDmVttPlayersRefresh', () => {
 
     await act(async () => {
       result.current.onPlayersPoke();
-      await Promise.resolve();
-      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
     });
 
     expect(fetchFn).toHaveBeenCalledWith(
@@ -48,7 +52,7 @@ describe('useDmVttPlayersRefresh', () => {
     expect(applyPlayersToEncounter).toHaveBeenCalledWith(ENCOUNTER_ID, PLAYERS);
   });
 
-  it('debounces a second poke within 1s', async () => {
+  it('debounces a second poke within 1s (no immediate second fetch)', async () => {
     const fetchFn = mockFetchResponse(200, { players: PLAYERS });
     const { result } = renderHook(() =>
       useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
@@ -57,10 +61,67 @@ describe('useDmVttPlayersRefresh', () => {
     await act(async () => {
       result.current.onPlayersPoke();
       result.current.onPlayersPoke();
-      await Promise.resolve();
-      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
     });
 
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('a poke during the debounce window schedules one trailing fetch at window expiry', async () => {
+    const fetchFn = mockFetchResponse(200, { players: PLAYERS });
+    const { result } = renderHook(() =>
+      useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
+    );
+
+    // Two pokes back-to-back: the first is a leading fetch, the second lands
+    // inside the debounce window and must schedule a trailing fetch instead
+    // of being silently dropped.
+    await act(async () => {
+      result.current.onPlayersPoke();
+      result.current.onPlayersPoke();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // A third poke, still inside the window, must coalesce with the already
+    // scheduled trailing fetch rather than stacking a second timeout.
+    await act(async () => {
+      result.current.onPlayersPoke();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // Window expires: exactly one trailing fetch fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    // No further fetch from a stacked/duplicate timeout.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears a pending trailing fetch on unmount', async () => {
+    const fetchFn = mockFetchResponse(200, { players: PLAYERS });
+    const { result, unmount } = renderHook(() =>
+      useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
+    );
+
+    await act(async () => {
+      result.current.onPlayersPoke(); // leading
+      result.current.onPlayersPoke(); // schedules trailing
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
@@ -72,7 +133,7 @@ describe('useDmVttPlayersRefresh', () => {
 
     await act(async () => {
       result.current.onPlayersPoke();
-      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
     });
 
     expect(fetchFn).not.toHaveBeenCalled();
@@ -89,8 +150,7 @@ describe('useDmVttPlayersRefresh', () => {
 
     await act(async () => {
       expect(() => result.current.onPlayersPoke()).not.toThrow();
-      await Promise.resolve();
-      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
     });
 
     expect(applyPlayersToEncounter).not.toHaveBeenCalled();
@@ -104,8 +164,7 @@ describe('useDmVttPlayersRefresh', () => {
 
     await act(async () => {
       result.current.onPlayersPoke();
-      await Promise.resolve();
-      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
     });
 
     expect(applyPlayersToEncounter).not.toHaveBeenCalled();

--- a/src/components/ui/campaign/dm-vtt/useDmVttPlayersRefresh.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttPlayersRefresh.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { applyPlayersToEncounter } from '@/utils/encounterSync';
 import type { CampaignPlayerData } from '@/types/campaign';
@@ -19,12 +19,11 @@ export function useDmVttPlayersRefresh(
   encounterId: string | null
 ): { onPlayersPoke: () => void } {
   const lastFetchRef = useRef(0);
+  const trailingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const onPlayersPoke = useCallback(() => {
+  const doFetch = useCallback(() => {
     if (!encounterId) return;
-    const now = Date.now();
-    if (now - lastFetchRef.current < PLAYERS_REFETCH_DEBOUNCE_MS) return;
-    lastFetchRef.current = now;
+    lastFetchRef.current = Date.now();
     void (async () => {
       try {
         const res = await fetch(`/api/campaign/${campaignCode}/players`);
@@ -37,6 +36,35 @@ export function useDmVttPlayersRefresh(
       }
     })();
   }, [campaignCode, encounterId]);
+
+  // Leading-edge fire immediately; a poke inside the debounce window
+  // schedules ONE trailing fetch at window expiry instead of being dropped
+  // (a burst of pokes — e.g. two players hit by one AoE — must not leave
+  // the second player's HP stale indefinitely). Repeated pokes inside the
+  // window coalesce onto the single pending timeout rather than stacking.
+  const onPlayersPoke = useCallback(() => {
+    if (!encounterId) return;
+    const now = Date.now();
+    const elapsed = now - lastFetchRef.current;
+    if (elapsed >= PLAYERS_REFETCH_DEBOUNCE_MS) {
+      doFetch();
+      return;
+    }
+    if (trailingTimeoutRef.current) return;
+    trailingTimeoutRef.current = setTimeout(() => {
+      trailingTimeoutRef.current = null;
+      doFetch();
+    }, PLAYERS_REFETCH_DEBOUNCE_MS - elapsed);
+  }, [encounterId, doFetch]);
+
+  useEffect(() => {
+    return () => {
+      if (trailingTimeoutRef.current) {
+        clearTimeout(trailingTimeoutRef.current);
+        trailingTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   return { onPlayersPoke };
 }

--- a/src/components/ui/campaign/dm-vtt/useDmVttPlayersRefresh.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttPlayersRefresh.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+
+import { applyPlayersToEncounter } from '@/utils/encounterSync';
+import type { CampaignPlayerData } from '@/types/campaign';
+
+const PLAYERS_REFETCH_DEBOUNCE_MS = 1000;
+
+/**
+ * Poke-driven player refresh for the DM VTT. The DM VTT has no player
+ * polling of its own (EncounterView's poll only runs on the encounters
+ * page), so without this the VTT's player HP is frozen until that other
+ * tab is foregrounded. Best-effort: failures are silent, the next poke or
+ * the EncounterView poll catches up.
+ */
+export function useDmVttPlayersRefresh(
+  campaignCode: string,
+  encounterId: string | null
+): { onPlayersPoke: () => void } {
+  const lastFetchRef = useRef(0);
+
+  const onPlayersPoke = useCallback(() => {
+    if (!encounterId) return;
+    const now = Date.now();
+    if (now - lastFetchRef.current < PLAYERS_REFETCH_DEBOUNCE_MS) return;
+    lastFetchRef.current = now;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/campaign/${campaignCode}/players`);
+        if (!res.ok) return;
+        const data = await res.json();
+        const players: CampaignPlayerData[] = data.players ?? [];
+        applyPlayersToEncounter(encounterId, players);
+      } catch {
+        // silent — poke is best-effort
+      }
+    })();
+  }, [campaignCode, encounterId]);
+
+  return { onPlayersPoke };
+}

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -216,6 +216,12 @@ export function PlayerBattleMapCanvas({
   const [status, setStatus] = useState<BattleMapConnectionStatus>('connecting');
   const [hasSelection, setHasSelection] = useState(false);
   const connectionRef = useRef<{ stop: () => void } | null>(null);
+  // The connection is created once inside the fire-once `handleReady`
+  // callback; a plain closure over `onPoke` would go stale if the prop's
+  // identity changes later after the connection is already established.
+  // Read the latest value via a ref instead.
+  const onPokeRef = useRef(onPoke);
+  onPokeRef.current = onPoke;
   // Read by the (single, canvas-retained) token tool at placement time;
   // starts as the square avatar and upgrades to the circular render async.
   const tokenSrcRef = useRef<string | null>(tokenAvatarUrl(characterAvatar));
@@ -325,7 +331,7 @@ export function PlayerBattleMapCanvas({
         onStatusProp?.(s);
         if (s === 'live') requestAnimationFrame(() => vp.fitToContent(60));
       },
-      onPoke,
+      onPoke: feature => onPokeRef.current?.(feature),
     });
   };
 

--- a/src/components/ui/campaign/player-vtt/PlayerVttScreen.hooks.ts
+++ b/src/components/ui/campaign/player-vtt/PlayerVttScreen.hooks.ts
@@ -1,10 +1,11 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useAutoSave } from '@/hooks/useAutoSave';
 import { useCharacterRosterSync } from '@/hooks/useCharacterRosterSync';
 import { useHydration } from '@/hooks/useHydration';
+import { usePartySync } from '@/hooks/usePartySync';
 import { usePlayerSync } from '@/hooks/usePlayerSync';
 import { useSharedCampaignState } from '@/hooks/useSharedCampaignState';
 import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
@@ -12,6 +13,7 @@ import { useCharacterStore } from '@/store/characterStore';
 import { usePlayerStore } from '@/store/playerStore';
 import { ToastData, useToast } from '@/components/ui/feedback/Toast';
 import type { SpellAoe } from '@/types/spellAoe';
+import { overlayLiveHp, type LiveHp } from '@/utils/sharedInitiativeOverlay';
 
 import type { PendingPlacement } from './SpellPlacementController';
 import type { SpellTemplateConfig } from './SpellTemplateTool';
@@ -96,6 +98,31 @@ export function usePlayerVttState(campaignCode: string, characterId: string) {
     campaignCode,
     characterId
   );
+  const { partyMembers, refetchNow: refetchPartyHpNow } = usePartySync({
+    campaignCode,
+    currentCharacterId: characterId,
+  });
+  const liveHp = useMemo(() => {
+    const map: Record<string, LiveHp> = {};
+    for (const member of partyMembers) {
+      if (!member.hitPoints) continue;
+      map[member.characterId] = {
+        current: member.hitPoints.current,
+        max: member.hitPoints.max,
+      };
+    }
+    if (character && character.id === characterId) {
+      map[characterId] = {
+        current: character.hitPoints.current,
+        max: character.hitPoints.max,
+      };
+    }
+    return map;
+  }, [partyMembers, character, characterId]);
+  const liveInitiative = useMemo(
+    () => overlayLiveHp(sharedState?.initiative ?? null, liveHp),
+    [sharedState?.initiative, liveHp]
+  );
   const handleEndTurn = useCallback(
     async (entityId: string) => {
       const init = sharedState?.initiative;
@@ -136,6 +163,8 @@ export function usePlayerVttState(campaignCode: string, characterId: string) {
     character,
     sharedState,
     refetchNow,
+    liveInitiative,
+    refetchPartyHpNow,
     handleEndTurn,
     pendingPlacement,
     requestPlacement,

--- a/src/components/ui/campaign/player-vtt/PlayerVttScreen.tsx
+++ b/src/components/ui/campaign/player-vtt/PlayerVttScreen.tsx
@@ -45,6 +45,8 @@ export function PlayerVttScreen({
     character,
     sharedState,
     refetchNow,
+    liveInitiative,
+    refetchPartyHpNow,
     handleEndTurn,
     pendingPlacement,
     requestPlacement,
@@ -62,9 +64,7 @@ export function PlayerVttScreen({
   const [tokenInfoMode, cycleTokenInfo] = useTokenInfoMode(
     'rollkeeper-vtt-token-info-player'
   );
-  const decorations = usePlayerTokenDecorations(
-    sharedState?.initiative ?? null
-  );
+  const decorations = usePlayerTokenDecorations(liveInitiative);
   const initiativePrompt = useInitiativePrompt({
     campaignCode,
     characterId,
@@ -74,8 +74,9 @@ export function PlayerVttScreen({
   const handlePoke = useCallback(
     (feature: string) => {
       if (feature === 'initiative') refetchNow();
+      if (feature === 'players') refetchPartyHpNow();
     },
-    [refetchNow]
+    [refetchNow, refetchPartyHpNow]
   );
 
   return (
@@ -117,7 +118,7 @@ export function PlayerVttScreen({
           </Link>
         </div>
         <CombatPanel
-          state={sharedState?.initiative ?? null}
+          state={liveInitiative}
           characterId={characterId}
           onEndTurn={handleEndTurn}
           collapsed={combatCollapsed}

--- a/src/components/ui/encounter/EncounterView.tsx
+++ b/src/components/ui/encounter/EncounterView.tsx
@@ -13,11 +13,7 @@ import { useEncounterStore } from '@/store/encounterStore';
 import { useNPCStore } from '@/store/npcStore';
 import { useDmStore } from '@/store/dmStore';
 import { useCampaignSync } from '@/hooks/useCampaignSync';
-import {
-  mergePlayerSyncData,
-  hasPlayerDataChanged,
-  syncSummonsToEncounter,
-} from '@/utils/encounterSync';
+import { applyPlayersToEncounter } from '@/utils/encounterSync';
 import { useDmEffectsSync } from '@/hooks/useDmEffectsSync';
 import { useDmCounterSync } from '@/hooks/useDmCounterSync';
 import { useDmInitiativeSync } from '@/hooks/useDmInitiativeSync';
@@ -161,30 +157,7 @@ export function EncounterView({
       return;
     }
 
-    for (const entity of encounter.entities) {
-      if (entity.type === 'player' && entity.playerCharacterId) {
-        const playerData = campaignPlayers.find(
-          p => p.playerId === entity.playerCharacterId
-        );
-        if (playerData) {
-          // Sync player HP/AC/conditions
-          const updates = mergePlayerSyncData(entity, playerData);
-          if (updates && hasPlayerDataChanged(entity, updates)) {
-            updateEntity(encounterId, entity.id, updates);
-          }
-          // Sync player's summons into encounter
-          const playerSummons = playerData.characterData?.summons ?? [];
-          syncSummonsToEncounter(
-            encounter,
-            entity,
-            playerSummons,
-            addEntity,
-            updateEntity,
-            removeEntity
-          );
-        }
-      }
-    }
+    applyPlayersToEncounter(encounterId, campaignPlayers);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [campaignPlayers]);
 

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/buildEntity.ts
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/buildEntity.ts
@@ -81,6 +81,7 @@ export function buildNpcEntity(
           : npc.abilityScores
             ? Math.floor((npc.abilityScores.dex - 10) / 2)
             : 0,
+    proficiencyBonus: npc.proficiencyBonus,
     currentHp: npc.currentHp ?? npc.maxHp,
     maxHp: npc.maxHp,
     tempHp: 0,

--- a/src/components/ui/encounter/combat-screen/CombatantRow.tsx
+++ b/src/components/ui/encounter/combat-screen/CombatantRow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import type {
   EncounterEntity,
   EntityType,
@@ -70,20 +70,10 @@ export function CombatantRow({
   actions,
   onSelect,
 }: CombatantRowProps): React.JSX.Element {
-  const [editingName, setEditingName] = useState(false);
-  const [nameInput, setNameInput] = useState('');
-
   const isDead = getIsDead(entity);
   const isRail = density === 'rail';
   const stripeClass = getStripeClass(entity.playerDisposition, entity.type);
   const rowClass = getRowClass(isActive, isSelected, isOnDeck);
-
-  function commitName() {
-    const trimmed = nameInput.trim();
-    if (trimmed && trimmed !== entity.name)
-      actions.onUpdate(entity.id, { name: trimmed });
-    setEditingName(false);
-  }
 
   return (
     <div
@@ -113,35 +103,11 @@ export function CombatantRow({
 
         <div className="min-w-0 flex-1">
           <div className="mb-0.5 flex flex-wrap items-center gap-1.5">
-            {editingName ? (
-              <input
-                type="text"
-                value={nameInput}
-                onChange={e => setNameInput(e.target.value)}
-                onBlur={commitName}
-                onKeyDown={e => {
-                  if (e.key === 'Enter') commitName();
-                  if (e.key === 'Escape') setEditingName(false);
-                }}
-                onClick={e => e.stopPropagation()}
-                className="bg-surface-raised text-heading max-w-[200px] min-w-0 rounded px-1.5 py-0.5 font-semibold shadow-sm"
-                autoFocus
-              />
-            ) : (
-              <span
-                className={`font-display text-heading truncate text-sm font-bold ${isDead ? 'line-through' : ''} ${entity.type !== 'player' ? 'hover:text-body cursor-pointer rounded transition-colors' : ''}`}
-                onClick={e => {
-                  if (entity.type !== 'player') {
-                    e.stopPropagation();
-                    setNameInput(entity.name);
-                    setEditingName(true);
-                  }
-                }}
-                title={entity.type !== 'player' ? 'Click to rename' : undefined}
-              >
-                {entity.name}
-              </span>
-            )}
+            <span
+              className={`font-display text-heading truncate text-sm font-bold ${isDead ? 'line-through' : ''}`}
+            >
+              {entity.name}
+            </span>
             <RowBadges
               entity={entity}
               isOnDeck={isOnDeck}

--- a/src/components/ui/encounter/combat-screen/detail/DetailCombatInfo.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailCombatInfo.tsx
@@ -135,7 +135,10 @@ export function DetailCombatInfo({ entity, actions }: DetailSectionProps) {
       return;
     }
     const num = parseFloat(trimmed);
-    if (!Number.isNaN(num)) actions.onUpdate(entity.id, { initiative: num });
+    // Route through onSetInitiative (not the generic onUpdate) — it also
+    // re-sorts entities and remaps currentTurn when combat is active with a
+    // non-manual sort order, which a plain entity patch would silently skip.
+    if (!Number.isNaN(num)) actions.onSetInitiative(entity.id, num);
   };
 
   const updateProficiencyBonus = (value: string) => {

--- a/src/components/ui/encounter/combat-screen/detail/DetailCombatInfo.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailCombatInfo.tsx
@@ -8,10 +8,17 @@ interface InfoRowProps {
   label: string;
   value?: string;
   editable?: boolean;
+  type?: 'text' | 'number';
   onChange?: (v: string) => void;
 }
 
-function InfoRow({ label, value, editable, onChange }: InfoRowProps) {
+function InfoRow({
+  label,
+  value,
+  editable,
+  type = 'text',
+  onChange,
+}: InfoRowProps) {
   if (!editable && !value) return null;
   return (
     <div className="flex items-start gap-3 py-1">
@@ -20,7 +27,7 @@ function InfoRow({ label, value, editable, onChange }: InfoRowProps) {
       </span>
       {editable ? (
         <input
-          type="text"
+          type={type}
           defaultValue={value ?? ''}
           onBlur={e => onChange?.(e.target.value)}
           className="bg-surface-raised border-divider text-body flex-1 rounded border px-2 py-0.5 text-xs"
@@ -59,6 +66,7 @@ export function DetailCombatInfo({ entity, actions }: DetailSectionProps) {
   const sb = entity.monsterStatBlock;
   const isPlayer = entity.type === 'player';
   const canEdit = !isPlayer && sb != null;
+  const canEditBasics = !isPlayer;
 
   const resistances =
     (sb != null ? sbField(sb, 'resistances') : undefined) ??
@@ -73,8 +81,19 @@ export function DetailCombatInfo({ entity, actions }: DetailSectionProps) {
     (sb != null ? sbField(sb, 'senses') : undefined) ??
     entity.senses?.map(s => `${s.name} ${s.range} ft.`).join(', ');
 
+  const initiativeValue =
+    entity.initiative != null ? String(entity.initiative) : undefined;
+  const proficiencyBonusValue =
+    entity.proficiencyBonus != null
+      ? String(entity.proficiencyBonus)
+      : undefined;
+  const passivePerceptionValue =
+    sb?.passivePerception != null ? String(sb.passivePerception) : undefined;
+
   const hasAnyData =
     sb != null ||
+    entity.initiative != null ||
+    entity.proficiencyBonus != null ||
     (entity.damageResistances?.length ?? 0) > 0 ||
     (entity.damageImmunities?.length ?? 0) > 0 ||
     (entity.conditionImmunities?.length ?? 0) > 0 ||
@@ -89,11 +108,72 @@ export function DetailCombatInfo({ entity, actions }: DetailSectionProps) {
     });
   };
 
+  const updatePassivePerception = (value: string) => {
+    if (!sb) return;
+    const num = parseInt(value, 10);
+    if (Number.isNaN(num)) return;
+    actions.onUpdate(entity.id, {
+      monsterStatBlock: { ...sb, passivePerception: num },
+    });
+  };
+
+  const updateConditionImmunities = (value: string) => {
+    if (!sb) return;
+    const list = value
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+    actions.onUpdate(entity.id, {
+      monsterStatBlock: { ...sb, conditionImmunities: list },
+    });
+  };
+
+  const updateInitiative = (value: string) => {
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      actions.onUpdate(entity.id, { initiative: null });
+      return;
+    }
+    const num = parseFloat(trimmed);
+    if (!Number.isNaN(num)) actions.onUpdate(entity.id, { initiative: num });
+  };
+
+  const updateProficiencyBonus = (value: string) => {
+    const trimmed = value.trim();
+    if (trimmed === '') return;
+    const num = parseInt(trimmed, 10);
+    if (!Number.isNaN(num))
+      actions.onUpdate(entity.id, { proficiencyBonus: num });
+  };
+
   return (
     <div className="border-divider space-y-0 border-t p-4">
       <h3 className="text-heading mb-1 text-xs font-semibold tracking-wider uppercase">
         Combat Details
       </h3>
+      {canEditBasics ? (
+        <>
+          <InfoRow
+            label="Initiative"
+            value={initiativeValue}
+            editable
+            type="number"
+            onChange={updateInitiative}
+          />
+          <InfoRow
+            label="Proficiency Bonus"
+            value={proficiencyBonusValue}
+            editable
+            type="number"
+            onChange={updateProficiencyBonus}
+          />
+        </>
+      ) : (
+        <>
+          <StaticRow label="Initiative" value={initiativeValue} />
+          <StaticRow label="Proficiency Bonus" value={proficiencyBonusValue} />
+        </>
+      )}
       {canEdit ? (
         <>
           <InfoRow
@@ -108,25 +188,72 @@ export function DetailCombatInfo({ entity, actions }: DetailSectionProps) {
             editable
             onChange={v => updateSb('saves', v)}
           />
+          <InfoRow
+            label="Skills"
+            value={sb?.skills}
+            editable
+            onChange={v => updateSb('skills', v)}
+          />
+          <InfoRow
+            label="Resistances"
+            value={resistances}
+            editable
+            onChange={v => updateSb('resistances', v)}
+          />
+          <InfoRow
+            label="Immunities"
+            value={immunities}
+            editable
+            onChange={v => updateSb('immunities', v)}
+          />
+          <InfoRow
+            label="Vulnerabilities"
+            value={sb?.vulnerabilities}
+            editable
+            onChange={v => updateSb('vulnerabilities', v)}
+          />
+          <InfoRow
+            label="Condition Immunities"
+            value={condImmunities}
+            editable
+            onChange={updateConditionImmunities}
+          />
+          <InfoRow
+            label="Senses"
+            value={senses}
+            editable
+            onChange={v => updateSb('senses', v)}
+          />
+          <InfoRow
+            label="Languages"
+            value={sb?.languages}
+            editable
+            onChange={v => updateSb('languages', v)}
+          />
+          <InfoRow
+            label="Passive Perception"
+            value={passivePerceptionValue}
+            editable
+            type="number"
+            onChange={updatePassivePerception}
+          />
         </>
       ) : (
         <>
           <StaticRow label="Speed" value={sb?.speed} />
           <StaticRow label="Saving Throws" value={sb?.saves} />
+          <StaticRow label="Skills" value={sb?.skills} />
+          <StaticRow label="Resistances" value={resistances} />
+          <StaticRow label="Immunities" value={immunities} />
+          <StaticRow label="Vulnerabilities" value={sb?.vulnerabilities} />
+          <StaticRow label="Condition Immunities" value={condImmunities} />
+          <StaticRow label="Senses" value={senses} />
+          <StaticRow label="Languages" value={sb?.languages} />
+          <StaticRow
+            label="Passive Perception"
+            value={passivePerceptionValue}
+          />
         </>
-      )}
-      <StaticRow label="Skills" value={sb?.skills} />
-      <StaticRow label="Resistances" value={resistances} />
-      <StaticRow label="Immunities" value={immunities} />
-      <StaticRow label="Vulnerabilities" value={sb?.vulnerabilities} />
-      <StaticRow label="Condition Immunities" value={condImmunities} />
-      <StaticRow label="Senses" value={senses} />
-      <StaticRow label="Languages" value={sb?.languages} />
-      {sb?.passivePerception != null && (
-        <StaticRow
-          label="Passive Perception"
-          value={String(sb.passivePerception)}
-        />
       )}
     </div>
   );

--- a/src/components/ui/encounter/combat-screen/detail/DetailHeader.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailHeader.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React from 'react';
-import { Eye, X } from 'lucide-react';
+import React, { useState } from 'react';
+import { Eye, Pencil, X } from 'lucide-react';
 import type { EncounterEntity } from '@/types/encounter';
 import type { EntityActions } from '../types';
 import { HeaderControls } from './HeaderControls';
@@ -42,6 +42,9 @@ export function DetailHeader({
   actions,
   onOpenSheet,
 }: DetailSectionProps & { onOpenSheet?: () => void }) {
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [nameInput, setNameInput] = useState('');
+
   const isPlayer = entity.type === 'player';
   const isSummon = !!entity.summonId;
   const badge = isSummon
@@ -72,13 +75,52 @@ export function DetailHeader({
     }
   };
 
+  const commitName = () => {
+    const trimmed = nameInput.trim();
+    if (trimmed && trimmed !== entity.name) {
+      actions.onUpdate(entity.id, { name: trimmed });
+    }
+    setIsEditingName(false);
+  };
+
   return (
     <div className="space-y-2 p-4">
       <div className="flex items-start gap-2">
         <div className="min-w-0 flex-1">
-          <h2 className="font-display text-heading text-2xl leading-tight font-bold">
-            {entity.name}
-          </h2>
+          {isEditingName ? (
+            <input
+              type="text"
+              value={nameInput}
+              onChange={e => setNameInput(e.target.value)}
+              onBlur={commitName}
+              onKeyDown={e => {
+                if (e.key === 'Enter') commitName();
+                if (e.key === 'Escape') setIsEditingName(false);
+              }}
+              className="font-display text-heading bg-surface-raised border-divider w-full rounded border px-2 py-0.5 text-2xl leading-tight font-bold"
+              aria-label="Combatant name"
+              autoFocus
+            />
+          ) : (
+            <div className="flex items-center gap-1">
+              <h2 className="font-display text-heading min-w-0 truncate text-2xl leading-tight font-bold">
+                {entity.name}
+              </h2>
+              {!isPlayer && (
+                <button
+                  onClick={() => {
+                    setNameInput(entity.name);
+                    setIsEditingName(true);
+                  }}
+                  aria-label="Rename"
+                  title="Rename"
+                  className="text-faint hover:text-body hover:bg-surface-raised flex h-11 w-11 shrink-0 items-center justify-center rounded transition-colors"
+                >
+                  <Pencil size={14} />
+                </button>
+              )}
+            </div>
+          )}
           <div className="mt-1 flex flex-wrap items-center gap-1.5">
             <span
               className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${badge.bg} ${badge.text} ${badge.border}`}

--- a/src/hooks/__tests__/usePartySync.test.ts
+++ b/src/hooks/__tests__/usePartySync.test.ts
@@ -369,4 +369,55 @@ describe('usePartySync', () => {
       ).toBeGreaterThan(callsAfterIdle);
     });
   });
+
+  // ── refetchNow ──────────────────────────────────────────────────────────────
+
+  describe('refetchNow', () => {
+    it('fetches immediately on refetchNow', async () => {
+      const fetchFn = mockFetchResponse(200, { members: [] });
+
+      const { result } = renderHook(() => usePartySync(defaultOptions));
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.refetchNow();
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+
+      const url = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[1][0];
+      expect(url).toBe(`/api/campaign/${CAMPAIGN_CODE}/party-hp`);
+    });
+
+    it('debounces a second refetchNow within 1s', async () => {
+      const fetchFn = mockFetchResponse(200, { members: [] });
+
+      const { result } = renderHook(() => usePartySync(defaultOptions));
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.refetchNow();
+        result.current.refetchNow(); // within the same second — swallowed
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+
+      // No additional fetch even after some time short of the debounce window
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/hooks/__tests__/usePartySync.test.ts
+++ b/src/hooks/__tests__/usePartySync.test.ts
@@ -394,7 +394,46 @@ describe('usePartySync', () => {
       expect(url).toBe(`/api/campaign/${CAMPAIGN_CODE}/party-hp`);
     });
 
-    it('debounces a second refetchNow within 1s', async () => {
+    it('a second refetchNow within 1s does not fetch immediately, but schedules a trailing fetch at window expiry', async () => {
+      const fetchFn = mockFetchResponse(200, { members: [] });
+
+      const { result } = renderHook(() => usePartySync(defaultOptions));
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1); // initial mount fetch
+      });
+
+      act(() => {
+        result.current.refetchNow(); // outside the debounce window — leading fetch
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+
+      act(() => {
+        result.current.refetchNow(); // within the window — schedules a trailing fetch
+        result.current.refetchNow(); // still within the window — coalesces, no second timeout
+      });
+
+      // No immediate fetch from either of the two pokes above.
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+
+      // Just short of the debounce window — trailing fetch not due yet.
+      await act(async () => {
+        vi.advanceTimersByTime(900);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+
+      // Window expires — exactly one trailing fetch fires (the burst's last
+      // poke is not silently dropped).
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(3);
+    });
+
+    it('fetches immediately again once the debounce window reopens', async () => {
       const fetchFn = mockFetchResponse(200, { members: [] });
 
       const { result } = renderHook(() => usePartySync(defaultOptions));
@@ -405,18 +444,50 @@ describe('usePartySync', () => {
 
       act(() => {
         result.current.refetchNow();
-        result.current.refetchNow(); // within the same second — swallowed
       });
-
       await waitFor(() => {
         expect(fetchFn).toHaveBeenCalledTimes(2);
       });
 
-      // No additional fetch even after some time short of the debounce window
+      // Let the debounce window fully close with no further pokes.
       await act(async () => {
-        vi.advanceTimersByTime(500);
+        vi.advanceTimersByTime(1100);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+
+      // A fresh poke after the window reopens fetches immediately again.
+      act(() => {
+        result.current.refetchNow();
+      });
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(3);
+      });
+    });
+
+    it('clears a pending trailing fetch on unmount', async () => {
+      const fetchFn = mockFetchResponse(200, { members: [] });
+
+      const { result, unmount } = renderHook(() =>
+        usePartySync(defaultOptions)
+      );
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
       });
 
+      act(() => {
+        result.current.refetchNow(); // leading
+        result.current.refetchNow(); // schedules trailing
+      });
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+
+      unmount();
+
+      await act(async () => {
+        vi.advanceTimersByTime(1100);
+      });
       expect(fetchFn).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/hooks/usePartySync.ts
+++ b/src/hooks/usePartySync.ts
@@ -56,13 +56,30 @@ export function usePartySync({
   }, [campaignCode, currentCharacterId]);
 
   const lastManualFetchRef = useRef(0);
-  /** Immediate refetch (poke-triggered), at most once per second. */
+  const trailingFetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  /**
+   * Immediate refetch (poke-triggered). Leading-edge fires immediately; a
+   * poke landing inside the debounce window schedules ONE trailing fetch at
+   * window expiry instead of being dropped — otherwise the last poke of a
+   * burst (e.g. two players hit by one AoE) leaves party HP stale. Repeated
+   * pokes inside the window coalesce onto the single pending timeout.
+   */
   const refetchNow = useCallback(() => {
     if (!campaignCode) return;
     const now = Date.now();
-    if (now - lastManualFetchRef.current < PARTY_REFETCH_DEBOUNCE_MS) return;
-    lastManualFetchRef.current = now;
-    fetchPartyHP();
+    const elapsed = now - lastManualFetchRef.current;
+    if (elapsed >= PARTY_REFETCH_DEBOUNCE_MS) {
+      lastManualFetchRef.current = now;
+      fetchPartyHP();
+      return;
+    }
+    if (trailingFetchTimeoutRef.current) return;
+    trailingFetchTimeoutRef.current = setTimeout(() => {
+      trailingFetchTimeoutRef.current = null;
+      lastManualFetchRef.current = Date.now();
+      fetchPartyHP();
+    }, PARTY_REFETCH_DEBOUNCE_MS - elapsed);
   }, [campaignCode, fetchPartyHP]);
 
   const stopPolling = useCallback(() => {
@@ -154,6 +171,16 @@ export function usePartySync({
       stopPolling();
     };
   }, [campaignCode, enabled, fetchPartyHP, startPolling, stopPolling]);
+
+  // Clear any pending trailing refetchNow fetch on unmount.
+  useEffect(() => {
+    return () => {
+      if (trailingFetchTimeoutRef.current) {
+        clearTimeout(trailingFetchTimeoutRef.current);
+        trailingFetchTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   return { partyMembers, loading, refetchNow };
 }

--- a/src/hooks/usePartySync.ts
+++ b/src/hooks/usePartySync.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { PartyMemberHP } from '@/app/api/campaign/[code]/party-hp/route';
 
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const PARTY_REFETCH_DEBOUNCE_MS = 1000;
 const ACTIVITY_EVENTS = [
   'mousemove',
   'keydown',
@@ -20,6 +21,8 @@ interface UsePartySyncOptions {
 interface UsePartySyncResult {
   partyMembers: PartyMemberHP[];
   loading: boolean;
+  /** Immediate refetch (e.g. on a relay poke). Debounced: at most one per second. */
+  refetchNow: () => void;
 }
 
 export function usePartySync({
@@ -51,6 +54,16 @@ export function usePartySync({
       setLoading(false);
     }
   }, [campaignCode, currentCharacterId]);
+
+  const lastManualFetchRef = useRef(0);
+  /** Immediate refetch (poke-triggered), at most once per second. */
+  const refetchNow = useCallback(() => {
+    if (!campaignCode) return;
+    const now = Date.now();
+    if (now - lastManualFetchRef.current < PARTY_REFETCH_DEBOUNCE_MS) return;
+    lastManualFetchRef.current = now;
+    fetchPartyHP();
+  }, [campaignCode, fetchPartyHP]);
 
   const stopPolling = useCallback(() => {
     if (intervalRef.current) {
@@ -142,5 +155,5 @@ export function usePartySync({
     };
   }, [campaignCode, enabled, fetchPartyHP, startPolling, stopPolling]);
 
-  return { partyMembers, loading };
+  return { partyMembers, loading, refetchNow };
 }

--- a/src/lib/__tests__/relayPoke.test.ts
+++ b/src/lib/__tests__/relayPoke.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { sendInitiativePoke, relayHttpUrl } from '@/lib/relayPoke';
+import {
+  sendInitiativePoke,
+  sendBattleMapPoke,
+  relayHttpUrl,
+} from '@/lib/relayPoke';
 import { verifyBattleMapToken } from '@/lib/battlemapToken';
 
 const CODE = 'CAMP1';
@@ -98,5 +102,46 @@ describe('sendInitiativePoke', () => {
     const redis = redisWith({ activeBattleMapId: 'map-42' });
     await sendInitiativePoke(CODE, redis, { fetchFn });
     expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('sendBattleMapPoke posts the given feature to the relay poke endpoint', async () => {
+    const fetchFn = vi.fn(async () => new Response('{"sent":1}'));
+    const redis = redisWith(
+      JSON.stringify({ activeBattleMapId: 'map-42', activatedAt: 'x' })
+    );
+
+    await sendBattleMapPoke(CODE, redis, 'players', {
+      fetchFn,
+      now: 1_000_000,
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const call = fetchFn.mock.calls[0];
+    if (!call || call.length < 2) {
+      throw new Error('fetchFn not called with expected arguments');
+    }
+    const [url, init] = call as unknown as [string, RequestInit];
+    expect(url).toBe('https://relay.example.com/poke');
+    const body = JSON.parse(init.body as string);
+    expect(body.room).toBe('CAMP1:map-42');
+    expect(body.feature).toBe('players');
+  });
+
+  it('sendInitiativePoke still posts feature "initiative" (wrapper)', async () => {
+    const fetchFn = vi.fn(async () => new Response('{"sent":1}'));
+    const redis = redisWith(
+      JSON.stringify({ activeBattleMapId: 'map-42', activatedAt: 'x' })
+    );
+
+    await sendInitiativePoke(CODE, redis, { fetchFn, now: 1_000_000 });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const call = fetchFn.mock.calls[0];
+    if (!call || call.length < 2) {
+      throw new Error('fetchFn not called with expected arguments');
+    }
+    const [, init] = call as unknown as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.feature).toBe('initiative');
   });
 });

--- a/src/lib/relayPoke.ts
+++ b/src/lib/relayPoke.ts
@@ -17,14 +17,17 @@ interface RedisReader {
   get<T = unknown>(key: string): Promise<T | null>;
 }
 
+export type BattleMapPokeFeature = 'initiative' | 'players';
+
 /**
- * Best-effort WS poke after an initiative write: tells clients in the active
- * battle-map room to refetch /shared immediately. Never throws — the 5s poll
- * is the source-of-truth fallback; this only shaves latency.
+ * Best-effort WS poke after a write: tells clients in the active battle-map
+ * room to refetch /shared immediately for the given feature. Never throws —
+ * the 5s poll is the source-of-truth fallback; this only shaves latency.
  */
-export async function sendInitiativePoke(
+export async function sendBattleMapPoke(
   code: string,
   redis: RedisReader,
+  feature: BattleMapPokeFeature,
   deps: { fetchFn?: typeof fetch; now?: number } = {}
 ): Promise<void> {
   const relayUrl = process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
@@ -53,10 +56,19 @@ export async function sendInitiativePoke(
     await fetchFn(`${relayHttpUrl(relayUrl)}/poke`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ room, feature: 'initiative', token }),
+      body: JSON.stringify({ room, feature, token }),
       signal: AbortSignal.timeout(POKE_TIMEOUT_MS),
     });
   } catch (err) {
     console.warn('[relayPoke] poke failed (poll remains fallback):', err);
   }
+}
+
+/** Back-compat wrapper — the shared route's call sites keep this name. */
+export async function sendInitiativePoke(
+  code: string,
+  redis: RedisReader,
+  deps: { fetchFn?: typeof fetch; now?: number } = {}
+): Promise<void> {
+  return sendBattleMapPoke(code, redis, 'initiative', deps);
 }

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -115,6 +115,7 @@ export interface EncounterEntity {
   name: string;
   initiative: number | null;
   initiativeModifier: number;
+  proficiencyBonus?: number; // Auto-derived from CR for monsters; overridable by DM
 
   // Combat stats
   currentHp: number;

--- a/src/utils/__tests__/encounterConverter.test.ts
+++ b/src/utils/__tests__/encounterConverter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   monsterToEncounterEntity,
   createLairEntity,
+  proficiencyBonusForCr,
 } from '@/utils/encounterConverter';
 import { createMockProcessedMonster } from '@/test/helpers';
 
@@ -233,6 +234,35 @@ describe('monsterToEncounterEntity', () => {
       createMockProcessedMonster({ spellcastingEntries: undefined })
     );
     expect(entity.spellcasting).toBeUndefined();
+  });
+
+  // ── Proficiency bonus ──
+
+  it('populates proficiencyBonus derived from CR', () => {
+    // Mock monster CR is '17' → PB +6
+    const entity = monsterToEncounterEntity(createMockProcessedMonster());
+    expect(entity.proficiencyBonus).toBe(6);
+  });
+});
+
+describe('proficiencyBonusForCr', () => {
+  it('derives the standard 5e proficiency bonus from CR (CR 0–4 → +2)', () => {
+    expect(proficiencyBonusForCr('0')).toBe(2);
+    expect(proficiencyBonusForCr('1/8')).toBe(2);
+    expect(proficiencyBonusForCr('1/4')).toBe(2);
+    expect(proficiencyBonusForCr('1/2')).toBe(2);
+    expect(proficiencyBonusForCr('4')).toBe(2);
+    expect(proficiencyBonusForCr('5')).toBe(3);
+    expect(proficiencyBonusForCr('8')).toBe(3);
+    expect(proficiencyBonusForCr('9')).toBe(4);
+    expect(proficiencyBonusForCr('12')).toBe(4);
+    expect(proficiencyBonusForCr('13')).toBe(5);
+    expect(proficiencyBonusForCr('17')).toBe(6);
+    expect(proficiencyBonusForCr('30')).toBe(9);
+  });
+
+  it('treats missing/empty CR as CR 0 (→ +2)', () => {
+    expect(proficiencyBonusForCr('')).toBe(2);
   });
 });
 

--- a/src/utils/__tests__/encounterSync.applyPlayers.test.ts
+++ b/src/utils/__tests__/encounterSync.applyPlayers.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useEncounterStore } from '@/store/encounterStore';
+import { applyPlayersToEncounter } from '@/utils/encounterSync';
+import { createMockCharacterState } from '@/test/helpers';
+import type { CampaignPlayerData } from '@/types/campaign';
+
+describe('applyPlayersToEncounter', () => {
+  let encounterId: string;
+
+  beforeEach(() => {
+    useEncounterStore.setState({ encounters: [] });
+    encounterId = useEncounterStore
+      .getState()
+      .createEncounter('Test Encounter');
+    useEncounterStore.getState().addEntity(encounterId, {
+      type: 'player',
+      name: 'Thorn',
+      initiative: null,
+      initiativeModifier: 0,
+      currentHp: 44,
+      maxHp: 44,
+      tempHp: 0,
+      armorClass: 16,
+      conditions: [],
+      isHidden: false,
+      playerCharacterId: 'char-1',
+    });
+  });
+
+  it('updates a player entity HP from the snapshot', () => {
+    const player: CampaignPlayerData = {
+      playerId: 'char-1',
+      playerName: 'Alice',
+      characterId: 'char-1',
+      characterName: 'Thorn',
+      characterData: {
+        ...createMockCharacterState({ id: 'char-1' }),
+        hitPoints: {
+          current: 30,
+          max: 44,
+          temporary: 0,
+          calculationMode: 'auto',
+        },
+      },
+      lastSynced: new Date().toISOString(),
+    };
+    applyPlayersToEncounter(encounterId, [player]);
+
+    const entity = useEncounterStore
+      .getState()
+      .encounters.find(e => e.id === encounterId)!
+      .entities.find(e => e.playerCharacterId === 'char-1')!;
+    expect(entity.currentHp).toBe(30);
+  });
+
+  it('is a no-op for unknown encounter ids and empty player lists', () => {
+    expect(() => applyPlayersToEncounter('nope', [])).not.toThrow();
+  });
+});

--- a/src/utils/__tests__/sharedInitiativeOverlay.test.ts
+++ b/src/utils/__tests__/sharedInitiativeOverlay.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { overlayLiveHp } from '@/utils/sharedInitiativeOverlay';
+import type {
+  SharedInitiativeState,
+  SharedTurnEntry,
+} from '@/types/sharedState';
+
+function makeState(entries: Partial<SharedTurnEntry>[]): SharedInitiativeState {
+  return {
+    encounterId: 'enc-1',
+    isActive: true,
+    round: 1,
+    currentEntityId: null,
+    enemyHpMode: 'off',
+    turnOrder: entries.map((e, i) => ({
+      entityId: `e${i}`,
+      displayName: `E${i}`,
+      type: 'player',
+      ...e,
+    })) as SharedTurnEntry[],
+  } as SharedInitiativeState;
+}
+
+describe('overlayLiveHp', () => {
+  it('replaces player-row HP with live values and derives isDead', () => {
+    const state = makeState([
+      { playerCharacterId: 'char-a', currentHp: 44, maxHp: 44, isDead: false },
+    ]);
+    const out = overlayLiveHp(state, { 'char-a': { current: 0, max: 44 } })!;
+    expect(out.turnOrder[0].currentHp).toBe(0);
+    expect(out.turnOrder[0].maxHp).toBe(44);
+    expect(out.turnOrder[0].isDead).toBe(true);
+  });
+
+  it('leaves non-player rows untouched even on characterId collision', () => {
+    const state = makeState([
+      { type: 'monster', playerCharacterId: undefined, hpPercent: 80 },
+    ]);
+    const out = overlayLiveHp(state, { e0: { current: 1, max: 10 } })!;
+    expect(out.turnOrder[0]).toEqual(state.turnOrder[0]);
+  });
+
+  it('leaves player rows without a live entry untouched', () => {
+    const state = makeState([
+      { playerCharacterId: 'char-b', currentHp: 20, maxHp: 30 },
+    ]);
+    const out = overlayLiveHp(state, {})!;
+    expect(out.turnOrder[0].currentHp).toBe(20);
+  });
+
+  it('passes null through', () => {
+    expect(overlayLiveHp(null, {})).toBeNull();
+  });
+});

--- a/src/utils/encounterConverter.ts
+++ b/src/utils/encounterConverter.ts
@@ -215,6 +215,22 @@ function abilityModifier(score: number): number {
   return Math.floor((score - 10) / 2);
 }
 
+/** Parse a CR string ("1/8", "1/4", "1/2", "3", "24") to a number. */
+function crToNumber(cr: string): number {
+  if (!cr) return 0;
+  if (cr.includes('/')) {
+    const [numerator, denominator] = cr.split('/');
+    return parseInt(numerator, 10) / parseInt(denominator, 10);
+  }
+  return parseFloat(cr) || 0;
+}
+
+/** Standard 5e proficiency-bonus-by-CR formula (CR 0–4 → +2). */
+export function proficiencyBonusForCr(cr: string): number {
+  const crNum = crToNumber(cr);
+  return 2 + Math.floor(Math.max(crNum - 1, 0) / 4);
+}
+
 /** 5eTools size code → token cells: T/S/M 1, L 2, H 3, G 4 (unknown → 1). */
 export function sizeCodeToTokenCells(code: string | undefined): TokenCellSize {
   switch (code) {
@@ -301,6 +317,7 @@ export function monsterToEncounterEntity(
     name: options?.nameOverride ?? monster.name,
     initiative: null,
     initiativeModifier: abilityModifier(dex),
+    proficiencyBonus: proficiencyBonusForCr(monster.cr),
     currentHp: hp,
     maxHp: hp,
     tempHp: 0,

--- a/src/utils/encounterSync.ts
+++ b/src/utils/encounterSync.ts
@@ -368,6 +368,9 @@ export function applyPlayersToEncounter(
 
   for (const entity of encounter.entities) {
     if (entity.type === 'player' && entity.playerCharacterId) {
+      // Matches on playerId === playerCharacterId; this is only correct
+      // because usePlayerSync sends `playerId: characterId` — the player-VTT
+      // overlay keys by characterId, so the two are coupled by convention.
       const playerData = players.find(
         p => p.playerId === entity.playerCharacterId
       );

--- a/src/utils/encounterSync.ts
+++ b/src/utils/encounterSync.ts
@@ -6,6 +6,7 @@ import {
 import type { Summon } from '@/types/summon';
 import { CampaignPlayerData } from '@/types/campaign';
 import { calculateCharacterArmorClass } from '@/utils/calculations';
+import { useEncounterStore } from '@/store/encounterStore';
 
 /**
  * Merge live player data from campaign sync into an encounter entity.
@@ -344,6 +345,49 @@ export function syncSummonsToEncounter(
   for (const entity of existingSummonEntities) {
     if (entity.summonId && !activeSummonIds.has(entity.summonId)) {
       removeEntity(encounter.id, entity.id);
+    }
+  }
+}
+
+/**
+ * Merge live campaign player data into an encounter's player-linked entities
+ * and their summons. Reads/writes `useEncounterStore.getState()` directly so
+ * it is callable outside React (e.g. from a poke-driven refresh hook) as well
+ * as from a component effect. No-ops silently for an unknown encounter id or
+ * an empty player list. Extracted verbatim from `EncounterView`'s player-sync
+ * effect — see `applyPlayersToEncounter`'s callers for the two use sites.
+ */
+export function applyPlayersToEncounter(
+  encounterId: string,
+  players: CampaignPlayerData[]
+): void {
+  const { encounters, addEntity, updateEntity, removeEntity } =
+    useEncounterStore.getState();
+  const encounter = encounters.find(e => e.id === encounterId);
+  if (!encounter) return;
+
+  for (const entity of encounter.entities) {
+    if (entity.type === 'player' && entity.playerCharacterId) {
+      const playerData = players.find(
+        p => p.playerId === entity.playerCharacterId
+      );
+      if (playerData) {
+        // Sync player HP/AC/conditions
+        const updates = mergePlayerSyncData(entity, playerData);
+        if (updates && hasPlayerDataChanged(entity, updates)) {
+          updateEntity(encounterId, entity.id, updates);
+        }
+        // Sync player's summons into encounter
+        const playerSummons = playerData.characterData?.summons ?? [];
+        syncSummonsToEncounter(
+          encounter,
+          entity,
+          playerSummons,
+          addEntity,
+          updateEntity,
+          removeEntity
+        );
+      }
     }
   }
 }

--- a/src/utils/sharedInitiativeOverlay.ts
+++ b/src/utils/sharedInitiativeOverlay.ts
@@ -1,0 +1,41 @@
+import type {
+  SharedInitiativeState,
+  SharedTurnEntry,
+} from '@/types/sharedState';
+
+export interface LiveHp {
+  current: number;
+  max: number;
+}
+
+/**
+ * Overlays live player HP (own characterStore + poke-fresh /party-hp data)
+ * onto the DM-published initiative snapshot, so player-row HP does not wait
+ * on the DM tab's poll→merge→push round trip. Only rows with
+ * type === 'player' and a playerCharacterId are touched — enemy HP masking
+ * (hpState/hpPercent/hpTier) is a DM privacy feature and must pass through
+ * untouched.
+ */
+export function overlayLiveHp(
+  state: SharedInitiativeState | null,
+  liveHp: Record<string, LiveHp>
+): SharedInitiativeState | null {
+  if (!state) return state;
+  let changed = false;
+  const turnOrder = state.turnOrder.map((entry: SharedTurnEntry) => {
+    if (entry.type !== 'player' || !entry.playerCharacterId) return entry;
+    const live = liveHp[entry.playerCharacterId];
+    if (!live) return entry;
+    if (entry.currentHp === live.current && entry.maxHp === live.max) {
+      return entry;
+    }
+    changed = true;
+    return {
+      ...entry,
+      currentHp: live.current,
+      maxHp: live.max,
+      isDead: live.current <= 0,
+    };
+  });
+  return changed ? { ...state, turnOrder } : state;
+}


### PR DESCRIPTION
## Problem

HP shown on the player battle map's initiative rail round-tripped through the DM tab: player → Redis → **DM tab poll (paused when backgrounded)** → merge → DM push → Redis → player poll. A backgrounded DM tab froze the pipeline — player HP in the rail only updated when the DM tab was focused. The DM VTT itself never refreshed player HP at all (only the separate EncounterView tab's poll did).

## Fix — poke-then-refetch over the existing relay

Reuses the shipped poke pipeline (API route → HTTP `POST /poke` → relay broadcasts to the battle-map room). **No relay changes, no redeploy** — the feature string passes through.

- `sendBattleMapPoke(code, redis, feature)` generalization (`'initiative' | 'players'`)
- `POST /sync` pokes `'players'` after every **accepted** write (never on 400/409/410 — stale tabs can't cause poke storms)
- **Player VTT overlays live player HP** onto the DM-published initiative state (`overlayLiveHp`): own HP from characterStore (instant), other players from `/party-hp` refetched on poke (~1–2 s). Player-row HP no longer depends on the DM tab. Enemy HP masking passes through untouched.
- **DM VTT refreshes player entities on poke** (`useDmVttPlayersRefresh` → `applyPlayersToEncounter`, extracted verbatim from EncounterView); its existing push-on-change re-broadcasts fresh initiative automatically
- Trailing-edge debounces (burst of syncs → exactly one coalesced trailing fetch) + latest-ref `onPoke` closures (final-review fixes)
- Polling everywhere stays as fallback — kill the relay and everything still converges at poll cadence

## Encounter tracker UX (DM feedback)

- Clicking a combatant's name in the list now **selects** it (shows stats); rename moved to a pencil affordance in the detail-panel header (non-players only, Enter/blur commits, Escape cancels)
- Combat Details card: added **Initiative** (edits go through `setInitiative` so the turn order re-sorts mid-combat) and **Proficiency Bonus** (`EncounterEntity.proficiencyBonus`, derived from CR for monsters); **every listed detail is now DM-editable** (skills, resistances, immunities, senses, languages, passive perception, …) — players stay read-only (sheet-owned)
- DM VTT: drawing toolbar no longer overlaps the top bar at wide viewports (removed the ≥1350px `top-3` variant; toolbar always sits below)

## Tests

42 new tests (poke sender/route, debounces, overlay privacy invariants, applyPlayersToEncounter, rename/Combat Details characterization, toolbar regression pin). Full unit: 2914 passed / 1 skipped. type-check clean; lint only pre-existing warnings.

## Manual smoke suggested

- Two browsers + DM: damage on player VTT → own rail instant, other player ≤2 s, DM VTT ≤2 s, with the EncounterView tab closed/backgrounded
- Relay stopped → converges at poll cadence
- DM VTT at ~2000 px: toolbar below top bar (screenshot bug)
- Enemy HP masking modes unchanged on the player rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)