### PR TITLE
fix(sync): multi-tab roster clobber + initiative freshness + Playwright e2e suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,32 @@ jobs:
 
       - name: Unit tests
         run: npm run test
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      # playwright.config.ts starts the dev server itself (webServer) and
+      # refuses to reuse a stale one on CI (reuseExistingServer: !CI).
+      # The e2e specs are relay/Redis-free — no service env needed.
+      - name: E2E tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
 
 # next.js
 /.next/

--- a/e2e/cross-tab-character.spec.ts
+++ b/e2e/cross-tab-character.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+import {
+  createCharacter,
+  waitForStoresReady,
+  storeHp,
+  damageCharacter,
+} from './helpers';
+
+// Mechanism pin (PR #170): two tabs holding the SAME character converge via
+// `initCrossTabCharacterSync` — a real `storage` event + revision-guarded
+// apply. Proven working end-to-end in real Chromium (see
+// scratchpad/repro/evidence.md, Experiment A). This spec must stay GREEN;
+// if it ever fails, the bug is in the spec, not in this mechanism.
+test('damage applied in one tab reaches another tab of the same character', async ({
+  browser,
+}) => {
+  const context = await browser.newContext();
+  const tab1 = await context.newPage();
+
+  const characterUrl = await createCharacter(tab1, 'SoloHero');
+
+  const tab2 = await context.newPage();
+  await tab2.goto(characterUrl, { waitUntil: 'networkidle' });
+  await waitForStoresReady(tab2);
+
+  const { max: hpMax } = await storeHp(tab1);
+
+  await damageCharacter(tab1, 5);
+
+  await expect
+    .poll(async () => (await storeHp(tab2)).current, {
+      message:
+        'tab2 should observe the damage applied in tab1 via the storage event',
+      timeout: 10_000,
+    })
+    .toBeLessThan(hpMax);
+
+  // Both tabs must agree on the same, correct value — not just "less than max".
+  const [tab1Current, tab2Current] = await Promise.all([
+    storeHp(tab1).then(hp => hp.current),
+    storeHp(tab2).then(hp => hp.current),
+  ]);
+  expect(tab1Current).toBe(hpMax - 5);
+  expect(tab2Current).toBe(hpMax - 5);
+});

--- a/e2e/global.d.ts
+++ b/e2e/global.d.ts
@@ -1,0 +1,15 @@
+import type { useCharacterStore } from '@/store/characterStore';
+import type { usePlayerStore } from '@/store/playerStore';
+
+// Dev/test-only global exposed by `exposeStoreForE2E` (see src/lib/e2eStoreHandles.ts).
+// Only ever present when NODE_ENV !== 'production'.
+declare global {
+  interface Window {
+    __rkStores?: {
+      character: typeof useCharacterStore;
+      player: typeof usePlayerStore;
+    };
+  }
+}
+
+export {};

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -94,6 +94,33 @@ export async function storeHp(
   });
 }
 
+/** Live in-memory revision for whichever character is currently loaded in
+ * this tab's characterStore. The revision bump happens synchronously inside
+ * the same `set` call as the mutation, so this can be read immediately after
+ * a damage call with no polling — unlike the roster blob (`readRosterEntry`),
+ * which only reflects the write-back once the debounced sync effect fires. */
+export async function storeRevision(page: Page): Promise<number | undefined> {
+  return page.evaluate(
+    () => window.__rkStores!.character.getState().character.revision
+  );
+}
+
+/** Id of the character currently occupying the single-character
+ * `rollkeeper-character` localStorage slot (the live characterStore's
+ * persisted blob) — distinct from the whole-roster `rollkeeper-player-data`
+ * blob read by `readRosterEntry`. Used to confirm a tab's write-back has
+ * actually landed before another tab reloads. */
+export async function characterSlotId(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const raw = window.localStorage.getItem('rollkeeper-character');
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as {
+      state?: { character?: { id?: string } };
+    };
+    return parsed.state?.character?.id ?? null;
+  });
+}
+
 /** Applies damage via the live characterStore handle (same mechanism as the
  * app's damage controls, bypassing the UI for speed/determinism). */
 export async function damageCharacter(

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,106 @@
+import { Page } from '@playwright/test';
+
+/** Waits until the dev-only `__rkStores.character` handle exists and the
+ * character store has finished rehydrating from localStorage. */
+export async function waitForStoresReady(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () =>
+      !!window.__rkStores?.character &&
+      window.__rkStores.character.getState().hasHydrated,
+    undefined,
+    { timeout: 15_000 }
+  );
+}
+
+/**
+ * Drives the working `/player/characters/new` creation flow (selectors
+ * verified against the real app in scratchpad/repro/repro.js + repro3.js)
+ * and waits for the resulting sheet to hydrate.
+ * Returns the full sheet URL (e.g. http://localhost:3000/player/characters/abc123).
+ */
+export async function createCharacter(
+  page: Page,
+  name: string
+): Promise<string> {
+  await page.goto('/player/characters/new', { waitUntil: 'networkidle' });
+  await page.fill('#characterName', name);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(
+    url =>
+      /\/player\/characters\/[^/]+$/.test(url.pathname) &&
+      !url.pathname.endsWith('/new'),
+    { timeout: 15_000 }
+  );
+  await waitForStoresReady(page);
+  return page.url();
+}
+
+/** Extracts the character id from a sheet URL produced by createCharacter(). */
+export function characterIdFromUrl(url: string): string {
+  const id = new URL(url).pathname.split('/').pop();
+  if (!id) throw new Error(`Could not extract character id from URL: ${url}`);
+  return id;
+}
+
+export interface RosterEntrySnapshot {
+  id: string;
+  name: string;
+  revision: number | undefined;
+  hpCurrent: number | undefined;
+  hpMax: number | undefined;
+}
+
+/** Reads one character's entry out of the whole-roster `rollkeeper-player-data`
+ * localStorage blob (playerStore) — the artifact at the center of the clobber bug. */
+export async function readRosterEntry(
+  page: Page,
+  characterId: string
+): Promise<RosterEntrySnapshot | null> {
+  return page.evaluate(id => {
+    const raw = window.localStorage.getItem('rollkeeper-player-data');
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as {
+      state?: {
+        characters?: Array<{
+          id: string;
+          name: string;
+          characterData?: {
+            revision?: number;
+            hitPoints?: { current?: number; max?: number };
+          };
+        }>;
+      };
+    };
+    const entry = parsed.state?.characters?.find(c => c.id === id);
+    if (!entry) return null;
+    return {
+      id: entry.id,
+      name: entry.name,
+      revision: entry.characterData?.revision,
+      hpCurrent: entry.characterData?.hitPoints?.current,
+      hpMax: entry.characterData?.hitPoints?.max,
+    };
+  }, characterId);
+}
+
+/** Live in-memory hit points for whichever character is currently loaded in
+ * this tab's characterStore. */
+export async function storeHp(
+  page: Page
+): Promise<{ current: number; max: number }> {
+  return page.evaluate(() => {
+    const hp = window.__rkStores!.character.getState().character.hitPoints;
+    return { current: hp.current, max: hp.max };
+  });
+}
+
+/** Applies damage via the live characterStore handle (same mechanism as the
+ * app's damage controls, bypassing the UI for speed/determinism). */
+export async function damageCharacter(
+  page: Page,
+  amount: number
+): Promise<void> {
+  await page.evaluate(dmg => {
+    window.__rkStores!.character.getState().applyDamageToCharacter(dmg);
+  }, amount);
+}

--- a/e2e/roster-clobber.spec.ts
+++ b/e2e/roster-clobber.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+
+import {
+  createCharacter,
+  characterIdFromUrl,
+  waitForStoresReady,
+  readRosterEntry,
+  storeHp,
+  damageCharacter,
+} from './helpers';
+
+// Reproduces the bug found by hand in scratchpad/repro/evidence.md,
+// "EXPERIMENT 2 — DM + multiple players (two DIFFERENT characters) in one
+// profile". Root cause: `updateCharacterData` in src/store/playerStore.ts
+// re-persists the WHOLE in-memory roster on every local mutation, using
+// each tab's own (possibly stale) copy of characters it isn't actively
+// editing. tab1 holds character A, tab2 holds character B (same browser
+// profile/localStorage). Every time tab1 writes back A, it also re-writes
+// its stale in-memory copy of B — clobbering whatever tab2 most recently
+// persisted for B.
+//
+// Expected verdict TODAY (pre-fix): RED — both assertions fail. Tasks 2-3
+// make this pass. Do not weaken this spec to make it pass early.
+test("a tab holding another character must not revert this character's roster entry", async ({
+  browser,
+}) => {
+  const context = await browser.newContext();
+  const tab1 = await context.newPage();
+
+  // tab1 creates both characters sequentially (matches evidence.md's Setup:
+  // tab1 creates A, then B, so its in-memory roster starts as [A, B]).
+  const urlA = await createCharacter(tab1, 'Roster Clobber A');
+  const idA = characterIdFromUrl(urlA);
+  const urlB = await createCharacter(tab1, 'Roster Clobber B');
+  const idB = characterIdFromUrl(urlB);
+
+  // Fresh navigation to A's sheet in tab1 (captures tab1's in-memory roster
+  // snapshot at this point: [A, B]).
+  await tab1.goto(urlA, { waitUntil: 'networkidle' });
+  await waitForStoresReady(tab1);
+
+  // tab2: fresh page, first-ever load of B's sheet (captures tab2's
+  // in-memory roster snapshot: [A, B] too, both read from the same
+  // localStorage at load time).
+  const tab2 = await context.newPage();
+  await tab2.goto(urlB, { waitUntil: 'networkidle' });
+  await waitForStoresReady(tab2);
+
+  const { max: hpMaxA } = await storeHp(tab1);
+  const { max: hpMaxB } = await storeHp(tab2);
+
+  // --- Interleave: tab1 dmg A (-3); tab2 dmg B (-4); tab1 dmg A (-2) ---
+  await damageCharacter(tab1, 3);
+  await expect
+    .poll(async () => (await readRosterEntry(tab1, idA))?.hpCurrent, {
+      message: "tab1's write-back of A(-3) should land in the roster blob",
+      timeout: 10_000,
+    })
+    .toBe(hpMaxA - 3);
+
+  await damageCharacter(tab2, 4);
+  await expect
+    .poll(async () => (await readRosterEntry(tab2, idB))?.hpCurrent, {
+      message: "tab2's write-back of B(-4) should land in the roster blob",
+      timeout: 10_000,
+    })
+    .toBe(hpMaxB - 4);
+
+  await damageCharacter(tab1, 2);
+  await expect
+    .poll(async () => (await readRosterEntry(tab1, idA))?.hpCurrent, {
+      message: "tab1's write-back of A(-2) should land in the roster blob",
+      timeout: 10_000,
+    })
+    .toBe(hpMaxA - 5);
+
+  // --- Assert 1 (roster integrity): both entries must carry their LATEST
+  // hp/revision. Pre-fix: tab1's last write-back (A) re-persists tab1's
+  // stale in-memory copy of B (captured at creation, hp = hpMaxB),
+  // reverting B's roster entry back to full hp — this assertion fails.
+  const finalA = await readRosterEntry(tab1, idA);
+  const finalB = await readRosterEntry(tab1, idB);
+  expect
+    .soft(finalA?.hpCurrent, "A's roster entry must reflect its latest damage")
+    .toBe(hpMaxA - 5);
+  expect
+    .soft(finalB?.hpCurrent, "B's roster entry must reflect its latest damage")
+    .toBe(hpMaxB - 4);
+
+  // Mirrors evidence.md's Evidence Set 2: tab1 reloads (control case — A
+  // comes back correct because tab1 was the last writer of A throughout),
+  // then does a no-op /player round-trip nav. Both are tab1-only actions on
+  // A, but each is itself a fresh write-back of tab1's (still-stale-for-B)
+  // roster snapshot, which is what makes tab1 the definitive last writer of
+  // the single `rollkeeper-character` slot by the time tab2 reloads next.
+  await tab1.reload({ waitUntil: 'networkidle' });
+  await waitForStoresReady(tab1);
+  await tab1.goto('/player', { waitUntil: 'networkidle' });
+  await tab1.goto(urlA, { waitUntil: 'networkidle' });
+  await waitForStoresReady(tab1);
+
+  // --- Assert 2 (user-visible data loss): reloading tab2 (B's sheet) must
+  // NOT undo B's damage. Pre-fix: characterStore rehydrates from the single
+  // `rollkeeper-character` slot (now holding A, since tab1 wrote it last);
+  // the id mismatch bypasses useCharacterRosterSync's staleness guard, so it
+  // unconditionally loads B from the (already-clobbered) roster blob —
+  // reverting B's live hp back to full.
+  await tab2.reload({ waitUntil: 'networkidle' });
+  await waitForStoresReady(tab2);
+  const hpAfterReload = await storeHp(tab2);
+  expect
+    .soft(
+      hpAfterReload.current,
+      "B's hp must still reflect its damage after reload"
+    )
+    .toBe(hpMaxB - 4);
+});

--- a/e2e/roster-clobber.spec.ts
+++ b/e2e/roster-clobber.spec.ts
@@ -6,6 +6,8 @@ import {
   waitForStoresReady,
   readRosterEntry,
   storeHp,
+  storeRevision,
+  characterSlotId,
   damageCharacter,
 } from './helpers';
 
@@ -50,6 +52,10 @@ test("a tab holding another character must not revert this character's roster en
   const { max: hpMaxB } = await storeHp(tab2);
 
   // --- Interleave: tab1 dmg A (-3); tab2 dmg B (-4); tab1 dmg A (-2) ---
+  // Revisions are captured from the live characterStore handle right after
+  // each damage call (the bump is synchronous with the mutation) rather than
+  // from the roster blob, which only reflects a write-back once the debounced
+  // sync effect fires.
   await damageCharacter(tab1, 3);
   await expect
     .poll(async () => (await readRosterEntry(tab1, idA))?.hpCurrent, {
@@ -59,6 +65,7 @@ test("a tab holding another character must not revert this character's roster en
     .toBe(hpMaxA - 3);
 
   await damageCharacter(tab2, 4);
+  const revB = await storeRevision(tab2);
   await expect
     .poll(async () => (await readRosterEntry(tab2, idB))?.hpCurrent, {
       message: "tab2's write-back of B(-4) should land in the roster blob",
@@ -67,6 +74,7 @@ test("a tab holding another character must not revert this character's roster en
     .toBe(hpMaxB - 4);
 
   await damageCharacter(tab1, 2);
+  const revA = await storeRevision(tab1);
   await expect
     .poll(async () => (await readRosterEntry(tab1, idA))?.hpCurrent, {
       message: "tab1's write-back of A(-2) should land in the roster blob",
@@ -75,17 +83,24 @@ test("a tab holding another character must not revert this character's roster en
     .toBe(hpMaxA - 5);
 
   // --- Assert 1 (roster integrity): both entries must carry their LATEST
-  // hp/revision. Pre-fix: tab1's last write-back (A) re-persists tab1's
-  // stale in-memory copy of B (captured at creation, hp = hpMaxB),
-  // reverting B's roster entry back to full hp — this assertion fails.
+  // hp AND revision. Pre-fix: tab1's last write-back (A) re-persists tab1's
+  // stale in-memory copy of B (captured at creation, hp = hpMaxB, revision =
+  // its creation-time revision), reverting B's roster entry back to full hp
+  // and a stale revision — this assertion fails.
   const finalA = await readRosterEntry(tab1, idA);
   const finalB = await readRosterEntry(tab1, idB);
   expect
     .soft(finalA?.hpCurrent, "A's roster entry must reflect its latest damage")
     .toBe(hpMaxA - 5);
   expect
+    .soft(finalA?.revision, "A's roster entry must carry its latest revision")
+    .toBe(revA);
+  expect
     .soft(finalB?.hpCurrent, "B's roster entry must reflect its latest damage")
     .toBe(hpMaxB - 4);
+  expect
+    .soft(finalB?.revision, "B's roster entry must carry its latest revision")
+    .toBe(revB);
 
   // Mirrors evidence.md's Evidence Set 2: tab1 reloads (control case — A
   // comes back correct because tab1 was the last writer of A throughout),
@@ -98,6 +113,29 @@ test("a tab holding another character must not revert this character's roster en
   await tab1.goto('/player', { waitUntil: 'networkidle' });
   await tab1.goto(urlA, { waitUntil: 'networkidle' });
   await waitForStoresReady(tab1);
+
+  // Force the ordering explicitly rather than relying on navigation overhead
+  // outlasting useCharacterRosterSync's 50ms initial-load timer: confirm
+  // tab1's final write-back (the single `rollkeeper-character` slot holding
+  // A, and A's roster entry reflecting tab1's last write) has actually landed
+  // before tab2 reloads next. (Revision is not asserted here: remounting the
+  // sheet after `reload`/navigation legitimately re-runs mount-time effects
+  // that can bump revision again with no change in hp — that's unrelated to
+  // the clobber bug this spec targets, so only hp/id are checked.)
+  await expect
+    .poll(async () => characterSlotId(tab1), {
+      message:
+        "tab1's reload round-trip must finish writing A into the rollkeeper-character slot before tab2 reloads",
+      timeout: 10_000,
+    })
+    .toBe(idA);
+  await expect
+    .poll(async () => (await readRosterEntry(tab1, idA))?.hpCurrent, {
+      message:
+        "tab1's reload round-trip must finish writing A's roster entry before tab2 reloads",
+      timeout: 10_000,
+    })
+    .toBe(hpMaxA - 5);
 
   // --- Assert 2 (user-visible data loss): reloading tab2 (B's sheet) must
   // NOT undo B's damage. Pre-fix: characterStore rehydrates from the single

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.3",
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.61.1",
         "@storybook/addon-a11y": "^10.1.9",
         "@storybook/addon-docs": "^10.1.9",
         "@storybook/addon-onboarding": "^10.1.9",
@@ -3119,6 +3120,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -13691,13 +13708,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13710,9 +13727,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format": "npm run prettier && npm run lint:fix",
     "format:check": "npm run prettier:check && npm run lint",
     "test": "vitest run --project unit",
+    "test:e2e": "playwright test",
     "test:watch": "vitest --project unit",
     "test:visual": "vitest run --project storybook",
     "test:all": "vitest run",
@@ -79,6 +80,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.61.1",
     "@storybook/addon-a11y": "^10.1.9",
     "@storybook/addon-docs": "^10.1.9",
     "@storybook/addon-onboarding": "^10.1.9",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   webServer: {
     command: 'npm run dev',
     url: 'http://localhost:3000/player',
-    reuseExistingServer: true,
+    reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },
   projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  retries: 0,
+  workers: 1,
+  use: { baseURL: 'http://localhost:3000' },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000/player',
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+});

--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -64,6 +64,7 @@ import RestDialog from '@/components/ui/character/RestDialog';
 import { useCalendarStore } from '@/store/calendarStore';
 import { useSharedCampaignState } from '@/hooks/useSharedCampaignState';
 import { useJoinedBattleMap } from '@/hooks/useJoinedBattleMap';
+import { useBattleMapPokes } from '@/hooks/useBattleMapPokes';
 import { getMsPerDay, getCampaignDays } from '@/utils/calendarCalculations';
 import TabbedCharacterSheet from '@/components/ui/character/TabbedCharacterSheet';
 import type { TabbedCharacterSheetRef } from '@/components/ui/character/TabbedCharacterSheet';
@@ -262,7 +263,7 @@ export default function CharacterSheet() {
   );
 
   // Party sync — used for send-item targets
-  const { partyMembers, refetchNow } = usePartySync({
+  const { partyMembers, refetchNow: refetchPartyHpNow } = usePartySync({
     campaignCode: playerSync.campaignCode ?? null,
     currentCharacterId: characterId,
   });
@@ -275,8 +276,29 @@ export default function CharacterSheet() {
     acknowledgeTransfers,
     pendingTransfers,
     clearPendingTransfer,
+    refetchNow,
   } = useSharedCampaignState(playerSync.campaignCode, characterId);
   const sharedCalendar = sharedState?.calendar ?? null;
+
+  // Live battle map join-state derives from this too — derived here (rather
+  // than lower in the file, where it used to live) so it's available before
+  // the poke listener hook below without violating hook-order rules.
+  const activeBattleMapId = sharedState?.battleMap?.activeBattleMapId ?? null;
+
+  // Best-effort relay listener: a DM poke shaves latency off the next
+  // initiative/party-HP refetch instead of waiting on the poll interval.
+  // Polling remains the source-of-truth guarantee if this never connects.
+  useBattleMapPokes({
+    campaignCode: playerSync.campaignCode,
+    battleMapId: activeBattleMapId,
+    tokenRequest: characterId
+      ? { role: 'player', playerId: characterId }
+      : null,
+    onPoke: feature => {
+      if (feature === 'initiative') refetchNow();
+      if (feature === 'players') refetchPartyHpNow();
+    },
+  });
 
   // DM → player "roll for initiative" prompt
   const initiativePrompt = useInitiativePrompt({
@@ -593,8 +615,8 @@ export default function CharacterSheet() {
   );
 
   // Live battle map join-state: the bottom banner hides once THIS map was
-  // joined (a new map id brings it back).
-  const activeBattleMapId = sharedState?.battleMap?.activeBattleMapId ?? null;
+  // joined (a new map id brings it back). `activeBattleMapId` is derived
+  // earlier in this file (see the poke listener wiring above).
   const { joined: joinedBattleMap, markJoined: markBattleMapJoinedNow } =
     useJoinedBattleMap(activeBattleMapId);
   useEffect(() => {

--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -262,8 +262,14 @@ export default function CharacterSheet() {
     playerSync.campaignCode ?? undefined
   );
 
-  // Party sync — used for send-item targets
-  const { partyMembers, refetchNow: refetchPartyHpNow } = usePartySync({
+  // Party sync — used for send-item targets, the party HP sidebar, and the
+  // initiative panel. A single instance shared across all three so poke-
+  // driven refreshes reach everything and polling isn't duplicated.
+  const {
+    partyMembers,
+    loading: partyMembersLoading,
+    refetchNow: refetchPartyHpNow,
+  } = usePartySync({
     campaignCode: playerSync.campaignCode ?? null,
     currentCharacterId: characterId,
   });
@@ -906,7 +912,8 @@ export default function CharacterSheet() {
           {/* Party HP Sidebar */}
           <PartyHPSidebar
             campaignCode={playerSync.campaignCode ?? null}
-            currentCharacterId={characterId}
+            partyMembers={partyMembers}
+            loading={partyMembersLoading}
           />
 
           {/* Shared initiative panel — shown during active combat */}

--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -50,6 +50,7 @@ import {
 import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { NavigationContext } from '@/contexts/NavigationContext';
 import { useSimpleDiceRoll } from '@/hooks/useSimpleDiceRoll';
+import { useLiveInitiative } from '@/hooks/useLiveInitiative';
 import { useLocationSync } from '@/hooks/useLocationSync';
 import { usePartySync } from '@/hooks/usePartySync';
 
@@ -261,7 +262,7 @@ export default function CharacterSheet() {
   );
 
   // Party sync — used for send-item targets
-  const { partyMembers } = usePartySync({
+  const { partyMembers, refetchNow } = usePartySync({
     campaignCode: playerSync.campaignCode ?? null,
     currentCharacterId: characterId,
   });
@@ -581,6 +582,16 @@ export default function CharacterSheet() {
   const initiativeRound = sharedState?.initiative?.round ?? 0;
   const initiativeEncounterId = sharedState?.initiative?.encounterId ?? null;
 
+  // Overlay live player HP onto the DM-published initiative snapshot so the
+  // InitiativePanel doesn't wait on the DM tab's poll -> merge -> push
+  // round trip (mirrors the player VTT screen's usePlayerVttState).
+  const liveInitiative = useLiveInitiative(
+    sharedState?.initiative ?? null,
+    character,
+    characterId,
+    partyMembers
+  );
+
   // Live battle map join-state: the bottom banner hides once THIS map was
   // joined (a new map id brings it back).
   const activeBattleMapId = sharedState?.battleMap?.activeBattleMapId ?? null;
@@ -878,7 +889,7 @@ export default function CharacterSheet() {
 
           {/* Shared initiative panel — shown during active combat */}
           <InitiativePanel
-            state={sharedState?.initiative ?? null}
+            state={liveInitiative}
             characterId={characterId}
             onEndTurn={handleEndTurn}
             battleMapHref={

--- a/src/components/ui/campaign/PartyHPSidebar.tsx
+++ b/src/components/ui/campaign/PartyHPSidebar.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import { Users, User, Heart, Skull, EyeOff, Shield } from 'lucide-react';
-import { usePartySync } from '@/hooks/usePartySync';
 import { useDraggableY } from '@/hooks/useDraggableY';
 import { getHpBarColor } from '@/utils/hpColor';
 import { PartyMemberHP } from '@/app/api/campaign/[code]/party-hp/route';
@@ -142,19 +141,24 @@ function PartyMemberRow({ member }: { member: PartyMemberHP }) {
 
 interface PartyHPSidebarProps {
   campaignCode: string | null;
-  currentCharacterId: string;
+  partyMembers: PartyMemberHP[];
+  loading: boolean;
 }
 
+/**
+ * Presentational — the party-sync polling instance lives one level up
+ * (page-level `usePartySync`) so the sidebar and the initiative panel share
+ * ONE poll/poke-fed data source instead of each running its own; a second
+ * instance here would never see poke-driven refreshes and would double the
+ * polling traffic.
+ */
 export function PartyHPSidebar({
   campaignCode,
-  currentCharacterId,
+  partyMembers,
+  loading,
 }: PartyHPSidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
   const { topPx, containerRef: sidebarRef, startDrag } = useDraggableY(POS_KEY);
-  const { partyMembers, loading } = usePartySync({
-    campaignCode,
-    currentCharacterId,
-  });
 
   // Load persisted open state
   useEffect(() => {

--- a/src/components/ui/campaign/__tests__/PartyHPSidebar.test.tsx
+++ b/src/components/ui/campaign/__tests__/PartyHPSidebar.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { PartyHPSidebar } from '../PartyHPSidebar';
+import type { PartyMemberHP } from '@/app/api/campaign/[code]/party-hp/route';
+
+const MEMBER: PartyMemberHP = {
+  characterId: 'char-1',
+  characterName: 'Thorn',
+  playerName: 'Alice',
+  className: 'Fighter',
+  level: 3,
+  armorClass: 16,
+  hitPoints: { current: 20, max: 30, temporary: 0 },
+  lastSynced: '2025-01-01T00:00:00.000Z',
+};
+
+describe('PartyHPSidebar', () => {
+  afterEach(() => cleanup());
+
+  it('renders nothing when not in a campaign', () => {
+    const { container } = render(
+      <PartyHPSidebar campaignCode={null} partyMembers={[]} loading={false} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders members passed in as props — no data fetching of its own', () => {
+    render(
+      <PartyHPSidebar
+        campaignCode="ABCD"
+        partyMembers={[MEMBER]}
+        loading={false}
+      />
+    );
+    expect(screen.getByText('Thorn')).toBeInTheDocument();
+    expect(screen.getByText(/20\/30/)).toBeInTheDocument();
+  });
+
+  it('shows a loading state when loading is true, regardless of partyMembers', () => {
+    render(
+      <PartyHPSidebar campaignCode="ABCD" partyMembers={[]} loading={true} />
+    );
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('shows an empty state once loaded with no synced members', () => {
+    render(
+      <PartyHPSidebar campaignCode="ABCD" partyMembers={[]} loading={false} />
+    );
+    expect(screen.getByText(/no party members synced/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/useDmVttPlayersRefresh.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useDmVttPlayersRefresh.test.ts
@@ -169,4 +169,45 @@ describe('useDmVttPlayersRefresh', () => {
 
     expect(applyPlayersToEncounter).not.toHaveBeenCalled();
   });
+
+  it('polls every 45s even when no poke ever arrives (relay-down fallback)', async () => {
+    const fetchFn = mockFetchResponse(200, { players: PLAYERS });
+    renderHook(() => useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID));
+
+    // No poke — only the passive interval should drive fetches.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(applyPlayersToEncounter).toHaveBeenCalledWith(ENCOUNTER_ID, PLAYERS);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000);
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops polling after unmount', async () => {
+    const fetchFn = mockFetchResponse(200, { players: PLAYERS });
+    const { unmount } = renderHook(() =>
+      useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
+    );
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000);
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('does not poll when encounterId is null', async () => {
+    const fetchFn = mockFetchResponse(200, { players: PLAYERS });
+    renderHook(() => useDmVttPlayersRefresh(CAMPAIGN_CODE, null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000);
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/ui/campaign/dm-vtt/useDmVttPlayersRefresh.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttPlayersRefresh.ts
@@ -6,6 +6,7 @@ import { applyPlayersToEncounter } from '@/utils/encounterSync';
 import type { CampaignPlayerData } from '@/types/campaign';
 
 const PLAYERS_REFETCH_DEBOUNCE_MS = 1000;
+const FALLBACK_POLL_MS = 45_000;
 
 /**
  * Poke-driven player refresh for the DM VTT. The DM VTT has no player
@@ -65,6 +66,17 @@ export function useDmVttPlayersRefresh(
       }
     };
   }, []);
+
+  // Passive polling fallback: without this, if pokes never arrive (relay
+  // env unset, relay down, no active battlemap key) player HP freezes
+  // forever. No document.hidden gating — background operation is the point.
+  useEffect(() => {
+    if (!encounterId) return;
+    const id = setInterval(() => {
+      onPlayersPoke(); // same debounced path — poke+poll coalesce
+    }, FALLBACK_POLL_MS);
+    return () => clearInterval(id);
+  }, [encounterId, onPlayersPoke]);
 
   return { onPlayersPoke };
 }

--- a/src/components/ui/campaign/player-vtt/PlayerVttScreen.hooks.ts
+++ b/src/components/ui/campaign/player-vtt/PlayerVttScreen.hooks.ts
@@ -1,10 +1,11 @@
 'use client';
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { useAutoSave } from '@/hooks/useAutoSave';
 import { useCharacterRosterSync } from '@/hooks/useCharacterRosterSync';
 import { useHydration } from '@/hooks/useHydration';
+import { useLiveInitiative } from '@/hooks/useLiveInitiative';
 import { usePartySync } from '@/hooks/usePartySync';
 import { usePlayerSync } from '@/hooks/usePlayerSync';
 import { useSharedCampaignState } from '@/hooks/useSharedCampaignState';
@@ -13,7 +14,6 @@ import { useCharacterStore } from '@/store/characterStore';
 import { usePlayerStore } from '@/store/playerStore';
 import { ToastData, useToast } from '@/components/ui/feedback/Toast';
 import type { SpellAoe } from '@/types/spellAoe';
-import { overlayLiveHp, type LiveHp } from '@/utils/sharedInitiativeOverlay';
 
 import type { PendingPlacement } from './SpellPlacementController';
 import type { SpellTemplateConfig } from './SpellTemplateTool';
@@ -102,26 +102,11 @@ export function usePlayerVttState(campaignCode: string, characterId: string) {
     campaignCode,
     currentCharacterId: characterId,
   });
-  const liveHp = useMemo(() => {
-    const map: Record<string, LiveHp> = {};
-    for (const member of partyMembers) {
-      if (!member.hitPoints) continue;
-      map[member.characterId] = {
-        current: member.hitPoints.current,
-        max: member.hitPoints.max,
-      };
-    }
-    if (character && character.id === characterId) {
-      map[characterId] = {
-        current: character.hitPoints.current,
-        max: character.hitPoints.max,
-      };
-    }
-    return map;
-  }, [partyMembers, character, characterId]);
-  const liveInitiative = useMemo(
-    () => overlayLiveHp(sharedState?.initiative ?? null, liveHp),
-    [sharedState?.initiative, liveHp]
+  const liveInitiative = useLiveInitiative(
+    sharedState?.initiative ?? null,
+    character,
+    characterId,
+    partyMembers
   );
   const handleEndTurn = useCallback(
     async (entityId: string) => {

--- a/src/components/ui/encounter/EncounterView.tsx
+++ b/src/components/ui/encounter/EncounterView.tsx
@@ -21,6 +21,7 @@ import { useTurnRequestSync } from '@/hooks/useTurnRequestSync';
 import { useInitiativeSubmissionSync } from '@/hooks/useInitiativeSubmissionSync';
 import { useActiveBattleMapId } from '@/hooks/useActiveBattleMapId';
 import { useBattleMapPokes } from '@/hooks/useBattleMapPokes';
+import { useDebouncedRefetch } from '@/hooks/useDebouncedRefetch';
 import { buildSharedInitiative } from '@/utils/buildSharedInitiative';
 import { Button } from '@/components/ui/forms/button';
 import { CombatScreen } from './combat-screen/CombatScreen';
@@ -153,6 +154,11 @@ export function EncounterView({
   // (see useActiveBattleMapId) — only used to pick the poke room below.
   const activeBattleMapId = useActiveBattleMapId(campaignCode);
 
+  // A poke burst (one per party member autosave) must not fan out into an
+  // uncoalesced fetch of the heaviest campaign endpoint per poke — debounce
+  // to a single leading + trailing refresh per window.
+  const refreshPlayersDebounced = useDebouncedRefetch(refreshPlayers);
+
   // Best-effort relay listener: a 'players' poke shaves latency off the
   // next player-HP refresh instead of waiting on the 15s poll. 'initiative'
   // pokes are ignored — EncounterView authors initiative, it doesn't
@@ -161,7 +167,7 @@ export function EncounterView({
     campaignCode,
     battleMapId: activeBattleMapId,
     tokenRequest: dmId ? { role: 'dm', dmId } : null,
-    onPoke: feature => handleEncounterPoke(feature, refreshPlayers),
+    onPoke: feature => handleEncounterPoke(feature, refreshPlayersDebounced),
   });
 
   const mappedPlayers = campaignPlayers.map(p => ({

--- a/src/components/ui/encounter/EncounterView.tsx
+++ b/src/components/ui/encounter/EncounterView.tsx
@@ -19,6 +19,8 @@ import { useDmCounterSync } from '@/hooks/useDmCounterSync';
 import { useDmInitiativeSync } from '@/hooks/useDmInitiativeSync';
 import { useTurnRequestSync } from '@/hooks/useTurnRequestSync';
 import { useInitiativeSubmissionSync } from '@/hooks/useInitiativeSubmissionSync';
+import { useActiveBattleMapId } from '@/hooks/useActiveBattleMapId';
+import { useBattleMapPokes } from '@/hooks/useBattleMapPokes';
 import { buildSharedInitiative } from '@/utils/buildSharedInitiative';
 import { Button } from '@/components/ui/forms/button';
 import { CombatScreen } from './combat-screen/CombatScreen';
@@ -35,6 +37,20 @@ import type { CampaignNPC } from '@/types/encounter';
 interface EncounterViewProps {
   encounterId: string;
   campaignCode: string;
+}
+
+/**
+ * `useBattleMapPokes` onPoke handler, extracted so the wiring is unit
+ * testable without a full `EncounterView` render harness. EncounterView is
+ * the initiative author for its own encounters, so 'initiative' pokes are
+ * ignored here — only a 'players' poke (DM battle-map activity nudging
+ * player HP/state) triggers an immediate campaign-sync refresh.
+ */
+export function handleEncounterPoke(
+  feature: string,
+  refresh: () => void
+): void {
+  if (feature === 'players') refresh();
 }
 
 export function EncounterView({
@@ -123,12 +139,29 @@ export function EncounterView({
     pushInitiative,
   ]);
 
-  const { players: campaignPlayers } = useCampaignSync({
-    code: campaignCode,
-    dmId,
-    campaignName: campaign?.name ?? 'Campaign',
-    createdAt: campaign?.createdAt ?? new Date().toISOString(),
-    interval: 15000,
+  const { players: campaignPlayers, refresh: refreshPlayers } = useCampaignSync(
+    {
+      code: campaignCode,
+      dmId,
+      campaignName: campaign?.name ?? 'Campaign',
+      createdAt: campaign?.createdAt ?? new Date().toISOString(),
+      interval: 15000,
+    }
+  );
+
+  // Slow-poll discovery of which battle map is currently live to players
+  // (see useActiveBattleMapId) — only used to pick the poke room below.
+  const activeBattleMapId = useActiveBattleMapId(campaignCode);
+
+  // Best-effort relay listener: a 'players' poke shaves latency off the
+  // next player-HP refresh instead of waiting on the 15s poll. 'initiative'
+  // pokes are ignored — EncounterView authors initiative, it doesn't
+  // consume it.
+  useBattleMapPokes({
+    campaignCode,
+    battleMapId: activeBattleMapId,
+    tokenRequest: dmId ? { role: 'dm', dmId } : null,
+    onPoke: feature => handleEncounterPoke(feature, refreshPlayers),
   });
 
   const mappedPlayers = campaignPlayers.map(p => ({

--- a/src/components/ui/encounter/__tests__/handleEncounterPoke.test.ts
+++ b/src/components/ui/encounter/__tests__/handleEncounterPoke.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { handleEncounterPoke } from '../EncounterView';
+
+describe('handleEncounterPoke', () => {
+  it('calls refresh on a players poke', () => {
+    const refresh = vi.fn();
+    handleEncounterPoke('players', refresh);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores an initiative poke — EncounterView authors initiative', () => {
+    const refresh = vi.fn();
+    handleEncounterPoke('initiative', refresh);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('ignores unknown feature strings', () => {
+    const refresh = vi.fn();
+    handleEncounterPoke('something-else', refresh);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/encounter/__tests__/handleEncounterPoke.test.ts
+++ b/src/components/ui/encounter/__tests__/handleEncounterPoke.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
 
 import { handleEncounterPoke } from '../EncounterView';
+import { useDebouncedRefetch } from '@/hooks/useDebouncedRefetch';
 
 describe('handleEncounterPoke', () => {
   it('calls refresh on a players poke', () => {
@@ -19,5 +21,36 @@ describe('handleEncounterPoke', () => {
     const refresh = vi.fn();
     handleEncounterPoke('something-else', refresh);
     expect(refresh).not.toHaveBeenCalled();
+  });
+});
+
+// EncounterView routes the 'players' poke through
+// `useDebouncedRefetch(refreshPlayers)` before handleEncounterPoke — a burst
+// of pokes (one per party member autosave) must coalesce into a single
+// immediate underlying refresh plus one trailing refresh at window expiry,
+// not one uncoalesced fetch per poke.
+describe('EncounterView poke wiring (debounced path)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('a burst of two players pokes yields one immediate underlying call and one trailing call after 1s', () => {
+    const refresh = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(refresh));
+
+    act(() => {
+      handleEncounterPoke('players', result.current);
+      handleEncounterPoke('players', result.current);
+    });
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(refresh).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/hooks/__tests__/useActiveBattleMapId.test.ts
+++ b/src/hooks/__tests__/useActiveBattleMapId.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useActiveBattleMapId } from '@/hooks/useActiveBattleMapId';
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body));
+}
+
+describe('useActiveBattleMapId', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn(async () =>
+      jsonResponse({ battleMap: { activeBattleMapId: 'map-1' } })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches on mount and returns the active id', async () => {
+    const { result, unmount } = renderHook(() => useActiveBattleMapId('CAMP1'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      '/api/campaign/CAMP1/shared?role=dm'
+    );
+    expect(result.current).toBe('map-1');
+    unmount();
+  });
+
+  it('refetches every 60s', async () => {
+    const { result, unmount } = renderHook(() => useActiveBattleMapId('CAMP1'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockImplementationOnce(async () =>
+      jsonResponse({ battleMap: { activeBattleMapId: 'map-2' } })
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current).toBe('map-2');
+    unmount();
+  });
+
+  it('refetches immediately when the tab becomes visible', async () => {
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => false,
+    });
+
+    const { unmount } = renderHook(() => useActiveBattleMapId('CAMP1'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it('does not fetch when the tab is hidden on visibilitychange', async () => {
+    const { unmount } = renderHook(() => useActiveBattleMapId('CAMP1'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => true,
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('is a no-op when campaignCode is null', async () => {
+    const { result, unmount } = renderHook(() => useActiveBattleMapId(null));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current).toBeNull();
+    unmount();
+  });
+
+  it('keeps the last known id on fetch failure', async () => {
+    const { result, unmount } = renderHook(() => useActiveBattleMapId('CAMP1'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current).toBe('map-1');
+
+    fetchMock.mockImplementationOnce(async () => {
+      throw new Error('network down');
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current).toBe('map-1');
+    unmount();
+  });
+
+  it('treats a non-ok response like a silent failure, keeping the last id', async () => {
+    const { result, unmount } = renderHook(() => useActiveBattleMapId('CAMP1'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current).toBe('map-1');
+
+    fetchMock.mockImplementationOnce(
+      async () => new Response('error', { status: 500 })
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current).toBe('map-1');
+    unmount();
+  });
+});

--- a/src/hooks/__tests__/useBattleMapPokes.test.ts
+++ b/src/hooks/__tests__/useBattleMapPokes.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useBattleMapPokes } from '@/hooks/useBattleMapPokes';
+import { createBattleMapPokeListener } from '@/lib/battlemapPokeListener';
+
+vi.mock('@/lib/battlemapPokeListener', () => ({
+  createBattleMapPokeListener: vi.fn(),
+}));
+
+const mockCreateListener = vi.mocked(createBattleMapPokeListener);
+
+type Props = Parameters<typeof useBattleMapPokes>[0];
+
+function makeProps(overrides: Partial<Props> = {}): Props {
+  return {
+    campaignCode: 'ABCD',
+    battleMapId: 'map-1',
+    tokenRequest: { role: 'player', playerId: 'char-1' },
+    onPoke: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('useBattleMapPokes', () => {
+  beforeEach(() => {
+    mockCreateListener.mockReset();
+  });
+
+  it('starts the listener once all params are non-null, with the right options', () => {
+    const stop = vi.fn();
+    mockCreateListener.mockReturnValue(stop);
+    const props = makeProps();
+
+    renderHook(p => useBattleMapPokes(p), { initialProps: props });
+
+    expect(mockCreateListener).toHaveBeenCalledTimes(1);
+    const opts = mockCreateListener.mock.calls[0][0];
+    expect(opts.campaignCode).toBe('ABCD');
+    expect(opts.battleMapId).toBe('map-1');
+    expect(opts.tokenRequest).toEqual({ role: 'player', playerId: 'char-1' });
+    expect(typeof opts.onPoke).toBe('function');
+  });
+
+  it('never creates a listener when battleMapId is null', () => {
+    const props = makeProps({ battleMapId: null });
+
+    renderHook(p => useBattleMapPokes(p), { initialProps: props });
+
+    expect(mockCreateListener).not.toHaveBeenCalled();
+  });
+
+  it('stops the old listener and starts a new one when battleMapId changes', () => {
+    const stop1 = vi.fn();
+    const stop2 = vi.fn();
+    mockCreateListener.mockReturnValueOnce(stop1).mockReturnValueOnce(stop2);
+    const props = makeProps();
+
+    const { rerender } = renderHook(p => useBattleMapPokes(p), {
+      initialProps: props,
+    });
+    expect(mockCreateListener).toHaveBeenCalledTimes(1);
+
+    rerender({ ...props, battleMapId: 'map-2' });
+
+    expect(stop1).toHaveBeenCalledTimes(1);
+    expect(mockCreateListener).toHaveBeenCalledTimes(2);
+    expect(mockCreateListener.mock.calls[1][0].battleMapId).toBe('map-2');
+    expect(stop2).not.toHaveBeenCalled();
+  });
+
+  it('stops the listener on unmount', () => {
+    const stop = vi.fn();
+    mockCreateListener.mockReturnValue(stop);
+    const props = makeProps();
+
+    const { unmount } = renderHook(p => useBattleMapPokes(p), {
+      initialProps: props,
+    });
+    unmount();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not rebuild on onPoke identity change, but pokes reach the newest callback (latest-ref pin)', () => {
+    const stop = vi.fn();
+    mockCreateListener.mockReturnValue(stop);
+    const onPokeFirst = vi.fn();
+    const props = makeProps({ onPoke: onPokeFirst });
+
+    const { rerender } = renderHook(p => useBattleMapPokes(p), {
+      initialProps: props,
+    });
+    expect(mockCreateListener).toHaveBeenCalledTimes(1);
+
+    const onPokeSecond = vi.fn();
+    rerender({ ...props, onPoke: onPokeSecond });
+
+    // No rebuild: still just the one call, no new stop.
+    expect(mockCreateListener).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+
+    // Firing the poke callback captured at creation time must reach the
+    // LATEST onPoke, not the one that was live when the listener was built.
+    const capturedOnPoke = mockCreateListener.mock.calls[0][0].onPoke;
+    capturedOnPoke('initiative');
+
+    expect(onPokeFirst).not.toHaveBeenCalled();
+    expect(onPokeSecond).toHaveBeenCalledWith('initiative');
+  });
+});

--- a/src/hooks/__tests__/useDebouncedRefetch.test.ts
+++ b/src/hooks/__tests__/useDebouncedRefetch.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useDebouncedRefetch } from '../useDebouncedRefetch';
+
+describe('useDebouncedRefetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires the first call immediately (leading edge)', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(fn));
+
+    act(() => {
+      result.current();
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces a burst inside the window into one trailing call at expiry', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(fn));
+
+    act(() => {
+      result.current(); // leading
+      result.current(); // inside window -> schedules trailing
+      result.current(); // inside window -> coalesces onto same trailing
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    // no further stray fetch from a stacked/duplicate timeout
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('reopens the window after expiry — the next call fires immediately again', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(fn));
+
+    act(() => {
+      result.current();
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current();
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears a pending trailing call on unmount', () => {
+    const fn = vi.fn();
+    const { result, unmount } = renderHook(() => useDebouncedRefetch(fn));
+
+    act(() => {
+      result.current(); // leading
+      result.current(); // schedules trailing
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors a custom windowMs', () => {
+    const fn = vi.fn();
+    const { result } = renderHook(() => useDebouncedRefetch(fn, 500));
+
+    act(() => {
+      result.current(); // leading
+      result.current(); // schedules trailing at +500ms
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('trailing call invokes the latest fn identity, not the one captured at call time', () => {
+    const fnA = vi.fn();
+    const fnB = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ fn }) => useDebouncedRefetch(fn),
+      { initialProps: { fn: fnA } }
+    );
+
+    act(() => {
+      result.current(); // leading -> calls fnA
+      result.current(); // schedules trailing
+    });
+    expect(fnA).toHaveBeenCalledTimes(1);
+
+    // swap fn identity mid-window (e.g. a fresh closure from re-render)
+    rerender({ fn: fnB });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // the trailing call must invoke the NEW fn, not the stale fnA
+    expect(fnA).toHaveBeenCalledTimes(1);
+    expect(fnB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/useLiveInitiative.test.ts
+++ b/src/hooks/__tests__/useLiveInitiative.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useLiveInitiative } from '@/hooks/useLiveInitiative';
+import type { PartyMemberHP } from '@/app/api/campaign/[code]/party-hp/route';
+import type { CharacterState } from '@/types/character';
+import type { SharedInitiativeState } from '@/types/sharedState';
+
+const SELF_ID = 'char-self';
+const OTHER_ID = 'char-other';
+
+function makeInitiative(
+  overrides: Partial<SharedInitiativeState> = {}
+): SharedInitiativeState {
+  return {
+    encounterId: 'enc-1',
+    isActive: true,
+    round: 1,
+    currentEntityId: null,
+    turnOrder: [
+      {
+        entityId: 'entity-self',
+        displayName: 'Hero',
+        type: 'player',
+        playerCharacterId: SELF_ID,
+        currentHp: 44,
+        maxHp: 44,
+      },
+      {
+        entityId: 'entity-other',
+        displayName: 'Gandalf',
+        type: 'player',
+        playerCharacterId: OTHER_ID,
+        currentHp: 60,
+        maxHp: 80,
+      },
+    ],
+    enemyHpMode: 'off',
+    enemyConditionsMode: 'off',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeCharacter(
+  overrides: Partial<CharacterState> = {}
+): CharacterState {
+  return {
+    id: SELF_ID,
+    hitPoints: {
+      current: 5,
+      max: 44,
+      temporary: 0,
+      calculationMode: 'manual',
+    },
+    ...overrides,
+  } as CharacterState;
+}
+
+function makePartyMember(
+  overrides: Partial<PartyMemberHP> = {}
+): PartyMemberHP {
+  return {
+    characterId: OTHER_ID,
+    characterName: 'Gandalf',
+    playerName: 'Player One',
+    className: 'Wizard',
+    level: 10,
+    armorClass: 13,
+    hitPoints: { current: 12, max: 80, temporary: 0 },
+    lastSynced: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('useLiveInitiative', () => {
+  it('overlays own character HP instantly', () => {
+    const initiative = makeInitiative();
+    const character = makeCharacter();
+    const { result } = renderHook(() =>
+      useLiveInitiative(initiative, character, SELF_ID, [])
+    );
+
+    const selfEntry = result.current!.turnOrder.find(
+      e => e.entityId === 'entity-self'
+    );
+    expect(selfEntry?.currentHp).toBe(5);
+    expect(selfEntry?.maxHp).toBe(44);
+  });
+
+  it('overlays party member HP', () => {
+    const initiative = makeInitiative();
+    const { result } = renderHook(() =>
+      useLiveInitiative(initiative, null, SELF_ID, [makePartyMember()])
+    );
+
+    const otherEntry = result.current!.turnOrder.find(
+      e => e.entityId === 'entity-other'
+    );
+    expect(otherEntry?.currentHp).toBe(12);
+    expect(otherEntry?.maxHp).toBe(80);
+  });
+
+  it('skips a party member with null hitPoints — entry HP passes through', () => {
+    const initiative = makeInitiative();
+    const member = makePartyMember({
+      hitPoints: null as unknown as PartyMemberHP['hitPoints'],
+    });
+    const { result } = renderHook(() =>
+      useLiveInitiative(initiative, null, SELF_ID, [member])
+    );
+
+    const otherEntry = result.current!.turnOrder.find(
+      e => e.entityId === 'entity-other'
+    );
+    expect(otherEntry?.currentHp).toBe(60);
+    expect(otherEntry?.maxHp).toBe(80);
+  });
+
+  it('does not apply own-character overlay when the character id does not match characterId', () => {
+    const initiative = makeInitiative();
+    const character = makeCharacter({ id: 'some-other-id' });
+    const { result } = renderHook(() =>
+      useLiveInitiative(initiative, character, SELF_ID, [])
+    );
+
+    const selfEntry = result.current!.turnOrder.find(
+      e => e.entityId === 'entity-self'
+    );
+    expect(selfEntry?.currentHp).toBe(44);
+    expect(selfEntry?.maxHp).toBe(44);
+  });
+
+  it('returns null when sharedInitiative is null', () => {
+    const { result } = renderHook(() =>
+      useLiveInitiative(null, makeCharacter(), SELF_ID, [])
+    );
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/hooks/useActiveBattleMapId.ts
+++ b/src/hooks/useActiveBattleMapId.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { SharedCampaignState } from '@/types/sharedState';
+
+const POLL_INTERVAL_MS = 60_000;
+
+/**
+ * Discovers which battle map is currently active (shared live with
+ * players) for a campaign, by slow-polling the shared-state endpoint from
+ * the DM side.
+ *
+ * This is deliberately NOT the same as `useSharedCampaignState` /
+ * `useBattleMapPokes`'s data-freshness guarantee — this hook only exists to
+ * learn *which room to poke-listen on* (`battleMapId`). The actual
+ * low-latency data (player HP, initiative, etc.) arrives via the poke
+ * listener itself once the room is known; a battle map is normally
+ * activated well before combat starts, so a 60s discovery latency here is
+ * acceptable. Silent on failure — keeps the last known id and lets the next
+ * tick retry.
+ *
+ * `GET /api/campaign/[code]/shared` has no DM-authority check for reads
+ * (it's keyed only by campaign code); `role=dm` is sent for semantic
+ * correctness, matching the DM identity that owns this page, even though
+ * the route does not require a `dmId` for GET.
+ */
+export function useActiveBattleMapId(
+  campaignCode: string | null
+): string | null {
+  const [activeBattleMapId, setActiveBattleMapId] = useState<string | null>(
+    null
+  );
+  const mountedRef = useRef(true);
+
+  const fetchActiveId = useCallback(async () => {
+    if (!campaignCode) return;
+    try {
+      const res = await fetch(`/api/campaign/${campaignCode}/shared?role=dm`);
+      if (!res.ok) return;
+      const data: SharedCampaignState = await res.json();
+      if (!mountedRef.current) return;
+      setActiveBattleMapId(data.battleMap?.activeBattleMapId ?? null);
+    } catch {
+      // Silent failure — keep last known id; polling/visibility will retry.
+    }
+  }, [campaignCode]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (!campaignCode) {
+      setActiveBattleMapId(null);
+      return;
+    }
+
+    fetchActiveId();
+    const intervalId = setInterval(fetchActiveId, POLL_INTERVAL_MS);
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) fetchActiveId();
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      mountedRef.current = false;
+      clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [campaignCode, fetchActiveId]);
+
+  return activeBattleMapId;
+}

--- a/src/hooks/useBattleMapPokes.ts
+++ b/src/hooks/useBattleMapPokes.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+
+import {
+  createBattleMapPokeListener,
+  type PokeListenerOptions,
+} from '@/lib/battlemapPokeListener';
+
+export interface UseBattleMapPokesOptions {
+  campaignCode: string | null;
+  battleMapId: string | null;
+  tokenRequest: PokeListenerOptions['tokenRequest'] | null;
+  onPoke: (feature: string) => void;
+}
+
+/**
+ * Mounts a read-only `createBattleMapPokeListener` for non-canvas pages (the
+ * character sheet, party HP sidebar, etc.) so a DM poke shaves latency off
+ * the next initiative/party-HP refetch instead of waiting on the poll
+ * interval. Starts only once `campaignCode`, `battleMapId`, and
+ * `tokenRequest` are all non-null; stops on unmount or whenever
+ * `campaignCode`/`battleMapId`/the token identity changes.
+ *
+ * `onPoke` is read via a latest-value ref (the established house pattern —
+ * see `DmBattleMapCanvas.hooks.ts` / `PlayerBattleMapCanvas`): a plain
+ * closure would go stale after the listener is created, but rebuilding the
+ * socket on every `onPoke` identity change (e.g. an inline arrow prop) would
+ * churn the connection for no reason.
+ */
+export function useBattleMapPokes({
+  campaignCode,
+  battleMapId,
+  tokenRequest,
+  onPoke,
+}: UseBattleMapPokesOptions): void {
+  const onPokeRef = useRef(onPoke);
+  onPokeRef.current = onPoke;
+
+  // Only primitives that identify "which token" go in the dep array — the
+  // tokenRequest object's reference identity is not stable across renders.
+  const tokenRole = tokenRequest?.role ?? null;
+  const tokenSubjectId =
+    tokenRequest?.role === 'player'
+      ? tokenRequest.playerId
+      : tokenRequest?.role === 'dm'
+        ? tokenRequest.dmId
+        : null;
+
+  useEffect(() => {
+    if (!campaignCode || !battleMapId || !tokenRequest) return;
+
+    const stop = createBattleMapPokeListener({
+      campaignCode,
+      battleMapId,
+      tokenRequest,
+      onPoke: feature => onPokeRef.current(feature),
+    });
+
+    return () => stop();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [campaignCode, battleMapId, tokenRole, tokenSubjectId]);
+}

--- a/src/hooks/useCharacterRosterSync.ts
+++ b/src/hooks/useCharacterRosterSync.ts
@@ -105,6 +105,11 @@ export function useCharacterRosterSync({
         // Create a deep copy to avoid reference issues
         const characterCopy = JSON.parse(JSON.stringify(character));
         updateCharacterData(characterId, characterCopy);
+        // `updateCharacterData` may refuse a stale-revision write, so this
+        // ref only records what THIS tab attempted, not confirmed roster
+        // state. That's benign: the live characterStore state (which the
+        // storage listener keeps fresh) is what other consumers converge
+        // on, not this ref.
         lastSyncedCharacterRef.current = characterCopy;
       }
     }

--- a/src/hooks/useDebouncedRefetch.ts
+++ b/src/hooks/useDebouncedRefetch.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const DEFAULT_WINDOW_MS = 1000;
+
+/**
+ * Generic leading+trailing debounce for refetch-style callbacks (e.g. relay
+ * poke handlers fanning out to a heavy fetch). Mirrors the semantics of
+ * `useDmVttPlayersRefresh`'s debounce: the first call in a window fires
+ * `fn` immediately (leading edge); any call landing inside the window
+ * coalesces into exactly ONE trailing call fired at window expiry instead
+ * of being dropped — otherwise the last call of a burst (e.g. one poke per
+ * party member autosave) would leave state stale until the next poll. A
+ * latest-value ref on `fn` ensures the trailing call always invokes the
+ * most recent callback identity, even if it changes mid-window. Pending
+ * timeout is cleared on unmount.
+ */
+export function useDebouncedRefetch(
+  fn: () => void,
+  windowMs: number = DEFAULT_WINDOW_MS
+): () => void {
+  const fnRef = useRef(fn);
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
+
+  const lastFireRef = useRef(0);
+  const trailingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const trigger = useCallback(() => {
+    const now = Date.now();
+    const elapsed = now - lastFireRef.current;
+    if (elapsed >= windowMs) {
+      lastFireRef.current = now;
+      fnRef.current();
+      return;
+    }
+    if (trailingTimeoutRef.current) return;
+    trailingTimeoutRef.current = setTimeout(() => {
+      trailingTimeoutRef.current = null;
+      lastFireRef.current = Date.now();
+      fnRef.current();
+    }, windowMs - elapsed);
+  }, [windowMs]);
+
+  useEffect(() => {
+    return () => {
+      if (trailingTimeoutRef.current) {
+        clearTimeout(trailingTimeoutRef.current);
+        trailingTimeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  return trigger;
+}

--- a/src/hooks/useLiveInitiative.ts
+++ b/src/hooks/useLiveInitiative.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import type { PartyMemberHP } from '@/app/api/campaign/[code]/party-hp/route';
+import type { CharacterState } from '@/types/character';
+import type { SharedInitiativeState } from '@/types/sharedState';
+import { overlayLiveHp, type LiveHp } from '@/utils/sharedInitiativeOverlay';
+
+/**
+ * Overlays live player HP (own characterStore + poke-fresh party-hp data)
+ * onto a DM-published initiative snapshot, so player-row HP does not wait on
+ * the DM tab's poll -> merge -> push round trip. Shared between the player
+ * VTT screen and the character sheet's InitiativePanel — see
+ * `overlayLiveHp` for the privacy invariant (only player rows with a
+ * `playerCharacterId` are touched).
+ */
+export function useLiveInitiative(
+  sharedInitiative: SharedInitiativeState | null,
+  character: CharacterState | null | undefined,
+  characterId: string,
+  partyMembers: PartyMemberHP[]
+): SharedInitiativeState | null {
+  const liveHp = useMemo(() => {
+    const map: Record<string, LiveHp> = {};
+    for (const member of partyMembers) {
+      if (!member.hitPoints) continue;
+      map[member.characterId] = {
+        current: member.hitPoints.current,
+        max: member.hitPoints.max,
+      };
+    }
+    if (character && character.id === characterId) {
+      map[characterId] = {
+        current: character.hitPoints.current,
+        max: character.hitPoints.max,
+      };
+    }
+    return map;
+  }, [partyMembers, character, characterId]);
+
+  return useMemo(
+    () => overlayLiveHp(sharedInitiative, liveHp),
+    [sharedInitiative, liveHp]
+  );
+}

--- a/src/lib/__tests__/battlemapPokeListener.test.ts
+++ b/src/lib/__tests__/battlemapPokeListener.test.ts
@@ -266,4 +266,100 @@ describe('createBattleMapPokeListener', () => {
 
     stop();
   });
+
+  it('8. backoff keeps escalating across repeated fatal closes when no message is ever received (open alone must not reset it)', async () => {
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockMint).toHaveBeenCalledTimes(1);
+
+    // cycle 1: open, never a message, fatal close -> next retry after 1s
+    FakeWebSocket.instances[0].triggerOpen();
+    FakeWebSocket.instances[0].triggerClose(4401);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    // cycle 2: same story -> next retry after 2s (escalated, not reset to 1s)
+    FakeWebSocket.instances[1].triggerOpen();
+    FakeWebSocket.instances[1].triggerClose(4401);
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+
+    // cycle 3: -> next retry after 4s (still escalating)
+    FakeWebSocket.instances[2].triggerOpen();
+    FakeWebSocket.instances[2].triggerClose(4401);
+    await vi.advanceTimersByTimeAsync(3999);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(FakeWebSocket.instances).toHaveLength(4);
+
+    stop();
+  });
+
+  it('9. a received message resets backoff so the next close retries after 1s again', async () => {
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // cycle 1: no message, fatal close -> escalates attempt (next delay would be 2s)
+    FakeWebSocket.instances[0].triggerOpen();
+    FakeWebSocket.instances[0].triggerClose(4401);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    // cycle 2: this time a message arrives -> proves the room is live, resets backoff
+    FakeWebSocket.instances[1].triggerOpen();
+    FakeWebSocket.instances[1].triggerMessage(pokeEnvelope('players'));
+    FakeWebSocket.instances[1].triggerClose(4401);
+
+    // if backoff had NOT reset, the next delay would be 4s; it should be 1s
+    await vi.advanceTimersByTimeAsync(999);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+
+    stop();
+  });
+
+  it('10. a proactive rebuild firing while a connect is still awaiting its token mint yields exactly one live socket', async () => {
+    mockMint.mockReset();
+    let resolveFirst!: (token: string | null) => void;
+    let resolveSecond!: (token: string | null) => void;
+    const firstMint = new Promise<string | null>(res => {
+      resolveFirst = res;
+    });
+    const secondMint = new Promise<string | null>(res => {
+      resolveSecond = res;
+    });
+    mockMint.mockImplementationOnce(() => firstMint);
+    mockMint.mockImplementationOnce(() => secondMint);
+
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    // initial connect() is in flight, awaiting firstMint — never resolved yet
+    await vi.advanceTimersByTimeAsync(0);
+    expect(FakeWebSocket.instances).toHaveLength(0);
+
+    // proactive rebuild fires before the first mint resolves, starting a
+    // second connect() (awaiting secondMint) concurrently
+    await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+    expect(mockMint).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances).toHaveLength(0);
+
+    // resolve the stale (first) mint after it has been superseded, then the
+    // fresh (second) one
+    resolveFirst('tok-stale');
+    await vi.advanceTimersByTimeAsync(0);
+    resolveSecond('tok-fresh');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0].url).toContain('token=tok-fresh');
+
+    stop();
+  });
 });

--- a/src/lib/__tests__/battlemapPokeListener.test.ts
+++ b/src/lib/__tests__/battlemapPokeListener.test.ts
@@ -234,7 +234,7 @@ describe('createBattleMapPokeListener', () => {
     expect(mockMint).toHaveBeenCalledTimes(1);
   });
 
-  it('7. missing relay URL schedules a retry with backoff and never throws', async () => {
+  it('7. missing relay URL at creation returns a no-op listener — no timers, no mint, ever', async () => {
     delete process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
     const opts = baseOpts();
     const stop = createBattleMapPokeListener(opts);
@@ -243,12 +243,19 @@ describe('createBattleMapPokeListener', () => {
     expect(mockMint).not.toHaveBeenCalled();
     expect(FakeWebSocket.instances).toHaveLength(0);
 
-    process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL = 'wss://relay.example';
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(mockMint).toHaveBeenCalledTimes(1);
-    expect(FakeWebSocket.instances).toHaveLength(1);
+    // NEXT_PUBLIC_* is build-time inlined — it can never appear at runtime,
+    // so no retry should ever be scheduled, no matter how long we wait, even
+    // if the var is (unrealistically) set afterward.
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+    expect(mockMint).not.toHaveBeenCalled();
+    expect(FakeWebSocket.instances).toHaveLength(0);
 
-    stop();
+    process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL = 'wss://relay.example';
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+    expect(mockMint).not.toHaveBeenCalled();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+
+    expect(() => stop()).not.toThrow();
   });
 
   it('7b. a token-mint failure schedules a retry with backoff and never throws', async () => {

--- a/src/lib/__tests__/battlemapPokeListener.test.ts
+++ b/src/lib/__tests__/battlemapPokeListener.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { createBattleMapPokeListener } from '@/lib/battlemapPokeListener';
+
+vi.mock('@/lib/battlemapSync', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/battlemapSync')>();
+  return {
+    ...actual,
+    mintBattleMapToken: vi.fn(),
+  };
+});
+
+import { mintBattleMapToken } from '@/lib/battlemapSync';
+
+const mockMint = vi.mocked(mintBattleMapToken);
+
+const pokeEnvelope = (feature: string): string =>
+  JSON.stringify({
+    from: '@poke',
+    op: { kind: 'presence', data: { kind: 'poke', feature } },
+  });
+
+const snapshotEnvelope = (): string =>
+  JSON.stringify({
+    from: 'hub',
+    op: { kind: 'snapshot', to: 'char-1', elements: [] },
+  });
+
+const upsertEnvelope = (): string =>
+  JSON.stringify({
+    from: 'peer',
+    op: { kind: 'upsert', element: { id: 'x' } },
+  });
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  url: string;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: ((event: { code: number; reason?: string }) => void) | null = null;
+  sent: string[] = [];
+  closeCalls = 0;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.closeCalls += 1;
+  }
+  triggerOpen(): void {
+    this.onopen?.();
+  }
+  triggerMessage(data: string): void {
+    this.onmessage?.({ data });
+  }
+  triggerClose(code: number, reason = ''): void {
+    this.onclose?.({ code, reason });
+  }
+}
+
+describe('createBattleMapPokeListener', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+    process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL = 'wss://relay.example';
+    mockMint.mockReset();
+    mockMint.mockResolvedValue('tok-1');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    delete process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
+  });
+
+  const baseOpts = () => ({
+    campaignCode: 'CODE',
+    battleMapId: 'map-1',
+    tokenRequest: { role: 'player' as const, playerId: 'char-1' },
+    onPoke: vi.fn(),
+  });
+
+  it('1. mints a token, opens the ws url, surfaces pokes and ignores everything else', async () => {
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockMint).toHaveBeenCalledWith('CODE', {
+      role: 'player',
+      playerId: 'char-1',
+      battleMapId: 'map-1',
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    const ws = FakeWebSocket.instances[0];
+    expect(ws.url).toBe('wss://relay.example?room=CODE%3Amap-1&token=tok-1');
+
+    ws.triggerMessage(pokeEnvelope('players'));
+    expect(opts.onPoke).toHaveBeenCalledWith('players');
+
+    opts.onPoke.mockClear();
+    ws.triggerMessage(snapshotEnvelope());
+    ws.triggerMessage(upsertEnvelope());
+    ws.triggerMessage('not json');
+    expect(opts.onPoke).not.toHaveBeenCalled();
+
+    stop();
+  });
+
+  it('2. never calls socket.send', async () => {
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+    const ws = FakeWebSocket.instances[0];
+
+    ws.triggerMessage(pokeEnvelope('initiative'));
+    expect(ws.sent).toHaveLength(0);
+
+    stop();
+  });
+
+  it('3. transient close retries same token once after 1s, then fresh token after 2s', async () => {
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockMint).toHaveBeenCalledTimes(1);
+
+    const ws1 = FakeWebSocket.instances[0];
+    ws1.triggerClose(1006);
+
+    // not yet due
+    await vi.advanceTimersByTimeAsync(999);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(mockMint).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    // same-token retry: no new mint call, same url
+    expect(mockMint).toHaveBeenCalledTimes(1);
+    expect(FakeWebSocket.instances[1].url).toBe(ws1.url);
+
+    mockMint.mockResolvedValue('tok-2');
+    const ws2 = FakeWebSocket.instances[1];
+    ws2.triggerClose(1006);
+
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+    // second consecutive transient close -> fresh token minted
+    expect(mockMint).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances[2].url).toContain('token=tok-2');
+
+    stop();
+  });
+
+  it('4. fatal close (4401 token expiry) mints a fresh token and reconnects', async () => {
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockMint).toHaveBeenCalledTimes(1);
+
+    mockMint.mockResolvedValue('tok-2');
+    FakeWebSocket.instances[0].triggerClose(4401);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(mockMint).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(FakeWebSocket.instances[1].url).toContain('token=tok-2');
+
+    stop();
+  });
+
+  it('4b. other fatal codes in the 4000-4999 range also force a fresh token', async () => {
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+
+    mockMint.mockResolvedValue('tok-2');
+    FakeWebSocket.instances[0].triggerClose(4000);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(mockMint).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    stop();
+  });
+
+  it('5. proactively rebuilds the connection every 4 minutes', async () => {
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockMint).toHaveBeenCalledTimes(1);
+    const ws1 = FakeWebSocket.instances[0];
+
+    mockMint.mockResolvedValue('tok-refreshed');
+    await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+
+    expect(ws1.closeCalls).toBe(1);
+    expect(mockMint).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(FakeWebSocket.instances[1].url).toContain('token=tok-refreshed');
+
+    stop();
+  });
+
+  it('6. stop() closes the live socket and is safe to call twice', async () => {
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+    const ws = FakeWebSocket.instances[0];
+
+    stop();
+    expect(ws.closeCalls).toBe(1);
+    expect(() => stop()).not.toThrow();
+  });
+
+  it('6b. stop() clears pending timers and suppresses reconnects', async () => {
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+    const ws = FakeWebSocket.instances[0];
+
+    ws.triggerClose(1006); // schedule a same-token retry in 1s
+    stop();
+
+    // no reconnect after stop, even once the pending backoff/refresh would fire
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(mockMint).toHaveBeenCalledTimes(1);
+  });
+
+  it('7. missing relay URL schedules a retry with backoff and never throws', async () => {
+    delete process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockMint).not.toHaveBeenCalled();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+
+    process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL = 'wss://relay.example';
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(mockMint).toHaveBeenCalledTimes(1);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    stop();
+  });
+
+  it('7b. a token-mint failure schedules a retry with backoff and never throws', async () => {
+    mockMint.mockResolvedValueOnce(null);
+    const opts = baseOpts();
+    const stop = createBattleMapPokeListener(opts);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    mockMint.mockResolvedValue('tok-1');
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(mockMint).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    stop();
+  });
+});

--- a/src/lib/battlemapPokeListener.ts
+++ b/src/lib/battlemapPokeListener.ts
@@ -28,6 +28,14 @@ const PROACTIVE_REFRESH_MS = 4 * 60 * 1000;
 export function createBattleMapPokeListener(
   opts: PokeListenerOptions
 ): () => void {
+  // NEXT_PUBLIC_* env vars are inlined at build time, so if this is absent
+  // now it can never become available at runtime — retrying for it would
+  // just be a pointless perpetual backoff loop. No-op immediately instead.
+  const relayUrl = process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
+  if (!relayUrl) {
+    return () => {};
+  }
+
   let stopped = false;
   let socket: WebSocket | null = null;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -111,11 +119,6 @@ export function createBattleMapPokeListener(
     connecting = true;
     const myGeneration = generation;
     try {
-      const relayUrl = process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
-      if (!relayUrl) {
-        scheduleRetry(() => void connect());
-        return;
-      }
       const token = await mintBattleMapToken(opts.campaignCode, {
         ...opts.tokenRequest,
         battleMapId: opts.battleMapId,
@@ -130,7 +133,10 @@ export function createBattleMapPokeListener(
       const url = `${relayUrl}?room=${encodeURIComponent(room)}&token=${encodeURIComponent(token)}`;
       openSocket(url);
     } finally {
-      connecting = false;
+      // A stale, superseded attempt (generation bumped by rebuild() while
+      // this one was still awaiting its mint) must not clear the flag for
+      // its successor, which may still be genuinely in-flight.
+      if (myGeneration === generation) connecting = false;
     }
   };
 

--- a/src/lib/battlemapPokeListener.ts
+++ b/src/lib/battlemapPokeListener.ts
@@ -1,0 +1,142 @@
+import {
+  mintBattleMapToken,
+  pokeFeatureFromEnvelope,
+  type BattleMapTokenRequest,
+} from '@/lib/battlemapSync';
+
+export interface PokeListenerOptions {
+  campaignCode: string;
+  battleMapId: string;
+  tokenRequest:
+    | { role: 'player'; playerId: string }
+    | { role: 'dm'; dmId: string };
+  onPoke: (feature: string) => void;
+}
+
+const BACKOFF_BASE_MS = 1000;
+const BACKOFF_CAP_MS = 30000;
+const PROACTIVE_REFRESH_MS = 4 * 60 * 1000;
+
+/**
+ * Starts a read-only relay socket that only surfaces poke envelopes to
+ * non-canvas pages. No SyncClient, no store, no sends — this is deliberately
+ * much simpler than `createManagedBattleMapConnection`: every non-poke
+ * message (element ops, snapshots, presence) is silently ignored.
+ *
+ * Best-effort throughout: never throws, silent on failure. Polling remains
+ * the source-of-truth guarantee; this only shaves latency. Returns stop().
+ */
+export function createBattleMapPokeListener(
+  opts: PokeListenerOptions
+): () => void {
+  let stopped = false;
+  let socket: WebSocket | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let refreshTimer: ReturnType<typeof setInterval> | null = null;
+  let attempt = 0;
+  let lastUrl: string | null = null;
+  // Each fresh token gets exactly one same-token reconnect attempt before
+  // the next transient close forces a re-mint.
+  let usedSameTokenRetry = false;
+
+  const room = `${opts.campaignCode}:${opts.battleMapId}`;
+
+  const clearRetryTimer = (): void => {
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+  };
+
+  const teardownSocket = (): void => {
+    if (!socket) return;
+    socket.onopen = null;
+    socket.onmessage = null;
+    socket.onclose = null;
+    socket.close();
+    socket = null;
+  };
+
+  const openSocket = (url: string): void => {
+    if (stopped) return;
+    lastUrl = url;
+    const ws = new WebSocket(url);
+    socket = ws;
+    ws.onopen = (): void => {
+      attempt = 0;
+    };
+    ws.onmessage = (event: MessageEvent): void => {
+      const raw = typeof event.data === 'string' ? event.data : '';
+      const feature = pokeFeatureFromEnvelope(raw);
+      if (feature) opts.onPoke(feature);
+    };
+    ws.onclose = (event: CloseEvent): void => {
+      if (stopped) return;
+      socket = null;
+      const fatal = event.code >= 4000 && event.code <= 4999;
+      if (!fatal && !usedSameTokenRetry) {
+        // Transient close, first time on this token: retry the same URL.
+        usedSameTokenRetry = true;
+        scheduleRetry(() => {
+          if (lastUrl) openSocket(lastUrl);
+        });
+      } else {
+        // Fatal (incl. 4401 expiry), or a second consecutive transient
+        // close on this token: mint a fresh token and rebuild.
+        usedSameTokenRetry = false;
+        scheduleRetry(() => void connect());
+      }
+    };
+  };
+
+  const scheduleRetry = (run: () => void): void => {
+    if (stopped) return;
+    const delay = Math.min(BACKOFF_CAP_MS, BACKOFF_BASE_MS * 2 ** attempt);
+    attempt += 1;
+    clearRetryTimer();
+    retryTimer = setTimeout(run, delay);
+  };
+
+  const connect = async (): Promise<void> => {
+    if (stopped) return;
+    const relayUrl = process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
+    if (!relayUrl) {
+      scheduleRetry(() => void connect());
+      return;
+    }
+    const token = await mintBattleMapToken(opts.campaignCode, {
+      ...opts.tokenRequest,
+      battleMapId: opts.battleMapId,
+    } as BattleMapTokenRequest);
+    if (stopped) return;
+    if (!token) {
+      scheduleRetry(() => void connect());
+      return;
+    }
+    const url = `${relayUrl}?room=${encodeURIComponent(room)}&token=${encodeURIComponent(token)}`;
+    openSocket(url);
+  };
+
+  const rebuild = (): void => {
+    if (stopped) return;
+    clearRetryTimer();
+    teardownSocket();
+    attempt = 0;
+    usedSameTokenRetry = false;
+    void connect();
+  };
+
+  void connect();
+  refreshTimer = setInterval(rebuild, PROACTIVE_REFRESH_MS);
+
+  return (): void => {
+    if (stopped) return;
+    stopped = true;
+    clearRetryTimer();
+    if (refreshTimer) {
+      clearInterval(refreshTimer);
+      refreshTimer = null;
+    }
+    teardownSocket();
+  };
+}

--- a/src/lib/battlemapPokeListener.ts
+++ b/src/lib/battlemapPokeListener.ts
@@ -1,7 +1,6 @@
 import {
   mintBattleMapToken,
   pokeFeatureFromEnvelope,
-  type BattleMapTokenRequest,
 } from '@/lib/battlemapSync';
 
 export interface PokeListenerOptions {
@@ -38,6 +37,11 @@ export function createBattleMapPokeListener(
   // Each fresh token gets exactly one same-token reconnect attempt before
   // the next transient close forces a re-mint.
   let usedSameTokenRetry = false;
+  // Guards connect() against overlapping with itself; bumped by rebuild()
+  // so a superseded in-flight connect() discards its (stale) mint result
+  // instead of racing rebuild's own connect() to open a second socket.
+  let connecting = false;
+  let generation = 0;
 
   const room = `${opts.campaignCode}:${opts.battleMapId}`;
 
@@ -62,10 +66,15 @@ export function createBattleMapPokeListener(
     lastUrl = url;
     const ws = new WebSocket(url);
     socket = ws;
-    ws.onopen = (): void => {
-      attempt = 0;
-    };
     ws.onmessage = (event: MessageEvent): void => {
+      // Any message — poke, snapshot, or op — proves this is an
+      // authenticated, live room connection, so it's the right signal to
+      // reset backoff. A bare `open` event is NOT enough: a relay that
+      // accepts the transport handshake but immediately rejects the token
+      // (repeated 4401s) would otherwise reset `attempt` to 0 on every
+      // cycle and retry every ~1s forever instead of escalating.
+      attempt = 0;
+      usedSameTokenRetry = false;
       const raw = typeof event.data === 'string' ? event.data : '';
       const feature = pokeFeatureFromEnvelope(raw);
       if (feature) opts.onPoke(feature);
@@ -98,27 +107,37 @@ export function createBattleMapPokeListener(
   };
 
   const connect = async (): Promise<void> => {
-    if (stopped) return;
-    const relayUrl = process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
-    if (!relayUrl) {
-      scheduleRetry(() => void connect());
-      return;
+    if (stopped || connecting) return;
+    connecting = true;
+    const myGeneration = generation;
+    try {
+      const relayUrl = process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
+      if (!relayUrl) {
+        scheduleRetry(() => void connect());
+        return;
+      }
+      const token = await mintBattleMapToken(opts.campaignCode, {
+        ...opts.tokenRequest,
+        battleMapId: opts.battleMapId,
+      });
+      // Discard a stale result: rebuild()/stop() ran while we were
+      // awaiting the mint and superseded this attempt.
+      if (stopped || myGeneration !== generation) return;
+      if (!token) {
+        scheduleRetry(() => void connect());
+        return;
+      }
+      const url = `${relayUrl}?room=${encodeURIComponent(room)}&token=${encodeURIComponent(token)}`;
+      openSocket(url);
+    } finally {
+      connecting = false;
     }
-    const token = await mintBattleMapToken(opts.campaignCode, {
-      ...opts.tokenRequest,
-      battleMapId: opts.battleMapId,
-    } as BattleMapTokenRequest);
-    if (stopped) return;
-    if (!token) {
-      scheduleRetry(() => void connect());
-      return;
-    }
-    const url = `${relayUrl}?room=${encodeURIComponent(room)}&token=${encodeURIComponent(token)}`;
-    openSocket(url);
   };
 
   const rebuild = (): void => {
     if (stopped) return;
+    generation += 1;
+    connecting = false;
     clearRetryTimer();
     teardownSocket();
     attempt = 0;

--- a/src/lib/crossTabRosterSync.ts
+++ b/src/lib/crossTabRosterSync.ts
@@ -1,0 +1,62 @@
+import { PLAYER_STORAGE_KEY } from '@/utils/constants';
+import type { PlayerCharacter } from '@/store/playerStore';
+
+type RosterEntryLike = PlayerCharacter;
+interface PlayerStoreLike {
+  getState: () => { characters: RosterEntryLike[] };
+  setState: (partial: { characters: RosterEntryLike[] }) => void;
+}
+
+/**
+ * Cross-tab roster convergence. Each tab persists its WHOLE roster, so a tab
+ * holding character B used to write back a stale copy of character A over
+ * A's fresh entry (multi-tab clobber). Merge per entry by
+ * characterData.revision — strictly newer wins; unknown ids are adopted
+ * (created elsewhere); local-only entries are kept (deletion sync is out of
+ * scope). setState only on change, so the echo event the other tab receives
+ * finds equal revisions and terminates.
+ */
+export function initCrossTabRosterSync(store: PlayerStoreLike): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== PLAYER_STORAGE_KEY || !event.newValue) return;
+    let incoming: RosterEntryLike[] | undefined;
+    try {
+      const parsed: unknown = JSON.parse(event.newValue);
+      incoming = (
+        parsed as { state?: { characters?: RosterEntryLike[] } } | null
+      )?.state?.characters;
+    } catch {
+      return;
+    }
+    if (!Array.isArray(incoming)) return;
+
+    const incomingById = new Map(
+      incoming
+        .filter(entry => entry && typeof entry.id === 'string')
+        .map(entry => [entry.id, entry])
+    );
+    let changed = false;
+    const merged = store.getState().characters.map(entry => {
+      const candidate = incomingById.get(entry.id);
+      incomingById.delete(entry.id);
+      if (!candidate) return entry;
+      const incomingRevision = candidate.characterData?.revision ?? 0;
+      const localRevision = entry.characterData?.revision ?? 0;
+      if (incomingRevision > localRevision) {
+        changed = true;
+        return candidate;
+      }
+      return entry;
+    });
+    for (const adopted of incomingById.values()) {
+      merged.push(adopted);
+      changed = true;
+    }
+    if (changed) store.setState({ characters: merged });
+  };
+
+  window.addEventListener('storage', onStorage);
+  return () => window.removeEventListener('storage', onStorage);
+}

--- a/src/lib/e2eStoreHandles.ts
+++ b/src/lib/e2eStoreHandles.ts
@@ -1,0 +1,8 @@
+/** Dev/test-only: exposes zustand stores on window for Playwright e2e.
+ * Guarded so production builds never attach anything. */
+export function exposeStoreForE2E(name: string, store: unknown): void {
+  if (typeof window === 'undefined') return;
+  if (process.env.NODE_ENV === 'production') return;
+  const w = window as unknown as { __rkStores?: Record<string, unknown> };
+  w.__rkStores = { ...w.__rkStores, [name]: store };
+}

--- a/src/store/__tests__/characterRevision.test.ts
+++ b/src/store/__tests__/characterRevision.test.ts
@@ -42,4 +42,24 @@ describe('characterStore — revision bumping', () => {
     useCharacterStore.getState().updateAbilityScore('strength', 18);
     expect(useCharacterStore.getState().character.revision).toBe(1);
   });
+
+  it('does not bump revision when recalculateMaxHP is a no-op', () => {
+    // makeCharacter's default (auto mode, level 5, Fighter d10, CON 14) already
+    // has hitPoints.max equal to what calculateMaxHP produces, so the first
+    // call is already a no-op — but exercise it once anyway to mirror how the
+    // real app calls this unconditionally on every sheet mount, then confirm
+    // the second call stays a no-op.
+    useCharacterStore.getState().recalculateMaxHP();
+    const { character: characterAfterFirst, revision: revisionAfterFirst } = {
+      character: useCharacterStore.getState().character,
+      revision: useCharacterStore.getState().character.revision,
+    };
+    expect(characterAfterFirst.hitPoints.max).toBe(44);
+    expect(revisionAfterFirst).toBe(3);
+
+    useCharacterStore.getState().recalculateMaxHP();
+
+    expect(useCharacterStore.getState().character.revision).toBe(3);
+    expect(useCharacterStore.getState().character).toBe(characterAfterFirst);
+  });
 });

--- a/src/store/__tests__/crossTabRosterSync.test.ts
+++ b/src/store/__tests__/crossTabRosterSync.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePlayerStore, PlayerCharacter } from '@/store/playerStore';
+import { PLAYER_STORAGE_KEY } from '@/utils/constants';
+import { makeCharacter } from '@/utils/__tests__/test-utils';
+import type { CharacterState } from '@/types/character';
+
+/**
+ * Repro for the roster clobber: each tab persists its WHOLE roster, so a tab
+ * holding character B writes back a stale copy of character A over A's fresh
+ * entry. The fix: zustand-persist localStorage writes are the cross-tab
+ * transport — a `storage` event carrying the other tab's roster is merged
+ * per-entry by `characterData.revision` (strictly newer wins).
+ */
+
+function makePlayerCharacter(
+  id: string,
+  characterData: CharacterState
+): PlayerCharacter {
+  const now = new Date();
+  return {
+    id,
+    name: characterData.name,
+    race: characterData.race,
+    class: characterData.class?.name || 'Fighter',
+    level: characterData.level,
+    createdAt: now,
+    updatedAt: now,
+    lastPlayed: now,
+    characterData,
+    tags: [],
+    isArchived: false,
+  };
+}
+
+function simulateOtherTabPersist(characters: PlayerCharacter[]) {
+  const persisted = JSON.stringify({
+    state: { characters },
+    version: 1,
+  });
+  const oldValue = window.localStorage.getItem(PLAYER_STORAGE_KEY);
+  window.localStorage.setItem(PLAYER_STORAGE_KEY, persisted);
+  window.dispatchEvent(
+    new StorageEvent('storage', {
+      key: PLAYER_STORAGE_KEY,
+      oldValue,
+      newValue: persisted,
+      storageArea: window.localStorage,
+    })
+  );
+}
+
+describe('cross-tab roster sync (multi-character clobber)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    usePlayerStore.setState({
+      characters: [
+        makePlayerCharacter(
+          'char-a',
+          makeCharacter({ id: 'char-a', revision: 3, hitPoints: hp(7) })
+        ),
+        makePlayerCharacter(
+          'char-b',
+          makeCharacter({ id: 'char-b', revision: 2, hitPoints: hp(6) })
+        ),
+      ],
+      activeCharacterId: null,
+      lastSelectedCharacterId: null,
+    });
+  });
+
+  it('applies a newer-revision entry for a character this tab does not hold in characterStore', () => {
+    simulateOtherTabPersist([
+      makePlayerCharacter(
+        'char-a',
+        makeCharacter({ id: 'char-a', revision: 1, hitPoints: hp(10) }) // stale
+      ),
+      makePlayerCharacter(
+        'char-b',
+        makeCharacter({ id: 'char-b', revision: 4, hitPoints: hp(2) }) // fresh
+      ),
+    ]);
+
+    const { characters } = usePlayerStore.getState();
+    const a = characters.find(c => c.id === 'char-a')!;
+    const b = characters.find(c => c.id === 'char-b')!;
+    expect(a.characterData.revision).toBe(3);
+    expect(a.characterData.hitPoints.current).toBe(7);
+    expect(b.characterData.revision).toBe(4);
+    expect(b.characterData.hitPoints.current).toBe(2);
+  });
+
+  it('ignores equal and older revisions', () => {
+    const before = usePlayerStore.getState().characters;
+
+    simulateOtherTabPersist([
+      makePlayerCharacter(
+        'char-a',
+        makeCharacter({ id: 'char-a', revision: 3, hitPoints: hp(99) }) // equal
+      ),
+      makePlayerCharacter(
+        'char-b',
+        makeCharacter({ id: 'char-b', revision: 1, hitPoints: hp(99) }) // older
+      ),
+    ]);
+
+    expect(usePlayerStore.getState().characters).toBe(before);
+  });
+
+  it('adopts an entry created in another tab', () => {
+    simulateOtherTabPersist([
+      makePlayerCharacter(
+        'char-a',
+        makeCharacter({ id: 'char-a', revision: 3, hitPoints: hp(7) })
+      ),
+      makePlayerCharacter(
+        'char-b',
+        makeCharacter({ id: 'char-b', revision: 2, hitPoints: hp(6) })
+      ),
+      makePlayerCharacter(
+        'char-c',
+        makeCharacter({ id: 'char-c', revision: 1, hitPoints: hp(20) })
+      ),
+    ]);
+
+    const { characters } = usePlayerStore.getState();
+    expect(characters.map(c => c.id)).toContain('char-c');
+    expect(
+      characters.find(c => c.id === 'char-c')?.characterData.hitPoints.current
+    ).toBe(20);
+  });
+
+  it('keeps local-only entries', () => {
+    simulateOtherTabPersist([
+      makePlayerCharacter(
+        'char-b',
+        makeCharacter({ id: 'char-b', revision: 5, hitPoints: hp(1) })
+      ),
+    ]);
+
+    const { characters } = usePlayerStore.getState();
+    expect(characters.map(c => c.id)).toContain('char-a');
+    expect(
+      characters.find(c => c.id === 'char-a')?.characterData.revision
+    ).toBe(3);
+  });
+
+  it('ignores malformed payloads and other keys', () => {
+    const before = usePlayerStore.getState().characters;
+
+    window.localStorage.setItem(PLAYER_STORAGE_KEY, 'not json');
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: PLAYER_STORAGE_KEY,
+        newValue: 'not json',
+        storageArea: window.localStorage,
+      })
+    );
+    expect(usePlayerStore.getState().characters).toBe(before);
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'some-other-key',
+        newValue: JSON.stringify({
+          state: {
+            characters: [
+              makePlayerCharacter(
+                'char-a',
+                makeCharacter({ id: 'char-a', revision: 99, hitPoints: hp(1) })
+              ),
+            ],
+          },
+        }),
+        storageArea: window.localStorage,
+      })
+    );
+    expect(usePlayerStore.getState().characters).toBe(before);
+  });
+});
+
+function hp(current: number) {
+  return {
+    current,
+    max: 44,
+    temporary: 0,
+    calculationMode: 'auto' as const,
+  };
+}

--- a/src/store/__tests__/playerStore.test.ts
+++ b/src/store/__tests__/playerStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { vi } from 'vitest';
 import { mockFetchResponse } from '@/test/mocks/fetch';
+import { makeCharacter } from '@/utils/__tests__/test-utils';
 import { usePlayerStore } from '@/store/playerStore';
 
 function resetStore() {
@@ -314,6 +315,75 @@ describe('playerStore', () => {
         .updateCharacterData(id, { ...original, name: 'Synced' });
       expect(usePlayerStore.getState().getCharacterById(id)?.name).toBe(
         'Synced'
+      );
+    });
+
+    it('refuses stale-revision write-backs (strictly lower)', () => {
+      const id = usePlayerStore.getState().createCharacter('Hero');
+      // Seed with revision 5
+      const charWithRevision5 = makeCharacter({ revision: 5, name: 'Fresh' });
+      usePlayerStore.getState().updateCharacterData(id, charWithRevision5);
+      expect(
+        usePlayerStore.getState().getCharacterById(id)?.characterData.revision
+      ).toBe(5);
+      expect(usePlayerStore.getState().getCharacterById(id)?.name).toBe(
+        'Fresh'
+      );
+
+      // Try to update with revision 3 (stale) - should be a no-op
+      const staleChar = makeCharacter({ revision: 3, name: 'Stale' });
+      usePlayerStore.getState().updateCharacterData(id, staleChar);
+      // Entry should remain unchanged
+      expect(
+        usePlayerStore.getState().getCharacterById(id)?.characterData.revision
+      ).toBe(5);
+      expect(usePlayerStore.getState().getCharacterById(id)?.name).toBe(
+        'Fresh'
+      );
+
+      // Update with same revision (5) - should write (idempotent)
+      const sameRevisionChar = makeCharacter({
+        revision: 5,
+        name: 'Same Revision',
+      });
+      usePlayerStore.getState().updateCharacterData(id, sameRevisionChar);
+      expect(
+        usePlayerStore.getState().getCharacterById(id)?.characterData.revision
+      ).toBe(5);
+      expect(usePlayerStore.getState().getCharacterById(id)?.name).toBe(
+        'Same Revision'
+      );
+
+      // Update with higher revision (7) - should write
+      const newerChar = makeCharacter({ revision: 7, name: 'Newer' });
+      usePlayerStore.getState().updateCharacterData(id, newerChar);
+      expect(
+        usePlayerStore.getState().getCharacterById(id)?.characterData.revision
+      ).toBe(7);
+      expect(usePlayerStore.getState().getCharacterById(id)?.name).toBe(
+        'Newer'
+      );
+    });
+
+    it('treats missing revision as 0', () => {
+      const id = usePlayerStore.getState().createCharacter('Hero');
+      // Seed with revision 3
+      const charWithRevision3 = makeCharacter({ revision: 3, name: 'Fresh' });
+      usePlayerStore.getState().updateCharacterData(id, charWithRevision3);
+      expect(
+        usePlayerStore.getState().getCharacterById(id)?.characterData.revision
+      ).toBe(3);
+
+      // Try to update with missing revision (treated as 0) - should be a no-op
+      const noRevisionChar = makeCharacter({ name: 'No Revision' });
+      delete (noRevisionChar as Partial<typeof noRevisionChar>).revision;
+      usePlayerStore.getState().updateCharacterData(id, noRevisionChar);
+      // Entry should remain unchanged
+      expect(
+        usePlayerStore.getState().getCharacterById(id)?.characterData.revision
+      ).toBe(3);
+      expect(usePlayerStore.getState().getCharacterById(id)?.name).toBe(
+        'Fresh'
       );
     });
   });

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -1345,6 +1345,17 @@ export const useCharacterStore = create<CharacterStore>()(
             state.character.abilities.constitution
           );
 
+          // No-op guard: recalculation runs unconditionally on every
+          // sheet mount, so when the recalculated max matches the current
+          // max, return the untouched state. Otherwise `withRevisionBump`
+          // sees a fresh (but content-identical) character object on every
+          // mount and mints a revision bump with zero real change, which
+          // degrades every revision-comparison site (roster merge,
+          // cross-tab apply, server 409 gate).
+          if (newMaxHP === state.character.hitPoints.max) {
+            return state;
+          }
+
           return {
             character: {
               ...state.character,

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -62,6 +62,7 @@ import { detectSpellAoe } from '@/utils/spellAoeDetection';
 import { usePlayerStore } from '@/store/playerStore';
 import { isApplyingExternal, withExternalApply } from '@/lib/characterRevision';
 import { initCrossTabCharacterSync } from '@/lib/crossTabCharacterSync';
+import { exposeStoreForE2E } from '@/lib/e2eStoreHandles';
 
 // Function to migrate weapon damage from old format to new array format
 function migrateWeaponDamage(weapon: Record<string, unknown>): Weapon {
@@ -5214,3 +5215,5 @@ export const useCharacterStore = create<CharacterStore>()(
 // Cross-tab convergence: apply newer-revision persists from other tabs
 // (battle map opens in its own tab — see BattleMapLiveBanner).
 initCrossTabCharacterSync(useCharacterStore);
+
+exposeStoreForE2E('character', useCharacterStore);

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -279,20 +279,23 @@ export const usePlayerStore = create<PlayerStoreState>()(
         set(state => ({
           characters: state.characters.map(char =>
             char.id === characterId
-              ? {
-                  ...char,
-                  characterData,
-                  name: characterData.name || char.name,
-                  race: characterData.race || char.race,
-                  class: characterData.class?.name || char.class,
-                  level:
-                    characterData.totalLevel ||
-                    characterData.level ||
-                    char.level,
-                  avatar: characterData.avatar, // Update top-level avatar from characterData
-                  updatedAt: new Date(),
-                  lastPlayed: new Date(),
-                }
+              ? (characterData.revision ?? 0) <
+                (char.characterData?.revision ?? 0)
+                ? char // stale write-back (outdated tab copy) — keep the newer entry
+                : {
+                    ...char,
+                    characterData,
+                    name: characterData.name || char.name,
+                    race: characterData.race || char.race,
+                    class: characterData.class?.name || char.class,
+                    level:
+                      characterData.totalLevel ||
+                      characterData.level ||
+                      char.level,
+                    avatar: characterData.avatar, // Update top-level avatar from characterData
+                    updatedAt: new Date(),
+                    lastPlayed: new Date(),
+                  }
               : char
           ),
         }));

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { createSafeStorage } from '@/lib/safeStorage';
+import { exposeStoreForE2E } from '@/lib/e2eStoreHandles';
 import { CharacterState, CharacterExport } from '@/types/character';
 import { DEFAULT_CHARACTER_STATE, STORAGE_KEY } from '@/utils/constants';
 
@@ -498,5 +499,7 @@ export const usePlayerStore = create<PlayerStoreState>()(
     }
   )
 );
+
+exposeStoreForE2E('player', usePlayerStore);
 
 export default usePlayerStore;

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -2,11 +2,13 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { createSafeStorage } from '@/lib/safeStorage';
 import { exposeStoreForE2E } from '@/lib/e2eStoreHandles';
+import { initCrossTabRosterSync } from '@/lib/crossTabRosterSync';
 import { CharacterState, CharacterExport } from '@/types/character';
-import { DEFAULT_CHARACTER_STATE, STORAGE_KEY } from '@/utils/constants';
-
-// Storage configuration
-const PLAYER_STORAGE_KEY = 'rollkeeper-player-data';
+import {
+  DEFAULT_CHARACTER_STATE,
+  STORAGE_KEY,
+  PLAYER_STORAGE_KEY,
+} from '@/utils/constants';
 
 // Player character interface - contains full CharacterState
 export interface PlayerCharacter {
@@ -501,5 +503,7 @@ export const usePlayerStore = create<PlayerStoreState>()(
 );
 
 exposeStoreForE2E('player', usePlayerStore);
+
+initCrossTabRosterSync(usePlayerStore);
 
 export default usePlayerStore;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -634,6 +634,7 @@ export const SPELL_SOURCE_BOOKS: Record<string, string> = {
 // Auto-save settings
 export const AUTOSAVE_DELAY = 500; // ms
 export const STORAGE_KEY = 'rollkeeper-character';
+export const PLAYER_STORAGE_KEY = 'rollkeeper-player-data';
 export const APP_VERSION = '1.0.0';
 
 // Avatar upload settings


### PR DESCRIPTION
## Part 1 — the bug you were still seeing (roster clobber)

Reproduced in real Chromium: with tabs holding **different characters** in one browser profile (DM+players setup), every tab persisted its **whole in-memory roster**, so a tab holding character B reverted character A's fresh entry and vice versa. Reload then loaded the reverted data. The PR #170 protection only covered the single `rollkeeper-character` slot.

- **`initCrossTabRosterSync`**: storage-event listener merges rosters **per entry** by `characterData.revision` (strictly newer wins, new entries adopted, setState only on change — echo-terminating)
- **`updateCharacterData`** refuses strictly-lower-revision write-backs
- **`recalculateMaxHP` no-op guard**: was minting a spurious revision every sheet mount (identity-based change detection) — degraded every revision comparison, enabled a cross-device stale-win
- **DM VTT 45 s polling fallback**: player stats converge even when relay pokes never arrive

## Part 2 — initiative freshness (sheet + encounters page)

Initiative HP everywhere except the battle-map rail still rode the DM's poll→merge→push pipeline. Now:

- **Sheet `InitiativePanel` live overlay** (`useLiveInitiative`, shared with the VTT): own HP instant, party HP live
- **`createBattleMapPokeListener`**: read-only raw WebSocket to the relay room for non-canvas pages — parses poke envelopes only, never sends; backoff resets only on live traffic, connect re-entrancy generation-guarded, 4-min proactive token rebuild, silent no-op without relay env
- **Sheet**: `'initiative'`/`'players'` pokes trigger the existing debounced refetches (`useBattleMapPokes` + `useActiveBattleMapId` 60 s room-discovery poll)
- **DM encounters page**: `'players'` pokes trigger an immediate (1 s-debounced via new `useDebouncedRefetch`) players refresh — no more waiting for the visibility-paused poll
- **`PartyHPSidebar`** now presentational, fed by the page's single `usePartySync` instance — sidebar and initiative panel can no longer disagree

## New: Playwright e2e suite

`npm run test:e2e` (`@playwright/test`, auto-starts dev server; CI-safe `reuseExistingServer`). One Chromium profile = shared localStorage, pages = tabs — real storage events:
- `e2e/roster-clobber.spec.ts` — the exact reproduced clobber sequence; RED before the fixes, revert-verified to still detect the bug
- `e2e/cross-tab-character.spec.ts` — pins the PR #170 cross-tab mechanism
- Dev-only `window.__rkStores` handles (`NODE_ENV !== 'production'`)

## Tests

Unit 2969 passed / 1 skipped; e2e 2/2 stable across repeated runs; type-check clean; lint pre-existing warnings only. Every task per-reviewed; two whole-branch reviews with fix rounds (backoff state machine, debounce coverage, sidebar unification all reviewer-caught).

## Manual smoke suggested

- DM+players tabs in Brave: damage/AC converge across all tabs AND survive reloads
- With relay: sheet InitiativePanel + DM encounters page update ≤ ~2 s without focusing the DM tab
- Without relay: everything converges at poll cadence, console quiet

## Deferred (tracked)

Settings/activeCharacterId still last-write-wins across tabs; character deletion sync; poke-listener mint-failure give-up cap; `document.hidden` parking for the listener; debounce consolidation; e2e in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)