### PR TITLE
feat(dm): monster token images on battlemap (lazy S3-cached 5e.tools art)

### DIFF
--- a/src/app/api/bestiary/token/[source]/[name]/route.ts
+++ b/src/app/api/bestiary/token/[source]/[name]/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3';
+
+import {
+  fiveEToolsTokenUrl,
+  isValidTokenSource,
+  tokenS3Key,
+} from '@/utils/bestiaryTokenUrl';
+
+const IMAGE_HEADERS = {
+  'Content-Type': 'image/webp',
+  'Cache-Control': 'public, max-age=31536000, immutable',
+};
+
+function getS3() {
+  const region = process.env.AWS_S3_REGION;
+  const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const bucket = process.env.AWS_S3_BUCKET_NAME;
+
+  if (!region || !accessKeyId || !secretAccessKey || !bucket) {
+    return null;
+  }
+
+  return {
+    client: new S3Client({
+      region,
+      credentials: { accessKeyId, secretAccessKey },
+    }),
+    bucket,
+  };
+}
+
+/**
+ * Serves a monster token image. S3 is a lazy cache: on miss the image is
+ * fetched from 5e.tools, written to S3 (bestiary-tokens/{SOURCE}/{Name}.webp),
+ * and streamed back. Without S3 config this degrades to a pure proxy.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ source: string; name: string }> }
+) {
+  const { source, name } = await params;
+
+  if (!isValidTokenSource(source) || name.trim() === '') {
+    return NextResponse.json({ error: 'Invalid token path' }, { status: 400 });
+  }
+
+  const s3 = getS3();
+
+  if (s3) {
+    try {
+      const cached = await s3.client.send(
+        new GetObjectCommand({
+          Bucket: s3.bucket,
+          Key: tokenS3Key(source, name),
+        })
+      );
+      if (cached.Body) {
+        const bytes = await cached.Body.transformToByteArray();
+        return new NextResponse(Buffer.from(bytes), {
+          status: 200,
+          headers: IMAGE_HEADERS,
+        });
+      }
+    } catch {
+      // NoSuchKey or any S3 read error — fall through to upstream fetch.
+    }
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(fiveEToolsTokenUrl(source, name));
+  } catch (error) {
+    console.error('Bestiary token upstream fetch failed:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch token image' },
+      { status: 502 }
+    );
+  }
+
+  if (!upstream.ok) {
+    return NextResponse.json(
+      { error: `Token not found upstream (${upstream.status})` },
+      { status: upstream.status }
+    );
+  }
+
+  const buffer = Buffer.from(await upstream.arrayBuffer());
+
+  if (s3) {
+    try {
+      await s3.client.send(
+        new PutObjectCommand({
+          Bucket: s3.bucket,
+          Key: tokenS3Key(source, name),
+          Body: buffer,
+          ContentType: 'image/webp',
+          CacheControl: 'public, max-age=31536000, immutable',
+        })
+      );
+    } catch (error) {
+      // Cache-write failure must not break the response.
+      console.error('Failed to cache bestiary token in S3:', error);
+    }
+  }
+
+  return new NextResponse(buffer, { status: 200, headers: IMAGE_HEADERS });
+}

--- a/src/app/api/bestiary/token/[source]/[name]/route.ts
+++ b/src/app/api/bestiary/token/[source]/[name]/route.ts
@@ -46,7 +46,9 @@ export async function GET(
 ) {
   const { source, name } = await params;
 
-  if (!isValidTokenSource(source) || name.trim() === '') {
+  // No bestiary monster name contains a slash; rejecting them keeps
+  // %2F-smuggled dot-segments out of S3 keys entirely.
+  if (!isValidTokenSource(source) || name.trim() === '' || name.includes('/')) {
     return NextResponse.json({ error: 'Invalid token path' }, { status: 400 });
   }
 

--- a/src/components/ui/campaign/location-map/PlayerTokenTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerTokenTool.ts
@@ -48,12 +48,24 @@ const TOKEN_RING_PX = 8;
  * /api/bestiary/token route) may become token images: a base64 data-URL
  * avatar would ride along in every sync upsert for the token (huge
  * payloads). Protocol-relative "//host/…" is rejected — that is an
- * external host, not our origin.
+ * external host, not our origin. Root-relative candidates are resolved
+ * against a sentinel origin and re-checked, since a prefix check alone is
+ * bypassable (WHATWG URL parsing normalizes backslashes to slashes and
+ * strips tab/newline for http(s) schemes, so e.g. "/\evil.example/x" or
+ * tab/newline-smuggled "//host" forms pass a naive startsWith check but
+ * resolve to an external host in <img src> / new URL()).
  */
 export function tokenAvatarUrl(avatar: string | undefined): string | null {
   if (!avatar) return null;
   if (/^https?:\/\//.test(avatar)) return avatar;
-  if (avatar.startsWith('/') && !avatar.startsWith('//')) return avatar;
+  if (avatar.startsWith('/')) {
+    try {
+      const resolved = new URL(avatar, 'http://internal.invalid');
+      if (resolved.origin === 'http://internal.invalid') return avatar;
+    } catch {
+      return null;
+    }
+  }
   return null;
 }
 

--- a/src/components/ui/campaign/location-map/PlayerTokenTool.ts
+++ b/src/components/ui/campaign/location-map/PlayerTokenTool.ts
@@ -44,11 +44,17 @@ const TOKEN_RENDER_PX = 128;
 const TOKEN_RING_PX = 8;
 
 /**
- * Only http(s) avatars may become token images: a base64 data-URL avatar
- * would ride along in every sync upsert for the token (huge payloads).
+ * Only http(s) avatars or same-origin root-relative paths (e.g. the
+ * /api/bestiary/token route) may become token images: a base64 data-URL
+ * avatar would ride along in every sync upsert for the token (huge
+ * payloads). Protocol-relative "//host/…" is rejected — that is an
+ * external host, not our origin.
  */
 export function tokenAvatarUrl(avatar: string | undefined): string | null {
-  return avatar && /^https?:\/\//.test(avatar) ? avatar : null;
+  if (!avatar) return null;
+  if (/^https?:\/\//.test(avatar)) return avatar;
+  if (avatar.startsWith('/') && !avatar.startsWith('//')) return avatar;
+  return null;
 }
 
 /** Same-origin proxy for S3 URLs so canvas compositing isn't CORS-tainted. */

--- a/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
@@ -236,4 +236,10 @@ describe('tokenAvatarUrl', () => {
     expect(tokenAvatarUrl(undefined)).toBeNull();
     expect(tokenAvatarUrl('')).toBeNull();
   });
+
+  test('rejects backslash and control-char tricks that resolve off-origin', () => {
+    expect(tokenAvatarUrl('/\\evil.example/a.png')).toBeNull();
+    expect(tokenAvatarUrl('/\t/evil.example/a.png')).toBeNull();
+    expect(tokenAvatarUrl('/\n/evil.example/a.png')).toBeNull();
+  });
 });

--- a/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, test } from 'vitest';
 import { TemplateTool } from '@fieldnotes/core';
 import {
   PlayerTokenTool,
   PlayerTemplateTool,
+  tokenAvatarUrl,
 } from '@/components/ui/campaign/location-map/PlayerTokenTool';
 import {
   TOKEN_ELEMENT_ZINDEX,
@@ -206,5 +207,33 @@ describe('PlayerTemplateTool zIndex stamping', () => {
     ]);
 
     spy.mockRestore();
+  });
+});
+
+describe('tokenAvatarUrl', () => {
+  test('accepts http(s) URLs', () => {
+    expect(tokenAvatarUrl('https://example.com/a.png')).toBe(
+      'https://example.com/a.png'
+    );
+    expect(tokenAvatarUrl('http://example.com/a.png')).toBe(
+      'http://example.com/a.png'
+    );
+  });
+
+  test('accepts root-relative paths (bestiary token route)', () => {
+    expect(tokenAvatarUrl('/api/bestiary/token/XMM/Zombie')).toBe(
+      '/api/bestiary/token/XMM/Zombie'
+    );
+  });
+
+  test('rejects protocol-relative URLs — external host, not our origin', () => {
+    expect(tokenAvatarUrl('//evil.example/a.png')).toBeNull();
+  });
+
+  test('rejects data URLs, garbage, and undefined', () => {
+    expect(tokenAvatarUrl('data:image/png;base64,AAAA')).toBeNull();
+    expect(tokenAvatarUrl('not a url')).toBeNull();
+    expect(tokenAvatarUrl(undefined)).toBeNull();
+    expect(tokenAvatarUrl('')).toBeNull();
   });
 });

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/MonsterDetail.stories.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/MonsterDetail.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect } from 'storybook/test';
+
+import { MonsterDetail } from './MonsterDetail';
+
+import type { ProcessedMonster } from '@/types/bestiary';
+
+function makeMonster(
+  overrides: Partial<ProcessedMonster> = {}
+): ProcessedMonster {
+  return {
+    id: 'mon-zombie',
+    name: 'Zombie',
+    size: ['M'],
+    type: 'undead',
+    alignment: 'neutral evil',
+    ac: '8',
+    hp: '15 (2d8+6)',
+    speed: '20 ft.',
+    str: 13,
+    dex: 6,
+    con: 16,
+    int: 3,
+    wis: 6,
+    cha: 5,
+    saves: 'WIS +0',
+    skills: '',
+    resistances: '',
+    immunities: 'poison',
+    vulnerabilities: '',
+    senses: 'darkvision 60 ft., passive Perception 8',
+    passivePerception: 8,
+    languages: 'None',
+    cr: '1/4',
+    source: 'XMM',
+    page: 1,
+    acValue: 8,
+    hpAverage: 15,
+    hpFormula: '2d8+6',
+    legendaryActionCount: 0,
+    conditionImmunities: ['poisoned'],
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+const meta: Meta<typeof MonsterDetail> = {
+  title: 'Encounter/AddCombatantDialog/MonsterDetail',
+  component: MonsterDetail,
+  args: {
+    hp: '15',
+    onHpChange: noop,
+    ac: '8',
+    onAcChange: noop,
+    count: 1,
+    onCountChange: noop,
+    hideName: false,
+    onHideNameChange: noop,
+    playerAlias: '',
+    onPlayerAliasChange: noop,
+    disposition: 'enemy',
+    onDispositionChange: noop,
+    onBack: noop,
+    onEditStatBlock: noop,
+    hasEdits: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MonsterDetail>;
+
+export const WithTokenPreview: Story = {
+  args: {
+    selected: makeMonster({ hasToken: true, tokenSource: 'XMM' }),
+  },
+  play: async ({ canvasElement }) => {
+    const img = canvasElement.querySelector('img');
+    await expect(img).not.toBeNull();
+    await expect(img!.getAttribute('src')).toBe(
+      '/api/bestiary/token/XMM/Zombie'
+    );
+  },
+};
+
+export const WithoutToken: Story = {
+  args: {
+    selected: makeMonster({ hasToken: false }),
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('img')).toBeNull();
+  },
+};

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/MonsterDetail.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/MonsterDetail.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Plus, Minus, FilePen } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import type { ProcessedMonster } from '@/types/bestiary';
 import type { PlayerDisposition } from '@/types/encounter';
+import { bestiaryTokenUrl } from '@/utils/bestiaryTokenUrl';
 import { SharedOptions } from './SharedOptions';
 
 interface MonsterDetailProps {
@@ -59,14 +60,27 @@ export function MonsterDetail({
       {/* Stat card */}
       <div className="border-accent-purple-border bg-surface-raised rounded-[16px] border-[1.5px] p-[18px]">
         <div className="flex items-start justify-between gap-2">
-          <div>
-            <h4 className="font-display text-heading text-[21px] leading-tight font-extrabold">
-              {selected.name}
-            </h4>
-            <p className="text-muted text-[12.5px]">
-              {selected.size.join('/')} {mType}
-              {selected.alignment ? `, ${selected.alignment}` : ''}
-            </p>
+          <div className="flex min-w-0 items-start gap-3">
+            {selected.hasToken && selected.tokenSource && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={bestiaryTokenUrl(selected.tokenSource, selected.name)}
+                alt=""
+                className="border-divider h-12 w-12 shrink-0 rounded-full border object-cover"
+                onError={e => {
+                  e.currentTarget.style.display = 'none';
+                }}
+              />
+            )}
+            <div className="min-w-0">
+              <h4 className="font-display text-heading text-[21px] leading-tight font-extrabold">
+                {selected.name}
+              </h4>
+              <p className="text-muted text-[12.5px]">
+                {selected.size.join('/')} {mType}
+                {selected.alignment ? `, ${selected.alignment}` : ''}
+              </p>
+            </div>
           </div>
           <span className="bg-accent-purple-bg text-accent-purple-text shrink-0 rounded-full px-2 py-0.5 text-[11px] font-extrabold">
             CR {selected.cr}

--- a/src/types/bestiary.ts
+++ b/src/types/bestiary.ts
@@ -34,6 +34,10 @@ export interface ProcessedMonster {
   legendaryActions?: ProcessedTrait[];
   source: string;
   page: number;
+  /** Monster has token art on 5e.tools (true for all current bestiary data). */
+  hasToken?: boolean;
+  /** RAW source code (XMM, FTD…) for token URLs — `source` is display-formatted. */
+  tokenSource?: string;
 
   // Numeric values for encounter use
   acValue: number;
@@ -110,6 +114,7 @@ export interface RawMonsterData {
   spellcasting?: RawSpellcasting[];
   source: string;
   page?: number;
+  hasToken?: boolean;
 }
 
 export interface RawSpellcasting {

--- a/src/utils/bestiaryDataLoader.token.test.ts
+++ b/src/utils/bestiaryDataLoader.token.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+
+import { processMonster } from './bestiaryDataLoader';
+
+import type { RawMonsterData } from '@/types/bestiary';
+
+function makeRaw(overrides: Partial<RawMonsterData> = {}): RawMonsterData {
+  return {
+    name: 'Zombie',
+    source: 'XMM',
+    ...overrides,
+  };
+}
+
+describe('processMonster token fields', () => {
+  test('carries hasToken and raw source as tokenSource', () => {
+    const m = processMonster(makeRaw({ hasToken: true }));
+    expect(m.hasToken).toBe(true);
+    expect(m.tokenSource).toBe('XMM');
+  });
+
+  test('hasToken defaults to false when absent in raw data', () => {
+    const m = processMonster(makeRaw());
+    expect(m.hasToken).toBe(false);
+  });
+
+  test('tokenSource stays raw even when display source is transformed', () => {
+    const m = processMonster(makeRaw({ source: 'XPHB', hasToken: true }));
+    expect(m.source).toBe('PHB2024'); // display transform
+    expect(m.tokenSource).toBe('XPHB'); // raw code for URLs
+  });
+});

--- a/src/utils/bestiaryDataLoader.ts
+++ b/src/utils/bestiaryDataLoader.ts
@@ -230,7 +230,7 @@ function processSpellcasting(raw: RawSpellcasting[]): ProcessedSpellcasting[] {
   });
 }
 
-function processMonster(monster: RawMonsterData): ProcessedMonster {
+export function processMonster(monster: RawMonsterData): ProcessedMonster {
   const id = generateMonsterId(monster.name, monster.source);
   const typeData =
     typeof monster.type === 'object'
@@ -292,6 +292,8 @@ function processMonster(monster: RawMonsterData): ProcessedMonster {
     legendaryActions: processTraits(monster.legendary),
     source: formatSourceForDisplay(monster.source),
     page: monster.page ?? 0,
+    hasToken: monster.hasToken ?? false,
+    tokenSource: monster.source,
 
     // Numeric encounter fields
     acValue: extractAcValue(monster.ac),

--- a/src/utils/bestiaryTokenUrl.test.ts
+++ b/src/utils/bestiaryTokenUrl.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  bestiaryTokenUrl,
+  fiveEToolsTokenUrl,
+  isValidTokenSource,
+  tokenS3Key,
+} from './bestiaryTokenUrl';
+
+describe('bestiaryTokenUrl', () => {
+  test('builds root-relative route URL with encoded name', () => {
+    expect(bestiaryTokenUrl('XMM', 'Zombie')).toBe(
+      '/api/bestiary/token/XMM/Zombie'
+    );
+    expect(bestiaryTokenUrl('FTD', 'Adult Crystal Dragon')).toBe(
+      '/api/bestiary/token/FTD/Adult%20Crystal%20Dragon'
+    );
+  });
+
+  test('encodes apostrophes-adjacent and special characters safely', () => {
+    // encodeURIComponent leaves ' alone but escapes # ? / &
+    expect(bestiaryTokenUrl('MM', "Ezmerelda d'Avenir")).toBe(
+      "/api/bestiary/token/MM/Ezmerelda%20d'Avenir"
+    );
+    expect(bestiaryTokenUrl('MM', 'A/B?C')).toBe(
+      '/api/bestiary/token/MM/A%2FB%3FC'
+    );
+  });
+});
+
+describe('fiveEToolsTokenUrl', () => {
+  test('matches the 5e.tools pattern', () => {
+    expect(fiveEToolsTokenUrl('XMM', 'Zombie')).toBe(
+      'https://5e.tools/img/bestiary/tokens/XMM/Zombie.webp'
+    );
+    expect(fiveEToolsTokenUrl('RHW', 'Strahd von Zarovich')).toBe(
+      'https://5e.tools/img/bestiary/tokens/RHW/Strahd%20von%20Zarovich.webp'
+    );
+  });
+});
+
+describe('tokenS3Key', () => {
+  test('mirrors the 5etools layout, unencoded (S3 keys allow spaces)', () => {
+    expect(tokenS3Key('XMM', 'Zombie')).toBe('bestiary-tokens/XMM/Zombie.webp');
+    expect(tokenS3Key('FTD', 'Adult Crystal Dragon')).toBe(
+      'bestiary-tokens/FTD/Adult Crystal Dragon.webp'
+    );
+  });
+});
+
+describe('isValidTokenSource', () => {
+  test('accepts alphanumeric and hyphen source codes', () => {
+    expect(isValidTokenSource('XMM')).toBe(true);
+    expect(isValidTokenSource('AitFR-DN')).toBe(true);
+  });
+
+  test('rejects empty, slashes, dots, and other traversal characters', () => {
+    expect(isValidTokenSource('')).toBe(false);
+    expect(isValidTokenSource('XMM/..')).toBe(false);
+    expect(isValidTokenSource('..')).toBe(false);
+    expect(isValidTokenSource('a b')).toBe(false);
+  });
+});

--- a/src/utils/bestiaryTokenUrl.ts
+++ b/src/utils/bestiaryTokenUrl.ts
@@ -1,0 +1,28 @@
+/**
+ * URL and S3-key builders for bestiary monster token images.
+ *
+ * 5etools serves token art at
+ *   https://5e.tools/img/bestiary/tokens/{SOURCE}/{Name}.webp
+ * using the RAW source code (XMM, FTD, RHW…). Our API route mirrors that
+ * layout in S3 under bestiary-tokens/ and proxies/caches lazily.
+ */
+
+/** Root-relative URL for a monster's token, served by our caching route. */
+export function bestiaryTokenUrl(tokenSource: string, name: string): string {
+  return `/api/bestiary/token/${encodeURIComponent(tokenSource)}/${encodeURIComponent(name)}`;
+}
+
+/** Upstream 5e.tools token image URL. */
+export function fiveEToolsTokenUrl(source: string, name: string): string {
+  return `https://5e.tools/img/bestiary/tokens/${encodeURIComponent(source)}/${encodeURIComponent(name)}.webp`;
+}
+
+/** S3 object key mirroring the 5etools layout (keys may contain spaces). */
+export function tokenS3Key(source: string, name: string): string {
+  return `bestiary-tokens/${source}/${name}.webp`;
+}
+
+/** Source codes are alphanumeric with hyphens (e.g. XMM, AitFR-DN). */
+export function isValidTokenSource(source: string): boolean {
+  return /^[A-Za-z0-9-]+$/.test(source);
+}

--- a/src/utils/encounterConverter.overrides.test.ts
+++ b/src/utils/encounterConverter.overrides.test.ts
@@ -158,3 +158,38 @@ describe('abilityModifier export', () => {
     expect(abilityModifier(8)).toBe(-1);
   });
 });
+
+describe('monster token avatarUrl', () => {
+  test('sets root-relative token URL when hasToken and tokenSource present', () => {
+    const monster = makeMonster({
+      name: 'Adult Crystal Dragon',
+      hasToken: true,
+      tokenSource: 'FTD',
+    });
+    const entity = monsterToEncounterEntity(monster);
+    expect(entity.avatarUrl).toBe(
+      '/api/bestiary/token/FTD/Adult%20Crystal%20Dragon'
+    );
+  });
+
+  test('leaves avatarUrl undefined without hasToken', () => {
+    const entity = monsterToEncounterEntity(
+      makeMonster({ hasToken: false, tokenSource: 'XMM' })
+    );
+    expect(entity.avatarUrl).toBeUndefined();
+  });
+
+  test('leaves avatarUrl undefined without tokenSource (legacy data)', () => {
+    const entity = monsterToEncounterEntity(makeMonster({ hasToken: true }));
+    expect(entity.avatarUrl).toBeUndefined();
+  });
+
+  test('URL uses original monster name even with nameOverride', () => {
+    const entity = monsterToEncounterEntity(
+      makeMonster({ name: 'Zombie', hasToken: true, tokenSource: 'XMM' }),
+      { nameOverride: 'Zombie A' }
+    );
+    expect(entity.name).toBe('Zombie A');
+    expect(entity.avatarUrl).toBe('/api/bestiary/token/XMM/Zombie');
+  });
+});

--- a/src/utils/encounterConverter.ts
+++ b/src/utils/encounterConverter.ts
@@ -7,6 +7,7 @@ import {
   MonsterSpellcasting,
   TokenCellSize,
 } from '@/types/encounter';
+import { bestiaryTokenUrl } from '@/utils/bestiaryTokenUrl';
 
 function generateId(): string {
   return Date.now().toString(36) + Math.random().toString(36).substr(2, 9);
@@ -356,6 +357,10 @@ export function monsterToEncounterEntity(
     color: options?.color,
     isHidden: false,
     tokenSize: sizeCodeToTokenCells(monster.size[0]),
+    avatarUrl:
+      monster.hasToken && monster.tokenSource
+        ? bestiaryTokenUrl(monster.tokenSource, monster.name)
+        : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

Bestiary monsters added to encounters now automatically get token images on the battlemap and roster tray — no more manually pasting portrait URLs per entity. Token art comes from 5e.tools, lazily cached in our S3 bucket on first request so 5e.tools availability is never a runtime dependency afterwards.

- **`src/utils/bestiaryTokenUrl.ts`** — pure helpers: root-relative route URL, upstream 5e.tools URL, S3 key (`bestiary-tokens/{SOURCE}/{Name}.webp`, mirroring the 5etools layout), source-code validation
- **`GET /api/bestiary/token/[source]/[name]`** — serves image/webp: S3 hit → stream; miss → fetch 5e.tools, cache to S3, stream; S3 unconfigured (local dev) → pure passthrough proxy. Immutable cache headers; upstream non-200 passed through; cache-write failure never breaks the response. Rejects invalid sources and slash-containing names
- **Loader** carries `hasToken` + raw `tokenSource` (XMM/FTD/…) onto `ProcessedMonster` — raw code kept separate from the display-formatted `source` (XPHB→PHB2024 transform)
- **`monsterToEncounterEntity`** auto-fills `avatarUrl` with the route URL when `hasToken`; multi-count copies share one token; existing custom URL/upload flow in StudioPanel TokenSettings overwrites it per entity
- **`tokenAvatarUrl`** now accepts root-relative paths, hardened against WHATWG URL-normalization bypasses (`/\evil.example/…`, tab/newline-smuggled protocol-relative forms) via sentinel-origin resolution
- **MonsterDetail** (AddCombatantDialog) shows a round token preview; `onError` hides it cleanly on rare upstream 404s

Client never sees a 5e.tools URL — all image traffic is same-origin through the route, so canvas compositing stays CORS-clean.

## Test plan

- [x] Unit: 3027 passed (helpers encoding, loader raw-source carry, converter fill/skip branches, `tokenAvatarUrl` accept/reject incl. bypass vectors)
- [x] Storybook: MonsterDetail preview stories 2/2 (AddCombatantDialog suite 10/13 — 3 failures are the pre-existing `index.stories.tsx` master baseline)
- [x] Route live-verified: `curl /api/bestiary/token/XMM/Zombie` → 200 valid webp (passthrough path, real 5e.tools fetch); traversal attempt → 400
- [x] type-check + lint clean
- [x] Manual smoke (recommended): add Zombie to encounter → roster disc shows token → drag onto battlemap → image token; set custom portrait in TokenSettings → custom wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)