### PR TITLE
fix(dm): battlemap live sync, stale active-map fix, player detail on VTT

### DIFF
--- a/e2e/cross-tab-encounter.spec.ts
+++ b/e2e/cross-tab-encounter.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+import { waitForEncounterStore } from './helpers';
+
+// Mechanism pin: two DM tabs converge via `initCrossTabEncounterSync` — a
+// real `storage` event + per-encounter updatedAt merge. Pins the fix for
+// "the battlemap tab needs a reload to see encounter changes".
+test('encounter created and combat started in one DM tab reach another tab', async ({
+  browser,
+}) => {
+  const context = await browser.newContext();
+  const tab1 = await context.newPage();
+  await tab1.goto('/dm/campaign/E2E01/encounters', {
+    waitUntil: 'networkidle',
+  });
+  await waitForEncounterStore(tab1);
+
+  const tab2 = await context.newPage();
+  await tab2.goto('/dm/campaign/E2E01/encounters', {
+    waitUntil: 'networkidle',
+  });
+  await waitForEncounterStore(tab2);
+
+  // Created AFTER tab2 loaded — only the storage event can deliver it.
+  const encounterId = await tab1.evaluate(() =>
+    window
+      .__rkStores!.encounter.getState()
+      .createEncounter('E2E Sync Pin', 'E2E01')
+  );
+
+  // Adoption path: unknown id appears in tab2.
+  await expect
+    .poll(
+      async () =>
+        tab2.evaluate(
+          id =>
+            window
+              .__rkStores!.encounter.getState()
+              .encounters.some(e => e.id === id),
+          encounterId
+        ),
+      { timeout: 10_000 }
+    )
+    .toBe(true);
+
+  // Newer-updatedAt path: start combat in tab1, tab2 observes isActive.
+  await tab1.evaluate(
+    id => window.__rkStores!.encounter.getState().startCombat(id),
+    encounterId
+  );
+  await expect
+    .poll(
+      async () =>
+        tab2.evaluate(
+          id =>
+            window
+              .__rkStores!.encounter.getState()
+              .encounters.find(e => e.id === id)?.isActive,
+          encounterId
+        ),
+      { timeout: 10_000 }
+    )
+    .toBe(true);
+});

--- a/e2e/global.d.ts
+++ b/e2e/global.d.ts
@@ -1,5 +1,6 @@
 import type { useCharacterStore } from '@/store/characterStore';
 import type { usePlayerStore } from '@/store/playerStore';
+import type { useEncounterStore } from '@/store/encounterStore';
 
 // Dev/test-only global exposed by `exposeStoreForE2E` (see src/lib/e2eStoreHandles.ts).
 // Only ever present when NODE_ENV !== 'production'.
@@ -8,6 +9,7 @@ declare global {
     __rkStores?: {
       character: typeof useCharacterStore;
       player: typeof usePlayerStore;
+      encounter: typeof useEncounterStore;
     };
   }
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -131,3 +131,17 @@ export async function damageCharacter(
     window.__rkStores!.character.getState().applyDamageToCharacter(dmg);
   }, amount);
 }
+
+/** Waits until the dev-only `__rkStores.encounter` handle exists and the
+ * encounter store has finished rehydrating from localStorage. The encounter
+ * store has no `hasHydrated` state flag (unlike characterStore), so this
+ * reads zustand's own persist API instead. */
+export async function waitForEncounterStore(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () =>
+      !!window.__rkStores?.encounter &&
+      window.__rkStores.encounter.persist.hasHydrated(),
+    undefined,
+    { timeout: 15_000 }
+  );
+}

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
@@ -54,7 +54,7 @@ export function useDmVttScreen({
     handlePrevTurn,
   } = useDmVttInitiative({ campaignCode, dmId, linkedEncounterIds });
 
-  const { onPlayersPoke } = useDmVttPlayersRefresh(
+  const { onPlayersPoke, players } = useDmVttPlayersRefresh(
     campaignCode,
     encounter?.id ?? null
   );
@@ -77,6 +77,12 @@ export function useDmVttScreen({
       if (npc) setViewingNpc({ npc, entityId });
     },
     [npcs]
+  );
+
+  const [viewingPlayerId, setViewingPlayerId] = useState<string | null>(null);
+  const onViewPlayer = useCallback(
+    (playerCharacterId: string) => setViewingPlayerId(playerCharacterId),
+    []
   );
 
   const actions = useDmVttActions({ campaignCode, dmId, encounter, onViewNPC });
@@ -170,6 +176,13 @@ export function useDmVttScreen({
       npc: viewingNpc?.npc ?? null,
       entityId: viewingNpc?.entityId ?? null,
       onClose: () => setViewingNpc(null),
+    },
+    onViewPlayer,
+    // Looked up at render time so each poke-driven players refresh
+    // live-updates an open dialog (same freshness as the encounter page).
+    playerDialog: {
+      player: players.find(p => p.playerId === viewingPlayerId) ?? null,
+      onClose: () => setViewingPlayerId(null),
     },
   };
 }

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { PlayerDetailDialog } from '@/components/ui/campaign/PlayerDetailDialog';
 import { TokenDecorationLayer } from '@/components/ui/campaign/token-overlay';
 import { useDmTokenDecorations } from '@/components/ui/campaign/token-overlay/useDmTokenDecorations';
 import { useTokenInfoMode } from '@/components/ui/campaign/token-overlay/useTokenInfoToggle';
@@ -99,6 +100,7 @@ export function DmVttScreen({
           onArmPlacement={entity => !vtt.wasDrag() && vtt.armPlacement(entity)}
           onSelectEntity={vtt.selectEntity}
           onDragStart={vtt.startDrag}
+          onViewPlayer={vtt.onViewPlayer}
           collapsed={rosterCollapsed}
           onToggleCollapsed={() => setRosterCollapsed(v => !v)}
           hasLinkedEncounter={vtt.linkedEncounterIds.length > 0}
@@ -138,6 +140,15 @@ export function DmVttScreen({
         encounterId={vtt.encounter?.id}
         {...vtt.npcDialog}
       />
+      {vtt.playerDialog.player && (
+        <PlayerDetailDialog
+          open
+          onOpenChange={open => {
+            if (!open) vtt.playerDialog.onClose();
+          }}
+          player={vtt.playerDialog.player}
+        />
+      )}
     </DmBattleMapCanvas>
   );
 }

--- a/src/components/ui/campaign/dm-vtt/RosterRow.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterRow.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Eye } from 'lucide-react';
+
 import { dispositionColor } from './combatantToken';
 
 import { tokenAvatarUrl } from '@/components/ui/campaign/location-map/PlayerTokenTool';
@@ -14,6 +16,7 @@ export interface RosterRowProps {
   onArmPlacement: (entity: EncounterEntity) => void;
   onSelectEntity: (entityId: string) => void;
   onDragStart: (entity: EncounterEntity, e: PointerEvent) => void;
+  onViewPlayer?: (playerCharacterId: string) => void;
 }
 
 /**
@@ -21,6 +24,8 @@ export interface RosterRowProps {
  * line. Unplaced rows arm placement on click and forward pointerdown to
  * `onDragStart` (Task 4's drag logic decides tap-vs-drag by movement
  * threshold — this row just forwards both). Placed rows select the token.
+ * Player rows linked to a character get a sibling eye button (never nest
+ * buttons) that opens `PlayerDetailDialog` without disturbing placement.
  */
 export function RosterRow({
   entity,
@@ -29,6 +34,7 @@ export function RosterRow({
   onArmPlacement,
   onSelectEntity,
   onDragStart,
+  onViewPlayer,
 }: RosterRowProps) {
   const color = dispositionColor(entity);
   const firstName = entity.name.split(' ')[0];
@@ -43,13 +49,18 @@ export function RosterRow({
     if (!placed) onDragStart(entity, e);
   };
 
+  const viewablePcId =
+    entity.type === 'player' && entity.playerCharacterId && onViewPlayer
+      ? entity.playerCharacterId
+      : null;
+
   return (
-    <li>
+    <li className="flex items-center gap-0.5">
       <button
         type="button"
         onClick={handleClick}
         onPointerDown={handlePointerDown}
-        className={`flex min-h-[44px] w-full items-center gap-2 rounded-lg border border-transparent px-1.5 py-1 text-left transition-colors ${
+        className={`flex min-h-[44px] min-w-0 flex-1 items-center gap-2 rounded-lg border border-transparent px-1.5 py-1 text-left transition-colors ${
           placed ? 'opacity-60' : ''
         } ${
           armed
@@ -81,6 +92,17 @@ export function RosterRow({
           </span>
         </span>
       </button>
+      {viewablePcId && (
+        <button
+          type="button"
+          onClick={() => onViewPlayer?.(viewablePcId)}
+          aria-label={`View ${firstName} details`}
+          title="View character details"
+          className="text-muted hover:text-heading hover:bg-surface-secondary flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors"
+        >
+          <Eye size={14} aria-hidden="true" />
+        </button>
+      )}
     </li>
   );
 }

--- a/src/components/ui/campaign/dm-vtt/RosterTray.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterTray.tsx
@@ -19,6 +19,7 @@ export interface RosterTrayProps {
   collapsed: boolean;
   onToggleCollapsed: () => void;
   hasLinkedEncounter: boolean;
+  onViewPlayer?: (playerCharacterId: string) => void;
 }
 
 const GROUP_SECTIONS: { key: keyof RosterGroups; label: string }[] = [
@@ -42,6 +43,7 @@ export function RosterTray({
   collapsed,
   onToggleCollapsed,
   hasLinkedEncounter,
+  onViewPlayer,
 }: RosterTrayProps) {
   if (collapsed) {
     return (
@@ -98,6 +100,7 @@ export function RosterTray({
                       onArmPlacement={onArmPlacement}
                       onSelectEntity={onSelectEntity}
                       onDragStart={onDragStart}
+                      onViewPlayer={onViewPlayer}
                     />
                   ))}
                 </ul>

--- a/src/components/ui/campaign/dm-vtt/__tests__/RosterTray.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/RosterTray.test.tsx
@@ -156,3 +156,59 @@ describe('RosterTray', () => {
     expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('RosterRow player eye button', () => {
+  afterEach(() => cleanup());
+
+  const playerWithPc = makeEntity({
+    id: 'p2',
+    type: 'player',
+    name: 'Aria Windrider',
+    playerCharacterId: 'char-9',
+  });
+
+  it('renders an eye for player rows with a playerCharacterId and fires onViewPlayer', () => {
+    const onViewPlayer = vi.fn();
+    render(
+      <RosterTray {...baseProps({ entities: [playerWithPc], onViewPlayer })} />
+    );
+
+    fireEvent.click(screen.getByLabelText('View Aria details'));
+    expect(onViewPlayer).toHaveBeenCalledWith('char-9');
+  });
+
+  it('renders no eye for monsters, players without playerCharacterId, or when onViewPlayer is absent', () => {
+    const onViewPlayer = vi.fn();
+    const bareplayer = makeEntity({ id: 'p3', type: 'player', name: 'Bo' });
+    const { unmount } = render(
+      <RosterTray
+        {...baseProps({ entities: [monster, bareplayer], onViewPlayer })}
+      />
+    );
+    expect(screen.queryByLabelText(/View .* details/)).not.toBeInTheDocument();
+    unmount();
+
+    render(<RosterTray {...baseProps({ entities: [playerWithPc] })} />);
+    expect(screen.queryByLabelText(/View .* details/)).not.toBeInTheDocument();
+  });
+
+  it('eye click does not arm placement; the row click still does', () => {
+    const onViewPlayer = vi.fn();
+    const onArmPlacement = vi.fn();
+    render(
+      <RosterTray
+        {...baseProps({
+          entities: [playerWithPc],
+          onViewPlayer,
+          onArmPlacement,
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('View Aria details'));
+    expect(onArmPlacement).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('Aria'));
+    expect(onArmPlacement).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/__tests__/useDmVttPlayersRefresh.test.ts
+++ b/src/components/ui/campaign/dm-vtt/__tests__/useDmVttPlayersRefresh.test.ts
@@ -41,11 +41,18 @@ describe('useDmVttPlayersRefresh', () => {
       useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
     );
 
+    // Clear the mount's own leading-fetch debounce window first so the
+    // poke below produces its own fetch instead of being coalesced into it.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
     await act(async () => {
       result.current.onPlayersPoke();
       await vi.advanceTimersByTimeAsync(0);
     });
 
+    expect(fetchFn).toHaveBeenCalledTimes(2); // mount fetch + poke fetch
     expect(fetchFn).toHaveBeenCalledWith(
       `/api/campaign/${CAMPAIGN_CODE}/players`
     );
@@ -58,13 +65,19 @@ describe('useDmVttPlayersRefresh', () => {
       useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
     );
 
+    // Clear the mount's own leading-fetch debounce window first so the
+    // first poke below is a genuine leading fetch, not coalesced with mount.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
     await act(async () => {
       result.current.onPlayersPoke();
       result.current.onPlayersPoke();
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2); // mount fetch + poke1 leading
   });
 
   it('a poke during the debounce window schedules one trailing fetch at window expiry', async () => {
@@ -72,6 +85,13 @@ describe('useDmVttPlayersRefresh', () => {
     const { result } = renderHook(() =>
       useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
     );
+
+    // Clear the mount's own leading-fetch debounce window first so poke1
+    // below is a genuine leading fetch, matching the scenario this test
+    // is documenting (not coalesced with the mount fetch).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
 
     // Two pokes back-to-back: the first is a leading fetch, the second lands
     // inside the debounce window and must schedule a trailing fetch instead
@@ -81,7 +101,7 @@ describe('useDmVttPlayersRefresh', () => {
       result.current.onPlayersPoke();
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2); // mount fetch + poke1 leading
 
     // A third poke, still inside the window, must coalesce with the already
     // scheduled trailing fetch rather than stacking a second timeout.
@@ -89,19 +109,19 @@ describe('useDmVttPlayersRefresh', () => {
       result.current.onPlayersPoke();
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
 
     // Window expires: exactly one trailing fetch fires.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1000);
     });
-    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
 
     // No further fetch from a stacked/duplicate timeout.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1000);
     });
-    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
   });
 
   it('clears a pending trailing fetch on unmount', async () => {
@@ -110,19 +130,25 @@ describe('useDmVttPlayersRefresh', () => {
       useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
     );
 
+    // Clear the mount's own leading-fetch debounce window first so the
+    // pokes below exercise poke-driven leading/trailing behavior.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
     await act(async () => {
       result.current.onPlayersPoke(); // leading
       result.current.onPlayersPoke(); // schedules trailing
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2); // mount fetch + poke1 leading
 
     unmount();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1000);
     });
-    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2); // trailing fetch was cleared
   });
 
   it('never fetches when encounterId is null', async () => {
@@ -174,17 +200,18 @@ describe('useDmVttPlayersRefresh', () => {
     const fetchFn = mockFetchResponse(200, { players: PLAYERS });
     renderHook(() => useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID));
 
-    // No poke — only the passive interval should drive fetches.
+    // Mount already fires one leading fetch; from there, no poke ever
+    // arrives — only the passive interval should drive further fetches.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(45_000);
     });
-    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
     expect(applyPlayersToEncounter).toHaveBeenCalledWith(ENCOUNTER_ID, PLAYERS);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(45_000);
     });
-    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
   });
 
   it('stops polling after unmount', async () => {
@@ -192,13 +219,15 @@ describe('useDmVttPlayersRefresh', () => {
     const { unmount } = renderHook(() =>
       useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
     );
+    // Mount's own leading fetch already fired synchronously on render.
+    expect(fetchFn).toHaveBeenCalledTimes(1);
 
     unmount();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(45_000);
     });
-    expect(fetchFn).not.toHaveBeenCalled();
+    expect(fetchFn).toHaveBeenCalledTimes(1); // interval never fires post-unmount
   });
 
   it('does not poll when encounterId is null', async () => {
@@ -209,5 +238,45 @@ describe('useDmVttPlayersRefresh', () => {
       await vi.advanceTimersByTimeAsync(45_000);
     });
     expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('fetches once on mount without any poke (leading fetch)', async () => {
+    const fetchFn = mockFetchResponse(200, { players: PLAYERS });
+    renderHook(() => useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(applyPlayersToEncounter).toHaveBeenCalledWith(ENCOUNTER_ID, PLAYERS);
+  });
+
+  it('exposes the fetched players array and updates it on later fetches', async () => {
+    mockFetchResponse(200, { players: PLAYERS });
+    const { result } = renderHook(() =>
+      useDmVttPlayersRefresh(CAMPAIGN_CODE, ENCOUNTER_ID)
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.players).toEqual(PLAYERS);
+
+    const updated = [{ ...PLAYERS[0], characterName: 'Thorn II' }];
+    mockFetchResponse(200, { players: updated });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000); // clear the debounce window
+      result.current.onPlayersPoke();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.players).toEqual(updated);
+  });
+
+  it('exposes an empty players array when there is no linked encounter', () => {
+    const { result } = renderHook(() =>
+      useDmVttPlayersRefresh(CAMPAIGN_CODE, null)
+    );
+    expect(result.current.players).toEqual([]);
   });
 });

--- a/src/components/ui/campaign/dm-vtt/useDmVttPlayersRefresh.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttPlayersRefresh.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { applyPlayersToEncounter } from '@/utils/encounterSync';
 import type { CampaignPlayerData } from '@/types/campaign';
@@ -18,7 +18,8 @@ const FALLBACK_POLL_MS = 45_000;
 export function useDmVttPlayersRefresh(
   campaignCode: string,
   encounterId: string | null
-): { onPlayersPoke: () => void } {
+): { onPlayersPoke: () => void; players: CampaignPlayerData[] } {
+  const [players, setPlayers] = useState<CampaignPlayerData[]>([]);
   const lastFetchRef = useRef(0);
   const trailingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -30,13 +31,22 @@ export function useDmVttPlayersRefresh(
         const res = await fetch(`/api/campaign/${campaignCode}/players`);
         if (!res.ok) return;
         const data = await res.json();
-        const players: CampaignPlayerData[] = data.players ?? [];
-        applyPlayersToEncounter(encounterId, players);
+        const fetched: CampaignPlayerData[] = data.players ?? [];
+        applyPlayersToEncounter(encounterId, fetched);
+        setPlayers(fetched);
       } catch {
         // silent — poke is best-effort
       }
     })();
   }, [campaignCode, encounterId]);
+
+  // Leading mount fetch: without it, both player HP and the roster's
+  // player-detail dialog would be up to FALLBACK_POLL_MS stale right
+  // after the map opens (pokes only fire on player activity).
+  useEffect(() => {
+    if (!encounterId) return;
+    doFetch();
+  }, [encounterId, doFetch]);
 
   // Leading-edge fire immediately; a poke inside the debounce window
   // schedules ONE trailing fetch at window expiry instead of being dropped
@@ -78,5 +88,5 @@ export function useDmVttPlayersRefresh(
     return () => clearInterval(id);
   }, [encounterId, onPlayersPoke]);
 
-  return { onPlayersPoke };
+  return { onPlayersPoke, players };
 }

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -18,12 +18,12 @@ import {
 import type { FieldNotesCanvasRef } from '@fieldnotes/react';
 import { useLocationStore } from '@/store/locationStore';
 import { useBattleMapStore } from '@/store/battleMapStore';
-import { useDmBattleMapSync } from '@/hooks/useDmBattleMapSync';
 import {
   createManagedBattleMapConnection,
   type BattleMapConnectionStatus,
 } from '@/lib/battlemapSync';
 import { openTvDisplay } from '@/lib/openTvDisplay';
+import { useShareWithPlayers } from './useShareWithPlayers';
 import type { DmLocationEditorProps } from './DmLocationEditor.types';
 import type { GridSettings } from '@/types/location';
 
@@ -215,20 +215,9 @@ export function useDmLocationEditor(
   const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
   const [hasUnsyncedChanges, setHasUnsyncedChanges] = useState(true);
 
-  // Share with players (battlemap mode only)
-  const { pushActive } = useDmBattleMapSync(campaignCode, dmId);
-  const [sharedWithPlayers, setSharedWithPlayers] = useState(false);
-
-  const handleToggleShareWithPlayers = useCallback(() => {
-    setSharedWithPlayers(prev => {
-      const next = !prev;
-      void pushActive(
-        next ? location.id : null,
-        next ? location.name : undefined
-      );
-      return next;
-    });
-  }, [pushActive, location.id, location.name]);
+  // Share with players (battlemap mode only) — hydrated from server truth
+  const { sharedWithPlayers, handleToggleShareWithPlayers } =
+    useShareWithPlayers(campaignCode, dmId, location, mode === 'battlemap');
 
   // Build tools once — no PencilTool or EraserTool for the location editor
   const tools = useMemo<Tool[]>(() => {

--- a/src/components/ui/campaign/location-map/__tests__/useShareWithPlayers.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/useShareWithPlayers.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useShareWithPlayers } from '@/components/ui/campaign/location-map/useShareWithPlayers';
+import { useActiveBattleMapId } from '@/hooks/useActiveBattleMapId';
+import { mockFetchResponse, resetFetch } from '@/test/mocks/fetch';
+
+vi.mock('@/hooks/useActiveBattleMapId', () => ({
+  useActiveBattleMapId: vi.fn(() => null),
+}));
+
+const LOCATION = { id: 'map-a', name: 'Cave' };
+
+describe('useShareWithPlayers', () => {
+  beforeEach(() => {
+    resetFetch();
+    vi.mocked(useActiveBattleMapId).mockReturnValue(null);
+  });
+
+  it('hydrates ON when the server says this map is live', () => {
+    vi.mocked(useActiveBattleMapId).mockReturnValue('map-a');
+    const { result } = renderHook(() =>
+      useShareWithPlayers('CODE', 'dm-1', LOCATION, true)
+    );
+    expect(result.current.sharedWithPlayers).toBe(true);
+  });
+
+  it('hydrates OFF when a DIFFERENT map is live — the stale-share trap', () => {
+    vi.mocked(useActiveBattleMapId).mockReturnValue('map-b');
+    const { result } = renderHook(() =>
+      useShareWithPlayers('CODE', 'dm-1', LOCATION, true)
+    );
+    expect(result.current.sharedWithPlayers).toBe(false);
+  });
+
+  it('disabled (location mode) passes null code and stays OFF', () => {
+    const { result } = renderHook(() =>
+      useShareWithPlayers('CODE', 'dm-1', LOCATION, false)
+    );
+    expect(vi.mocked(useActiveBattleMapId)).toHaveBeenCalledWith(null);
+    expect(result.current.sharedWithPlayers).toBe(false);
+  });
+
+  it('toggling ON pushes this map live', async () => {
+    const fetchFn = mockFetchResponse(200, {});
+    const { result } = renderHook(() =>
+      useShareWithPlayers('CODE', 'dm-1', LOCATION, true)
+    );
+    await act(async () => {
+      result.current.handleToggleShareWithPlayers();
+    });
+    expect(result.current.sharedWithPlayers).toBe(true);
+    const [url, init] = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/campaign/CODE/shared');
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.feature).toBe('battlemap');
+    expect(body.data.activeBattleMapId).toBe('map-a');
+    expect(body.data.name).toBe('Cave');
+    expect(body.dmId).toBe('dm-1');
+  });
+
+  it('toggling OFF clears the live map', async () => {
+    vi.mocked(useActiveBattleMapId).mockReturnValue('map-a');
+    const fetchFn = mockFetchResponse(200, {});
+    const { result } = renderHook(() =>
+      useShareWithPlayers('CODE', 'dm-1', LOCATION, true)
+    );
+    await act(async () => {
+      result.current.handleToggleShareWithPlayers();
+    });
+    expect(result.current.sharedWithPlayers).toBe(false);
+    const body = JSON.parse(
+      ((fetchFn as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit)
+        .body as string
+    );
+    expect(body.data.activeBattleMapId).toBeNull();
+  });
+
+  it('reconciles when the server-active id changes (e.g. combat started in another tab)', () => {
+    const { result, rerender } = renderHook(() =>
+      useShareWithPlayers('CODE', 'dm-1', LOCATION, true)
+    );
+    expect(result.current.sharedWithPlayers).toBe(false);
+    vi.mocked(useActiveBattleMapId).mockReturnValue('map-a');
+    rerender();
+    expect(result.current.sharedWithPlayers).toBe(true);
+  });
+});

--- a/src/components/ui/campaign/location-map/useShareWithPlayers.ts
+++ b/src/components/ui/campaign/location-map/useShareWithPlayers.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { useActiveBattleMapId } from '@/hooks/useActiveBattleMapId';
+import { useDmBattleMapSync } from '@/hooks/useDmBattleMapSync';
+
+/**
+ * "Share with players" toggle state, hydrated from server truth. The
+ * activeBattleMapId is a single per-campaign value whose only writer used
+ * to be this toggle — and the toggle booted as `useState(false)` with no
+ * hydration, so a map shared in an earlier session stayed silently live
+ * while the editor showed "not shared" (with two same-named maps, players
+ * joined the stale one and the matching banner name masked it). Hydration:
+ * ON iff the server's active id IS this map. The click stays optimistic;
+ * useActiveBattleMapId's poll (60s + visibilitychange) reconciles later
+ * drift, e.g. start-combat auto-share from the encounter tab. A poll
+ * response in flight across a toggle can flip the state back for one
+ * cycle; the next poll self-corrects.
+ */
+export function useShareWithPlayers(
+  campaignCode: string,
+  dmId: string,
+  location: { id: string; name: string },
+  enabled: boolean
+): {
+  sharedWithPlayers: boolean;
+  handleToggleShareWithPlayers: () => void;
+} {
+  const { pushActive } = useDmBattleMapSync(campaignCode, dmId);
+  const [sharedWithPlayers, setSharedWithPlayers] = useState(false);
+  const activeBattleMapId = useActiveBattleMapId(enabled ? campaignCode : null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    setSharedWithPlayers(activeBattleMapId === location.id);
+  }, [enabled, activeBattleMapId, location.id]);
+
+  const handleToggleShareWithPlayers = useCallback(() => {
+    setSharedWithPlayers(prev => {
+      const next = !prev;
+      void pushActive(
+        next ? location.id : null,
+        next ? location.name : undefined
+      );
+      return next;
+    });
+  }, [pushActive, location.id, location.name]);
+
+  return { sharedWithPlayers, handleToggleShareWithPlayers };
+}

--- a/src/components/ui/encounter/EncounterView.tsx
+++ b/src/components/ui/encounter/EncounterView.tsx
@@ -22,6 +22,10 @@ import { useInitiativeSubmissionSync } from '@/hooks/useInitiativeSubmissionSync
 import { useActiveBattleMapId } from '@/hooks/useActiveBattleMapId';
 import { useBattleMapPokes } from '@/hooks/useBattleMapPokes';
 import { useDebouncedRefetch } from '@/hooks/useDebouncedRefetch';
+import { useBattleMapStore } from '@/store/battleMapStore';
+import { useDmBattleMapSync } from '@/hooks/useDmBattleMapSync';
+import { findLinkedBattleMap } from '@/utils/battleMapLinks';
+import type { BattleMap } from '@/types/battlemap';
 import { buildSharedInitiative } from '@/utils/buildSharedInitiative';
 import { Button } from '@/components/ui/forms/button';
 import { CombatScreen } from './combat-screen/CombatScreen';
@@ -52,6 +56,25 @@ export function handleEncounterPoke(
   refresh: () => void
 ): void {
   if (feature === 'players') refresh();
+}
+
+/**
+ * Start-combat side effect, extracted for unit testability (same pattern
+ * as `handleEncounterPoke`). Starting combat makes the encounter's linked
+ * battle map the campaign's live map, so players who tap the banner land
+ * on the map the DM is actually fighting on — previously the only writer
+ * of activeBattleMapId was the editor's manual share toggle, and a map
+ * shared in an earlier session stayed live forever (with two same-named
+ * maps, players joined the wrong one). No linked map → no push: never
+ * clear a share the DM set up manually.
+ */
+export function pushLinkedMapLive(
+  battleMaps: BattleMap[],
+  encounterId: string,
+  pushActive: (battleMapId: string | null, name?: string) => Promise<void>
+): void {
+  const linked = findLinkedBattleMap(battleMaps, encounterId);
+  if (linked) void pushActive(linked.id, linked.name);
 }
 
 export function EncounterView({
@@ -115,6 +138,9 @@ export function EncounterView({
     campaignCode,
     dmId,
   });
+
+  const { pushActive } = useDmBattleMapSync(campaignCode, dmId);
+  const getBattleMaps = useBattleMapStore(state => state.getBattleMaps);
 
   useTurnRequestSync({
     campaignCode,
@@ -307,6 +333,7 @@ export function EncounterView({
       }).catch(() => {});
     }
     startCombat(encounterId);
+    pushLinkedMapLive(getBattleMaps(campaignCode), encounterId, pushActive);
   }, [
     encounter?.pendingInitiativeRequest,
     encounterId,
@@ -314,6 +341,8 @@ export function EncounterView({
     pushInitiativeRequest,
     setPendingInitiativeRequest,
     startCombat,
+    getBattleMaps,
+    pushActive,
   ]);
 
   if (!encounter || !actions) {

--- a/src/components/ui/encounter/__tests__/pushLinkedMapLive.test.ts
+++ b/src/components/ui/encounter/__tests__/pushLinkedMapLive.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { pushLinkedMapLive } from '../EncounterView';
+
+import type { BattleMap } from '@/types/battlemap';
+
+function makeMap(overrides: Partial<BattleMap>): BattleMap {
+  return {
+    id: 'map-1',
+    name: 'Cave',
+    linkedEncounterIds: [],
+    ...overrides,
+  } as BattleMap;
+}
+
+describe('pushLinkedMapLive', () => {
+  it('pushes the linked map live (id + name) on start combat', () => {
+    const pushActive = vi.fn().mockResolvedValue(undefined);
+    const maps = [
+      makeMap({ id: 'map-a', name: 'Cave A', linkedEncounterIds: ['enc-1'] }),
+      makeMap({ id: 'map-b', name: 'Cave B' }),
+    ];
+
+    pushLinkedMapLive(maps, 'enc-1', pushActive);
+
+    expect(pushActive).toHaveBeenCalledTimes(1);
+    expect(pushActive).toHaveBeenCalledWith('map-a', 'Cave A');
+  });
+
+  it('does nothing when no map links the encounter — never clears a manual share', () => {
+    const pushActive = vi.fn().mockResolvedValue(undefined);
+
+    pushLinkedMapLive([makeMap({})], 'enc-1', pushActive);
+
+    expect(pushActive).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/crossTabEncounterSync.test.ts
+++ b/src/lib/__tests__/crossTabEncounterSync.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { initCrossTabEncounterSync } from '@/lib/crossTabEncounterSync';
+import { ENCOUNTER_STORAGE_KEY } from '@/utils/constants';
+
+import type { Encounter } from '@/types/encounter';
+
+function makeEncounter(overrides: Partial<Encounter>): Encounter {
+  return {
+    id: 'enc-1',
+    name: 'Goblin Ambush',
+    entities: [],
+    currentTurn: 0,
+    round: 1,
+    isActive: false,
+    sortOrder: 'initiative',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  } as Encounter;
+}
+
+function makeStore(encounters: Encounter[]) {
+  const state = { encounters };
+  return {
+    getState: vi.fn(() => state),
+    setState: vi.fn((partial: { encounters: Encounter[] }) => {
+      state.encounters = partial.encounters;
+    }),
+  };
+}
+
+function fireStorage(key: string | null, newValue: string | null) {
+  window.dispatchEvent(new StorageEvent('storage', { key, newValue }));
+}
+
+const wrap = (encounters: Encounter[]) =>
+  JSON.stringify({ state: { encounters } });
+
+let cleanup: (() => void) | null = null;
+afterEach(() => {
+  cleanup?.();
+  cleanup = null;
+});
+
+describe('initCrossTabEncounterSync', () => {
+  it('adopts an incoming encounter with a strictly newer updatedAt', () => {
+    const local = makeEncounter({ updatedAt: '2026-07-01T00:00:00.000Z' });
+    const incoming = makeEncounter({
+      updatedAt: '2026-07-02T00:00:00.000Z',
+      isActive: true,
+    });
+    const store = makeStore([local]);
+    cleanup = initCrossTabEncounterSync(store);
+
+    fireStorage(ENCOUNTER_STORAGE_KEY, wrap([incoming]));
+
+    expect(store.setState).toHaveBeenCalledTimes(1);
+    expect(store.getState().encounters[0].isActive).toBe(true);
+  });
+
+  it('keeps local when incoming updatedAt is older', () => {
+    const local = makeEncounter({ updatedAt: '2026-07-02T00:00:00.000Z' });
+    const incoming = makeEncounter({
+      updatedAt: '2026-07-01T00:00:00.000Z',
+      isActive: true,
+    });
+    const store = makeStore([local]);
+    cleanup = initCrossTabEncounterSync(store);
+
+    fireStorage(ENCOUNTER_STORAGE_KEY, wrap([incoming]));
+
+    expect(store.setState).not.toHaveBeenCalled();
+  });
+
+  it('equal updatedAt is a no-op — the echo event terminates', () => {
+    const local = makeEncounter({});
+    const store = makeStore([local]);
+    cleanup = initCrossTabEncounterSync(store);
+
+    fireStorage(ENCOUNTER_STORAGE_KEY, wrap([makeEncounter({})]));
+
+    expect(store.setState).not.toHaveBeenCalled();
+  });
+
+  it('adopts encounters with unknown ids (created in another tab)', () => {
+    const store = makeStore([makeEncounter({ id: 'enc-1' })]);
+    cleanup = initCrossTabEncounterSync(store);
+
+    fireStorage(
+      ENCOUNTER_STORAGE_KEY,
+      wrap([makeEncounter({ id: 'enc-1' }), makeEncounter({ id: 'enc-2' })])
+    );
+
+    expect(store.setState).toHaveBeenCalledTimes(1);
+    expect(store.getState().encounters.map(e => e.id)).toEqual([
+      'enc-1',
+      'enc-2',
+    ]);
+  });
+
+  it('keeps local-only encounters missing from the incoming state', () => {
+    const store = makeStore([
+      makeEncounter({ id: 'enc-1' }),
+      makeEncounter({ id: 'enc-local' }),
+    ]);
+    cleanup = initCrossTabEncounterSync(store);
+
+    fireStorage(
+      ENCOUNTER_STORAGE_KEY,
+      wrap([
+        makeEncounter({ id: 'enc-1', updatedAt: '2026-07-02T00:00:00.000Z' }),
+      ])
+    );
+
+    expect(store.getState().encounters.map(e => e.id)).toEqual([
+      'enc-1',
+      'enc-local',
+    ]);
+  });
+
+  it('ignores other storage keys', () => {
+    const store = makeStore([makeEncounter({})]);
+    cleanup = initCrossTabEncounterSync(store);
+
+    fireStorage('some-other-key', wrap([makeEncounter({ isActive: true })]));
+
+    expect(store.setState).not.toHaveBeenCalled();
+  });
+
+  it('ignores malformed JSON and null newValue', () => {
+    const store = makeStore([makeEncounter({})]);
+    cleanup = initCrossTabEncounterSync(store);
+
+    fireStorage(ENCOUNTER_STORAGE_KEY, '{not json');
+    fireStorage(ENCOUNTER_STORAGE_KEY, null);
+    fireStorage(ENCOUNTER_STORAGE_KEY, JSON.stringify({ state: {} }));
+
+    expect(store.setState).not.toHaveBeenCalled();
+  });
+
+  it('cleanup removes the listener', () => {
+    const store = makeStore([makeEncounter({})]);
+    const dispose = initCrossTabEncounterSync(store);
+    dispose();
+
+    fireStorage(
+      ENCOUNTER_STORAGE_KEY,
+      wrap([makeEncounter({ updatedAt: '2027-01-01T00:00:00.000Z' })])
+    );
+
+    expect(store.setState).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/crossTabEncounterSync.ts
+++ b/src/lib/crossTabEncounterSync.ts
@@ -1,0 +1,64 @@
+import { ENCOUNTER_STORAGE_KEY } from '@/utils/constants';
+
+import type { Encounter } from '@/types/encounter';
+
+interface EncounterStoreLike {
+  getState: () => { encounters: Encounter[] };
+  setState: (partial: { encounters: Encounter[] }) => void;
+}
+
+/**
+ * Cross-tab encounter convergence (mirrors crossTabRosterSync). The DM
+ * routinely keeps the encounter page and the battlemap open in separate
+ * tabs; zustand persist writes localStorage but never listens for the
+ * `storage` event, so without this each tab's in-memory store goes stale
+ * until a reload. Merge per encounter by `updatedAt` — strictly newer
+ * wins (every store mutation stamps it); unknown ids are adopted (created
+ * in another tab); local-only encounters are kept (deletion sync is out
+ * of scope, same as the roster). setState only on change, so the echo
+ * event the other tab receives finds equal timestamps and terminates.
+ * Same-timestamp concurrent edits are last-writer-wins.
+ */
+export function initCrossTabEncounterSync(
+  store: EncounterStoreLike
+): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== ENCOUNTER_STORAGE_KEY || !event.newValue) return;
+    let incoming: Encounter[] | undefined;
+    try {
+      const parsed: unknown = JSON.parse(event.newValue);
+      incoming = (parsed as { state?: { encounters?: Encounter[] } } | null)
+        ?.state?.encounters;
+    } catch {
+      return;
+    }
+    if (!Array.isArray(incoming)) return;
+
+    const incomingById = new Map(
+      incoming
+        .filter(entry => entry && typeof entry.id === 'string')
+        .map(entry => [entry.id, entry])
+    );
+    let changed = false;
+    const merged = store.getState().encounters.map(entry => {
+      const candidate = incomingById.get(entry.id);
+      incomingById.delete(entry.id);
+      if (!candidate) return entry;
+      if ((candidate.updatedAt ?? '') > (entry.updatedAt ?? '')) {
+        changed = true;
+        return candidate;
+      }
+      return entry;
+    });
+    for (const adopted of incomingById.values()) {
+      merged.push(adopted);
+      changed = true;
+    }
+    if (changed) store.setState({ encounters: merged });
+  };
+
+  window.addEventListener('storage', onStorage);
+  return () => window.removeEventListener('storage', onStorage);
+}

--- a/src/store/encounterStore.ts
+++ b/src/store/encounterStore.ts
@@ -10,6 +10,7 @@ import {
 } from '@/types/encounter';
 import { useNPCStore } from './npcStore';
 import { initCrossTabEncounterSync } from '@/lib/crossTabEncounterSync';
+import { exposeStoreForE2E } from '@/lib/e2eStoreHandles';
 import { ENCOUNTER_STORAGE_KEY } from '@/utils/constants';
 
 function generateId(): string {
@@ -990,6 +991,8 @@ export const useEncounterStore = create<EncounterStoreState>()(
     }
   )
 );
+
+exposeStoreForE2E('encounter', useEncounterStore);
 
 initCrossTabEncounterSync(useEncounterStore);
 

--- a/src/store/encounterStore.ts
+++ b/src/store/encounterStore.ts
@@ -9,8 +9,8 @@ import {
   DEFAULT_COMBAT_CONFIG,
 } from '@/types/encounter';
 import { useNPCStore } from './npcStore';
-
-const ENCOUNTER_STORAGE_KEY = 'rollkeeper-encounter-data';
+import { initCrossTabEncounterSync } from '@/lib/crossTabEncounterSync';
+import { ENCOUNTER_STORAGE_KEY } from '@/utils/constants';
 
 function generateId(): string {
   return Date.now().toString(36) + Math.random().toString(36).substr(2, 9);
@@ -990,6 +990,8 @@ export const useEncounterStore = create<EncounterStoreState>()(
     }
   )
 );
+
+initCrossTabEncounterSync(useEncounterStore);
 
 export { getSortedEntities };
 export default useEncounterStore;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -635,6 +635,7 @@ export const SPELL_SOURCE_BOOKS: Record<string, string> = {
 export const AUTOSAVE_DELAY = 500; // ms
 export const STORAGE_KEY = 'rollkeeper-character';
 export const PLAYER_STORAGE_KEY = 'rollkeeper-player-data';
+export const ENCOUNTER_STORAGE_KEY = 'rollkeeper-encounter-data';
 export const APP_VERSION = '1.0.0';
 
 // Avatar upload settings


### PR DESCRIPTION
## Summary

Three DM-facing fixes/tweaks around the battlemap ↔ encounter workflow:

1. **Cross-tab encounter sync** — the DM battlemap and encounter page typically run in separate tabs, and the encounter store (unlike `characterStore`/`playerStore`) had no cross-tab `storage` listener, so the battlemap needed a full reload to see combatant/HP/combat-state changes. New `crossTabEncounterSync` mirrors the existing roster-sync pattern: per-encounter merge keyed by `updatedAt` (strictly newer wins), unknown ids adopted, echo events terminate on equal timestamps.

2. **Stale active-map fix (critical)** — with two same-named maps, players could join the wrong one. Root cause was not name-based lookup (all map plumbing is id-based) but a stale `activeBattleMapId` in Redis: the "Share with players" toggle booted `useState(false)` with no hydration, so a map shared in an earlier session stayed silently live and the matching name masked it. Fixes:
   - `useShareWithPlayers` hydrates the toggle from server truth via the existing `useActiveBattleMapId` poll (optimistic click, poll reconciles drift);
   - starting combat now auto-pushes the encounter's linked map live (`pushLinkedMapLive`); no linked map → no push, a manual share is never cleared.

3. **Player detail eye icon on the battlemap** — `useDmVttPlayersRefresh` now retains the fetched `CampaignPlayerData[]` (and fetches on mount, fixing up-to-45s-stale HP right after opening the map); player roster rows get an eye button (sibling of the row button — no nested buttons) opening the existing `PlayerDetailDialog`, looked up at render time so poke-driven refreshes live-update the open dialog. `PlayerDetailDialog` itself untouched.

## Test plan

- `npx vitest run --project unit` — 3049 pass / 0 fail (19 new tests: 8 cross-tab sync, 6 share hydration, 2 auto-share, 3 players retention; +3 roster eye tests; 6 existing refresh-hook tests re-timed for the mount fetch, intent preserved)
- `npm run type-check` clean
- Manual smoke: two DM tabs converge without reload; opening a map while another is live shows toggle OFF; start combat points the player banner at the fought-on map; eye icon opens live-updating character detail on the VTT

🤖 Generated with [Claude Code](https://claude.com/claude-code)