### PR TITLE
fix(battlemap): canonical layer bands + side-by-side map management

### DIFF
--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/campaign/dm-vtt/combatantToken';
 import {
   migrateCanvasToContract,
-  mirrorUnknownLayer,
+  attachUnknownLayerMirror,
   subscribePinCanonicalLayers,
 } from '@/components/ui/campaign/location-map/layerContract';
 
@@ -160,12 +160,9 @@ export function useDmBattleMapCanvas({
 
       // Mirror unknown remote layers (player tokens) into the player band —
       // without this they sort at layer order 0, under DM-added images.
-      vp.store.on('add', el => {
-        if (el.layerId && !vp.layerManager.getLayer(el.layerId)) {
-          mirrorUnknownLayer(vp, el.layerId, 'dm');
-          vp.requestRender();
-        }
-      });
+      // Covers both new elements (add) and relay snapshot reconcile
+      // re-applying remote elements as full updates (including layerId).
+      attachUnknownLayerMirror(vp, 'dm', () => vp.requestRender());
       pinUnsubRef.current?.();
       pinUnsubRef.current = subscribePinCanonicalLayers(vp);
 

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -20,6 +20,11 @@ import {
   isCombatantToken,
   type DmTokenConfig,
 } from '@/components/ui/campaign/dm-vtt/combatantToken';
+import {
+  migrateCanvasToContract,
+  mirrorUnknownLayer,
+  subscribePinCanonicalLayers,
+} from '@/components/ui/campaign/location-map/layerContract';
 
 import type { TokenInfoMode } from '@/components/ui/campaign/token-overlay';
 
@@ -76,6 +81,7 @@ export function useDmBattleMapCanvas({
   const [status, setStatus] = useState<BattleMapConnectionStatus>('connecting');
   const autoSaveRef = useRef<AutoSave | null>(null);
   const connectionRef = useRef<{ stop: () => void } | null>(null);
+  const pinUnsubRef = useRef<(() => void) | null>(null);
   // The connection is created once inside the fire-once `handleReady`
   // callback; a plain closure over `onPoke` would go stale if the prop's
   // identity changes later (e.g. encounterId change) after the connection
@@ -115,6 +121,19 @@ export function useDmBattleMapCanvas({
         }
       }
 
+      // Canonical bands + one-shot migration. Runs before the save listeners
+      // attach so element moves don't trigger a full-JSON save per element;
+      // if anything migrated, persist the result once.
+      const migrated = migrateCanvasToContract(vp, 'dm');
+      if (migrated) {
+        useBattleMapStore
+          .getState()
+          .updateBattleMap(campaignCode, battleMapId, {
+            canvasState: vp.exportJSON(),
+            updatedAt: new Date().toISOString(),
+          });
+      }
+
       const autoSave = new AutoSave(vp.store, vp.camera, {
         key: `battlemap-canvas-${battleMapId}`,
         debounceMs: 1500,
@@ -138,6 +157,17 @@ export function useDmBattleMapCanvas({
       vp.store.on('add', saveOnLocalOps);
       vp.store.on('remove', saveOnLocalOps);
       vp.store.on('update', saveOnLocalOps);
+
+      // Mirror unknown remote layers (player tokens) into the player band —
+      // without this they sort at layer order 0, under DM-added images.
+      vp.store.on('add', el => {
+        if (el.layerId && !vp.layerManager.getLayer(el.layerId)) {
+          mirrorUnknownLayer(vp, el.layerId, 'dm');
+          vp.requestRender();
+        }
+      });
+      pinUnsubRef.current?.();
+      pinUnsubRef.current = subscribePinCanonicalLayers(vp);
 
       const selectTool = vp.toolManager.getTool<SelectTool>('select');
       selectTool?.onSelectionChange(() => {
@@ -186,6 +216,7 @@ export function useDmBattleMapCanvas({
     return () => {
       autoSaveRef.current?.stop();
       connectionRef.current?.stop();
+      pinUnsubRef.current?.();
     };
   }, []);
 

--- a/src/components/ui/campaign/dm-vtt/useDmVttGrid.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttGrid.ts
@@ -3,6 +3,7 @@
 import { useCallback } from 'react';
 
 import { useBattleMapStore } from '@/store/battleMapStore';
+import { pinGridToMapLayer } from '@/components/ui/campaign/location-map/gridPin';
 
 import type { Viewport } from '@fieldnotes/core';
 import type { BattleMap } from '@/types/battlemap';
@@ -15,40 +16,6 @@ const DEFAULT_GRID: Omit<GridSettings, 'gridType' | 'hexOrientation'> = {
   strokeWidth: 1,
   opacity: 0.5,
 };
-
-/**
- * Map + grid must live on a layer-locked background so hit-testing skips
- * them, and grid elements must be `locked` so Select can't drag them.
- * Replicated verbatim from `DmLocationEditor.hooks.ts:62-89`
- * (`pinGridToMapBackgroundLayer`) — that helper is module-private there, so
- * it's copied here rather than imported. Keep in sync if the source changes.
- */
-function pinGridToMapBackgroundLayer(vp: Viewport): void {
-  let layers = vp.layerManager.getLayers();
-  if (layers.length === 0) return;
-
-  if (layers.length === 1) {
-    vp.layerManager.createLayer('Annotations');
-    layers = vp.layerManager.getLayers();
-  }
-
-  const bgLayer = layers[0];
-  vp.layerManager.renameLayer(bgLayer.id, 'Map Background');
-
-  if (vp.layerManager.activeLayerId === bgLayer.id) {
-    const fallback = layers.find(l => l.id !== bgLayer.id);
-    if (fallback) vp.layerManager.setActiveLayer(fallback.id);
-  }
-
-  vp.layerManager.setLayerLocked(bgLayer.id, true);
-
-  for (const g of vp.store.getElementsByType('grid')) {
-    vp.layerManager.moveElementToLayer(g.id, bgLayer.id);
-    vp.store.update(g.id, { locked: true });
-  }
-
-  vp.requestRender();
-}
 
 interface UseDmVttGridOptions {
   campaignCode: string;
@@ -90,7 +57,7 @@ export function useDmVttGrid({
         hexOrientation: target === 'hex' ? 'pointy' : undefined,
       };
       vp.addGrid(settings);
-      pinGridToMapBackgroundLayer(vp);
+      pinGridToMapLayer(vp);
 
       updateBattleMap(campaignCode, battleMapId, {
         gridEnabled: true,

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -27,7 +27,7 @@ import { useShareWithPlayers } from './useShareWithPlayers';
 import {
   ensureCanonicalLayers,
   migrateCanvasToContract,
-  mirrorUnknownLayer,
+  attachUnknownLayerMirror,
   subscribePinCanonicalLayers,
   MAP_LAYER_ID,
 } from './layerContract';
@@ -358,13 +358,10 @@ export function useDmLocationEditor(
       // Layers aren't synced: player tokens arrive referencing player-*
       // layer ids that don't exist on this canvas and would sort at layer
       // order 0 — UNDER the annotations layer where DM-added images live.
-      // Mirror unknown layers into their canonical band instead.
-      vp.store.on('add', el => {
-        if (el.layerId && !vp.layerManager.getLayer(el.layerId)) {
-          mirrorUnknownLayer(vp, el.layerId, 'dm');
-          vp.requestRender();
-        }
-      });
+      // Mirror unknown layers into their canonical band instead. Covers both
+      // new elements (add) and relay snapshot reconcile re-applying remote
+      // elements as full updates (including layerId) on reconnect.
+      attachUnknownLayerMirror(vp, 'dm', () => vp.requestRender());
       pinUnsubRef.current?.();
       pinUnsubRef.current = subscribePinCanonicalLayers(vp, () => ({
         mapUnlocked: arrangeActiveRef.current,

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -178,6 +178,10 @@ export function useDmLocationEditor(
   const [arrangeMapsActive, setArrangeMapsActive] = useState(false);
   const arrangeActiveRef = useRef(false);
   const arrangeSessionRef = useRef<ArrangeMapsSession | null>(null);
+  /** Live viewport for unmount-time cleanup — canvasRef is already nulled by
+   * React (child refs detach before ancestor effect cleanup) when the
+   * cleanup effect runs, so it cannot be used there. */
+  const vpRef = useRef<Viewport | null>(null);
 
   const [viewport, setViewport] = useState<Viewport | null>(null);
 
@@ -275,6 +279,7 @@ export function useDmLocationEditor(
   const handleReady = useCallback(
     async (vp: Viewport) => {
       setViewport(vp);
+      vpRef.current = vp;
 
       // Track selected element for DM-only toggle
       const syncSelection = () => {
@@ -469,7 +474,7 @@ export function useDmLocationEditor(
   // persisted lock flags would stay unlocked.
   useEffect(() => {
     return () => {
-      const vp = getVp();
+      const vp = vpRef.current;
       if (arrangeActiveRef.current && arrangeSessionRef.current && vp) {
         arrangeActiveRef.current = false;
         exitArrangeMaps(vp, arrangeSessionRef.current);
@@ -479,7 +484,7 @@ export function useDmLocationEditor(
       connectionRef.current?.stop();
       pinUnsubRef.current?.();
     };
-  }, [getVp]);
+  }, []);
 
   const handlePickImage = useCallback(() => {
     fileInputRef.current?.click();

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -24,6 +24,13 @@ import {
 } from '@/lib/battlemapSync';
 import { openTvDisplay } from '@/lib/openTvDisplay';
 import { useShareWithPlayers } from './useShareWithPlayers';
+import {
+  ensureCanonicalLayers,
+  migrateCanvasToContract,
+  mirrorUnknownLayer,
+  subscribePinCanonicalLayers,
+  MAP_LAYER_ID,
+} from './layerContract';
 import type { DmLocationEditorProps } from './DmLocationEditor.types';
 import type { GridSettings } from '@/types/location';
 
@@ -54,37 +61,17 @@ type ViewportHistoryAccess = {
 };
 
 /**
- * Map + grid must live on a layer-locked background so hit-testing skips them
- * (see @fieldnotes/core InputHandler / SelectTool + `isLayerLocked`).
- * Grid elements must also be `locked` so Select cannot drag them (otherwise they
- * appear to slide when panning/zooming).
+ * Map + grid must live on the layer-locked map layer so hit-testing skips
+ * them (see @fieldnotes/core InputHandler / SelectTool + `isLayerLocked`).
+ * Grid elements must also be `locked` so Select cannot drag them (otherwise
+ * they appear to slide when panning/zooming).
  */
-function pinGridToMapBackgroundLayer(vp: Viewport) {
-  let layers = vp.layerManager.getLayers();
-  if (layers.length === 0) return;
-
-  if (layers.length === 1) {
-    vp.layerManager.createLayer('Annotations');
-    layers = vp.layerManager.getLayers();
-  }
-
-  const bgLayer = layers[0];
-  vp.layerManager.renameLayer(bgLayer.id, 'Map Background');
-
-  if (vp.layerManager.activeLayerId === bgLayer.id) {
-    const fallback = layers.find(l => l.id !== bgLayer.id);
-    if (fallback) {
-      vp.layerManager.setActiveLayer(fallback.id);
-    }
-  }
-
-  vp.layerManager.setLayerLocked(bgLayer.id, true);
-
+function pinGridToMapLayer(vp: Viewport) {
+  ensureCanonicalLayers(vp, 'dm');
   for (const g of vp.store.getElementsByType('grid')) {
-    vp.layerManager.moveElementToLayer(g.id, bgLayer.id);
+    vp.layerManager.moveElementToLayer(g.id, MAP_LAYER_ID);
     vp.store.update(g.id, { locked: true });
   }
-
   vp.requestRender();
 }
 
@@ -158,6 +145,7 @@ export function useDmLocationEditor(
   const fileInputRef = useRef<HTMLInputElement>(null);
   const autoSaveRef = useRef<AutoSave | null>(null);
   const connectionRef = useRef<{ stop: () => void } | null>(null);
+  const pinUnsubRef = useRef<(() => void) | null>(null);
   const [syncStatus, setSyncStatus] = useState<
     BattleMapConnectionStatus | 'disabled'
   >('disabled');
@@ -294,10 +282,15 @@ export function useDmLocationEditor(
       if (location.canvasState && location.canvasState.trim().length > 0) {
         try {
           vp.loadJSON(location.canvasState);
-          pinGridToMapBackgroundLayer(vp);
+          const migrated = migrateCanvasToContract(vp, 'dm');
+          pinGridToMapLayer(vp);
           _fitCameraToMap(vp, location.mapImageSize);
           // Clear stale localStorage data after successful load
           await autoSave.clear();
+          if (migrated) {
+            onSave(vp.exportJSON());
+            setHasUnsyncedChanges(true);
+          }
         } catch {
           // Corrupt state — start fresh
           _initializeBackground(
@@ -307,7 +300,7 @@ export function useDmLocationEditor(
           );
         }
       } else {
-        // New location — place the map image as a locked background on the base layer
+        // New location — place the map image as a locked background on the map layer
         _initializeBackground(vp, location.mapImageUrl, location.mapImageSize);
       }
 
@@ -327,6 +320,19 @@ export function useDmLocationEditor(
       vp.store.on('add', saveAndMarkDirty);
       vp.store.on('remove', saveAndMarkDirty);
       vp.store.on('update', saveAndMarkDirty);
+
+      // Layers aren't synced: player tokens arrive referencing player-*
+      // layer ids that don't exist on this canvas and would sort at layer
+      // order 0 — UNDER the annotations layer where DM-added images live.
+      // Mirror unknown layers into their canonical band instead.
+      vp.store.on('add', el => {
+        if (el.layerId && !vp.layerManager.getLayer(el.layerId)) {
+          mirrorUnknownLayer(vp, el.layerId, 'dm');
+          vp.requestRender();
+        }
+      });
+      pinUnsubRef.current?.();
+      pinUnsubRef.current = subscribePinCanonicalLayers(vp);
 
       // Live sync — battlemap mode only; resolver reads Zustand LIVE via
       // getState() (a captured snapshot would go stale after the first toggle).
@@ -385,16 +391,12 @@ export function useDmLocationEditor(
     mapImageUrl: string,
     mapImageSize: { w: number; h: number }
   ) {
-    // Set up layers synchronously so they're always created on the
-    // active viewport, even if image loading completes asynchronously
-    // on a different (StrictMode-destroyed) viewport.
-    const baseLayer = vp.layerManager.getLayers()[0];
-    if (baseLayer) {
-      vp.layerManager.renameLayer(baseLayer.id, 'Map Background');
-      vp.layerManager.setLayerLocked(baseLayer.id, true);
-    }
-    const annotationLayer = vp.layerManager.createLayer('Annotations');
-    vp.layerManager.setActiveLayer(annotationLayer.id);
+    // Canonical layers are created synchronously so they always exist on the
+    // active viewport, even if image loading completes asynchronously on a
+    // different (StrictMode-destroyed) viewport. Migration drops the SDK's
+    // empty default "Layer 1".
+    ensureCanonicalLayers(vp, 'dm');
+    migrateCanvasToContract(vp, 'dm');
 
     if (!mapImageUrl) return;
 
@@ -409,10 +411,7 @@ export function useDmLocationEditor(
       const bgImage = allElements[allElements.length - 1];
       if (bgImage) {
         vp.store.update(bgImage.id, { locked: true });
-        // Ensure image is on the background layer
-        if (baseLayer) {
-          vp.layerManager.moveElementToLayer(bgImage.id, baseLayer.id);
-        }
+        vp.layerManager.moveElementToLayer(bgImage.id, MAP_LAYER_ID);
       }
       _fitCameraToMap(vp, mapImageSize);
       vp.requestRender();
@@ -439,6 +438,7 @@ export function useDmLocationEditor(
     return () => {
       autoSaveRef.current?.stop();
       connectionRef.current?.stop();
+      pinUnsubRef.current?.();
     };
   }, []);
 
@@ -476,7 +476,7 @@ export function useDmLocationEditor(
       };
       vp.addGrid(settings);
 
-      pinGridToMapBackgroundLayer(vp);
+      pinGridToMapLayer(vp);
 
       setGridEnabled(true);
       setGridType(type);

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -31,6 +31,7 @@ import {
   subscribePinCanonicalLayers,
   MAP_LAYER_ID,
 } from './layerContract';
+import { pinGridToMapLayer } from './gridPin';
 import type { DmLocationEditorProps } from './DmLocationEditor.types';
 import type { GridSettings } from '@/types/location';
 
@@ -59,21 +60,6 @@ function proxyUrl(url: string): string {
 type ViewportHistoryAccess = {
   historyRecorder: { begin: () => void; commit: () => void };
 };
-
-/**
- * Map + grid must live on the layer-locked map layer so hit-testing skips
- * them (see @fieldnotes/core InputHandler / SelectTool + `isLayerLocked`).
- * Grid elements must also be `locked` so Select cannot drag them (otherwise
- * they appear to slide when panning/zooming).
- */
-function pinGridToMapLayer(vp: Viewport) {
-  ensureCanonicalLayers(vp, 'dm');
-  for (const g of vp.store.getElementsByType('grid')) {
-    vp.layerManager.moveElementToLayer(g.id, MAP_LAYER_ID);
-    vp.store.update(g.id, { locked: true });
-  }
-  vp.requestRender();
-}
 
 export interface DmLocationEditorState {
   // Mode

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -32,6 +32,7 @@ import {
   MAP_LAYER_ID,
 } from './layerContract';
 import { pinGridToMapLayer } from './gridPin';
+import { nextMapImagePosition } from './mapImagePlacement';
 import type { DmLocationEditorProps } from './DmLocationEditor.types';
 import type { GridSettings } from '@/types/location';
 
@@ -61,6 +62,30 @@ type ViewportHistoryAccess = {
   historyRecorder: { begin: () => void; commit: () => void };
 };
 
+/** Upload to S3 via /api/assets/upload; base64 data-URL fallback when S3 is
+ *  not configured. Returns the canonical (non-proxied) src to store. */
+async function uploadCanvasImage(file: File): Promise<string> {
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('assetId', `canvas-${Date.now()}`);
+    const res = await fetch('/api/assets/upload', {
+      method: 'POST',
+      body: formData,
+    });
+    if (!res.ok) throw new Error('Upload failed');
+    const data = await res.json();
+    return data.url as string;
+  } catch {
+    return await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
+}
+
 export interface DmLocationEditorState {
   // Mode
   mode: 'location' | 'battlemap';
@@ -68,6 +93,7 @@ export interface DmLocationEditorState {
   // Refs
   canvasRef: React.RefObject<FieldNotesCanvasRef | null>;
   fileInputRef: React.RefObject<HTMLInputElement | null>;
+  mapImageInputRef: React.RefObject<HTMLInputElement | null>;
 
   /** Shared with `ViewportContext` for @fieldnotes/react hooks */
   viewport: Viewport | null;
@@ -117,6 +143,10 @@ export interface DmLocationEditorState {
   handleImageFileSelect: (
     e: React.ChangeEvent<HTMLInputElement>
   ) => Promise<void>;
+  handlePickMapImage: () => void;
+  handleMapImageFileSelect: (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => Promise<void>;
   handleOpenTvDisplay: () => Promise<void>;
   handleFitToMap: () => void;
 }
@@ -129,6 +159,7 @@ export function useDmLocationEditor(
 
   const canvasRef = useRef<FieldNotesCanvasRef>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const mapImageInputRef = useRef<HTMLInputElement>(null);
   const autoSaveRef = useRef<AutoSave | null>(null);
   const connectionRef = useRef<{ stop: () => void } | null>(null);
   const pinUnsubRef = useRef<(() => void) | null>(null);
@@ -753,28 +784,7 @@ export function useDmLocationEditor(
       e.target.value = '';
 
       setImageUploading(true);
-
-      let src: string;
-      try {
-        const formData = new FormData();
-        formData.append('file', file);
-        formData.append('assetId', `canvas-${Date.now()}`);
-        const res = await fetch('/api/assets/upload', {
-          method: 'POST',
-          body: formData,
-        });
-        if (!res.ok) throw new Error('Upload failed');
-        const data = await res.json();
-        src = data.url as string;
-      } catch {
-        // Fall back to base64 if S3 not configured
-        src = await new Promise<string>((resolve, reject) => {
-          const reader = new FileReader();
-          reader.onload = () => resolve(reader.result as string);
-          reader.onerror = reject;
-          reader.readAsDataURL(file);
-        });
-      }
+      const src = await uploadCanvasImage(file);
 
       const proxiedSrc = proxyUrl(src);
       const img = new window.Image();
@@ -803,6 +813,43 @@ export function useDmLocationEditor(
     [getVp]
   );
 
+  const handlePickMapImage = useCallback(() => {
+    mapImageInputRef.current?.click();
+  }, []);
+
+  const handleMapImageFileSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      const vp = getVp();
+      if (!file || !vp) return;
+      e.target.value = '';
+
+      setImageUploading(true);
+      const src = await uploadCanvasImage(file);
+
+      const proxiedSrc = proxyUrl(src);
+      const img = new window.Image();
+      img.crossOrigin = 'anonymous';
+      img.onload = () => {
+        // Natural size (it's a map, not an annotation) at the right edge of
+        // the existing map images. Store the canonical URL, render the proxy.
+        const position = nextMapImagePosition(vp.store.getAll());
+        const before = new Set(vp.store.getAll().map(el => el.id));
+        vp.addImage(src, position, { w: img.width, h: img.height });
+        const added = vp.store.getAll().find(el => !before.has(el.id));
+        if (added) {
+          vp.store.update(added.id, { locked: true });
+          vp.layerManager.moveElementToLayer(added.id, MAP_LAYER_ID);
+        }
+        vp.requestRender();
+        setImageUploading(false);
+      };
+      img.onerror = () => setImageUploading(false);
+      img.src = proxiedSrc;
+    },
+    [getVp]
+  );
+
   const handleOpenTvDisplay = useCallback(
     () => openTvDisplay(campaignCode, location.id, dmId),
     [campaignCode, dmId, location.id]
@@ -817,6 +864,7 @@ export function useDmLocationEditor(
     mode,
     canvasRef,
     fileInputRef,
+    mapImageInputRef,
     viewport,
     tools,
     layersPanelOpen,
@@ -847,6 +895,8 @@ export function useDmLocationEditor(
     handleSyncToPlayers,
     handleDownloadExport,
     handleImageFileSelect,
+    handlePickMapImage,
+    handleMapImageFileSelect,
     handleOpenTvDisplay,
     handleFitToMap,
   };

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -33,6 +33,11 @@ import {
 } from './layerContract';
 import { pinGridToMapLayer } from './gridPin';
 import { nextMapImagePosition } from './mapImagePlacement';
+import {
+  enterArrangeMaps,
+  exitArrangeMaps,
+  type ArrangeMapsSession,
+} from './arrangeMaps';
 import type { DmLocationEditorProps } from './DmLocationEditor.types';
 import type { GridSettings } from '@/types/location';
 
@@ -149,6 +154,10 @@ export interface DmLocationEditorState {
   ) => Promise<void>;
   handleOpenTvDisplay: () => Promise<void>;
   handleFitToMap: () => void;
+
+  // Arrange maps (battlemap mode only)
+  arrangeMapsActive: boolean;
+  handleToggleArrangeMaps: () => void;
 }
 
 export function useDmLocationEditor(
@@ -166,6 +175,9 @@ export function useDmLocationEditor(
   const [syncStatus, setSyncStatus] = useState<
     BattleMapConnectionStatus | 'disabled'
   >('disabled');
+  const [arrangeMapsActive, setArrangeMapsActive] = useState(false);
+  const arrangeActiveRef = useRef(false);
+  const arrangeSessionRef = useRef<ArrangeMapsSession | null>(null);
 
   const [viewport, setViewport] = useState<Viewport | null>(null);
 
@@ -349,7 +361,9 @@ export function useDmLocationEditor(
         }
       });
       pinUnsubRef.current?.();
-      pinUnsubRef.current = subscribePinCanonicalLayers(vp);
+      pinUnsubRef.current = subscribePinCanonicalLayers(vp, () => ({
+        mapUnlocked: arrangeActiveRef.current,
+      }));
 
       // Live sync — battlemap mode only; resolver reads Zustand LIVE via
       // getState() (a captured snapshot would go stale after the first toggle).
@@ -450,18 +464,44 @@ export function useDmLocationEditor(
     img.src = proxied;
   }
 
-  // Cleanup autosave and sync connection on unmount
+  // Cleanup autosave and sync connection on unmount. Also exits arrange-maps
+  // mid-arrange so leaving the page re-locks everything — otherwise the
+  // persisted lock flags would stay unlocked.
   useEffect(() => {
     return () => {
+      const vp = getVp();
+      if (arrangeActiveRef.current && arrangeSessionRef.current && vp) {
+        arrangeActiveRef.current = false;
+        exitArrangeMaps(vp, arrangeSessionRef.current);
+        arrangeSessionRef.current = null;
+      }
       autoSaveRef.current?.stop();
       connectionRef.current?.stop();
       pinUnsubRef.current?.();
     };
-  }, []);
+  }, [getVp]);
 
   const handlePickImage = useCallback(() => {
     fileInputRef.current?.click();
   }, []);
+
+  const handleToggleArrangeMaps = useCallback(() => {
+    const vp = getVp();
+    if (!vp) return;
+    if (arrangeActiveRef.current) {
+      arrangeActiveRef.current = false;
+      if (arrangeSessionRef.current) {
+        exitArrangeMaps(vp, arrangeSessionRef.current);
+        arrangeSessionRef.current = null;
+      }
+      setArrangeMapsActive(false);
+    } else {
+      arrangeActiveRef.current = true;
+      arrangeSessionRef.current = enterArrangeMaps(vp);
+      vp.setTool('select');
+      setArrangeMapsActive(true);
+    }
+  }, [getVp]);
 
   // ─── Handlers ────────────────────────────────────────────────
 
@@ -899,5 +939,7 @@ export function useDmLocationEditor(
     handleMapImageFileSelect,
     handleOpenTvDisplay,
     handleFitToMap,
+    arrangeMapsActive,
+    handleToggleArrangeMaps,
   };
 }

--- a/src/components/ui/campaign/location-map/DmLocationEditor.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.tsx
@@ -51,6 +51,8 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
     mode,
     handleOpenTvDisplay,
     handleFitToMap,
+    arrangeMapsActive,
+    handleToggleArrangeMaps,
   } = useDmLocationEditor(props);
 
   return (
@@ -98,12 +100,19 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
             syncStatus={syncStatus}
             sharedWithPlayers={sharedWithPlayers}
             onToggleShareWithPlayers={handleToggleShareWithPlayers}
+            arrangeMapsActive={arrangeMapsActive}
+            onToggleArrangeMaps={handleToggleArrangeMaps}
           />
         )}
 
         {viewport && <DmLocationToolOptions mode={mode} />}
 
         <div className="relative flex min-h-0 flex-1 overflow-hidden">
+          {arrangeMapsActive && (
+            <div className="border-accent-amber-border bg-accent-amber-bg text-accent-amber-text absolute top-2 left-1/2 z-20 -translate-x-1/2 rounded-lg border px-3 py-1.5 text-xs font-medium shadow-lg">
+              Arranging maps — other layers are locked
+            </div>
+          )}
           <div className="flex-1 overflow-hidden">
             <Canvas
               ref={canvasRef}

--- a/src/components/ui/campaign/location-map/DmLocationEditor.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.tsx
@@ -17,6 +17,7 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
   const {
     canvasRef,
     fileInputRef,
+    mapImageInputRef,
     viewport,
     tools,
     layersPanelOpen,
@@ -45,6 +46,8 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
     handleSyncToPlayers,
     handleDownloadExport,
     handleImageFileSelect,
+    handlePickMapImage,
+    handleMapImageFileSelect,
     mode,
     handleOpenTvDisplay,
     handleFitToMap,
@@ -60,10 +63,18 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
           className="hidden"
           onChange={handleImageFileSelect}
         />
+        <input
+          ref={mapImageInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleMapImageFileSelect}
+        />
 
         {viewport && (
           <DmLocationToolbar
             onPickImage={handlePickImage}
+            onPickMapImage={handlePickMapImage}
             onDelete={handleDeleteSelected}
             onClear={handleClear}
             onFitToMap={handleFitToMap}

--- a/src/components/ui/campaign/location-map/DmLocationLayersPanel.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationLayersPanel.tsx
@@ -4,6 +4,7 @@ import { Plus, Eye, EyeOff, Lock, Unlock, X } from 'lucide-react';
 import { useElements, useLayers, useViewport } from '@fieldnotes/react';
 import { Button } from '@/components/ui/forms/button';
 import EncounterLinkingPanel from '../battle-map/EncounterLinkingPanel';
+import { MAP_LAYER_ID, PLAYER_LAYER_PREFIX } from './layerContract';
 import type { EditorMode } from './DmLocationEditor.types';
 
 interface DmLocationLayersPanelProps {
@@ -63,95 +64,102 @@ export default function DmLocationLayersPanel({
       </div>
 
       <div className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-1.5">
-        {[...layers].reverse().map(layer => {
-          const isActive = layer.id === activeLayerId;
-          const isBgLayer = layer.name === 'Map Background';
+        {[...layers]
+          .filter(l => !l.id.startsWith(PLAYER_LAYER_PREFIX))
+          .reverse()
+          .map(layer => {
+            const isActive = layer.id === activeLayerId;
+            const isBgLayer = layer.id === MAP_LAYER_ID;
 
-          return (
-            <div
-              key={layer.id}
-              role="button"
-              tabIndex={0}
-              onClick={() => {
-                if (!isBgLayer) {
-                  setActiveLayer(layer.id);
-                  viewport.requestRender();
-                }
-              }}
-              onKeyDown={e => {
-                if (e.key === 'Enter' || e.key === ' ') {
+            return (
+              <div
+                key={layer.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => {
                   if (!isBgLayer) {
                     setActiveLayer(layer.id);
                     viewport.requestRender();
                   }
-                }
-              }}
-              className={`flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors ${
-                isBgLayer
-                  ? 'text-muted cursor-default opacity-60'
-                  : isActive
-                    ? 'bg-accent-blue-bg text-accent-blue-text cursor-pointer'
-                    : 'text-body hover:bg-surface-secondary cursor-pointer'
-              }`}
-            >
-              <button
-                type="button"
-                onClick={e => {
-                  e.stopPropagation();
-                  setVisible(layer.id, !layer.visible);
-                  viewport.requestRender();
                 }}
-                title={layer.visible ? 'Hide layer' : 'Show layer'}
-                className="shrink-0"
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    if (!isBgLayer) {
+                      setActiveLayer(layer.id);
+                      viewport.requestRender();
+                    }
+                  }
+                }}
+                className={`flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors ${
+                  isBgLayer
+                    ? 'text-muted cursor-default opacity-60'
+                    : isActive
+                      ? 'bg-accent-blue-bg text-accent-blue-text cursor-pointer'
+                      : 'text-body hover:bg-surface-secondary cursor-pointer'
+                }`}
               >
-                {layer.visible ? (
-                  <Eye size={11} />
-                ) : (
-                  <EyeOff size={11} className="text-muted" />
-                )}
-              </button>
-
-              {isBgLayer ? (
-                <Lock size={11} className="text-muted shrink-0" />
-              ) : (
                 <button
                   type="button"
                   onClick={e => {
                     e.stopPropagation();
-                    setLocked(layer.id, !layer.locked);
+                    setVisible(layer.id, !layer.visible);
                     viewport.requestRender();
                   }}
-                  title={layer.locked ? 'Unlock layer' : 'Lock layer'}
+                  title={layer.visible ? 'Hide layer' : 'Show layer'}
                   className="shrink-0"
                 >
-                  {layer.locked ? (
-                    <Lock size={11} className="text-accent-amber-text" />
+                  {layer.visible ? (
+                    <Eye size={11} />
                   ) : (
-                    <Unlock size={11} className="text-muted" />
+                    <EyeOff size={11} className="text-muted" />
                   )}
                 </button>
-              )}
 
-              <span className="min-w-0 flex-1 truncate">{layer.name}</span>
-
-              {!isBgLayer &&
-                layers.filter(l => l.name !== 'Map Background').length > 1 && (
+                {isBgLayer ? (
+                  <Lock size={11} className="text-muted shrink-0" />
+                ) : (
                   <button
                     type="button"
                     onClick={e => {
                       e.stopPropagation();
-                      removeLayer(layer.id);
+                      setLocked(layer.id, !layer.locked);
                       viewport.requestRender();
                     }}
-                    className="text-muted hover:text-accent-red-text shrink-0"
-                    title="Delete layer"
+                    title={layer.locked ? 'Unlock layer' : 'Lock layer'}
+                    className="shrink-0"
                   >
-                    <X size={11} />
+                    {layer.locked ? (
+                      <Lock size={11} className="text-accent-amber-text" />
+                    ) : (
+                      <Unlock size={11} className="text-muted" />
+                    )}
                   </button>
                 )}
-            </div>
-          );
-        })}
+
+                <span className="min-w-0 flex-1 truncate">{layer.name}</span>
+
+                {!isBgLayer &&
+                  layers.filter(
+                    l =>
+                      l.id !== MAP_LAYER_ID &&
+                      !l.id.startsWith(PLAYER_LAYER_PREFIX)
+                  ).length > 1 && (
+                    <button
+                      type="button"
+                      onClick={e => {
+                        e.stopPropagation();
+                        removeLayer(layer.id);
+                        viewport.requestRender();
+                      }}
+                      className="text-muted hover:text-accent-red-text shrink-0"
+                      title="Delete layer"
+                    >
+                      <X size={11} />
+                    </button>
+                  )}
+              </div>
+            );
+          })}
       </div>
 
       <div className="border-divider text-muted border-t px-3 py-2 text-xs">

--- a/src/components/ui/campaign/location-map/DmLocationLayersPanel.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationLayersPanel.tsx
@@ -4,7 +4,11 @@ import { Plus, Eye, EyeOff, Lock, Unlock, X } from 'lucide-react';
 import { useElements, useLayers, useViewport } from '@fieldnotes/react';
 import { Button } from '@/components/ui/forms/button';
 import EncounterLinkingPanel from '../battle-map/EncounterLinkingPanel';
-import { MAP_LAYER_ID, PLAYER_LAYER_PREFIX } from './layerContract';
+import {
+  MAP_LAYER_ID,
+  ANNOTATIONS_LAYER_ID,
+  PLAYER_LAYER_PREFIX,
+} from './layerContract';
 import type { EditorMode } from './DmLocationEditor.types';
 
 interface DmLocationLayersPanelProps {
@@ -70,6 +74,12 @@ export default function DmLocationLayersPanel({
           .map(layer => {
             const isActive = layer.id === activeLayerId;
             const isBgLayer = layer.id === MAP_LAYER_ID;
+            // SDK removeLayer reparents a deleted layer's elements to the
+            // highest-order fallback layer (a player-* mirror on DM
+            // canvases) — deleting layer-annotations would merge DM content
+            // into a player-owned layer id. Never offer delete for it.
+            const isProtectedLayer =
+              isBgLayer || layer.id === ANNOTATIONS_LAYER_ID;
 
             return (
               <div
@@ -138,10 +148,11 @@ export default function DmLocationLayersPanel({
 
                 <span className="min-w-0 flex-1 truncate">{layer.name}</span>
 
-                {!isBgLayer &&
+                {!isProtectedLayer &&
                   layers.filter(
                     l =>
                       l.id !== MAP_LAYER_ID &&
+                      l.id !== ANNOTATIONS_LAYER_ID &&
                       !l.id.startsWith(PLAYER_LAYER_PREFIX)
                   ).length > 1 && (
                     <button

--- a/src/components/ui/campaign/location-map/DmLocationLayersPanel.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationLayersPanel.tsx
@@ -148,26 +148,20 @@ export default function DmLocationLayersPanel({
 
                 <span className="min-w-0 flex-1 truncate">{layer.name}</span>
 
-                {!isProtectedLayer &&
-                  layers.filter(
-                    l =>
-                      l.id !== MAP_LAYER_ID &&
-                      l.id !== ANNOTATIONS_LAYER_ID &&
-                      !l.id.startsWith(PLAYER_LAYER_PREFIX)
-                  ).length > 1 && (
-                    <button
-                      type="button"
-                      onClick={e => {
-                        e.stopPropagation();
-                        removeLayer(layer.id);
-                        viewport.requestRender();
-                      }}
-                      className="text-muted hover:text-accent-red-text shrink-0"
-                      title="Delete layer"
-                    >
-                      <X size={11} />
-                    </button>
-                  )}
+                {!isProtectedLayer && (
+                  <button
+                    type="button"
+                    onClick={e => {
+                      e.stopPropagation();
+                      removeLayer(layer.id);
+                      viewport.requestRender();
+                    }}
+                    className="text-muted hover:text-accent-red-text shrink-0"
+                    title="Delete layer"
+                  >
+                    <X size={11} />
+                  </button>
+                )}
               </div>
             );
           })}

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
@@ -21,6 +21,7 @@ import {
   ExternalLink,
   Maximize,
   Map as MapIcon,
+  Move,
 } from 'lucide-react';
 import { useActiveTool, useHistory } from '@fieldnotes/react';
 import { Button } from '@/components/ui/forms/button';
@@ -82,6 +83,8 @@ export default function DmLocationToolbar({
   syncStatus,
   sharedWithPlayers,
   onToggleShareWithPlayers,
+  arrangeMapsActive,
+  onToggleArrangeMaps,
 }: DmLocationToolbarProps) {
   const [activeTool, setTool] = useActiveTool();
   const { canUndo, canRedo, undo, redo } = useHistory();
@@ -171,12 +174,28 @@ export default function DmLocationToolbar({
           <Button
             variant="ghost"
             onClick={onPickMapImage}
+            disabled={arrangeMapsActive}
             title="Add map image"
             className="flex items-center gap-1.5 px-2 py-1 text-xs"
           >
             <MapIcon size={15} />
             Add map
           </Button>
+          {onToggleArrangeMaps && (
+            <Button
+              variant={arrangeMapsActive ? 'warning' : 'ghost'}
+              onClick={onToggleArrangeMaps}
+              title={
+                arrangeMapsActive
+                  ? 'Finish arranging — re-locks map images'
+                  : 'Arrange map images (unlocks the map layer)'
+              }
+              className="flex items-center gap-1.5 px-2 py-1 text-xs"
+            >
+              <Move size={15} />
+              {arrangeMapsActive ? 'Done arranging' : 'Arrange maps'}
+            </Button>
+          )}
         </>
       )}
 

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
@@ -20,6 +20,7 @@ import {
   AlertCircle,
   ExternalLink,
   Maximize,
+  Map as MapIcon,
 } from 'lucide-react';
 import { useActiveTool, useHistory } from '@fieldnotes/react';
 import { Button } from '@/components/ui/forms/button';
@@ -57,6 +58,7 @@ function formatSyncTime(iso: string): string {
 
 export default function DmLocationToolbar({
   onPickImage,
+  onPickMapImage,
   onDelete,
   onClear,
   onFitToMap,
@@ -162,6 +164,21 @@ export default function DmLocationToolbar({
           <Eraser size={15} />
         </Button>
       </div>
+
+      {mode === 'battlemap' && onPickMapImage && (
+        <>
+          <div className="bg-divider mx-1 h-6 w-px" />
+          <Button
+            variant="ghost"
+            onClick={onPickMapImage}
+            title="Add map image"
+            className="flex items-center gap-1.5 px-2 py-1 text-xs"
+          >
+            <MapIcon size={15} />
+            Add map
+          </Button>
+        </>
+      )}
 
       {/* Spacer */}
       <div className="flex-1" />

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.types.ts
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.types.ts
@@ -37,4 +37,8 @@ export interface DmLocationToolbarProps {
   onToggleShareWithPlayers?: () => void;
   /** Add a map image onto the locked map layer (battlemap mode only). */
   onPickMapImage?: () => void;
+  /** Whether arrange-maps mode is active (battlemap mode only). */
+  arrangeMapsActive?: boolean;
+  /** Toggle arrange-maps mode, which temporarily unlocks the map layer. */
+  onToggleArrangeMaps?: () => void;
 }

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.types.ts
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.types.ts
@@ -35,4 +35,6 @@ export interface DmLocationToolbarProps {
   /** Whether the battle map is currently shared with players (battlemap mode only) */
   sharedWithPlayers?: boolean;
   onToggleShareWithPlayers?: () => void;
+  /** Add a map image onto the locked map layer (battlemap mode only). */
+  onPickMapImage?: () => void;
 }

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -47,7 +47,7 @@ import DmLocationToolOptions from './DmLocationToolOptions';
 import { ensurePlayerLayer } from './playerLayer';
 import {
   ensureCanonicalLayers,
-  mirrorUnknownLayer,
+  attachUnknownLayerMirror,
   subscribePinCanonicalLayers,
 } from './layerContract';
 import {
@@ -292,13 +292,10 @@ export function PlayerBattleMapCanvas({
     // don't exist here (old clients, other players). Mirror each unknown
     // layer locked into its band — hit-test and marquee skip remote content
     // (the relay rejects player writes to it anyway), and stacking matches
-    // the DM's view.
-    vp.store.on('add', el => {
-      if (el.layerId && !vp.layerManager.getLayer(el.layerId)) {
-        mirrorUnknownLayer(vp, el.layerId, 'player');
-        vp.requestRender();
-      }
-    });
+    // the DM's view. Covers both new elements (add) and relay snapshot
+    // reconcile re-applying remote elements as full updates (including
+    // layerId) on reconnect.
+    attachUnknownLayerMirror(vp, 'player', () => vp.requestRender());
 
     // Selection state for the touch-friendly delete button.
     const selectTool = vp.toolManager.getTool<SelectTool>('select');

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -46,6 +46,11 @@ import {
 import DmLocationToolOptions from './DmLocationToolOptions';
 import { ensurePlayerLayer } from './playerLayer';
 import {
+  ensureCanonicalLayers,
+  mirrorUnknownLayer,
+  subscribePinCanonicalLayers,
+} from './layerContract';
+import {
   PlayerTokenTool,
   PlayerTemplateTool,
   tokenColorForId,
@@ -275,29 +280,22 @@ export function PlayerBattleMapCanvas({
   const handleReady = (vp: Viewport) => {
     setViewport(vp);
 
-    // Everything this player places lives on a layer whose id is stable
-    // across sessions — after a reload, their own elements from the snapshot
-    // land on this known unlocked layer instead of being mirrored as locked
-    // "DM" content (which made them permanently uncontrollable).
+    // Canonical bands: map (locked) at the bottom, DM annotations (locked
+    // for players) above it, this player's own layer in the player band on
+    // top — see layerContract.ts. ensurePlayerLayer runs AFTER ensure so the
+    // player's own layer ends up active.
+    ensureCanonicalLayers(vp, 'player');
     ensurePlayerLayer(vp, characterId);
+    subscribePinCanonicalLayers(vp);
 
-    // Layers aren't synced: remote elements reference the DM's layer ids,
-    // which don't exist here — and unknown layers count as unlocked, making
-    // the (locked) map image hit-testable, so it swallowed every click and
-    // marquee multi-select never started. Mirror each unknown remote layer
-    // locally as a LOCKED layer: hit-test and marquee then skip DM content
-    // entirely (players couldn't move it anyway — the relay rejects that),
-    // and clicking the map pans/marquees like it does for the DM.
+    // Layers aren't synced: remote elements can reference layer ids that
+    // don't exist here (old clients, other players). Mirror each unknown
+    // layer locked into its band — hit-test and marquee skip remote content
+    // (the relay rejects player writes to it anyway), and stacking matches
+    // the DM's view.
     vp.store.on('add', el => {
       if (el.layerId && !vp.layerManager.getLayer(el.layerId)) {
-        vp.layerManager.addLayerDirect({
-          id: el.layerId,
-          name: 'DM layer',
-          visible: true,
-          locked: true,
-          order: -1,
-          opacity: 1,
-        });
+        mirrorUnknownLayer(vp, el.layerId, 'player');
         vp.requestRender();
       }
     });

--- a/src/components/ui/campaign/location-map/__tests__/DmLocationEditor.hooks.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/DmLocationEditor.hooks.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { ElementStore, LayerManager, createShape } from '@fieldnotes/core';
 import type { Viewport } from '@fieldnotes/core';
 import type { FieldNotesCanvasRef } from '@fieldnotes/react';
 import { useDmLocationEditor } from '../DmLocationEditor.hooks';
@@ -20,34 +21,27 @@ vi.mock('@fieldnotes/core', async importOriginal => {
 });
 
 /**
- * Minimal viewport stub covering only what `handleReady` (with empty
- * canvasState + empty mapImageUrl, so both load paths are skipped) and
- * `handleToggleDmOnly` touch.
+ * Viewport stub covering what `handleReady` (with empty canvasState + empty
+ * mapImageUrl, so both load paths are skipped) and `handleToggleDmOnly`
+ * touch. `store`/`layerManager` are the real SDK classes (not hand-mocked)
+ * because `handleReady` now runs `ensureCanonicalLayers` /
+ * `migrateCanvasToContract` / `subscribePinCanonicalLayers` unconditionally —
+ * see layerContract.test.ts, which exercises those against the same real
+ * classes.
  */
 function makeStubViewport() {
-  const selectTool = { name: 'select', selectedIds: ['el-1'] };
-  const store = {
-    on: vi.fn(() => vi.fn()),
-    onChange: vi.fn(() => vi.fn()),
-    getById: vi.fn((id: string) =>
-      id === 'el-1' ? { id: 'el-1', type: 'shape' } : undefined
-    ),
-    update: vi.fn(),
-    getAll: vi.fn(() => []),
-    getElementsByType: vi.fn(() => []),
-    snapshot: vi.fn(() => []),
-    count: 0,
-    clear: vi.fn(),
-  };
-  const layerManager = {
-    getLayers: vi.fn(() => [{ id: 'layer-1', name: 'Layer 1' }]),
-    createLayer: vi.fn(() => ({ id: 'layer-2', name: 'Annotations' })),
-    renameLayer: vi.fn(),
-    setLayerLocked: vi.fn(),
-    setActiveLayer: vi.fn(),
-    moveElementToLayer: vi.fn(),
-    activeLayerId: 'layer-1',
-  };
+  const store = new ElementStore();
+  const layerManager = new LayerManager(store);
+
+  // One pre-existing element so syncSelection (filters selectedIds against
+  // the store) and handleToggleDmOnly (`store.getById` guard) have something
+  // real to select. The id is SDK-generated, not a fixed string.
+  const el = createShape({ position: { x: 0, y: 0 }, size: { w: 10, h: 10 } });
+  store.add(el);
+  const elementId = el.id;
+  vi.spyOn(store, 'update');
+
+  const selectTool = { name: 'select', selectedIds: [elementId] };
   const vp = {
     store,
     layerManager,
@@ -72,7 +66,7 @@ function makeStubViewport() {
     updateGrid: vi.fn(),
     requestRender: vi.fn(),
   };
-  return { vp: vp as unknown as Viewport, store };
+  return { vp: vp as unknown as Viewport, store, elementId };
 }
 
 const baseLocation: LocationMap = {
@@ -89,7 +83,7 @@ const baseLocation: LocationMap = {
 };
 
 async function setup(mode: 'location' | 'battlemap') {
-  const { vp, store } = makeStubViewport();
+  const { vp, store, elementId } = makeStubViewport();
   const onSave = vi.fn();
   const { result } = renderHook(() =>
     useDmLocationEditor({
@@ -109,8 +103,8 @@ async function setup(mode: 'location' | 'battlemap') {
     await result.current.handleReady(vp);
   });
   // Sanity: syncSelection picked up the stub's single selected element.
-  expect(result.current.selectedElementId).toBe('el-1');
-  return { store, result };
+  expect(result.current.selectedElementId).toBe(elementId);
+  return { store, result, elementId };
 }
 
 describe('useDmLocationEditor — handleToggleDmOnly mode gating', () => {
@@ -139,14 +133,14 @@ describe('useDmLocationEditor — handleToggleDmOnly mode gating', () => {
   });
 
   it('battlemap mode: toggling visibility re-emits the element so the sync client re-stamps its audience', async () => {
-    const { store, result } = await setup('battlemap');
+    const { store, result, elementId } = await setup('battlemap');
 
     act(() => {
       result.current.handleToggleDmOnly();
     });
 
     expect(store.update).toHaveBeenCalledTimes(1);
-    expect(store.update).toHaveBeenCalledWith('el-1', {});
+    expect(store.update).toHaveBeenCalledWith(elementId, {});
   });
 });
 

--- a/src/components/ui/campaign/location-map/__tests__/arrangeMaps.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/arrangeMaps.test.ts
@@ -4,6 +4,8 @@ import {
   LayerManager,
   createImage,
   createGrid,
+  createShape,
+  createNote,
 } from '@fieldnotes/core';
 import {
   MAP_LAYER_ID,
@@ -86,5 +88,47 @@ describe('enter/exitArrangeMaps', () => {
     const session = enterArrangeMaps(vp);
     vp.store.remove(imageId);
     expect(() => exitArrangeMaps(vp, session)).not.toThrow();
+  });
+
+  it('sweeps non-image/grid elements created on layer-map (active layer while arranging) to annotations on exit, leaving images and grid in place', () => {
+    // Regression (I1): while arranging, active layer = layer-map. Any other
+    // creation path (drag-drop/paste ImageTool, drawing tools, annotation
+    // image button, DmTokenTool) targets the active layer, so shapes/notes/
+    // tokens can land on layer-map — after exit, that layer is locked again
+    // and those elements would be trapped under the map images.
+    const vp = makeVp();
+    const imageId = addLockedMapImage(vp);
+    const grid = createGrid({
+      gridType: 'square',
+      cellSize: 50,
+      strokeColor: '#000',
+      strokeWidth: 1,
+      opacity: 0.5,
+      layerId: MAP_LAYER_ID,
+    });
+    vp.store.add(grid);
+
+    const session = enterArrangeMaps(vp);
+
+    // Simulate a stray creation path (e.g. drawing/note tool) that dropped
+    // an element onto the currently-active map layer mid-arrange.
+    const shape = createShape({
+      position: { x: 0, y: 0 },
+      size: { w: 10, h: 10 },
+      layerId: MAP_LAYER_ID,
+    });
+    vp.store.add(shape);
+    const note = createNote({
+      position: { x: 0, y: 0 },
+      layerId: MAP_LAYER_ID,
+    });
+    vp.store.add(note);
+
+    exitArrangeMaps(vp, session);
+
+    expect(vp.store.getById(shape.id)?.layerId).toBe(ANNOTATIONS_LAYER_ID);
+    expect(vp.store.getById(note.id)?.layerId).toBe(ANNOTATIONS_LAYER_ID);
+    expect(vp.store.getById(imageId)?.layerId).toBe(MAP_LAYER_ID);
+    expect(vp.store.getById(grid.id)?.layerId).toBe(MAP_LAYER_ID);
   });
 });

--- a/src/components/ui/campaign/location-map/__tests__/arrangeMaps.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/arrangeMaps.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ElementStore,
+  LayerManager,
+  createImage,
+  createGrid,
+} from '@fieldnotes/core';
+import {
+  MAP_LAYER_ID,
+  ANNOTATIONS_LAYER_ID,
+  ensureCanonicalLayers,
+  migrateCanvasToContract,
+  type ViewportLike,
+} from '@/components/ui/campaign/location-map/layerContract';
+import {
+  enterArrangeMaps,
+  exitArrangeMaps,
+} from '@/components/ui/campaign/location-map/arrangeMaps';
+
+// migrateCanvasToContract (in addition to ensureCanonicalLayers) drops the
+// SDK's empty default "Layer 1", which otherwise stays active and breaks the
+// "previous active layer" assertions below — same fixture pattern as
+// makeCleanVp in layerContract.test.ts.
+function makeVp(): ViewportLike {
+  const store = new ElementStore();
+  const layerManager = new LayerManager(store);
+  const vp = { store, layerManager };
+  ensureCanonicalLayers(vp, 'dm');
+  migrateCanvasToContract(vp, 'dm');
+  return vp;
+}
+
+function addLockedMapImage(vp: ViewportLike): string {
+  const el = createImage({
+    position: { x: 0, y: 0 },
+    size: { w: 100, h: 100 },
+    src: 'map.png',
+    layerId: MAP_LAYER_ID,
+    zIndex: 0,
+  });
+  vp.store.add(el);
+  vp.store.update(el.id, { locked: true });
+  return el.id;
+}
+
+describe('enter/exitArrangeMaps', () => {
+  it('unlocks the map layer and its image elements, locks annotations, activates the map layer', () => {
+    const vp = makeVp();
+    const imageId = addLockedMapImage(vp);
+    const grid = createGrid({
+      gridType: 'square',
+      cellSize: 50,
+      strokeColor: '#000',
+      strokeWidth: 1,
+      opacity: 0.5,
+      layerId: MAP_LAYER_ID,
+    });
+    vp.store.add(grid);
+    vp.store.update(grid.id, { locked: true });
+
+    const session = enterArrangeMaps(vp);
+
+    expect(vp.layerManager.getLayer(MAP_LAYER_ID)!.locked).toBe(false);
+    expect(vp.store.getById(imageId)!.locked).toBe(false);
+    expect(vp.store.getById(grid.id)!.locked).toBe(true); // grid stays locked
+    expect(vp.layerManager.getLayer(ANNOTATIONS_LAYER_ID)!.locked).toBe(true);
+    expect(vp.layerManager.activeLayerId).toBe(MAP_LAYER_ID);
+    expect(session.unlockedElementIds).toEqual([imageId]);
+  });
+
+  it('exit restores locks and the previous active layer', () => {
+    const vp = makeVp();
+    const imageId = addLockedMapImage(vp);
+    const session = enterArrangeMaps(vp);
+    exitArrangeMaps(vp, session);
+
+    expect(vp.layerManager.getLayer(MAP_LAYER_ID)!.locked).toBe(true);
+    expect(vp.store.getById(imageId)!.locked).toBe(true);
+    expect(vp.layerManager.getLayer(ANNOTATIONS_LAYER_ID)!.locked).toBe(false);
+    expect(vp.layerManager.activeLayerId).toBe(ANNOTATIONS_LAYER_ID);
+  });
+
+  it('exit tolerates elements deleted during arranging', () => {
+    const vp = makeVp();
+    const imageId = addLockedMapImage(vp);
+    const session = enterArrangeMaps(vp);
+    vp.store.remove(imageId);
+    expect(() => exitArrangeMaps(vp, session)).not.toThrow();
+  });
+});

--- a/src/components/ui/campaign/location-map/__tests__/layerContract.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/layerContract.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   ElementStore,
   LayerManager,
@@ -16,6 +16,7 @@ import {
   pinCanonicalLayers,
   subscribePinCanonicalLayers,
   mirrorUnknownLayer,
+  attachUnknownLayerMirror,
   migrateCanvasToContract,
   type ViewportLike,
 } from '@/components/ui/campaign/location-map/layerContract';
@@ -166,6 +167,56 @@ describe('mirrorUnknownLayer', () => {
     const vp = makeCleanVp();
     mirrorUnknownLayer(vp, 'layer-oldclient', 'dm');
     expect(layer(vp, 'layer-oldclient').order).toBe(CUSTOM_BAND_ORDER);
+  });
+});
+
+describe('attachUnknownLayerMirror', () => {
+  it('mirrors an unknown layerId on add', () => {
+    const vp = makeCleanVp();
+    const onMirrored = vi.fn();
+    attachUnknownLayerMirror(vp, 'dm', onMirrored);
+    addImageOn(vp, 'player-remote');
+    expect(vp.layerManager.getLayer('player-remote')).toBeDefined();
+    expect(onMirrored).toHaveBeenCalledTimes(1);
+  });
+
+  it('mirrors an unknown layerId when an existing element is moved via update (relay snapshot reconcile regression)', () => {
+    // Regression for C1: relay snapshot reconcile re-applies remote elements
+    // via store.update(id, el) — a full replace including layerId — not
+    // store.add. An add-only mirror misses this and the element ends up
+    // referencing a layer this canvas no longer has.
+    const vp = makeCleanVp();
+    const elId = addImageOn(vp, ANNOTATIONS_LAYER_ID);
+    const onMirrored = vi.fn();
+    attachUnknownLayerMirror(vp, 'dm', onMirrored);
+    vp.store.update(elId, { layerId: 'player-ghost' });
+    expect(vp.layerManager.getLayer('player-ghost')).toBeDefined();
+    expect(layer(vp, 'player-ghost').order).toBe(PLAYER_BAND_ORDER);
+    expect(onMirrored).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not create a layer when an update targets a known layer', () => {
+    const vp = makeCleanVp();
+    const elId = addImageOn(vp, ANNOTATIONS_LAYER_ID);
+    const before = vp.layerManager.getLayers().length;
+    const onMirrored = vi.fn();
+    attachUnknownLayerMirror(vp, 'dm', onMirrored);
+    vp.store.update(elId, { zIndex: 5 });
+    expect(vp.layerManager.getLayers().length).toBe(before);
+    expect(onMirrored).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribe stops both the add and update mirror paths', () => {
+    const vp = makeCleanVp();
+    const elId = addImageOn(vp, ANNOTATIONS_LAYER_ID);
+    const unsubscribe = attachUnknownLayerMirror(vp, 'dm');
+    unsubscribe();
+    addImageOn(vp, 'player-after-unsub-add');
+    vp.store.update(elId, { layerId: 'player-after-unsub-update' });
+    expect(vp.layerManager.getLayer('player-after-unsub-add')).toBeUndefined();
+    expect(
+      vp.layerManager.getLayer('player-after-unsub-update')
+    ).toBeUndefined();
   });
 });
 

--- a/src/components/ui/campaign/location-map/__tests__/layerContract.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/layerContract.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ElementStore,
+  LayerManager,
+  createImage,
+  type Layer,
+} from '@fieldnotes/core';
+import {
+  MAP_LAYER_ID,
+  ANNOTATIONS_LAYER_ID,
+  MAP_LAYER_ORDER,
+  ANNOTATIONS_LAYER_ORDER,
+  CUSTOM_BAND_ORDER,
+  PLAYER_BAND_ORDER,
+  ensureCanonicalLayers,
+  pinCanonicalLayers,
+  subscribePinCanonicalLayers,
+  mirrorUnknownLayer,
+  migrateCanvasToContract,
+  type ViewportLike,
+} from '@/components/ui/campaign/location-map/layerContract';
+
+function makeVp(): ViewportLike {
+  const store = new ElementStore();
+  const layerManager = new LayerManager(store);
+  return { store, layerManager };
+}
+
+/** Contract applied AND the SDK's empty default "Layer 1" dropped — use for
+ *  band-order assertions ("Layer 1" would otherwise occupy the first custom
+ *  slot and shift every expected order by one). */
+function makeCleanVp(role: 'dm' | 'player' = 'dm'): ViewportLike {
+  const vp = makeVp();
+  ensureCanonicalLayers(vp, role);
+  migrateCanvasToContract(vp, role);
+  return vp;
+}
+
+function addImageOn(vp: ViewportLike, layerId: string, zIndex = 0): string {
+  const el = createImage({
+    position: { x: 0, y: 0 },
+    size: { w: 10, h: 10 },
+    src: 'test.png',
+    layerId,
+    zIndex,
+  });
+  vp.store.add(el);
+  return el.id;
+}
+
+function layer(vp: ViewportLike, id: string): Layer {
+  const l = vp.layerManager.getLayer(id);
+  if (!l) throw new Error(`layer ${id} missing`);
+  return l;
+}
+
+describe('ensureCanonicalLayers', () => {
+  it('creates map + annotations with canonical ids, orders, and locks (dm)', () => {
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'dm');
+    expect(layer(vp, MAP_LAYER_ID).order).toBe(MAP_LAYER_ORDER);
+    expect(layer(vp, MAP_LAYER_ID).locked).toBe(true);
+    expect(layer(vp, ANNOTATIONS_LAYER_ID).order).toBe(ANNOTATIONS_LAYER_ORDER);
+    expect(layer(vp, ANNOTATIONS_LAYER_ID).locked).toBe(false);
+  });
+
+  it('locks annotations for role player', () => {
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'player');
+    expect(layer(vp, ANNOTATIONS_LAYER_ID).locked).toBe(true);
+  });
+
+  it('is idempotent — second call changes nothing', () => {
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'dm');
+    const before = vp.layerManager.getLayers();
+    ensureCanonicalLayers(vp, 'dm');
+    expect(vp.layerManager.getLayers()).toEqual(before);
+  });
+
+  it('moves the active layer off layer-map', () => {
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'dm');
+    vp.layerManager.setActiveLayer(MAP_LAYER_ID);
+    ensureCanonicalLayers(vp, 'dm');
+    expect(vp.layerManager.activeLayerId).toBe(ANNOTATIONS_LAYER_ID);
+  });
+});
+
+describe('pinCanonicalLayers', () => {
+  it('renumbers custom layers into the 200-band and player layers into the 500-band, preserving relative order', () => {
+    const vp = makeCleanVp();
+    const customA = vp.layerManager.createLayer('Traps'); // maxOrder+1 → above 100
+    const customB = vp.layerManager.createLayer('Notes');
+    vp.layerManager.addLayerDirect({
+      id: 'player-b',
+      name: 'x',
+      visible: true,
+      locked: false,
+      order: 3,
+      opacity: 1,
+    });
+    vp.layerManager.addLayerDirect({
+      id: 'player-a',
+      name: 'x',
+      visible: true,
+      locked: false,
+      order: 7,
+      opacity: 1,
+    });
+    pinCanonicalLayers(vp);
+    expect(layer(vp, customA.id).order).toBe(CUSTOM_BAND_ORDER);
+    expect(layer(vp, customB.id).order).toBe(CUSTOM_BAND_ORDER + 1);
+    expect(layer(vp, 'player-b').order).toBe(PLAYER_BAND_ORDER);
+    expect(layer(vp, 'player-a').order).toBe(PLAYER_BAND_ORDER + 1);
+  });
+
+  it('re-locks and re-orders layer-map, unless mapUnlocked', () => {
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'dm');
+    vp.layerManager.updateLayerDirect(MAP_LAYER_ID, {
+      locked: false,
+      order: 50,
+    });
+    pinCanonicalLayers(vp, { mapUnlocked: true });
+    expect(layer(vp, MAP_LAYER_ID).locked).toBe(false);
+    expect(layer(vp, MAP_LAYER_ID).order).toBe(MAP_LAYER_ORDER);
+    pinCanonicalLayers(vp);
+    expect(layer(vp, MAP_LAYER_ID).locked).toBe(true);
+  });
+});
+
+describe('subscribePinCanonicalLayers', () => {
+  it('pins on layer changes without infinite recursion', () => {
+    const vp = makeCleanVp();
+    const unsubscribe = subscribePinCanonicalLayers(vp);
+    const custom = vp.layerManager.createLayer('Overlay'); // fires 'change'
+    expect(layer(vp, custom.id).order).toBe(CUSTOM_BAND_ORDER);
+    // While subscribed, a rogue map reorder is snapped back.
+    vp.layerManager.updateLayerDirect(MAP_LAYER_ID, { order: 50 });
+    expect(layer(vp, MAP_LAYER_ID).order).toBe(MAP_LAYER_ORDER);
+    unsubscribe();
+    vp.layerManager.updateLayerDirect(MAP_LAYER_ID, { order: 50 });
+    expect(layer(vp, MAP_LAYER_ID).order).toBe(50); // no longer pinned
+  });
+});
+
+describe('mirrorUnknownLayer', () => {
+  it('puts player-* ids in the player band, locked for role player', () => {
+    const vp = makeCleanVp('player');
+    mirrorUnknownLayer(vp, 'player-remote', 'player');
+    expect(layer(vp, 'player-remote').order).toBe(PLAYER_BAND_ORDER);
+    expect(layer(vp, 'player-remote').locked).toBe(true);
+  });
+
+  it('is unlocked for role dm and no-ops on a known layer', () => {
+    const vp = makeCleanVp();
+    mirrorUnknownLayer(vp, 'player-remote', 'dm');
+    expect(layer(vp, 'player-remote').locked).toBe(false);
+    const before = layer(vp, 'player-remote');
+    mirrorUnknownLayer(vp, 'player-remote', 'dm');
+    expect(layer(vp, 'player-remote')).toEqual(before);
+  });
+
+  it('puts non-player unknown ids in the custom band', () => {
+    const vp = makeCleanVp();
+    mirrorUnknownLayer(vp, 'layer-oldclient', 'dm');
+    expect(layer(vp, 'layer-oldclient').order).toBe(CUSTOM_BAND_ORDER);
+  });
+});
+
+describe('migrateCanvasToContract', () => {
+  function legacyVp(): { vp: ViewportLike; bgId: string; annId: string } {
+    const vp = makeVp();
+    // Emulate the legacy editor: default layer renamed 'Map Background',
+    // a created 'Annotations' layer.
+    const bg = vp.layerManager.getLayers()[0];
+    vp.layerManager.renameLayer(bg.id, 'Map Background');
+    const ann = vp.layerManager.createLayer('Annotations');
+    return { vp, bgId: bg.id, annId: ann.id };
+  }
+
+  it('absorbs legacy layers into canonical ids, moving elements', () => {
+    const { vp, bgId, annId } = legacyVp();
+    const mapEl = addImageOn(vp, bgId);
+    const annEl = addImageOn(vp, annId);
+    const changed = migrateCanvasToContract(vp, 'dm');
+    expect(changed).toBe(true);
+    expect(vp.layerManager.getLayer(bgId)).toBeUndefined();
+    expect(vp.layerManager.getLayer(annId)).toBeUndefined();
+    expect(vp.store.getById(mapEl)?.layerId).toBe(MAP_LAYER_ID);
+    expect(vp.store.getById(annEl)?.layerId).toBe(ANNOTATIONS_LAYER_ID);
+  });
+
+  it('drops empty auto-named leftovers and keeps named custom + player layers', () => {
+    const vp = makeVp(); // default 'Layer 1' is empty
+    vp.layerManager.createLayer('Traps');
+    vp.layerManager.addLayerDirect({
+      id: 'player-x',
+      name: 'My elements',
+      visible: true,
+      locked: false,
+      order: 1,
+      opacity: 1,
+    });
+    migrateCanvasToContract(vp, 'dm');
+    const names = vp.layerManager.getLayers().map(l => l.name);
+    expect(names).not.toContain('Layer 1');
+    expect(names).toContain('Traps');
+    expect(vp.layerManager.getLayer('player-x')).toBeDefined();
+  });
+
+  it('repairs a dangling active layer and is change-false on second run', () => {
+    const { vp, annId } = legacyVp();
+    vp.layerManager.setActiveLayer(annId);
+    migrateCanvasToContract(vp, 'dm');
+    expect(
+      vp.layerManager.getLayer(vp.layerManager.activeLayerId)
+    ).toBeDefined();
+    expect(migrateCanvasToContract(vp, 'dm')).toBe(false);
+  });
+});
+
+describe('bug regression: DM-added image vs player token', () => {
+  it('a remote player token paints above a DM annotations image', () => {
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'dm');
+    const imageId = addImageOn(vp, ANNOTATIONS_LAYER_ID, 0);
+    // Remote token arrives referencing a layer this canvas has never seen.
+    mirrorUnknownLayer(vp, 'player-char1', 'dm');
+    const tokenId = addImageOn(vp, 'player-char1', 1000);
+    const order = vp.store.getAll().map(el => el.id);
+    expect(order.indexOf(tokenId)).toBeGreaterThan(order.indexOf(imageId));
+  });
+});

--- a/src/components/ui/campaign/location-map/__tests__/mapImagePlacement.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/mapImagePlacement.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  nextMapImagePosition,
+  MAP_IMAGE_GUTTER,
+  type PlacedElement,
+} from '@/components/ui/campaign/location-map/mapImagePlacement';
+import { MAP_LAYER_ID } from '@/components/ui/campaign/location-map/layerContract';
+
+const mapImage = (
+  x: number,
+  y: number,
+  w: number,
+  h: number
+): PlacedElement => ({
+  layerId: MAP_LAYER_ID,
+  type: 'image',
+  position: { x, y },
+  size: { w, h },
+});
+
+describe('nextMapImagePosition', () => {
+  it('returns the origin when no map images exist', () => {
+    expect(nextMapImagePosition([])).toEqual({ x: 0, y: 0 });
+  });
+
+  it('ignores non-map and non-image elements', () => {
+    const elements: PlacedElement[] = [
+      { ...mapImage(0, 0, 100, 100), layerId: 'layer-annotations' },
+      { ...mapImage(0, 0, 100, 100), type: 'grid' },
+    ];
+    expect(nextMapImagePosition(elements)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('places at the right edge of the widest extent, top-aligned, with a gutter', () => {
+    const elements = [mapImage(0, 50, 400, 300), mapImage(440, 0, 200, 200)];
+    expect(nextMapImagePosition(elements)).toEqual({
+      x: 640 + MAP_IMAGE_GUTTER,
+      y: 0,
+    });
+  });
+});

--- a/src/components/ui/campaign/location-map/__tests__/playerLayer.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/playerLayer.test.ts
@@ -4,6 +4,8 @@ import {
   playerLayerId,
 } from '@/components/ui/campaign/location-map/playerLayer';
 
+import { PLAYER_BAND_ORDER } from '@/components/ui/campaign/location-map/layerContract';
+
 import type { Viewport, Layer } from '@fieldnotes/core';
 
 function fakeViewport(existing: Layer[] = []) {
@@ -32,6 +34,7 @@ describe('ensurePlayerLayer', () => {
     expect(layer.locked).toBe(false);
     expect(layer.visible).toBe(true);
     expect(activeId()).toBe(id);
+    expect(layer.order).toBe(PLAYER_BAND_ORDER);
   });
 
   it('is idempotent: an existing layer is reused, not recreated (reload case)', () => {

--- a/src/components/ui/campaign/location-map/arrangeMaps.ts
+++ b/src/components/ui/campaign/location-map/arrangeMaps.ts
@@ -46,6 +46,21 @@ export function exitArrangeMaps(
   for (const id of session.unlockedElementIds) {
     if (vp.store.getById(id)) vp.store.update(id, { locked: true });
   }
+  // While arranging, the active layer is layer-map — every other creation
+  // path (drag-drop/paste ImageTool, drawing tools, the annotation image
+  // button, DmTokenTool) creates onto the active layer, not just the map
+  // image tool. Sweep anything that isn't a map image or grid off layer-map
+  // before re-locking it, or those elements get trapped on the locked
+  // bottom band.
+  for (const el of vp.store.getAll()) {
+    if (
+      el.layerId === MAP_LAYER_ID &&
+      el.type !== 'image' &&
+      el.type !== 'grid'
+    ) {
+      lm.moveElementToLayer(el.id, ANNOTATIONS_LAYER_ID);
+    }
+  }
   lm.updateLayerDirect(ANNOTATIONS_LAYER_ID, {
     locked: session.annotationsWasLocked,
   });

--- a/src/components/ui/campaign/location-map/arrangeMaps.ts
+++ b/src/components/ui/campaign/location-map/arrangeMaps.ts
@@ -1,0 +1,59 @@
+import {
+  ANNOTATIONS_LAYER_ID,
+  MAP_LAYER_ID,
+  type ViewportLike,
+} from './layerContract';
+
+export interface ArrangeMapsSession {
+  /** Map-layer image elements we unlocked on enter — re-locked on exit. */
+  unlockedElementIds: string[];
+  annotationsWasLocked: boolean;
+  previousActiveLayerId: string;
+}
+
+/**
+ * Arrange-maps mode: only map images are editable. Unlocks layer-map and its
+ * image elements (grid elements stay locked so they can't be dragged), locks
+ * annotations so nothing else is selectable, and activates the map layer.
+ * The caller must relax the pin invariant (mapUnlocked) for the duration —
+ * otherwise the pin subscription re-locks the map layer on the next change.
+ */
+export function enterArrangeMaps(vp: ViewportLike): ArrangeMapsSession {
+  const lm = vp.layerManager;
+  const session: ArrangeMapsSession = {
+    unlockedElementIds: [],
+    annotationsWasLocked: lm.getLayer(ANNOTATIONS_LAYER_ID)?.locked ?? false,
+    previousActiveLayerId: lm.activeLayerId,
+  };
+  lm.updateLayerDirect(MAP_LAYER_ID, { locked: false });
+  for (const el of vp.store.getAll()) {
+    if (el.layerId !== MAP_LAYER_ID || el.type !== 'image') continue;
+    if (el.locked) {
+      vp.store.update(el.id, { locked: false });
+      session.unlockedElementIds.push(el.id);
+    }
+  }
+  lm.updateLayerDirect(ANNOTATIONS_LAYER_ID, { locked: true });
+  lm.setActiveLayer(MAP_LAYER_ID);
+  return session;
+}
+
+export function exitArrangeMaps(
+  vp: ViewportLike,
+  session: ArrangeMapsSession
+): void {
+  const lm = vp.layerManager;
+  for (const id of session.unlockedElementIds) {
+    if (vp.store.getById(id)) vp.store.update(id, { locked: true });
+  }
+  lm.updateLayerDirect(ANNOTATIONS_LAYER_ID, {
+    locked: session.annotationsWasLocked,
+  });
+  const previous = lm.getLayer(session.previousActiveLayerId);
+  if (previous && session.previousActiveLayerId !== MAP_LAYER_ID) {
+    lm.setActiveLayer(session.previousActiveLayerId);
+  } else {
+    lm.setActiveLayer(ANNOTATIONS_LAYER_ID);
+  }
+  lm.updateLayerDirect(MAP_LAYER_ID, { locked: true });
+}

--- a/src/components/ui/campaign/location-map/gridPin.ts
+++ b/src/components/ui/campaign/location-map/gridPin.ts
@@ -1,0 +1,17 @@
+import type { Viewport } from '@fieldnotes/core';
+import { ensureCanonicalLayers, MAP_LAYER_ID } from './layerContract';
+
+/**
+ * Map + grid must live on the layer-locked map layer so hit-testing skips
+ * them (see @fieldnotes/core InputHandler / SelectTool + `isLayerLocked`).
+ * Grid elements must also be `locked` so Select cannot drag them (otherwise
+ * they appear to slide when panning/zooming).
+ */
+export function pinGridToMapLayer(vp: Viewport) {
+  ensureCanonicalLayers(vp, 'dm');
+  for (const g of vp.store.getElementsByType('grid')) {
+    vp.layerManager.moveElementToLayer(g.id, MAP_LAYER_ID);
+    vp.store.update(g.id, { locked: true });
+  }
+  vp.requestRender();
+}

--- a/src/components/ui/campaign/location-map/layerContract.ts
+++ b/src/components/ui/campaign/location-map/layerContract.ts
@@ -164,6 +164,35 @@ export function mirrorUnknownLayer(
 }
 
 /**
+ * Register the unknown-layer mirror on a store. Both 'add' AND 'update' must
+ * be covered: relay snapshot reconcile re-applies remote elements as full
+ * updates (including layerId), so a layerId referencing a layer this canvas
+ * no longer has (e.g. pre-migration legacy ids restored from the relay's
+ * persisted room state) can arrive on either event. Returns an unsubscribe
+ * for both listeners.
+ */
+export function attachUnknownLayerMirror(
+  vp: ViewportLike,
+  role: CanvasRole,
+  onMirrored?: () => void
+): () => void {
+  const check = (layerId: string | undefined) => {
+    if (layerId && !vp.layerManager.getLayer(layerId)) {
+      mirrorUnknownLayer(vp, layerId, role);
+      onMirrored?.();
+    }
+  };
+  const unsubAdd = vp.store.on('add', el => check(el.layerId));
+  const unsubUpdate = vp.store.on('update', ({ current }) =>
+    check(current.layerId)
+  );
+  return () => {
+    unsubAdd();
+    unsubUpdate();
+  };
+}
+
+/**
  * Lazy per-load migration of pre-contract canvases: legacy name-matched
  * layers are absorbed into the canonical ids (elements moved — the element
  * updates flow through the relay, which is what teaches OTHER canvases the

--- a/src/components/ui/campaign/location-map/layerContract.ts
+++ b/src/components/ui/campaign/location-map/layerContract.ts
@@ -1,0 +1,219 @@
+import type { ElementStore, LayerManager } from '@fieldnotes/core';
+
+/**
+ * Canonical layer bands shared by ALL battlemap canvases (DM setup editor,
+ * DM play canvas, player canvas). The FieldNotes SDK paints elements sorted
+ * by (layerOrder, zIndex) with zIndex compared only WITHIN a layer, and
+ * layers are not synced between clients — so stacking is only deterministic
+ * if every canvas assigns the same order band to the same layer id:
+ *
+ *   layer-map (0, locked)            map images + grid
+ *   layer-annotations (100)          DM annotations + combatant tokens
+ *   custom DM layers (200+)          extra layers from the layers panel
+ *   player-<characterId> (500+)      each player's token + drawings
+ *
+ * The player band sits above everything a DM can draw on, so a DM-added
+ * image can never cover a player token (the bug this module exists to fix).
+ */
+export const MAP_LAYER_ID = 'layer-map';
+export const ANNOTATIONS_LAYER_ID = 'layer-annotations';
+export const MAP_LAYER_ORDER = 0;
+export const ANNOTATIONS_LAYER_ORDER = 100;
+export const CUSTOM_BAND_ORDER = 200;
+export const PLAYER_BAND_ORDER = 500;
+export const PLAYER_LAYER_PREFIX = 'player-';
+
+export type CanvasRole = 'dm' | 'player';
+
+/** Structural subset of Viewport so tests run on real SDK stores headless. */
+export interface ViewportLike {
+  store: ElementStore;
+  layerManager: LayerManager;
+}
+
+const LEGACY_MAP_NAME = 'Map Background';
+const LEGACY_ANNOTATIONS_NAME = 'Annotations';
+const AUTO_LAYER_NAME = /^Layer \d+$/;
+
+/**
+ * Create the canonical layers if missing and pin the bands. Annotations is
+ * locked for players (their hit-testing must skip DM content — the relay
+ * would reject their writes anyway). Also guards the active layer off the
+ * locked map layer (loadJSON resets active to the lowest-order layer).
+ */
+export function ensureCanonicalLayers(
+  vp: ViewportLike,
+  role: CanvasRole
+): void {
+  const lm = vp.layerManager;
+  if (!lm.getLayer(MAP_LAYER_ID)) {
+    lm.addLayerDirect({
+      id: MAP_LAYER_ID,
+      name: 'Map',
+      visible: true,
+      locked: true,
+      order: MAP_LAYER_ORDER,
+      opacity: 1,
+    });
+  }
+  if (!lm.getLayer(ANNOTATIONS_LAYER_ID)) {
+    lm.addLayerDirect({
+      id: ANNOTATIONS_LAYER_ID,
+      name: 'Annotations',
+      visible: true,
+      locked: role === 'player',
+      order: ANNOTATIONS_LAYER_ORDER,
+      opacity: 1,
+    });
+  }
+  pinCanonicalLayers(vp);
+  if (lm.activeLayerId === MAP_LAYER_ID || !lm.getLayer(lm.activeLayerId)) {
+    lm.setActiveLayer(ANNOTATIONS_LAYER_ID);
+  }
+}
+
+/**
+ * Re-assert band invariants. Lock state of annotations/custom/player layers
+ * is NOT pinned (role- and user-controlled); only the map lock is, because
+ * only arrange-maps mode may relax it (opts.mapUnlocked).
+ */
+export function pinCanonicalLayers(
+  vp: ViewportLike,
+  opts?: { mapUnlocked?: boolean }
+): void {
+  const lm = vp.layerManager;
+  const map = lm.getLayer(MAP_LAYER_ID);
+  if (map) {
+    const wantLocked = !opts?.mapUnlocked;
+    if (map.order !== MAP_LAYER_ORDER || map.locked !== wantLocked) {
+      lm.updateLayerDirect(MAP_LAYER_ID, {
+        order: MAP_LAYER_ORDER,
+        locked: wantLocked,
+      });
+    }
+  }
+  const annotations = lm.getLayer(ANNOTATIONS_LAYER_ID);
+  if (annotations && annotations.order !== ANNOTATIONS_LAYER_ORDER) {
+    lm.updateLayerDirect(ANNOTATIONS_LAYER_ID, {
+      order: ANNOTATIONS_LAYER_ORDER,
+    });
+  }
+  // getLayers() is order-sorted (stable), so renumbering by enumeration
+  // index preserves each band's relative order.
+  const others = lm
+    .getLayers()
+    .filter(l => l.id !== MAP_LAYER_ID && l.id !== ANNOTATIONS_LAYER_ID);
+  const customs = others.filter(l => !l.id.startsWith(PLAYER_LAYER_PREFIX));
+  const players = others.filter(l => l.id.startsWith(PLAYER_LAYER_PREFIX));
+  customs.forEach((l, i) => {
+    if (l.order !== CUSTOM_BAND_ORDER + i) {
+      lm.updateLayerDirect(l.id, { order: CUSTOM_BAND_ORDER + i });
+    }
+  });
+  players.forEach((l, i) => {
+    if (l.order !== PLAYER_BAND_ORDER + i) {
+      lm.updateLayerDirect(l.id, { order: PLAYER_BAND_ORDER + i });
+    }
+  });
+}
+
+/**
+ * Keep bands pinned as layers come and go. updateLayerDirect emits 'change'
+ * synchronously, so the guard prevents self-recursion; the pin is
+ * idempotent, so the one re-entrant emit converges immediately.
+ */
+export function subscribePinCanonicalLayers(
+  vp: ViewportLike,
+  getOpts?: () => { mapUnlocked?: boolean }
+): () => void {
+  let pinning = false;
+  return vp.layerManager.on('change', () => {
+    if (pinning) return;
+    pinning = true;
+    try {
+      pinCanonicalLayers(vp, getOpts?.());
+    } finally {
+      pinning = false;
+    }
+  });
+}
+
+/**
+ * Layers don't sync: a remote element can reference a layer id this canvas
+ * has never seen (old clients mid-rollout, other players' layers). Mirror it
+ * locally into the right band so stacking stays deterministic. Locked for
+ * players (can't touch remote content anyway); unlocked for the DM (keeps
+ * the DM able to drag player tokens).
+ */
+export function mirrorUnknownLayer(
+  vp: ViewportLike,
+  layerId: string,
+  role: CanvasRole
+): void {
+  if (!layerId || vp.layerManager.getLayer(layerId)) return;
+  const isPlayerLayer = layerId.startsWith(PLAYER_LAYER_PREFIX);
+  vp.layerManager.addLayerDirect({
+    id: layerId,
+    name: 'Remote layer',
+    visible: true,
+    locked: role === 'player',
+    order: isPlayerLayer ? PLAYER_BAND_ORDER : CUSTOM_BAND_ORDER,
+    opacity: 1,
+  });
+  pinCanonicalLayers(vp);
+}
+
+/**
+ * Lazy per-load migration of pre-contract canvases: legacy name-matched
+ * layers are absorbed into the canonical ids (elements moved — the element
+ * updates flow through the relay, which is what teaches OTHER canvases the
+ * canonical ids), and empty auto-named leftovers (the SDK default "Layer 1")
+ * are dropped. Returns true when anything changed so the caller can persist.
+ */
+export function migrateCanvasToContract(
+  vp: ViewportLike,
+  role: CanvasRole
+): boolean {
+  const lm = vp.layerManager;
+  ensureCanonicalLayers(vp, role);
+  let changed = false;
+
+  for (const legacy of lm.getLayers()) {
+    if (legacy.id === MAP_LAYER_ID || legacy.id === ANNOTATIONS_LAYER_ID) {
+      continue;
+    }
+    const target =
+      legacy.name === LEGACY_MAP_NAME
+        ? MAP_LAYER_ID
+        : legacy.name === LEGACY_ANNOTATIONS_NAME
+          ? ANNOTATIONS_LAYER_ID
+          : null;
+    if (!target) continue;
+    for (const el of vp.store.getAll()) {
+      if (el.layerId === legacy.id) {
+        vp.store.update(el.id, { layerId: target });
+      }
+    }
+    lm.removeLayerDirect(legacy.id);
+    changed = true;
+  }
+
+  for (const leftover of lm.getLayers()) {
+    if (leftover.id === MAP_LAYER_ID || leftover.id === ANNOTATIONS_LAYER_ID) {
+      continue;
+    }
+    if (!AUTO_LAYER_NAME.test(leftover.name)) continue;
+    const empty = !vp.store.getAll().some(el => el.layerId === leftover.id);
+    if (empty) {
+      lm.removeLayerDirect(leftover.id);
+      changed = true;
+    }
+  }
+
+  // removeLayerDirect doesn't repair a dangling active layer.
+  if (!lm.getLayer(lm.activeLayerId)) {
+    lm.setActiveLayer(ANNOTATIONS_LAYER_ID);
+  }
+  if (changed) pinCanonicalLayers(vp);
+  return changed;
+}

--- a/src/components/ui/campaign/location-map/mapImagePlacement.ts
+++ b/src/components/ui/campaign/location-map/mapImagePlacement.ts
@@ -1,0 +1,31 @@
+import { MAP_LAYER_ID } from './layerContract';
+
+export const MAP_IMAGE_GUTTER = 40;
+
+/** Structural subset of CanvasElement — keeps the helper trivially testable. */
+export interface PlacedElement {
+  layerId: string;
+  type: string;
+  position: { x: number; y: number };
+  size?: { w: number; h: number };
+}
+
+/**
+ * Slot for the next map image: right edge of the existing map images'
+ * bounding box, top-aligned, with a gutter. Origin when the map is empty.
+ */
+export function nextMapImagePosition(elements: PlacedElement[]): {
+  x: number;
+  y: number;
+} {
+  let right = -Infinity;
+  let top = Infinity;
+  for (const el of elements) {
+    if (el.layerId !== MAP_LAYER_ID || el.type !== 'image') continue;
+    const size = el.size ?? { w: 0, h: 0 };
+    right = Math.max(right, el.position.x + size.w);
+    top = Math.min(top, el.position.y);
+  }
+  if (right === -Infinity) return { x: 0, y: 0 };
+  return { x: right + MAP_IMAGE_GUTTER, y: top };
+}

--- a/src/components/ui/campaign/location-map/playerLayer.ts
+++ b/src/components/ui/campaign/location-map/playerLayer.ts
@@ -1,4 +1,5 @@
 import type { Viewport } from '@fieldnotes/core';
+import { PLAYER_BAND_ORDER } from './layerContract';
 
 /** Deterministic layer id for a player's own canvas elements. */
 export function playerLayerId(characterId: string): string {
@@ -24,7 +25,7 @@ export function ensurePlayerLayer(vp: Viewport, characterId: string): string {
       name: 'My elements',
       visible: true,
       locked: false,
-      order: 1,
+      order: PLAYER_BAND_ORDER,
       opacity: 1,
     });
   }


### PR DESCRIPTION
## Summary

Fixes the live-play bug where player tokens were invisible on the DM battlemap when a DM-added image covered them, and adds first-class multi-map-image management in setup mode.

### Root cause of the bug

The fieldnotes SDK paints elements sorted by `(layerOrder, zIndex)` — zIndex is only compared *within* a layer, and layers never sync between clients. Player tokens live on per-player layers (`player-<characterId>`) that the DM canvas had never seen, so they fell back to layer order 0 — *under* the annotations layer where DM-added images live. The player canvas mirrored unknown layers at order -1, producing the opposite stacking: same elements, token visible for the player, hidden for the DM.

### The fix: canonical layer bands (`layerContract.ts`)

Every canvas (DM setup editor, DM play canvas, player canvas) now pins the same bands:

| Band | Order | Content |
|---|---|---|
| `layer-map` (locked) | 0 | map images + grid |
| `layer-annotations` | 100 | DM annotations + combatant tokens (zIndex 1000) |
| custom DM layers | 200+ | layers panel extras |
| `player-<id>` layers | 500+ | player tokens + drawings |

- Unknown remote layers are mirrored into their band on **add and update** — the update path matters: relay snapshot reconcile (48h Redis room TTL) re-applies elements as full updates and would otherwise revert the migration to deleted legacy layer ids (caught in final review).
- Legacy canvases ("Map Background"/"Annotations" layers) migrate lazily on load to the canonical ids; the element updates flow through the relay and teach other canvases the new ids.
- A pin subscription re-asserts band invariants on every layer change; DM custom layers can no longer stack above player tokens (that was the bug's foot-gun).
- Selection semantics preserved exactly: own layers unlocked, foreign content locked on player canvases, DM keeps drag rights over player tokens.

### Map management (setup mode, battlemap only)

- **Add map image** — uploads and places a natural-size image at the right edge of existing maps, locked onto `layer-map`.
- **Arrange maps** — toggle that unlocks *only* map images (grid stays locked, annotations locked for the duration, amber banner shown); exit re-locks everything, sweeps any stray elements created mid-arrange back to annotations, and survives unmount via a cached viewport ref (React nulls child refs before parent effect cleanup — caught in review).
- Layers panel: map + annotations rows protected from deletion, player layers hidden, custom layers always deletable.

No persistence-shape, relay, or token-tool changes. `canvasState` remains the single source of truth.

## Testing

- 26 new unit tests against real SDK `ElementStore`/`LayerManager` (headless, no canvas): band pinning, mirroring on add/update (C1 regression test), migration, arrange enter/exit incl. sweep, placement math, plus the original bug as a regression test (annotations image vs unknown-layer token paint order).
- Full unit suite: 3074 passed / 1 skipped. Type-check clean.
- Recommended manual smoke: DM adds a second map next to the first, player walks a token onto it — token visible on top on both screens; reload both, stacking persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)