### PR TITLE
feat(battlemap): smart alignment guides + align/distribute actions

### DIFF
--- a/src/components/ui/campaign/location-map/DmLocationAlignMenu.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationAlignMenu.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  AlignStartVertical,
+  AlignCenterVertical,
+  AlignEndVertical,
+  AlignStartHorizontal,
+  AlignCenterHorizontal,
+  AlignEndHorizontal,
+  AlignHorizontalSpaceBetween,
+  AlignVerticalSpaceBetween,
+} from 'lucide-react';
+import { useSelectionOps } from '@fieldnotes/react';
+import { Button } from '@/components/ui/forms/button';
+
+const ALIGN_ACTIONS = [
+  { edge: 'left', title: 'Align left', Icon: AlignStartVertical },
+  {
+    edge: 'center-x',
+    title: 'Align centers horizontally',
+    Icon: AlignCenterVertical,
+  },
+  { edge: 'right', title: 'Align right', Icon: AlignEndVertical },
+  { edge: 'top', title: 'Align top', Icon: AlignStartHorizontal },
+  {
+    edge: 'middle',
+    title: 'Align middles vertically',
+    Icon: AlignCenterHorizontal,
+  },
+  { edge: 'bottom', title: 'Align bottom', Icon: AlignEndHorizontal },
+] as const;
+
+const DISTRIBUTE_ACTIONS = [
+  {
+    axis: 'horizontal',
+    title: 'Distribute horizontally',
+    Icon: AlignHorizontalSpaceBetween,
+  },
+  {
+    axis: 'vertical',
+    title: 'Distribute vertically',
+    Icon: AlignVerticalSpaceBetween,
+  },
+] as const;
+
+/**
+ * Align/distribute actions for the current selection, behind one toolbar
+ * button (six always-visible icon buttons would bloat the freshly slimmed
+ * toolbar). Same local-popover pattern as DmLocationGridPopover. The panel
+ * stays open after an action — aligning then distributing is a common
+ * chain. Must render inside ViewportContext.Provider.
+ */
+export default function DmLocationAlignMenu() {
+  const { canAlign, canDistribute, align, distribute } = useSelectionOps();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  // Selection dropping below two movable elements leaves a dead panel — close it.
+  useEffect(() => {
+    if (!canAlign) setOpen(false);
+  }, [canAlign]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <Button
+        variant={open ? 'primary' : 'ghost'}
+        onClick={() => setOpen(o => !o)}
+        disabled={!canAlign}
+        title="Align & distribute"
+        aria-expanded={open}
+        className="flex items-center gap-1.5 px-2 py-1 text-xs"
+      >
+        <AlignStartVertical size={15} />
+        Align
+      </Button>
+
+      {open && (
+        <div className="border-divider bg-surface-raised absolute top-full left-0 z-20 mt-1 rounded-lg border p-2 shadow-lg">
+          <div className="flex items-center gap-0.5">
+            {ALIGN_ACTIONS.map(({ edge, title, Icon }) => (
+              <Button
+                key={edge}
+                variant="ghost"
+                onClick={() => align(edge)}
+                title={title}
+                className="h-8 w-8 p-0"
+              >
+                <Icon size={15} />
+              </Button>
+            ))}
+          </div>
+          <div className="mt-1 flex items-center gap-0.5">
+            {DISTRIBUTE_ACTIONS.map(({ axis, title, Icon }) => (
+              <Button
+                key={axis}
+                variant="ghost"
+                onClick={() => distribute(axis)}
+                disabled={!canDistribute}
+                title={title}
+                className="h-8 w-8 p-0"
+              >
+                <Icon size={15} />
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
@@ -28,6 +28,7 @@ import {
 import { useActiveTool, useHistory, useSelectionOps } from '@fieldnotes/react';
 import { Button } from '@/components/ui/forms/button';
 import DmLocationGridPopover from './DmLocationGridPopover';
+import DmLocationAlignMenu from './DmLocationAlignMenu';
 import DmOnlyToggle from './DmOnlyToggle';
 import { useSelectToolSelectionCount } from './useSelectToolSelectionCount';
 import type { DmLocationToolbarProps } from './DmLocationToolbar.types';
@@ -180,6 +181,7 @@ export default function DmLocationToolbar({
         >
           <RotateCw size={15} />
         </Button>
+        <DmLocationAlignMenu />
         <Button
           variant="ghost"
           onClick={onClear}

--- a/src/components/ui/campaign/location-map/__tests__/DmLocationAlignMenu.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/DmLocationAlignMenu.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+import DmLocationAlignMenu from '@/components/ui/campaign/location-map/DmLocationAlignMenu';
+
+const align = vi.fn();
+const distribute = vi.fn();
+let mockCanAlign = true;
+let mockCanDistribute = true;
+
+vi.mock('@fieldnotes/react', () => ({
+  useSelectionOps: () => ({
+    selectedIds: [],
+    selectedCount: 2,
+    canGroup: false,
+    canUngroup: false,
+    canAlign: mockCanAlign,
+    canDistribute: mockCanDistribute,
+    isLocked: null,
+    group: vi.fn(),
+    ungroup: vi.fn(),
+    toggleLock: vi.fn(),
+    align,
+    distribute,
+    rotateCW: vi.fn(),
+    rotateCCW: vi.fn(),
+  }),
+}));
+
+const ALIGN_CASES: Array<[title: string, edge: string]> = [
+  ['Align left', 'left'],
+  ['Align centers horizontally', 'center-x'],
+  ['Align right', 'right'],
+  ['Align top', 'top'],
+  ['Align middles vertically', 'middle'],
+  ['Align bottom', 'bottom'],
+];
+
+describe('DmLocationAlignMenu', () => {
+  beforeEach(() => {
+    mockCanAlign = true;
+    mockCanDistribute = true;
+    align.mockClear();
+    distribute.mockClear();
+  });
+
+  afterEach(() => cleanup());
+
+  it('disables the trigger when alignment is not possible', () => {
+    mockCanAlign = false;
+    render(<DmLocationAlignMenu />);
+    expect(screen.getByTitle('Align & distribute')).toBeDisabled();
+  });
+
+  it('forwards each align edge exactly', () => {
+    render(<DmLocationAlignMenu />);
+    fireEvent.click(screen.getByTitle('Align & distribute'));
+    for (const [title, edge] of ALIGN_CASES) {
+      fireEvent.click(screen.getByTitle(title));
+      expect(align).toHaveBeenLastCalledWith(edge);
+    }
+    expect(align).toHaveBeenCalledTimes(6);
+  });
+
+  it('keeps the panel open after an align action', () => {
+    render(<DmLocationAlignMenu />);
+    fireEvent.click(screen.getByTitle('Align & distribute'));
+    fireEvent.click(screen.getByTitle('Align left'));
+    expect(screen.getByTitle('Align top')).toBeInTheDocument();
+  });
+
+  it('disables distribute (but not align) below three movable elements', () => {
+    mockCanDistribute = false;
+    render(<DmLocationAlignMenu />);
+    fireEvent.click(screen.getByTitle('Align & distribute'));
+    expect(screen.getByTitle('Distribute horizontally')).toBeDisabled();
+    expect(screen.getByTitle('Align left')).toBeEnabled();
+  });
+
+  it('forwards distribute axes when possible', () => {
+    render(<DmLocationAlignMenu />);
+    fireEvent.click(screen.getByTitle('Align & distribute'));
+    fireEvent.click(screen.getByTitle('Distribute horizontally'));
+    fireEvent.click(screen.getByTitle('Distribute vertically'));
+    expect(distribute).toHaveBeenNthCalledWith(1, 'horizontal');
+    expect(distribute).toHaveBeenNthCalledWith(2, 'vertical');
+  });
+
+  it('closes on Escape and when alignment becomes impossible', () => {
+    const { rerender } = render(<DmLocationAlignMenu />);
+    fireEvent.click(screen.getByTitle('Align & distribute'));
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByTitle('Align left')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Align & distribute'));
+    expect(screen.getByTitle('Align left')).toBeInTheDocument();
+    mockCanAlign = false;
+    rerender(<DmLocationAlignMenu />);
+    expect(screen.queryByTitle('Align left')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/campaign/location-map/__tests__/DmLocationToolbar.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/DmLocationToolbar.test.tsx
@@ -107,4 +107,9 @@ describe('DmLocationToolbar rotation buttons', () => {
     const { container } = render(<DmLocationToolbar {...baseProps} />);
     expect(container.firstElementChild?.className).toContain('flex-wrap');
   });
+
+  it('renders the Align trigger in the center group', () => {
+    render(<DmLocationToolbar {...baseProps} />);
+    expect(screen.getByTitle('Align & distribute')).toBeInTheDocument();
+  });
 });

--- a/src/components/ui/campaign/location-map/__tests__/arrangeMaps.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/arrangeMaps.test.ts
@@ -17,16 +17,27 @@ import {
 import {
   enterArrangeMaps,
   exitArrangeMaps,
+  type ArrangeViewport,
 } from '@/components/ui/campaign/location-map/arrangeMaps';
 
 // migrateCanvasToContract (in addition to ensureCanonicalLayers) drops the
 // SDK's empty default "Layer 1", which otherwise stays active and breaks the
 // "previous active layer" assertions below — same fixture pattern as
 // makeCleanVp in layerContract.test.ts.
-function makeVp(): ViewportLike {
+function makeVp(): ArrangeViewport {
   const store = new ElementStore();
   const layerManager = new LayerManager(store);
-  const vp = { store, layerManager };
+  let smartGuides = false;
+  const vp: ArrangeViewport = {
+    store,
+    layerManager,
+    get smartGuides() {
+      return smartGuides;
+    },
+    setSmartGuides(enabled: boolean) {
+      smartGuides = enabled;
+    },
+  };
   ensureCanonicalLayers(vp, 'dm');
   migrateCanvasToContract(vp, 'dm');
   return vp;
@@ -130,5 +141,23 @@ describe('enter/exitArrangeMaps', () => {
     expect(vp.store.getById(note.id)?.layerId).toBe(ANNOTATIONS_LAYER_ID);
     expect(vp.store.getById(imageId)?.layerId).toBe(MAP_LAYER_ID);
     expect(vp.store.getById(grid.id)?.layerId).toBe(MAP_LAYER_ID);
+  });
+
+  it('enables smart guides on enter and restores the previous value on exit', () => {
+    const vp = makeVp();
+    const session = enterArrangeMaps(vp);
+    expect(vp.smartGuides).toBe(true);
+    expect(session.smartGuidesWasEnabled).toBe(false);
+    exitArrangeMaps(vp, session);
+    expect(vp.smartGuides).toBe(false);
+  });
+
+  it('keeps smart guides on after exit when they were already enabled', () => {
+    const vp = makeVp();
+    vp.setSmartGuides(true);
+    const session = enterArrangeMaps(vp);
+    expect(session.smartGuidesWasEnabled).toBe(true);
+    exitArrangeMaps(vp, session);
+    expect(vp.smartGuides).toBe(true);
   });
 });

--- a/src/components/ui/campaign/location-map/arrangeMaps.ts
+++ b/src/components/ui/campaign/location-map/arrangeMaps.ts
@@ -4,26 +4,40 @@ import {
   type ViewportLike,
 } from './layerContract';
 
+/** ViewportLike plus the smart-guides switch — `Viewport` satisfies this
+ *  structurally. Guides are only ever enabled inside arrange-maps mode:
+ *  the SDK's SelectTool drag uses smart guides OR grid snapping, never
+ *  both, and token drags outside this mode rely on grid snapping. */
+export interface ArrangeViewport extends ViewportLike {
+  smartGuides: boolean;
+  setSmartGuides(enabled: boolean): void;
+}
+
 export interface ArrangeMapsSession {
   /** Map-layer image elements we unlocked on enter — re-locked on exit. */
   unlockedElementIds: string[];
   annotationsWasLocked: boolean;
   previousActiveLayerId: string;
+  /** Smart-guides state before enter — restored (not forced off) on exit. */
+  smartGuidesWasEnabled: boolean;
 }
 
 /**
  * Arrange-maps mode: only map images are editable. Unlocks layer-map and its
  * image elements (grid elements stay locked so they can't be dragged), locks
  * annotations so nothing else is selectable, and activates the map layer.
+ * Also enables the SDK's smart alignment guides for the duration (map-to-map
+ * edge/center snapping while dragging).
  * The caller must relax the pin invariant (mapUnlocked) for the duration —
  * otherwise the pin subscription re-locks the map layer on the next change.
  */
-export function enterArrangeMaps(vp: ViewportLike): ArrangeMapsSession {
+export function enterArrangeMaps(vp: ArrangeViewport): ArrangeMapsSession {
   const lm = vp.layerManager;
   const session: ArrangeMapsSession = {
     unlockedElementIds: [],
     annotationsWasLocked: lm.getLayer(ANNOTATIONS_LAYER_ID)?.locked ?? false,
     previousActiveLayerId: lm.activeLayerId,
+    smartGuidesWasEnabled: vp.smartGuides,
   };
   lm.updateLayerDirect(MAP_LAYER_ID, { locked: false });
   for (const el of vp.store.getAll()) {
@@ -35,11 +49,12 @@ export function enterArrangeMaps(vp: ViewportLike): ArrangeMapsSession {
   }
   lm.updateLayerDirect(ANNOTATIONS_LAYER_ID, { locked: true });
   lm.setActiveLayer(MAP_LAYER_ID);
+  vp.setSmartGuides(true);
   return session;
 }
 
 export function exitArrangeMaps(
-  vp: ViewportLike,
+  vp: ArrangeViewport,
   session: ArrangeMapsSession
 ): void {
   const lm = vp.layerManager;
@@ -71,4 +86,5 @@ export function exitArrangeMaps(
     lm.setActiveLayer(ANNOTATIONS_LAYER_ID);
   }
   lm.updateLayerDirect(MAP_LAYER_ID, { locked: true });
+  vp.setSmartGuides(session.smartGuidesWasEnabled);
 }


### PR DESCRIPTION
## Summary

Two alignment features for the DM setup canvas, building on the arrange-maps mode and the `useSelectionOps` wiring from #177.

### Smart guides while arranging maps

Arrange-maps mode now auto-enables the fieldnotes SDK's smart alignment guides: dragging one map near another shows edge/center guide lines and snaps to them — exactly the "align maps to each other" interaction. The previous guides state is recorded on enter and restored on exit (including the unmount-mid-arrange cleanup path; verified safe against a destroyed viewport).

Guides stay **off outside arrange mode** deliberately: the SDK's SelectTool uses smart guides *or* grid snapping during a drag, never both, and token drags rely on grid snapping.

### Align & distribute popover

New `DmLocationAlignMenu` in the setup toolbar next to the rotate buttons (same local-popover pattern as the grid settings): six align actions (left / centers / right / top / middles / bottom) and two distribute actions (horizontal / vertical) via `useSelectionOps`. The panel stays open after an action — aligning then distributing is a common chain — and auto-closes when the selection drops below two elements.

Review-verified details:
- Every lucide glyph checked against its actual SVG geometry (the Align* naming is easy to mismap) — all eight pairings correct.
- Align/distribute during arrange mode cannot touch annotation elements: entering arrange wipes the selection (tool re-set clears SelectTool), and the layer lock blocks hit-test and marquee for the duration.

## Testing

- Full unit suite: 3096 passed / 1 skipped; type-check clean.
- New tests: 2 for the arrange-session guides lifecycle (restore for both prior states, against a faithful stateful fake), 6 for the align menu (exact edge/axis forwarding, distribute gating, panel persistence, Escape + canAlign-drop close), 1 toolbar presence test.
- Recommended manual smoke: arrange mode → drag maps together (guides + snap), exit → token drag still grid-snaps; select 3 notes → Align top → Distribute horizontally → undo twice.

Follow-ups logged: outside-click close is untested for both popovers (same gap as the pre-existing grid popover); keyboard-only dual-popover overlap is cosmetic (mouse cannot co-open them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)