### PR TITLE
chore(deps): bump @fieldnotes/core to 0.50.0 — image aspect-ratio lock on resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@3d-dice/dice-box": "^1.1.3",
         "@3d-dice/dice-ui": "^0.5.2",
         "@aws-sdk/client-s3": "^3.922.0",
-        "@fieldnotes/core": "^0.49.0",
+        "@fieldnotes/core": "^0.50.0",
         "@fieldnotes/react": "^0.8.0",
         "@fieldnotes/sync": "^0.7.0",
         "@radix-ui/react-checkbox": "^1.3.2",
@@ -2174,9 +2174,9 @@
       }
     },
     "node_modules/@fieldnotes/core": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.49.0.tgz",
-      "integrity": "sha512-f6jKgsox+rNBXCbYmo/nYwFSgHWxR+JLDYFsE8sc0c7R8GmlX2cFO/dVury6KjP2V2vQs6zJqKd5F2sCkgcyIA==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.50.0.tgz",
+      "integrity": "sha512-mmWhT95pO8FTY+s5lIL4P0LrkB4q+5CvuPqVbp0E/Fqns47TssuZyJe2AINH6YgilBXZhsqmKBcgaoQ0Hkx7Rg==",
       "license": "MIT"
     },
     "node_modules/@fieldnotes/react": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@3d-dice/dice-box": "^1.1.3",
     "@3d-dice/dice-ui": "^0.5.2",
     "@aws-sdk/client-s3": "^3.922.0",
-    "@fieldnotes/core": "^0.49.0",
+    "@fieldnotes/core": "^0.50.0",
     "@fieldnotes/react": "^0.8.0",
     "@fieldnotes/sync": "^0.7.0",
     "@radix-ui/react-checkbox": "^1.3.2",


### PR DESCRIPTION
## Summary

Bumps `@fieldnotes/core` from 0.49.0 to 0.50.0, which adds aspect-ratio locking for image resize inside the SDK's `SelectTool`. No app code changes — the behavior activates automatically in every canvas.

## Behavior change

- **Image elements** (map images, combatant tokens, any placed image): resize handles now keep the aspect ratio by default; holding **Shift** while dragging allows free resize.
- **Non-image elements**: unchanged — free resize by default, Shift enables the lock (`lockAspect = shiftKey !== (el.type === 'image')`).
- Applies in DM setup editor (including arrange-maps mode), DM VTT, and player canvases.

## Verification

- Full 0.49.0 → 0.50.0 dist diff reviewed: the aspect-lock logic (`computeResize`/`computeRotatedResize` + `handleResize`) is the **only** change; public API surface identical (`index.d.ts` diff is the VERSION constant plus a private field).
- `npm run type-check` clean.
- Test suite: **3096 passed / 1 skipped** — same baseline as #178.

## Manual smoke (suggested)

- Arrange-maps mode → resize a map image corner: stays proportional; Shift-drag stretches freely.
- Resize a combatant token: stays proportional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)