### PR TITLE
feat(npc): add XP field and fix rich-text list rendering

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -606,6 +606,23 @@ button {
   color: var(--heading) !important;
 }
 
+/* Restore list markers for rich-text HTML rendered outside RichTextRenderer
+   (Tailwind Preflight resets ul/ol to list-style:none; typography plugin not installed) */
+.statblock-rich-text ul {
+  list-style-type: disc;
+  margin: 0.25rem 0;
+  padding-left: 1.25rem;
+}
+.statblock-rich-text ol {
+  list-style-type: decimal;
+  margin: 0.25rem 0;
+  padding-left: 1.25rem;
+}
+.statblock-rich-text li {
+  display: list-item;
+  list-style-position: outside;
+}
+
 /* Fix text inputs in editor mode */
 .prose input[type='text'] {
   color: var(--input-text) !important;

--- a/src/components/ui/campaign/NPCDetailDialog.tsx
+++ b/src/components/ui/campaign/NPCDetailDialog.tsx
@@ -34,6 +34,7 @@ import { Button } from '@/components/ui/forms/button';
 import { Badge } from '@/components/ui/layout/badge';
 import { MonsterStatBlockPanel } from '@/components/ui/encounter/MonsterStatBlockPanel';
 import { NPCStatBlockExport } from './NPCStatBlockExport';
+import RichTextRenderer from '@/components/ui/utils/RichTextRenderer';
 import {
   ItemForm,
   initialInventoryFormData,
@@ -107,6 +108,7 @@ function AbilityScoreGrid({
 
 function ExtraStatsBadges({ npc }: { npc: CampaignNPC }) {
   const hasExtras =
+    npc.xp !== undefined ||
     npc.proficiencyBonus !== undefined ||
     npc.hitDice !== undefined ||
     npc.passivePerception !== undefined ||
@@ -125,6 +127,14 @@ function ExtraStatsBadges({ npc }: { npc: CampaignNPC }) {
 
   return (
     <div className="flex flex-wrap items-center gap-2">
+      {npc.xp !== undefined && (
+        <span className="bg-surface-secondary text-muted rounded-full px-2.5 py-0.5 text-xs font-medium">
+          XP{' '}
+          <span className="text-heading font-semibold">
+            {npc.xp.toLocaleString()}
+          </span>
+        </span>
+      )}
       {npc.proficiencyBonus !== undefined && (
         <span className="bg-surface-secondary text-muted rounded-full px-2.5 py-0.5 text-xs font-medium">
           PB{' '}
@@ -516,10 +526,7 @@ function NPCItemViewModal({
               <h4 className="text-heading mb-1.5 text-sm font-semibold">
                 Description
               </h4>
-              <div
-                className="prose prose-sm text-body max-w-none leading-relaxed"
-                dangerouslySetInnerHTML={{ __html: item.description }}
-              />
+              <RichTextRenderer content={item.description} />
             </div>
           )}
         </DialogBody>
@@ -839,10 +846,7 @@ export function NPCDetailDialog({
 
           {activeTab === 'lore' &&
             (npc.loreHtml ? (
-              <div
-                className="prose prose-sm text-body max-w-none"
-                dangerouslySetInnerHTML={{ __html: npc.loreHtml }}
-              />
+              <RichTextRenderer content={npc.loreHtml} />
             ) : (
               <div className="flex flex-1 items-center justify-center text-center">
                 <div>

--- a/src/components/ui/campaign/NPCFormDialog.tsx
+++ b/src/components/ui/campaign/NPCFormDialog.tsx
@@ -246,6 +246,7 @@ export function NPCFormDialog({
   const [alignment, setAlignment] = useState('');
   const [ac, setAc] = useState(10);
   const [hp, setHp] = useState(10);
+  const [xp, setXp] = useState(0);
   const [hpFormula, setHpFormula] = useState('');
   const [speed, setSpeed] = useState('30 ft.');
 
@@ -354,6 +355,7 @@ export function NPCFormDialog({
       setDescription(editingNpc.description ?? '');
       setAc(editingNpc.armorClass);
       setHp(editingNpc.maxHp);
+      setXp(editingNpc.xp ?? 0);
       setSpeed(editingNpc.speed);
       setAvatarUrl(editingNpc.avatarUrl ?? '');
       setBestiarySourceId(editingNpc.bestiarySourceId ?? null);
@@ -538,6 +540,7 @@ export function NPCFormDialog({
     setDescription('');
     setAc(10);
     setHp(10);
+    setXp(0);
     setHpFormula('');
     setSpeed('30 ft.');
     setSize('Medium');
@@ -623,6 +626,7 @@ export function NPCFormDialog({
     setDescription('');
     setAc(monster.acValue);
     setHp(monster.hpAverage);
+    setXp(0);
     setHpFormula(monster.hpFormula);
     setSpeed(sb.speed);
     setSize(sb.size);
@@ -827,6 +831,7 @@ export function NPCFormDialog({
       maxHp: hp,
       speed: speed.trim() || '30 ft.',
       description: description.trim() || undefined,
+      xp: xp > 0 ? xp : undefined,
       monsterStatBlock,
       bestiarySourceId: bestiarySourceId ?? undefined,
       loreHtml: loreHtml.trim() || undefined,
@@ -1191,7 +1196,7 @@ export function NPCFormDialog({
                         placeholder="2d8+2"
                       />
                     </div>
-                    <div className="grid grid-cols-2 gap-2">
+                    <div className="grid grid-cols-3 gap-2">
                       <Input
                         value={speed}
                         onChange={e => setSpeed(e.target.value)}
@@ -1207,6 +1212,15 @@ export function NPCFormDialog({
                         }}
                         label="Init Mod"
                         title="Initiative modifier (auto-calculated from DEX, overridable)"
+                      />
+                      <Input
+                        type="number"
+                        value={xp}
+                        onChange={e => setXp(parseInt(e.target.value) || 0)}
+                        label="XP"
+                        min={0}
+                        placeholder="0"
+                        title="XP awarded for defeating this NPC"
                       />
                     </div>
                   </div>

--- a/src/components/ui/campaign/NPCStatBlockExport.tsx
+++ b/src/components/ui/campaign/NPCStatBlockExport.tsx
@@ -76,6 +76,23 @@ function cleanHtmlForExport(html: string): string {
           // Unstyled element — clean up attrs but keep structure
           el.removeAttribute('style');
           el.removeAttribute('class');
+          // Re-apply list markers inline (Tailwind Preflight strips them)
+          if (el.tagName === 'UL') {
+            el.setAttribute(
+              'style',
+              'list-style-type:disc;padding-left:20px;margin:4px 0;'
+            );
+          } else if (el.tagName === 'OL') {
+            el.setAttribute(
+              'style',
+              'list-style-type:decimal;padding-left:20px;margin:4px 0;'
+            );
+          } else if (el.tagName === 'LI') {
+            el.setAttribute(
+              'style',
+              'display:list-item;list-style-position:outside;'
+            );
+          }
         }
       }
     }

--- a/src/components/ui/encounter/MonsterStatBlockPanel.tsx
+++ b/src/components/ui/encounter/MonsterStatBlockPanel.tsx
@@ -50,7 +50,7 @@ function TraitBlock({
             {entry.name}.
           </span>{' '}
           <span
-            className="text-body"
+            className="text-body statblock-rich-text"
             dangerouslySetInnerHTML={{ __html: entry.text }}
           />
         </div>

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -272,6 +272,9 @@ export interface CampaignNPC {
   // Lore (DM-written HTML from rich text editor)
   loreHtml?: string;
 
+  // XP reward for defeating this NPC
+  xp?: number;
+
   // Portrait (S3 URL)
   avatarUrl?: string;
 


### PR DESCRIPTION
## Summary

Two DM-requested NPC improvements:

1. **XP field** — NPCs can now have an XP reward value. Editable in the NPC form's Basic tab (Speed / Init Mod / XP row), initialized on edit, and shown as an `XP` badge in the NPC detail view.

2. **Rich-text lists fix** — bullet / numbered lists typed in NPC rich-text fields displayed fine in the editor but vanished when rendered. Cause: Tailwind Preflight resets `ul/ol` to `list-style: none` and `@tailwindcss/typography` is not installed, so raw `dangerouslySetInnerHTML` output had no markers.

## Changes

- `CampaignNPC.xp?: number` added to the type; wired through the form (state, edit-init, reset, bestiary-import reset, submit payload) and the detail badge.
- Lore + inventory item description now render via `RichTextRenderer` (which carries proper list CSS) instead of raw `prose` HTML.
- Stat block trait/action text gets a shared `.statblock-rich-text` class in `globals.css` that restores list markers — covers NPC detail, summons, and the encounter stat block panel (all use `MonsterStatBlockPanel`).
- Stat block **image export** re-applies list styles inline (html-to-image strips classes).

All rich-text formatting the compact editor produces (bold, italic, underline, strike, lists) now displays correctly; lists were the only casualty.

## Testing

- `npm run type-check` — clean
- `npm run lint` on touched files — clean (only pre-existing `<img>` warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)