### PR TITLE
fix(forms): clear-safe number inputs (no more stuck 0)

### DIFF
--- a/src/components/ArmorDefenseManager.tsx
+++ b/src/components/ArmorDefenseManager.tsx
@@ -16,6 +16,7 @@ import DragDropList from '@/components/ui/layout/DragDropList';
 import { Button } from '@/components/ui/forms/button';
 import { Badge } from '@/components/ui/layout/badge';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import { Checkbox } from '@/components/ui/forms/checkbox';
 import RichTextEditor from '@/components/ui/forms/RichTextEditor';
@@ -395,30 +396,27 @@ export default function ArmorDefenseManager() {
                 </h4>
 
                 <div className="grid grid-cols-3 gap-4">
-                  <Input
+                  <NumberInput
                     label="Base AC"
-                    type="number"
-                    value={formData.baseAC.toString()}
-                    onChange={e =>
+                    value={formData.baseAC}
+                    onChange={v =>
                       setFormData({
                         ...formData,
-                        baseAC: parseInt(e.target.value) || 10,
+                        baseAC: v ?? 10,
                       })
                     }
                     min={10}
                     max={30}
                   />
 
-                  <Input
+                  <NumberInput
                     label="Max Dex Bonus"
-                    type="number"
-                    value={formData.maxDexBonus?.toString() || ''}
-                    onChange={e =>
+                    allowEmpty
+                    value={formData.maxDexBonus}
+                    onChange={v =>
                       setFormData({
                         ...formData,
-                        maxDexBonus: e.target.value
-                          ? parseInt(e.target.value)
-                          : undefined,
+                        maxDexBonus: v,
                       })
                     }
                     placeholder="Unlimited"
@@ -426,14 +424,13 @@ export default function ArmorDefenseManager() {
                     max={10}
                   />
 
-                  <Input
+                  <NumberInput
                     label="Enhancement"
-                    type="number"
-                    value={formData.enhancementBonus.toString()}
-                    onChange={e =>
+                    value={formData.enhancementBonus}
+                    onChange={v =>
                       setFormData({
                         ...formData,
-                        enhancementBonus: parseInt(e.target.value) || 0,
+                        enhancementBonus: v ?? 0,
                       })
                     }
                     min={0}

--- a/src/components/SpellcastingStats.tsx
+++ b/src/components/SpellcastingStats.tsx
@@ -12,7 +12,7 @@ import {
   isSpellcaster,
 } from '@/utils/calculations';
 import { Button } from '@/components/ui/forms/button';
-import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { Switch } from '@/components/ui/forms/switch';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import { Badge } from '@/components/ui/layout/badge';
@@ -67,8 +67,7 @@ export const SpellcastingStats: React.FC = () => {
     });
   };
 
-  const handleAttackBonusOverride = (value: string) => {
-    const bonus = value === '' ? undefined : parseInt(value);
+  const handleAttackBonusOverride = (bonus: number | undefined) => {
     updateCharacter({
       spellcastingStats: {
         ...character.spellcastingStats,
@@ -77,8 +76,7 @@ export const SpellcastingStats: React.FC = () => {
     });
   };
 
-  const handleSaveDCOverride = (value: string) => {
-    const dc = value === '' ? undefined : parseInt(value);
+  const handleSaveDCOverride = (dc: number | undefined) => {
     updateCharacter({
       spellcastingStats: {
         ...character.spellcastingStats,
@@ -183,13 +181,10 @@ export const SpellcastingStats: React.FC = () => {
                 Spell Attack
               </div>
               {showOverrides ? (
-                <Input
-                  type="number"
-                  value={
-                    character.spellcastingStats.spellAttackBonus?.toString() ||
-                    ''
-                  }
-                  onChange={e => handleAttackBonusOverride(e.target.value)}
+                <NumberInput
+                  value={character.spellcastingStats.spellAttackBonus}
+                  onChange={handleAttackBonusOverride}
+                  allowEmpty
                   placeholder="Auto"
                   className="mb-2 w-full text-center text-xl font-bold"
                   size="sm"
@@ -222,12 +217,10 @@ export const SpellcastingStats: React.FC = () => {
                 Spell Save DC
               </div>
               {showOverrides ? (
-                <Input
-                  type="number"
-                  value={
-                    character.spellcastingStats.spellSaveDC?.toString() || ''
-                  }
-                  onChange={e => handleSaveDCOverride(e.target.value)}
+                <NumberInput
+                  value={character.spellcastingStats.spellSaveDC}
+                  onChange={handleSaveDCOverride}
+                  allowEmpty
                   placeholder="Auto"
                   className="mb-2 w-full text-center text-xl font-bold"
                   size="sm"

--- a/src/components/__tests__/combatant-detail-vitals.test.tsx
+++ b/src/components/__tests__/combatant-detail-vitals.test.tsx
@@ -86,7 +86,7 @@ describe('DetailVitals', () => {
     await user.clear(amountInput);
     await user.type(amountInput, '10');
     await user.click(screen.getByRole('button', { name: '½×' }));
-    expect(amountInput).toHaveValue(5);
+    expect(amountInput).toHaveValue('5');
     expect(actions.onDamage).not.toHaveBeenCalled();
   });
 
@@ -99,7 +99,7 @@ describe('DetailVitals', () => {
     await user.clear(amountInput);
     await user.type(amountInput, '6');
     await user.click(screen.getByRole('button', { name: '2×' }));
-    expect(amountInput).toHaveValue(12);
+    expect(amountInput).toHaveValue('12');
     expect(actions.onDamage).not.toHaveBeenCalled();
   });
 

--- a/src/components/__tests__/combatant-detail.test.tsx
+++ b/src/components/__tests__/combatant-detail.test.tsx
@@ -144,7 +144,7 @@ describe('CombatantDetail — monster with full stat block', () => {
     const actions = makeActions();
     render(<CombatantDetail entity={monsterEntity} actions={actions} />);
 
-    const strInput = screen.getByRole('spinbutton', { name: 'STR' });
+    const strInput = screen.getByRole('textbox', { name: 'STR' });
     fireEvent.change(strInput, { target: { value: '20' } });
 
     expect(actions.onUpdate).toHaveBeenCalledWith(
@@ -282,7 +282,7 @@ describe('CombatantDetail — player entity', () => {
       screen.getByText(/synced from character sheet/i)
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('spinbutton', { name: 'STR' })
+      screen.queryByRole('textbox', { name: 'STR' })
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/bestiary/BestiaryFiltersPanel.tsx
+++ b/src/components/bestiary/BestiaryFiltersPanel.tsx
@@ -10,7 +10,7 @@ import {
 import { Checkbox } from '@/components/ui/forms/checkbox';
 import { Card, CardContent } from '@/components/ui/layout/card';
 import { Button } from '@/components/ui/forms/button';
-import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { Filter, Skull, X } from 'lucide-react';
 import { Badge } from '@/components/ui/layout/badge';
 
@@ -52,9 +52,11 @@ export default function BestiaryFiltersPanel({
     onFilterChange({ alignments: newAlignments });
   };
 
-  const handleCRRangeChange = (type: 'min' | 'max', value: string) => {
-    const numValue = value === '' ? undefined : parseFloat(value);
-    onFilterChange({ crRange: { ...filters.crRange, [type]: numValue } });
+  const handleCRRangeChange = (
+    type: 'min' | 'max',
+    value: number | undefined
+  ) => {
+    onFilterChange({ crRange: { ...filters.crRange, [type]: value } });
   };
 
   const crOptions = [
@@ -142,18 +144,20 @@ export default function BestiaryFiltersPanel({
               })}
             </div>
             <div className="grid grid-cols-2 gap-2">
-              <Input
-                type="number"
+              <NumberInput
                 label="Min CR"
-                value={filters.crRange.min?.toString() ?? ''}
-                onChange={e => handleCRRangeChange('min', e.target.value)}
+                allowEmpty
+                integer={false}
+                value={filters.crRange.min}
+                onChange={v => handleCRRangeChange('min', v)}
                 placeholder="0"
               />
-              <Input
-                type="number"
+              <NumberInput
                 label="Max CR"
-                value={filters.crRange.max?.toString() ?? ''}
-                onChange={e => handleCRRangeChange('max', e.target.value)}
+                allowEmpty
+                integer={false}
+                value={filters.crRange.max}
+                onChange={v => handleCRRangeChange('max', v)}
                 placeholder="30"
               />
             </div>

--- a/src/components/shared/character/CurrencyManager.tsx
+++ b/src/components/shared/character/CurrencyManager.tsx
@@ -5,7 +5,7 @@ import { Currency } from '@/types/character';
 import { Coins, Plus, Minus, Info } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { Badge } from '@/components/ui/layout/badge';
-import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 
 const CURRENCY_TYPES: {
   [key in keyof Currency]: {
@@ -138,9 +138,11 @@ export function CurrencyManager({
     return breakdown.join(', ');
   };
 
-  const handleCurrencyChange = (type: keyof Currency, value: string) => {
-    const amount = parseInt(value) || 0;
-    setCurrencyAmounts(prev => ({ ...prev, [type]: amount }));
+  const handleCurrencyChange = (
+    type: keyof Currency,
+    value: number | undefined
+  ) => {
+    setCurrencyAmounts(prev => ({ ...prev, [type]: value ?? 0 }));
   };
 
   const addCurrencyAmount = (type: keyof Currency) => {
@@ -270,14 +272,13 @@ export function CurrencyManager({
                       >
                         {config.name}
                       </label>
-                      <Input
-                        type="number"
-                        value={currencyAmounts[type as keyof Currency] || ''}
-                        onChange={e =>
-                          handleCurrencyChange(
-                            type as keyof Currency,
-                            e.target.value
-                          )
+                      <NumberInput
+                        allowEmpty
+                        value={
+                          currencyAmounts[type as keyof Currency] || undefined
+                        }
+                        onChange={v =>
+                          handleCurrencyChange(type as keyof Currency, v)
                         }
                         placeholder="0"
                         min={0}

--- a/src/components/shared/combat/HitPointTracker.tsx
+++ b/src/components/shared/combat/HitPointTracker.tsx
@@ -18,6 +18,7 @@ import {
 import { HitPoints, ClassInfo } from '@/types/character';
 import { isDying, isDead, isStabilized } from '@/utils/hpCalculations';
 import { Button } from '@/components/ui/forms';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 
 interface HitPointTrackerProps {
   hitPoints: HitPoints;
@@ -63,9 +64,15 @@ export function HitPointTracker({
   hideLabels = false,
   className = '',
 }: HitPointTrackerProps) {
-  const [damageAmount, setDamageAmount] = useState('');
-  const [healingAmount, setHealingAmount] = useState('');
-  const [tempHPAmount, setTempHPAmount] = useState('');
+  const [damageAmount, setDamageAmount] = useState<number | undefined>(
+    undefined
+  );
+  const [healingAmount, setHealingAmount] = useState<number | undefined>(
+    undefined
+  );
+  const [tempHPAmount, setTempHPAmount] = useState<number | undefined>(
+    undefined
+  );
 
   const isCharacterDying = isDying(hitPoints);
   const isCharacterDead = isDead(hitPoints);
@@ -73,26 +80,23 @@ export function HitPointTracker({
   const isUnconscious = hitPoints.current === 0;
 
   const handleDamage = () => {
-    const damage = parseInt(damageAmount);
-    if (!isNaN(damage) && damage > 0 && onApplyDamage) {
-      onApplyDamage(damage);
-      setDamageAmount('');
+    if (damageAmount != null && damageAmount > 0 && onApplyDamage) {
+      onApplyDamage(damageAmount);
+      setDamageAmount(undefined);
     }
   };
 
   const handleHealing = () => {
-    const healing = parseInt(healingAmount);
-    if (!isNaN(healing) && healing > 0 && onApplyHealing) {
-      onApplyHealing(healing);
-      setHealingAmount('');
+    if (healingAmount != null && healingAmount > 0 && onApplyHealing) {
+      onApplyHealing(healingAmount);
+      setHealingAmount(undefined);
     }
   };
 
   const handleTempHP = () => {
-    const tempHP = parseInt(tempHPAmount);
-    if (!isNaN(tempHP) && tempHP > 0 && onAddTemporaryHP) {
-      onAddTemporaryHP(tempHP);
-      setTempHPAmount('');
+    if (tempHPAmount != null && tempHPAmount > 0 && onAddTemporaryHP) {
+      onAddTemporaryHP(tempHPAmount);
+      setTempHPAmount(undefined);
     }
   };
 
@@ -246,16 +250,11 @@ export function HitPointTracker({
                 {hitPoints.current}
               </div>
             ) : (
-              <input
-                type="number"
+              <NumberField
                 value={hitPoints.current}
-                onChange={e =>
-                  onUpdateHitPoints?.({
-                    current: parseInt(e.target.value) || 0,
-                  })
-                }
+                onChange={v => onUpdateHitPoints?.({ current: v ?? 0 })}
                 className={`${compact ? 'text-lg' : 'text-lg sm:text-xl'} w-full rounded-lg border-none bg-transparent text-center font-bold outline-none ${getCurrentHPTextColor()} leading-tight`}
-                min="0"
+                min={0}
                 max={hitPoints.max}
                 style={{ maxWidth: '100%' }}
               />
@@ -291,15 +290,12 @@ export function HitPointTracker({
                 {hitPoints.max}
               </div>
             ) : (
-              <input
-                type="number"
+              <NumberField
                 value={hitPoints.max}
-                onChange={e =>
-                  onUpdateHitPoints?.({ max: parseInt(e.target.value) || 0 })
-                }
+                onChange={v => onUpdateHitPoints?.({ max: v ?? 0 })}
                 className={`${compact ? 'text-lg' : 'text-lg sm:text-xl'} text-accent-red-text w-full rounded-lg border-none bg-transparent text-center leading-tight font-bold outline-none`}
                 disabled={hitPoints.calculationMode === 'auto'}
-                min="1"
+                min={1}
                 style={{ maxWidth: '100%' }}
               />
             )}
@@ -327,16 +323,11 @@ export function HitPointTracker({
                 {hitPoints.temporary}
               </div>
             ) : (
-              <input
-                type="number"
+              <NumberField
                 value={hitPoints.temporary}
-                onChange={e =>
-                  onUpdateHitPoints?.({
-                    temporary: parseInt(e.target.value) || 0,
-                  })
-                }
+                onChange={v => onUpdateHitPoints?.({ temporary: v ?? 0 })}
                 className={`${compact ? 'text-lg' : 'text-lg sm:text-xl'} text-accent-blue-text w-full rounded-lg border-none bg-transparent text-center leading-tight font-bold outline-none`}
-                min="0"
+                min={0}
                 style={{ maxWidth: '100%' }}
               />
             )}
@@ -353,19 +344,18 @@ export function HitPointTracker({
               Apply Damage
             </label>
             <div className="flex gap-2">
-              <input
-                type="number"
+              <NumberField
                 value={damageAmount}
-                onChange={e => setDamageAmount(e.target.value)}
+                onChange={setDamageAmount}
+                allowEmpty
                 placeholder="Amount"
                 className="border-accent-red-border bg-surface-raised text-heading focus:border-accent-red-border-strong focus:ring-accent-red-bg-strong min-w-0 flex-1 rounded-md border px-3 py-2 text-center text-lg font-semibold focus:ring-2"
-                min="1"
+                min={1}
               />
               <button
                 onClick={() => {
-                  const val = parseInt(damageAmount);
-                  if (!isNaN(val) && val > 0)
-                    setDamageAmount(String(Math.floor(val / 2)));
+                  if (damageAmount != null && damageAmount > 0)
+                    setDamageAmount(Math.floor(damageAmount / 2));
                 }}
                 className="bg-surface-secondary text-muted hover:text-heading min-h-[44px] min-w-[44px] rounded-md px-3 py-2 text-sm font-bold shadow-sm transition-colors"
                 title="Half (resistance)"
@@ -374,8 +364,8 @@ export function HitPointTracker({
               </button>
               <button
                 onClick={() => {
-                  const val = parseInt(damageAmount);
-                  if (!isNaN(val) && val > 0) setDamageAmount(String(val * 2));
+                  if (damageAmount != null && damageAmount > 0)
+                    setDamageAmount(damageAmount * 2);
                 }}
                 className="bg-surface-secondary text-muted hover:text-heading min-h-[44px] min-w-[44px] rounded-md px-3 py-2 text-sm font-bold shadow-sm transition-colors"
                 title="Double (vulnerability)"
@@ -384,7 +374,7 @@ export function HitPointTracker({
               </button>
               <button
                 onClick={handleDamage}
-                disabled={!damageAmount || parseInt(damageAmount) <= 0}
+                disabled={damageAmount == null || damageAmount <= 0}
                 className="disabled:bg-surface-hover disabled:text-muted flex min-h-[44px] items-center justify-center gap-1.5 rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed"
               >
                 <Minus size={16} />
@@ -399,17 +389,17 @@ export function HitPointTracker({
               Apply Healing
             </label>
             <div className="flex gap-2">
-              <input
-                type="number"
+              <NumberField
                 value={healingAmount}
-                onChange={e => setHealingAmount(e.target.value)}
+                onChange={setHealingAmount}
+                allowEmpty
                 placeholder="Amount"
                 className="border-accent-green-border bg-surface-raised text-heading focus:border-accent-green-border-strong focus:ring-accent-green-bg-strong min-w-0 flex-1 rounded-md border px-3 py-2 text-center text-lg font-semibold focus:ring-2"
-                min="1"
+                min={1}
               />
               <button
                 onClick={handleHealing}
-                disabled={!healingAmount || parseInt(healingAmount) <= 0}
+                disabled={healingAmount == null || healingAmount <= 0}
                 className="disabled:bg-surface-hover disabled:text-muted flex min-h-[44px] items-center justify-center gap-1.5 rounded-md bg-green-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:cursor-not-allowed"
               >
                 <Plus size={16} />
@@ -424,17 +414,17 @@ export function HitPointTracker({
               Add Temporary HP
             </label>
             <div className="flex gap-2">
-              <input
-                type="number"
+              <NumberField
                 value={tempHPAmount}
-                onChange={e => setTempHPAmount(e.target.value)}
+                onChange={setTempHPAmount}
+                allowEmpty
                 placeholder="Amount"
                 className="border-accent-blue-border bg-surface-raised text-heading focus:border-accent-blue-border-strong focus:ring-accent-blue-bg-strong min-w-0 flex-1 rounded-md border px-3 py-2 text-center text-lg font-semibold focus:ring-2"
-                min="1"
+                min={1}
               />
               <button
                 onClick={handleTempHP}
-                disabled={!tempHPAmount || parseInt(tempHPAmount) <= 0}
+                disabled={tempHPAmount == null || tempHPAmount <= 0}
                 className="disabled:bg-surface-hover disabled:text-muted flex min-h-[44px] items-center justify-center gap-1.5 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed"
               >
                 <Shield size={16} />

--- a/src/components/shared/spells/SpellFormFields.tsx
+++ b/src/components/shared/spells/SpellFormFields.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { X } from 'lucide-react';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import { Checkbox } from '@/components/ui/forms/checkbox';
 import RichTextEditor from '@/components/ui/forms/RichTextEditor';
@@ -330,13 +331,10 @@ export function SpellFormFields({
           </p>
         </div>
         {formData.freeCastMode === 'innate' && (
-          <Input
+          <NumberInput
             label="Free Casts per Long Rest"
-            type="number"
-            value={formData.freeCastMax.toString()}
-            onChange={e =>
-              set({ freeCastMax: Math.max(1, parseInt(e.target.value) || 1) })
-            }
+            value={formData.freeCastMax}
+            onChange={v => set({ freeCastMax: Math.max(1, v ?? 1) })}
             min={1}
             max={10}
             helperText="How many times this spell can be cast without a slot before needing a long rest"
@@ -496,31 +494,31 @@ export function SpellFormFields({
             </SelectField>
           </div>
           {formData.aoe && (
-            <Input
+            <NumberInput
               label={AOE_SIZE_LABEL[formData.aoe.shape]}
-              type="number"
               min={0}
-              value={formData.aoe.sizeFeet || ''}
-              onChange={e =>
+              integer={false}
+              value={formData.aoe.sizeFeet}
+              onChange={v =>
                 setAoe({
                   ...formData.aoe!,
-                  sizeFeet: Number(e.target.value) || 0,
+                  sizeFeet: v ?? 0,
                 })
               }
             />
           )}
           {formData.aoe?.shape === 'line' && (
-            <Input
+            <NumberInput
               label="Width (ft)"
-              type="number"
               min={0}
+              integer={false}
+              allowEmpty
               placeholder="5"
-              value={formData.aoe.widthFeet ?? ''}
-              onChange={e =>
+              value={formData.aoe.widthFeet}
+              onChange={v =>
                 setAoe({
                   ...formData.aoe!,
-                  widthFeet:
-                    e.target.value === '' ? undefined : Number(e.target.value),
+                  widthFeet: v,
                 })
               }
             />

--- a/src/components/ui/calendar/CalendarSettingsPanel.tsx
+++ b/src/components/ui/calendar/CalendarSettingsPanel.tsx
@@ -10,14 +10,8 @@ import {
 } from '@/components/ui/layout/card';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
-import type {
-  CalendarConfig,
-  WeekDay,
-  CalendarMonth,
-  Season,
-  Moon,
-  Era,
-} from '@/types/calendar';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
+import type { CalendarConfig } from '@/types/calendar';
 
 interface CalendarSettingsPanelProps {
   config: CalendarConfig;
@@ -47,39 +41,36 @@ export function CalendarSettingsPanel({
           <CardTitle>Clock</CardTitle>
         </CardHeader>
         <CardContent className="grid grid-cols-3 gap-4 p-4">
-          <Input
+          <NumberInput
             label="Hours per Day"
-            type="number"
             min={1}
             value={draft.clock.hoursPerDay}
-            onChange={e =>
+            onChange={v =>
               update('clock', {
                 ...draft.clock,
-                hoursPerDay: Number(e.target.value) || 1,
+                hoursPerDay: v ?? 1,
               })
             }
           />
-          <Input
+          <NumberInput
             label="Minutes per Hour"
-            type="number"
             min={1}
             value={draft.clock.minutesPerHour}
-            onChange={e =>
+            onChange={v =>
               update('clock', {
                 ...draft.clock,
-                minutesPerHour: Number(e.target.value) || 1,
+                minutesPerHour: v ?? 1,
               })
             }
           />
-          <Input
+          <NumberInput
             label="Seconds per Minute"
-            type="number"
             min={1}
             value={draft.clock.secondsPerMinute}
-            onChange={e =>
+            onChange={v =>
               update('clock', {
                 ...draft.clock,
-                secondsPerMinute: Number(e.target.value) || 1,
+                secondsPerMinute: v ?? 1,
               })
             }
           />
@@ -151,13 +142,12 @@ export function CalendarSettingsPanel({
                 }}
                 wrapperClassName="flex-1 min-w-0"
               />
-              <Input
-                type="number"
+              <NumberInput
                 min={1}
                 value={m.days}
-                onChange={e => {
+                onChange={v => {
                   const next = [...draft.months];
-                  next[i] = { ...next[i], days: Number(e.target.value) || 1 };
+                  next[i] = { ...next[i], days: v ?? 1 };
                   update('months', next);
                 }}
                 wrapperClassName="w-24"
@@ -215,58 +205,54 @@ export function CalendarSettingsPanel({
                 }}
                 wrapperClassName="flex-1 min-w-0"
               />
-              <Input
+              <NumberInput
                 label="Start Day"
-                type="number"
                 min={0}
                 value={s.startDay}
-                onChange={e => {
+                onChange={v => {
                   const next = [...draft.seasons];
                   next[i] = {
                     ...next[i],
-                    startDay: Number(e.target.value) || 0,
+                    startDay: v ?? 0,
                   };
                   update('seasons', next);
                 }}
                 wrapperClassName="w-20"
               />
-              <Input
+              <NumberInput
                 label="End Day"
-                type="number"
                 min={0}
                 value={s.endDay}
-                onChange={e => {
+                onChange={v => {
                   const next = [...draft.seasons];
-                  next[i] = { ...next[i], endDay: Number(e.target.value) || 0 };
+                  next[i] = { ...next[i], endDay: v ?? 0 };
                   update('seasons', next);
                 }}
                 wrapperClassName="w-20"
               />
-              <Input
+              <NumberInput
                 label="Sunrise"
-                type="number"
                 min={0}
                 value={s.sunriseHour}
-                onChange={e => {
+                onChange={v => {
                   const next = [...draft.seasons];
                   next[i] = {
                     ...next[i],
-                    sunriseHour: Number(e.target.value) || 0,
+                    sunriseHour: v ?? 0,
                   };
                   update('seasons', next);
                 }}
                 wrapperClassName="w-20"
               />
-              <Input
+              <NumberInput
                 label="Sunset"
-                type="number"
                 min={0}
                 value={s.sunsetHour}
-                onChange={e => {
+                onChange={v => {
                   const next = [...draft.seasons];
                   next[i] = {
                     ...next[i],
-                    sunsetHour: Number(e.target.value) || 0,
+                    sunsetHour: v ?? 0,
                   };
                   update('seasons', next);
                 }}
@@ -330,28 +316,26 @@ export function CalendarSettingsPanel({
                 wrapperClassName="flex-1 min-w-0"
                 helperText="&nbsp;"
               />
-              <Input
+              <NumberInput
                 label="Period"
-                type="number"
                 min={1}
                 value={m.period}
-                onChange={e => {
+                onChange={v => {
                   const next = [...draft.moons];
-                  next[i] = { ...next[i], period: Number(e.target.value) || 1 };
+                  next[i] = { ...next[i], period: v ?? 1 };
                   update('moons', next);
                 }}
                 wrapperClassName="w-20"
                 helperText="Days per cycle"
               />
-              <Input
+              <NumberInput
                 label="Offset"
-                type="number"
                 value={m.phaseOffset}
-                onChange={e => {
+                onChange={v => {
                   const next = [...draft.moons];
                   next[i] = {
                     ...next[i],
-                    phaseOffset: Number(e.target.value) || 0,
+                    phaseOffset: v ?? 0,
                   };
                   update('moons', next);
                 }}
@@ -422,30 +406,26 @@ export function CalendarSettingsPanel({
                 }}
                 wrapperClassName="w-20"
               />
-              <Input
+              <NumberInput
                 label="Start Year"
-                type="number"
                 value={e.startYear}
-                onChange={ev => {
+                onChange={v => {
                   const next = [...draft.eras];
                   next[i] = {
                     ...next[i],
-                    startYear: Number(ev.target.value) || 0,
+                    startYear: v ?? 0,
                   };
                   update('eras', next);
                 }}
                 wrapperClassName="w-24"
               />
-              <Input
+              <NumberInput
                 label="End Year"
-                type="number"
-                value={e.endYear ?? ''}
-                onChange={ev => {
+                allowEmpty
+                value={e.endYear}
+                onChange={v => {
                   const next = [...draft.eras];
-                  const val = ev.target.value
-                    ? Number(ev.target.value)
-                    : undefined;
-                  next[i] = { ...next[i], endYear: val };
+                  next[i] = { ...next[i], endYear: v };
                   update('eras', next);
                 }}
                 wrapperClassName="w-24"
@@ -486,57 +466,50 @@ export function CalendarSettingsPanel({
           <CardTitle>Year & Mechanics</CardTitle>
         </CardHeader>
         <CardContent className="grid grid-cols-2 gap-4 p-4 lg:grid-cols-3">
-          <Input
+          <NumberInput
             label="Starting Year"
-            type="number"
             value={draft.yearOffset}
-            onChange={e => update('yearOffset', Number(e.target.value) || 0)}
+            onChange={v => update('yearOffset', v ?? 0)}
             helperText="The year number shown at time zero"
           />
-          <Input
+          <NumberInput
             label="First Day of Week"
-            type="number"
             min={0}
             max={draft.weekDays.length - 1}
             value={draft.yearStartWeekdayOffset}
-            onChange={e =>
-              update('yearStartWeekdayOffset', Number(e.target.value) || 0)
-            }
+            onChange={v => update('yearStartWeekdayOffset', v ?? 0)}
             helperText={`0 = ${draft.weekDays[0]?.name ?? 'first day'}`}
           />
-          <Input
+          <NumberInput
             label="Long Rest (hours)"
-            type="number"
             min={1}
             value={draft.mechanics.hoursPerLongRest}
-            onChange={e =>
+            onChange={v =>
               update('mechanics', {
                 ...draft.mechanics,
-                hoursPerLongRest: Number(e.target.value) || 1,
+                hoursPerLongRest: v ?? 1,
               })
             }
           />
-          <Input
+          <NumberInput
             label="Short Rest (minutes)"
-            type="number"
             min={1}
             value={draft.mechanics.minutesPerShortRest}
-            onChange={e =>
+            onChange={v =>
               update('mechanics', {
                 ...draft.mechanics,
-                minutesPerShortRest: Number(e.target.value) || 1,
+                minutesPerShortRest: v ?? 1,
               })
             }
           />
-          <Input
+          <NumberInput
             label="Round (seconds)"
-            type="number"
             min={1}
             value={draft.mechanics.secondsPerRound}
-            onChange={e =>
+            onChange={v =>
               update('mechanics', {
                 ...draft.mechanics,
-                secondsPerRound: Number(e.target.value) || 1,
+                secondsPerRound: v ?? 1,
               })
             }
           />

--- a/src/components/ui/calendar/EventDialog.tsx
+++ b/src/components/ui/calendar/EventDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/feedback/dialog';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import RichTextEditor from '@/components/ui/forms/RichTextEditor';
 import type { CalendarConfig, CalendarEvent } from '@/types/calendar';
@@ -114,11 +115,7 @@ export function EventDialog({
               <label className="text-body mb-1 block text-sm font-medium">
                 Year
               </label>
-              <Input
-                type="number"
-                value={year}
-                onChange={e => setYear(Number(e.target.value))}
-              />
+              <NumberInput value={year} onChange={v => setYear(v ?? 0)} />
             </div>
             <SelectField
               label="Month"

--- a/src/components/ui/calendar/JumpToDateDialog.tsx
+++ b/src/components/ui/calendar/JumpToDateDialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogFooter,
 } from '@/components/ui/feedback/dialog';
 import { Button } from '@/components/ui/forms/button';
-import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import type { CalendarConfig, CalendarDate } from '@/types/calendar';
 
@@ -70,11 +70,7 @@ export function JumpToDateDialog({
               <label className="text-body mb-1 block text-sm font-medium">
                 Year
               </label>
-              <Input
-                type="number"
-                value={year}
-                onChange={e => setYear(Number(e.target.value))}
-              />
+              <NumberInput value={year} onChange={v => setYear(v ?? 0)} />
             </div>
             <SelectField
               label="Month"

--- a/src/components/ui/calendar/TimeDisplay.tsx
+++ b/src/components/ui/calendar/TimeDisplay.tsx
@@ -12,6 +12,7 @@ import {
   X,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/layout/badge';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 import { MoonPhaseIcon } from './MoonPhaseIcon';
 import type {
   CalendarDate,
@@ -97,12 +98,9 @@ export function TimeDisplay({
         <div className="flex items-center gap-3">
           {editing ? (
             <div className="flex items-center gap-1.5">
-              <input
-                type="number"
+              <NumberField
                 value={editHour}
-                onChange={e =>
-                  setEditHour(clamp(parseInt(e.target.value) || 0, maxHour))
-                }
+                onChange={v => setEditHour(clamp(v ?? 0, maxHour))}
                 min={0}
                 max={maxHour}
                 autoFocus
@@ -111,12 +109,9 @@ export function TimeDisplay({
               <span className="text-heading font-mono text-3xl font-bold">
                 :
               </span>
-              <input
-                type="number"
+              <NumberField
                 value={editMinute}
-                onChange={e =>
-                  setEditMinute(clamp(parseInt(e.target.value) || 0, maxMinute))
-                }
+                onChange={v => setEditMinute(clamp(v ?? 0, maxMinute))}
                 min={0}
                 max={maxMinute}
                 className="text-heading border-divider focus:border-divider-strong w-20 rounded-md border bg-transparent px-3 py-2 text-center font-mono text-3xl font-bold focus:outline-none"

--- a/src/components/ui/campaign/NPCFormDialog.tsx
+++ b/src/components/ui/campaign/NPCFormDialog.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/feedback/dialog';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput, NumberField } from '@/components/ui/forms/NumberInput';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import { CompactRichTextEditor } from '@/components/ui/forms/CompactRichTextEditor';
 import { Badge } from '@/components/ui/layout/badge';
@@ -312,10 +313,14 @@ export function NPCFormDialog({
   const [casterLevel, setCasterLevel] = useState(1);
   const [spellcastingAbility, setSpellcastingAbility] =
     useState<NPCSpellcastingAbility>('intelligence');
-  const [spellAttackOverride, setSpellAttackOverride] = useState<string>('');
-  const [spellDCOverride, setSpellDCOverride] = useState<string>('');
+  const [spellAttackOverride, setSpellAttackOverride] = useState<
+    number | undefined
+  >(undefined);
+  const [spellDCOverride, setSpellDCOverride] = useState<number | undefined>(
+    undefined
+  );
   const [spellSlotOverrides, setSpellSlotOverrides] = useState<
-    Record<number, string>
+    Record<number, number | undefined>
   >({});
 
   // ---------- Auto-calc initiative from DEX ----------
@@ -373,22 +378,14 @@ export function NPCFormDialog({
         setSpellcastingEnabled(true);
         setCasterLevel(editingNpc.spellcasting.casterLevel);
         setSpellcastingAbility(editingNpc.spellcasting.ability);
-        setSpellAttackOverride(
-          editingNpc.spellcasting.spellAttackBonus !== undefined
-            ? String(editingNpc.spellcasting.spellAttackBonus)
-            : ''
-        );
-        setSpellDCOverride(
-          editingNpc.spellcasting.spellSaveDC !== undefined
-            ? String(editingNpc.spellcasting.spellSaveDC)
-            : ''
-        );
-        const overrides: Record<number, string> = {};
+        setSpellAttackOverride(editingNpc.spellcasting.spellAttackBonus);
+        setSpellDCOverride(editingNpc.spellcasting.spellSaveDC);
+        const overrides: Record<number, number | undefined> = {};
         if (editingNpc.spellcasting.slotOverrides) {
           for (const [lvl, count] of Object.entries(
             editingNpc.spellcasting.slotOverrides
           )) {
-            overrides[Number(lvl)] = String(count);
+            overrides[Number(lvl)] = Number(count);
           }
         }
         setSpellSlotOverrides(overrides);
@@ -396,8 +393,8 @@ export function NPCFormDialog({
         setSpellcastingEnabled(false);
         setCasterLevel(1);
         setSpellcastingAbility('intelligence');
-        setSpellAttackOverride('');
-        setSpellDCOverride('');
+        setSpellAttackOverride(undefined);
+        setSpellDCOverride(undefined);
         setSpellSlotOverrides({});
       }
 
@@ -567,8 +564,8 @@ export function NPCFormDialog({
     setSpellcastingEnabled(false);
     setCasterLevel(1);
     setSpellcastingAbility('intelligence');
-    setSpellAttackOverride('');
-    setSpellDCOverride('');
+    setSpellAttackOverride(undefined);
+    setSpellDCOverride(undefined);
     setSpellSlotOverrides({});
     resetAbilityScores();
     resetDetailFields();
@@ -865,18 +862,17 @@ export function NPCFormDialog({
         ? {
             casterLevel,
             ability: spellcastingAbility,
-            spellAttackBonus: spellAttackOverride
-              ? parseInt(spellAttackOverride)
-              : undefined,
-            spellSaveDC: spellDCOverride
-              ? parseInt(spellDCOverride)
-              : undefined,
+            spellAttackBonus: spellAttackOverride,
+            spellSaveDC: spellDCOverride,
             slotOverrides:
               Object.keys(spellSlotOverrides).length > 0
                 ? Object.fromEntries(
                     Object.entries(spellSlotOverrides)
-                      .filter(([, v]) => v !== '')
-                      .map(([k, v]) => [Number(k), parseInt(v)])
+                      .filter(
+                        (entry): entry is [string, number] =>
+                          entry[1] !== undefined
+                      )
+                      .map(([k, v]) => [Number(k), v])
                   )
                 : undefined,
             slotsUsed: editingNpc?.spellcasting?.slotsUsed ?? {},
@@ -1185,17 +1181,15 @@ export function NPCFormDialog({
                       />
                     </div>
                     <div className="grid grid-cols-3 gap-2">
-                      <Input
-                        type="number"
+                      <NumberInput
                         value={ac}
-                        onChange={e => setAc(parseInt(e.target.value) || 0)}
+                        onChange={v => setAc(v ?? 0)}
                         label="AC"
                         min={0}
                       />
-                      <Input
-                        type="number"
+                      <NumberInput
                         value={hp}
-                        onChange={e => setHp(parseInt(e.target.value) || 1)}
+                        onChange={v => setHp(v ?? 1)}
                         label="HP"
                         min={1}
                       />
@@ -1207,19 +1201,17 @@ export function NPCFormDialog({
                       />
                     </div>
                     <div className="grid grid-cols-2 gap-2">
-                      <Input
-                        type="number"
+                      <NumberInput
                         value={tempHp}
-                        onChange={e => setTempHp(parseInt(e.target.value) || 0)}
+                        onChange={v => setTempHp(v ?? 0)}
                         label="Temp HP"
                         min={0}
                         placeholder="0"
                         title="Temporary hit points (absorbed before real HP)"
                       />
-                      <Input
-                        type="number"
+                      <NumberInput
                         value={tempAc}
-                        onChange={e => setTempAc(parseInt(e.target.value) || 0)}
+                        onChange={v => setTempAc(v ?? 0)}
                         label="Temp AC"
                         min={0}
                         placeholder="0"
@@ -1233,20 +1225,18 @@ export function NPCFormDialog({
                         label="Speed"
                         placeholder="30 ft., fly 60 ft."
                       />
-                      <Input
-                        type="number"
+                      <NumberInput
                         value={initiativeModifier}
-                        onChange={e => {
-                          setInitiativeModifier(parseInt(e.target.value) || 0);
+                        onChange={v => {
+                          setInitiativeModifier(v ?? 0);
                           setInitiativeOverridden(true);
                         }}
                         label="Init Mod"
                         title="Initiative modifier (auto-calculated from DEX, overridable)"
                       />
-                      <Input
-                        type="number"
+                      <NumberInput
                         value={xp}
-                        onChange={e => setXp(parseInt(e.target.value) || 0)}
+                        onChange={v => setXp(v ?? 0)}
                         label="XP"
                         min={0}
                         placeholder="0"
@@ -1279,15 +1269,14 @@ export function NPCFormDialog({
                           <span className="text-muted block text-[10px] font-medium uppercase">
                             {label}
                           </span>
-                          <input
-                            type="number"
+                          <NumberField
                             value={value}
-                            onChange={e =>
+                            onChange={v =>
                               (
                                 setter as React.Dispatch<
                                   React.SetStateAction<number>
                                 >
-                              )(parseInt(e.target.value) || 0)
+                              )(v ?? 0)
                             }
                             min={1}
                             max={30}
@@ -1364,11 +1353,10 @@ export function NPCFormDialog({
                           placeholder="0"
                         />
                       </div>
-                      <Input
-                        type="number"
+                      <NumberInput
                         value={proficiencyBonus}
-                        onChange={e => {
-                          setProficiencyBonus(parseInt(e.target.value) || 2);
+                        onChange={v => {
+                          setProficiencyBonus(v ?? 2);
                           setProficiencyOverridden(true);
                         }}
                         label="Prof Bonus"
@@ -1384,12 +1372,9 @@ export function NPCFormDialog({
                         Hit Dice
                       </label>
                       <div className="grid grid-cols-3 gap-2">
-                        <Input
-                          type="number"
+                        <NumberInput
                           value={hitDiceMax}
-                          onChange={e =>
-                            setHitDiceMax(parseInt(e.target.value) || 0)
-                          }
+                          onChange={v => setHitDiceMax(v ?? 0)}
                           label="Max"
                           min={0}
                           placeholder="8"
@@ -1405,12 +1390,9 @@ export function NPCFormDialog({
                             </SelectItem>
                           ))}
                         </SelectField>
-                        <Input
-                          type="number"
+                        <NumberInput
                           value={hitDieCurrent}
-                          onChange={e =>
-                            setHitDieCurrent(parseInt(e.target.value) || 0)
-                          }
+                          onChange={v => setHitDieCurrent(v ?? 0)}
                           label="Current"
                           min={0}
                           placeholder="8"
@@ -1427,33 +1409,28 @@ export function NPCFormDialog({
                         </span>
                       </label>
                       <div className="grid grid-cols-3 gap-2">
-                        <Input
-                          type="number"
+                        <NumberInput
                           value={passivePerception}
-                          onChange={e => {
-                            setPassivePerception(parseInt(e.target.value) || 0);
+                          onChange={v => {
+                            setPassivePerception(v ?? 0);
                             setPassivesOverridden(true);
                           }}
                           label="Passive Perception"
                           min={1}
                         />
-                        <Input
-                          type="number"
+                        <NumberInput
                           value={passiveInsight}
-                          onChange={e => {
-                            setPassiveInsight(parseInt(e.target.value) || 0);
+                          onChange={v => {
+                            setPassiveInsight(v ?? 0);
                             setPassivesOverridden(true);
                           }}
                           label="Passive Insight"
                           min={1}
                         />
-                        <Input
-                          type="number"
+                        <NumberInput
                           value={passiveInvestigation}
-                          onChange={e => {
-                            setPassiveInvestigation(
-                              parseInt(e.target.value) || 0
-                            );
+                          onChange={v => {
+                            setPassiveInvestigation(v ?? 0);
                             setPassivesOverridden(true);
                           }}
                           label="Passive Investigation"
@@ -1547,15 +1524,14 @@ export function NPCFormDialog({
                                 placeholder="Item name"
                                 className="flex-1"
                               />
-                              <input
-                                type="number"
+                              <NumberField
                                 min={1}
                                 value={item.quantity}
-                                onChange={e => {
+                                onChange={v => {
                                   const updated = [...inventoryItems];
                                   updated[index] = {
                                     ...item,
-                                    quantity: parseInt(e.target.value) || 1,
+                                    quantity: v ?? 1,
                                   };
                                   setInventoryItems(updated);
                                 }}
@@ -1678,19 +1654,11 @@ export function NPCFormDialog({
                             <label className="text-muted mb-1 block text-xs font-medium">
                               Caster Level
                             </label>
-                            <Input
-                              type="number"
+                            <NumberInput
                               min={1}
                               max={20}
                               value={casterLevel}
-                              onChange={e =>
-                                setCasterLevel(
-                                  Math.max(
-                                    1,
-                                    Math.min(20, parseInt(e.target.value) || 1)
-                                  )
-                                )
-                              }
+                              onChange={v => setCasterLevel(v ?? 1)}
                             />
                           </div>
                           <div>
@@ -1748,24 +1716,22 @@ export function NPCFormDialog({
                             <label className="text-muted mb-1 block text-xs font-medium">
                               Spell Attack Override
                             </label>
-                            <Input
-                              type="number"
+                            <NumberInput
                               placeholder="Auto"
                               value={spellAttackOverride}
-                              onChange={e =>
-                                setSpellAttackOverride(e.target.value)
-                              }
+                              onChange={v => setSpellAttackOverride(v)}
+                              allowEmpty
                             />
                           </div>
                           <div>
                             <label className="text-muted mb-1 block text-xs font-medium">
                               Save DC Override
                             </label>
-                            <Input
-                              type="number"
+                            <NumberInput
                               placeholder="Auto"
                               value={spellDCOverride}
-                              onChange={e => setSpellDCOverride(e.target.value)}
+                              onChange={v => setSpellDCOverride(v)}
+                              allowEmpty
                             />
                           </div>
                         </div>
@@ -1787,7 +1753,7 @@ export function NPCFormDialog({
                                 const activeLevels = levels.filter(
                                   lvl =>
                                     (baseSlots[lvl] ?? 0) > 0 ||
-                                    spellSlotOverrides[lvl]
+                                    spellSlotOverrides[lvl] !== undefined
                                 );
                                 if (activeLevels.length === 0) {
                                   return (
@@ -1804,17 +1770,17 @@ export function NPCFormDialog({
                                     <span className="text-body w-20 text-xs font-medium">
                                       Level {lvl}: {baseSlots[lvl] ?? 0}
                                     </span>
-                                    <Input
-                                      type="number"
+                                    <NumberInput
                                       min={0}
                                       placeholder={String(baseSlots[lvl] ?? 0)}
-                                      value={spellSlotOverrides[lvl] ?? ''}
-                                      onChange={e => {
+                                      value={spellSlotOverrides[lvl]}
+                                      onChange={v => {
                                         setSpellSlotOverrides(prev => ({
                                           ...prev,
-                                          [lvl]: e.target.value,
+                                          [lvl]: v,
                                         }));
                                       }}
+                                      allowEmpty
                                       className="h-7 w-20 text-xs"
                                     />
                                     <span className="text-muted text-xs">
@@ -1894,10 +1860,9 @@ function AbilityListEditor({
     onChange(updated);
   };
 
-  const handleUsesChange = (index: number, value: string) => {
-    const num = value === '' ? undefined : parseInt(value, 10);
+  const handleUsesChange = (index: number, value: number | undefined) => {
     const updated = items.map((item, i) =>
-      i === index ? { ...item, uses: num } : item
+      i === index ? { ...item, uses: value } : item
     );
     onChange(updated);
   };
@@ -1967,11 +1932,11 @@ function AbilityListEditor({
                   placeholder={`${label.slice(0, -1)} name`}
                   className="flex-1"
                 />
-                <Input
-                  type="number"
+                <NumberInput
                   min={0}
-                  value={item.uses ?? ''}
-                  onChange={e => handleUsesChange(index, e.target.value)}
+                  value={item.uses}
+                  onChange={v => handleUsesChange(index, v)}
+                  allowEmpty
                   placeholder="Uses"
                   className="w-18"
                   title="Uses per day (leave empty for unlimited)"

--- a/src/components/ui/character/CharacterBasicInfo.tsx
+++ b/src/components/ui/character/CharacterBasicInfo.tsx
@@ -5,6 +5,7 @@ import { Settings } from 'lucide-react';
 import SimpleClassSelector from '@/components/ui/character/SimpleClassSelector';
 import MulticlassManager from '@/components/ui/character/MulticlassManager';
 import { Button, Input } from '@/components/ui/forms';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import { ALIGNMENTS, CREATURE_TYPES } from '@/utils/constants';
 import { CharacterState } from '@/types/character';
@@ -128,14 +129,13 @@ export default function CharacterBasicInfo({
           )}
 
           <div>
-            <Input
+            <NumberInput
               label="Level"
-              type="number"
               placeholder="1"
               min="1"
               max="20"
-              value={level.toString()}
-              onChange={e => onUpdateLevel(parseInt(e.target.value) || 1)}
+              value={level}
+              onChange={v => onUpdateLevel(v ?? 1)}
             />
           </div>
           <div>

--- a/src/components/ui/character/CharacterHUD.tsx
+++ b/src/components/ui/character/CharacterHUD.tsx
@@ -23,6 +23,7 @@ import {
   Wand2,
 } from 'lucide-react';
 import { CharacterState } from '@/types/character';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 import {
   calculateCharacterArmorClass,
   calculateModifier,
@@ -534,10 +535,10 @@ function SpeedRow({
         >
           <Minus size={12} />
         </button>
-        <input
-          type="number"
+        <NumberField
           value={value}
-          onChange={e => onChange(Math.max(0, parseInt(e.target.value) || 0))}
+          onChange={v => onChange(Math.max(0, v ?? 0))}
+          min={0}
           className="text-heading bg-surface-secondary w-14 [appearance:textfield] rounded px-1.5 py-0.5 text-center text-sm font-bold [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         />
         <button

--- a/src/components/ui/character/CharacterHeaderSection.tsx
+++ b/src/components/ui/character/CharacterHeaderSection.tsx
@@ -5,6 +5,7 @@ import { useCharacterStore } from '@/store/characterStore';
 import { useAutoSave } from '@/hooks/useAutoSave';
 import { SaveIndicator } from '@/components/ui/feedback/SaveIndicator';
 import { Button } from '@/components/ui/forms';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 import { Save, Download, Upload, RotateCcw } from 'lucide-react';
 
 export default function CharacterHeaderSection() {
@@ -81,14 +82,11 @@ export default function CharacterHeaderSection() {
                 <label className="mb-2 block text-sm font-medium text-slate-300">
                   Level
                 </label>
-                <input
-                  type="number"
+                <NumberField
                   min="1"
                   max="20"
                   value={character.level}
-                  onChange={e =>
-                    updateCharacter({ level: parseInt(e.target.value) || 1 })
-                  }
+                  onChange={v => updateCharacter({ level: v ?? 1 })}
                   className="w-full rounded-lg border border-slate-600 bg-slate-700 px-3 py-2 text-white placeholder-slate-400 focus:border-transparent focus:ring-2 focus:ring-blue-500 focus:outline-none"
                 />
               </div>
@@ -149,11 +147,7 @@ export default function CharacterHeaderSection() {
                 Export
               </Button>
 
-              <Button
-                asChild
-                variant="outline"
-                size="sm"
-              >
+              <Button asChild variant="outline" size="sm">
                 <label className="cursor-pointer">
                   <span className="flex items-center gap-2">
                     <Upload className="h-4 w-4" />

--- a/src/components/ui/character/CombatStats.tsx
+++ b/src/components/ui/character/CombatStats.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import { RotateCcw, Plus, X, Bird, Mountain, Waves, Zap } from 'lucide-react';
 import { formatModifier, getBuffSpeedBonus } from '@/utils/calculations';
-import { Button, Input, Switch } from '@/components/ui/forms';
+import { Button, Switch } from '@/components/ui/forms';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { CharacterState } from '@/types/character';
 
 interface CombatStatsProps {
@@ -68,12 +69,9 @@ export default function CombatStats({
                 🎲
               </Button>
             </div>
-            <Input
-              type="number"
-              value={getInitiativeModifier().toString()}
-              onChange={e =>
-                onUpdateInitiative(parseInt(e.target.value) || 0, true)
-              }
+            <NumberInput
+              value={getInitiativeModifier()}
+              onChange={v => onUpdateInitiative(v ?? 0, true)}
               className={`[appearance:textfield] border-none bg-transparent text-center text-xl font-bold [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none ${
                 character.initiative.isOverridden
                   ? 'text-accent-orange-text'
@@ -110,10 +108,10 @@ export default function CombatStats({
                 {showExtraSpeeds ? <X size={10} /> : <Plus size={10} />}
               </Button>
             </div>
-            <Input
-              type="number"
-              value={character.speed.toString()}
-              onChange={e => onUpdateSpeed(parseInt(e.target.value) || 30)}
+            <NumberInput
+              value={character.speed}
+              onChange={v => onUpdateSpeed(v ?? 30)}
+              min={0}
               className="text-accent-green-text [appearance:textfield] border-none bg-transparent text-center text-xl font-bold [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
             />
             {getBuffSpeedBonus(character) !== 0 && (
@@ -136,12 +134,10 @@ export default function CombatStats({
               <Bird size={12} />
               FLY
             </div>
-            <Input
-              type="number"
-              value={(character.flySpeed || 0).toString()}
-              onChange={e =>
-                onUpdateCharacter({ flySpeed: parseInt(e.target.value) || 0 })
-              }
+            <NumberInput
+              value={character.flySpeed || 0}
+              onChange={v => onUpdateCharacter({ flySpeed: v ?? 0 })}
+              min={0}
               className="text-accent-green-text [appearance:textfield] border-none bg-transparent text-center text-sm font-bold [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
               placeholder="0"
             />
@@ -151,12 +147,10 @@ export default function CombatStats({
               <Mountain size={12} />
               CLIMB
             </div>
-            <Input
-              type="number"
-              value={(character.climbSpeed || 0).toString()}
-              onChange={e =>
-                onUpdateCharacter({ climbSpeed: parseInt(e.target.value) || 0 })
-              }
+            <NumberInput
+              value={character.climbSpeed || 0}
+              onChange={v => onUpdateCharacter({ climbSpeed: v ?? 0 })}
+              min={0}
               className="text-accent-green-text [appearance:textfield] border-none bg-transparent text-center text-sm font-bold [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
               placeholder="0"
             />
@@ -166,12 +160,10 @@ export default function CombatStats({
               <Waves size={12} />
               SWIM
             </div>
-            <Input
-              type="number"
-              value={(character.swimSpeed || 0).toString()}
-              onChange={e =>
-                onUpdateCharacter({ swimSpeed: parseInt(e.target.value) || 0 })
-              }
+            <NumberInput
+              value={character.swimSpeed || 0}
+              onChange={v => onUpdateCharacter({ swimSpeed: v ?? 0 })}
+              min={0}
               className="text-accent-green-text [appearance:textfield] border-none bg-transparent text-center text-sm font-bold [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
               placeholder="0"
             />

--- a/src/components/ui/character/ExtendedFeatures/FeatureModal.tsx
+++ b/src/components/ui/character/ExtendedFeatures/FeatureModal.tsx
@@ -23,6 +23,7 @@ import {
   DialogTitle,
   DialogBody,
 } from '@/components/ui/feedback/dialog';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 
 interface FeatureModalProps {
   feature: ExtendedFeature;
@@ -422,14 +423,13 @@ export default function FeatureModal({
                               <label className="text-body mb-2 block text-sm font-semibold">
                                 Maximum Uses
                               </label>
-                              <input
-                                type="number"
+                              <NumberField
                                 min="0"
                                 value={editData.maxUses || 0}
-                                onChange={e =>
+                                onChange={v =>
                                   setEditData({
                                     ...editData,
-                                    maxUses: parseInt(e.target.value) || 0,
+                                    maxUses: v ?? 0,
                                   })
                                 }
                                 className="border-divider-strong bg-surface-raised text-heading focus:border-accent-indigo-border-strong focus:ring-accent-indigo-bg w-full rounded-lg border px-3 py-2 text-sm transition-colors focus:ring-2"
@@ -489,16 +489,15 @@ export default function FeatureModal({
                                 <label className="text-body mb-2 block text-sm font-semibold">
                                   Proficiency Multiplier
                                 </label>
-                                <input
-                                  type="number"
+                                <NumberField
                                   min="0.5"
                                   step="0.5"
+                                  integer={false}
                                   value={editData.proficiencyMultiplier || 1}
-                                  onChange={e =>
+                                  onChange={v =>
                                     setEditData({
                                       ...editData,
-                                      proficiencyMultiplier:
-                                        parseFloat(e.target.value) || 1,
+                                      proficiencyMultiplier: v ?? 1,
                                     })
                                   }
                                   className="border-divider-strong bg-surface-raised text-heading focus:border-accent-indigo-border-strong focus:ring-accent-indigo-bg w-32 rounded-lg border px-3 py-2 text-sm transition-colors focus:ring-2"

--- a/src/components/ui/character/ExtendedFeatures/UnifiedFeatureModal.tsx
+++ b/src/components/ui/character/ExtendedFeatures/UnifiedFeatureModal.tsx
@@ -28,6 +28,7 @@ import { useSpellsData } from '@/hooks/useSpellsData';
 import { FeatureAutocomplete } from '@/components/ui/forms/FeatureAutocomplete';
 import RichTextEditor from '@/components/ui/forms/RichTextEditor';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import {
   Dialog,
@@ -719,15 +720,14 @@ export default function UnifiedFeatureModal({
                         {!formData.isPassive && (
                           <div className="border-divider space-y-3 border-l-2 pl-6">
                             <div className="grid grid-cols-2 gap-4">
-                              <Input
+                              <NumberInput
                                 label="Maximum Uses"
-                                type="number"
                                 min="0"
-                                value={formData.maxUses.toString()}
-                                onChange={e =>
+                                value={formData.maxUses}
+                                onChange={v =>
                                   setFormData({
                                     ...formData,
-                                    maxUses: parseInt(e.target.value) || 0,
+                                    maxUses: v ?? 0,
                                   })
                                 }
                                 helperText="Set to 0 for unlimited uses"
@@ -772,20 +772,16 @@ export default function UnifiedFeatureModal({
 
                               {formData.scaleWithProficiency && (
                                 <div className="pl-6">
-                                  <Input
+                                  <NumberInput
                                     label="Proficiency Multiplier"
-                                    type="number"
                                     min="0.5"
                                     step="0.5"
-                                    value={
-                                      formData.proficiencyMultiplier?.toString() ||
-                                      '1'
-                                    }
-                                    onChange={e =>
+                                    integer={false}
+                                    value={formData.proficiencyMultiplier || 1}
+                                    onChange={v =>
                                       setFormData({
                                         ...formData,
-                                        proficiencyMultiplier:
-                                          parseFloat(e.target.value) || 1,
+                                        proficiencyMultiplier: v ?? 1,
                                       })
                                     }
                                     helperText="Maximum uses = base uses + (proficiency × multiplier)"

--- a/src/components/ui/character/LevelUpWizard/steps/HPStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/HPStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Heart } from 'lucide-react';
-import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { calculateModifier } from '@/utils/calculations';
 
 interface HPStepProps {
@@ -39,15 +39,12 @@ export default function HPStep({
         </div>
 
         <div className="mt-3 flex items-center justify-center gap-3">
-          <Input
-            type="number"
+          <NumberInput
             min={1}
             max={hitDie}
-            value={hpRollResult ?? ''}
-            onChange={e => {
-              const val = e.target.value;
-              onRollResultChange(val ? parseInt(val, 10) : undefined);
-            }}
+            allowEmpty
+            value={hpRollResult}
+            onChange={v => onRollResultChange(v)}
             placeholder={`1-${hitDie}`}
             className="w-24 text-center"
           />

--- a/src/components/ui/character/MulticlassManager.tsx
+++ b/src/components/ui/character/MulticlassManager.tsx
@@ -12,7 +12,8 @@ import {
 import { CharacterState } from '@/types/character';
 import { validateMulticlassRequirements } from '@/utils/multiclass';
 import { COMMON_CLASSES } from '@/utils/constants';
-import { Button, Input, SelectField, SelectItem } from '@/components/ui/forms';
+import { Button, SelectField, SelectItem } from '@/components/ui/forms';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { Badge } from '@/components/ui/layout';
 import { useClassData } from '@/hooks/useClassData';
 
@@ -204,17 +205,11 @@ export default function MulticlassManager({
             <div className="flex items-center gap-2">
               <div className="flex items-center gap-2">
                 <label className="text-muted text-sm font-medium">Level:</label>
-                <Input
-                  type="number"
+                <NumberInput
                   min="1"
                   max="20"
-                  value={classInfo.level.toString()}
-                  onChange={e =>
-                    handleLevelChange(
-                      classInfo.className,
-                      parseInt(e.target.value) || 1
-                    )
-                  }
+                  value={classInfo.level}
+                  onChange={v => handleLevelChange(classInfo.className, v ?? 1)}
                   className="w-16 text-center"
                   size="sm"
                 />

--- a/src/components/ui/character/equipment/ArmorFormDialog.tsx
+++ b/src/components/ui/character/equipment/ArmorFormDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/feedback/dialog';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import { Checkbox } from '@/components/ui/forms/checkbox';
 import RichTextEditor from '@/components/ui/forms/RichTextEditor';
@@ -255,43 +256,39 @@ export function ArmorFormDialog({
                 Armor Stats
               </h4>
               <div className="grid grid-cols-3 gap-4">
-                <Input
+                <NumberInput
                   label="Base AC"
-                  type="number"
-                  value={formData.baseAC.toString()}
-                  onChange={e =>
+                  value={formData.baseAC}
+                  onChange={v =>
                     setFormData({
                       ...formData,
-                      baseAC: parseInt(e.target.value) || 10,
+                      baseAC: v ?? 10,
                     })
                   }
                   min={0}
                   max={30}
                 />
-                <Input
+                <NumberInput
                   label="Max Dex Bonus"
-                  type="number"
-                  value={formData.maxDexBonus?.toString() || ''}
-                  onChange={e =>
+                  allowEmpty
+                  value={formData.maxDexBonus}
+                  onChange={v =>
                     setFormData({
                       ...formData,
-                      maxDexBonus: e.target.value
-                        ? parseInt(e.target.value)
-                        : undefined,
+                      maxDexBonus: v,
                     })
                   }
                   placeholder="Unlimited"
                   min={0}
                   max={10}
                 />
-                <Input
+                <NumberInput
                   label="Enhancement"
-                  type="number"
-                  value={formData.enhancementBonus.toString()}
-                  onChange={e =>
+                  value={formData.enhancementBonus}
+                  onChange={v =>
                     setFormData({
                       ...formData,
-                      enhancementBonus: parseInt(e.target.value) || 0,
+                      enhancementBonus: v ?? 0,
                     })
                   }
                   min={0}

--- a/src/components/ui/character/summons/CreatureCreatorForm.tsx
+++ b/src/components/ui/character/summons/CreatureCreatorForm.tsx
@@ -5,6 +5,7 @@ import { Plus, Trash2, ArrowLeft } from 'lucide-react';
 import type { SavedCreature } from '@/types/summon';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput, NumberField } from '@/components/ui/forms/NumberInput';
 import { CompactRichTextEditor } from '@/components/ui/forms/CompactRichTextEditor';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 
@@ -206,17 +207,15 @@ export function CreatureCreatorForm({
         </div>
 
         <div className="grid grid-cols-3 gap-2">
-          <Input
-            type="number"
+          <NumberInput
             value={ac}
-            onChange={e => setAc(parseInt(e.target.value) || 0)}
+            onChange={v => setAc(v ?? 0)}
             label="AC"
             min={0}
           />
-          <Input
-            type="number"
+          <NumberInput
             value={hp}
-            onChange={e => setHp(parseInt(e.target.value) || 1)}
+            onChange={v => setHp(v ?? 1)}
             label="HP"
             min={1}
           />
@@ -256,12 +255,11 @@ export function CreatureCreatorForm({
               <span className="text-muted block text-[10px] font-medium uppercase">
                 {label}
               </span>
-              <input
-                type="number"
+              <NumberField
                 value={value}
-                onChange={e =>
+                onChange={v =>
                   (setter as React.Dispatch<React.SetStateAction<number>>)(
-                    parseInt(e.target.value) || 0
+                    v ?? 0
                   )
                 }
                 min={1}
@@ -403,10 +401,9 @@ function AbilityListEditor({
     onChange(updated);
   };
 
-  const handleUsesChange = (index: number, value: string) => {
-    const num = value === '' ? undefined : parseInt(value, 10);
+  const handleUsesChange = (index: number, value: number | undefined) => {
     const updated = items.map((item, i) =>
-      i === index ? { ...item, uses: num } : item
+      i === index ? { ...item, uses: value } : item
     );
     onChange(updated);
   };
@@ -443,14 +440,14 @@ function AbilityListEditor({
                   placeholder={`${label.slice(0, -1)} name`}
                   className="flex-1"
                 />
-                <Input
-                  type="number"
+                <NumberInput
                   min={0}
-                  value={item.uses ?? ''}
-                  onChange={e => handleUsesChange(index, e.target.value)}
+                  value={item.uses}
+                  onChange={v => handleUsesChange(index, v)}
                   placeholder="Uses"
                   className="w-18"
                   title="Uses per day (leave empty for unlimited)"
+                  allowEmpty
                 />
                 <button
                   onClick={() => handleRemove(index)}

--- a/src/components/ui/encounter/CombatConfigDialog.tsx
+++ b/src/components/ui/encounter/CombatConfigDialog.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/feedback/dialog';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { Switch } from '@/components/ui/forms/switch';
 import {
   RadioGroupField,
@@ -195,11 +196,14 @@ export function CombatConfigDialog({
               <div className="space-y-2">
                 {bands.map((band, index) => (
                   <div key={index} className="flex items-center gap-2">
-                    <Input
-                      type="number"
-                      value={band.minPercent.toString()}
-                      onChange={e =>
-                        handleBandChange(index, 'minPercent', e.target.value)
+                    <NumberInput
+                      value={band.minPercent}
+                      onChange={v =>
+                        setBands(prev =>
+                          prev.map((b, i) =>
+                            i === index ? { ...b, minPercent: v ?? 0 } : b
+                          )
+                        )
                       }
                       min={0}
                       max={100}

--- a/src/components/ui/encounter/MonsterStatBlockPanel.tsx
+++ b/src/components/ui/encounter/MonsterStatBlockPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 import { MonsterStatBlock } from '@/types/encounter';
 import { formatUsesLabel } from '@/utils/encounterConverter';
 
@@ -90,13 +91,12 @@ export function MonsterStatBlockPanel({
               {ability}
             </span>
             {onUpdate ? (
-              <input
-                type="number"
+              <NumberField
                 value={statBlock[ability]}
-                onChange={e => {
-                  const val = parseInt(e.target.value);
-                  if (!isNaN(val)) onUpdate({ [ability]: val });
+                onChange={v => {
+                  if (v !== undefined) onUpdate({ [ability]: v });
                 }}
+                allowEmpty
                 className="bg-surface-secondary text-heading mx-auto w-full rounded px-0.5 py-0.5 text-center text-sm font-medium"
               />
             ) : (

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/CustomTab.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/CustomTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import type { PlayerDisposition } from '@/types/encounter';
 import { SharedOptions } from './SharedOptions';
 
@@ -90,23 +90,25 @@ export function CustomTab({
 
       {/* HP / AC / Init Mod grid */}
       <div className="grid grid-cols-3 gap-3">
-        <Input
-          value={hp}
-          onChange={e => onHpChange(e.target.value)}
+        <NumberInput
+          value={hp === '' ? undefined : Number(hp)}
+          onChange={v => onHpChange(v === undefined ? '' : String(v))}
+          allowEmpty
           label="HP"
-          type="number"
+          min={0}
         />
-        <Input
-          value={ac}
-          onChange={e => onAcChange(e.target.value)}
+        <NumberInput
+          value={ac === '' ? undefined : Number(ac)}
+          onChange={v => onAcChange(v === undefined ? '' : String(v))}
+          allowEmpty
           label="AC"
-          type="number"
+          min={0}
         />
-        <Input
-          value={initMod}
-          onChange={e => onInitModChange(e.target.value)}
+        <NumberInput
+          value={initMod === '' ? undefined : Number(initMod)}
+          onChange={v => onInitModChange(v === undefined ? '' : String(v))}
+          allowEmpty
           label="Init Mod"
-          type="number"
         />
       </div>
 

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/StatBlockEditor.stories.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/StatBlockEditor.stories.tsx
@@ -83,7 +83,7 @@ export const DexEditUpdatesInitiative: Story = {
     await userEvent.clear(dexInput);
     await userEvent.type(dexInput, '20');
     const initInput = canvas.getByLabelText('Initiative modifier');
-    await expect(initInput).toHaveValue(5);
+    await expect(initInput).toHaveValue('5');
   },
 };
 
@@ -96,7 +96,7 @@ export const ManualInitiativeStopsFollowing: Story = {
     const dexInput = canvas.getByLabelText('dex score');
     await userEvent.clear(dexInput);
     await userEvent.type(dexInput, '20');
-    await expect(initInput).toHaveValue(7);
+    await expect(initInput).toHaveValue('7');
   },
 };
 

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/StatBlockEditorStats.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/StatBlockEditorStats.tsx
@@ -7,6 +7,7 @@ import {
   updateDraftStatBlock,
 } from './monsterEditDraft';
 import { abilityModifier } from '@/utils/encounterConverter';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 import type { MonsterEditDraft } from './monsterEditDraft';
 import type { MonsterStatBlock } from '@/types/encounter';
 
@@ -73,14 +74,12 @@ export function StatBlockEditorStats({
             <label htmlFor={`ab-${ab}`} className={LABEL_CLASSES}>
               {ab}
             </label>
-            <input
+            <NumberField
               id={`ab-${ab}`}
               aria-label={`${ab} score`}
-              type="number"
               value={draft.statBlock[ab]}
-              onChange={e =>
-                patchBlock({ [ab]: parseInt(e.target.value, 10) || 0 })
-              }
+              onChange={v => patchBlock({ [ab]: v ?? 0 })}
+              min={0}
               className={`${FIELD_CLASSES} text-center font-bold`}
             />
             <span className="text-faint text-[11px] font-semibold">
@@ -97,16 +96,11 @@ export function StatBlockEditorStats({
           <label htmlFor="edit-init" className={LABEL_CLASSES}>
             Initiative
           </label>
-          <input
+          <NumberField
             id="edit-init"
             aria-label="Initiative modifier"
-            type="number"
             value={draft.initiativeModifier}
-            onChange={e =>
-              onDraftChange(
-                setDraftInitiative(draft, parseInt(e.target.value, 10) || 0)
-              )
-            }
+            onChange={v => onDraftChange(setDraftInitiative(draft, v ?? 0))}
             className={FIELD_CLASSES}
           />
         </div>
@@ -114,16 +108,11 @@ export function StatBlockEditorStats({
           <label htmlFor="edit-pb" className={LABEL_CLASSES}>
             Prof. Bonus
           </label>
-          <input
+          <NumberField
             id="edit-pb"
             aria-label="Proficiency bonus"
-            type="number"
             value={draft.proficiencyBonus}
-            onChange={e =>
-              onDraftChange(
-                setDraftProficiency(draft, parseInt(e.target.value, 10) || 0)
-              )
-            }
+            onChange={v => onDraftChange(setDraftProficiency(draft, v ?? 0))}
             className={FIELD_CLASSES}
           />
         </div>
@@ -131,16 +120,11 @@ export function StatBlockEditorStats({
           <label htmlFor="edit-pp" className={LABEL_CLASSES}>
             Passive Perc.
           </label>
-          <input
+          <NumberField
             id="edit-pp"
             aria-label="Passive perception"
-            type="number"
             value={draft.statBlock.passivePerception}
-            onChange={e =>
-              patchBlock({
-                passivePerception: parseInt(e.target.value, 10) || 0,
-              })
-            }
+            onChange={v => patchBlock({ passivePerception: v ?? 0 })}
             className={FIELD_CLASSES}
           />
         </div>

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/index.stories.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { fn } from 'storybook/test';
+import { fn, screen } from 'storybook/test';
 import { AddCombatantDialog } from './index';
 import type { CampaignNPC } from '@/types/encounter';
 
@@ -93,9 +93,10 @@ export const PlayerTab: Story = {
     ...sharedProps,
     campaignPlayers,
   },
-  play: async ({ canvas }) => {
-    const { getByRole } = canvas;
-    getByRole('button', { name: /player/i }).click();
+  play: async () => {
+    // Dialog content renders in a Radix portal (outside canvasElement),
+    // so query the whole document via `screen`.
+    screen.getByRole('button', { name: /player/i }).click();
   },
 };
 
@@ -105,8 +106,8 @@ export const NpcTab: Story = {
     ...sharedProps,
     campaignPlayers: [],
   },
-  play: async ({ canvas }) => {
-    canvas.getByRole('button', { name: /npc/i }).click();
+  play: async () => {
+    screen.getByRole('button', { name: /npc/i }).click();
   },
 };
 
@@ -125,7 +126,7 @@ export const CustomTab: Story = {
     ...sharedProps,
     campaignPlayers: [],
   },
-  play: async ({ canvas }) => {
-    canvas.getByRole('button', { name: /custom/i }).click();
+  play: async () => {
+    screen.getByRole('button', { name: /custom/i }).click();
   },
 };

--- a/src/components/ui/encounter/combat-screen/StatBlockEntriesEditor.tsx
+++ b/src/components/ui/encounter/combat-screen/StatBlockEntriesEditor.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 import {
   parseAttackTokens,
   replaceDamage,
@@ -157,18 +158,12 @@ export function StatBlockEntriesEditor({
                 placeholder="Name"
                 className={`${FIELD_BASE} min-w-0 flex-1 font-semibold`}
               />
-              <input
+              <NumberField
                 aria-label={`${title} entry uses`}
-                type="number"
-                value={entry.uses ?? ''}
-                onChange={e =>
-                  update(i, {
-                    uses:
-                      e.target.value === ''
-                        ? undefined
-                        : parseInt(e.target.value, 10) || undefined,
-                  })
-                }
+                value={entry.uses}
+                onChange={v => update(i, { uses: v })}
+                allowEmpty
+                min={0}
                 placeholder="Uses"
                 className={`${FIELD_BASE} w-20 shrink-0`}
               />

--- a/src/components/ui/encounter/combat-screen/detail/DamageControls.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DamageControls.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { Minus, Plus } from 'lucide-react';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 
 interface DamageControlsProps {
   entityId: string;
@@ -16,38 +17,37 @@ export function DamageControls({
   onHeal,
   onAddTempHp,
 }: DamageControlsProps) {
-  const [amount, setAmount] = useState('');
+  const [amount, setAmount] = useState<number | undefined>(undefined);
 
-  const parsed = parseInt(amount, 10);
-  const valid = !isNaN(parsed) && parsed > 0;
+  const valid = amount != null && amount > 0;
 
   const handleDamage = () => {
-    if (valid) {
-      onDamage(entityId, parsed);
-      setAmount('');
+    if (amount != null && amount > 0) {
+      onDamage(entityId, amount);
+      setAmount(undefined);
     }
   };
 
   const handleHeal = () => {
-    if (valid) {
-      onHeal(entityId, parsed);
-      setAmount('');
+    if (amount != null && amount > 0) {
+      onHeal(entityId, amount);
+      setAmount(undefined);
     }
   };
 
   const handleTemp = () => {
-    if (valid) {
-      onAddTempHp(entityId, parsed);
-      setAmount('');
+    if (amount != null && amount > 0) {
+      onAddTempHp(entityId, amount);
+      setAmount(undefined);
     }
   };
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <input
-        type="number"
+      <NumberField
         value={amount}
-        onChange={e => setAmount(e.target.value)}
+        onChange={setAmount}
+        allowEmpty
         onKeyDown={e => {
           if (e.key === 'Enter') handleDamage();
         }}
@@ -59,8 +59,7 @@ export function DamageControls({
       <div className="flex gap-1">
         <button
           onClick={() => {
-            const val = parseInt(amount, 10);
-            if (!isNaN(val) && val > 0) setAmount(String(Math.floor(val / 2)));
+            if (amount != null && amount > 0) setAmount(Math.floor(amount / 2));
           }}
           className="bg-surface-raised text-muted hover:text-heading rounded-md px-2.5 py-1.5 text-xs font-bold shadow-sm transition-colors"
           title="Half damage (resistance)"
@@ -69,8 +68,7 @@ export function DamageControls({
         </button>
         <button
           onClick={() => {
-            const val = parseInt(amount, 10);
-            if (!isNaN(val) && val > 0) setAmount(String(val * 2));
+            if (amount != null && amount > 0) setAmount(amount * 2);
           }}
           className="bg-surface-raised text-muted hover:text-heading rounded-md px-2.5 py-1.5 text-xs font-bold shadow-sm transition-colors"
           title="Double damage (vulnerability)"

--- a/src/components/ui/encounter/combat-screen/detail/DetailAbilityScores.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailAbilityScores.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 import type { DetailSectionProps } from './DetailHeader';
 
 const ABILITY_LABELS = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'] as const;
@@ -18,9 +19,8 @@ export function DetailAbilityScores({ entity, actions }: DetailSectionProps) {
 
   const isPlayer = entity.type === 'player';
 
-  const handleChange = (key: AbilityKey, raw: string) => {
-    const val = parseInt(raw, 10);
-    if (!isNaN(val) && sb) {
+  const handleChange = (key: AbilityKey, val: number | undefined) => {
+    if (val !== undefined && sb) {
       actions.onUpdate(entity.id, {
         monsterStatBlock: { ...sb, [key]: val },
       });
@@ -48,10 +48,9 @@ export function DetailAbilityScores({ entity, actions }: DetailSectionProps) {
                   {score}
                 </span>
               ) : (
-                <input
-                  type="number"
+                <NumberField
                   value={score}
-                  onChange={e => handleChange(key, e.target.value)}
+                  onChange={v => handleChange(key, v)}
                   aria-label={ABILITY_LABELS[i]}
                   className="bg-surface-raised text-heading w-full rounded px-0.5 py-0.5 text-center text-sm font-bold tabular-nums"
                 />

--- a/src/components/ui/encounter/combat-screen/detail/DetailVitals.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailVitals.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { Shield, Plus, X } from 'lucide-react';
 import { HPBar } from '@/components/shared/combat/HPBar';
 import { effectiveAc } from '@/utils/calculations';
+import { NumberField } from '@/components/ui/forms/NumberInput';
 import { rollHitDie } from '../spendHitDie';
 import type { DetailSectionProps } from './DetailHeader';
 import { DamageControls } from './DamageControls';
@@ -117,29 +118,26 @@ export function DetailVitals({ entity, actions }: DetailSectionProps) {
             </div>
           ) : (
             <div className="flex items-center gap-1">
-              <input
-                type="number"
+              <NumberField
                 value={entity.armorClass}
-                onChange={e =>
-                  actions.onUpdate(entity.id, {
-                    armorClass: parseInt(e.target.value, 10) || 0,
-                  })
+                onChange={v =>
+                  actions.onUpdate(entity.id, { armorClass: v ?? 0 })
                 }
+                min={0}
                 className="bg-surface-raised text-heading w-12 rounded px-1 py-0.5 text-center text-sm font-bold shadow-sm"
                 aria-label="Armor class"
                 title="Base armor class"
               />
               <span className="text-faint text-xs">+</span>
-              <input
-                type="number"
-                min={0}
-                value={entity.tempAc ?? 0}
-                onChange={e => {
-                  const n = parseInt(e.target.value, 10) || 0;
+              <NumberField
+                value={entity.tempAc}
+                onChange={v =>
                   actions.onUpdate(entity.id, {
-                    tempAc: n > 0 ? n : undefined,
-                  });
-                }}
+                    tempAc: v && v > 0 ? v : undefined,
+                  })
+                }
+                min={0}
+                allowEmpty
                 className="bg-surface-raised text-accent-blue-text w-10 rounded px-1 py-0.5 text-center text-sm font-medium shadow-sm"
                 aria-label="Temporary AC bonus"
                 title="Temporary AC bonus"

--- a/src/components/ui/forms/NumberInput.tsx
+++ b/src/components/ui/forms/NumberInput.tsx
@@ -1,0 +1,134 @@
+/**
+ * NumberInput Component
+ *
+ * A numeric wrapper around the design-system `Input`. Unlike a raw controlled
+ * `<Input type="number" onChange={e => set(parseInt(e.target.value) || 0)} />`,
+ * this keeps a string buffer while editing so the field can be cleared without
+ * snapping back to 0, and it clamps to min/max on blur.
+ *
+ * Props mirror `Input`, except `value`/`onChange` are numeric:
+ *   value:    number | undefined
+ *   onChange: (value: number | undefined) => void
+ */
+
+'use client';
+
+import * as React from 'react';
+import { Input, type InputProps } from './input';
+import { useNumberField } from '@/hooks/useNumberField';
+
+export interface NumberInputProps
+  extends Omit<InputProps, 'value' | 'onChange' | 'defaultValue' | 'type'> {
+  value: number | undefined;
+  onChange: (value: number | undefined) => void;
+  /** When true, an emptied field resolves to `undefined` instead of `min ?? 0`. */
+  allowEmpty?: boolean;
+  /** Parse as an integer (default) or a float. */
+  integer?: boolean;
+}
+
+const toNumber = (v: string | number | undefined): number | undefined =>
+  v === undefined || v === '' ? undefined : Number(v);
+
+export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
+  (
+    {
+      value,
+      onChange,
+      min,
+      max,
+      allowEmpty = false,
+      integer = true,
+      inputMode,
+      onBlur,
+      ...props
+    },
+    ref
+  ) => {
+    const field = useNumberField({
+      value,
+      onChange,
+      min: toNumber(min),
+      max: toNumber(max),
+      allowEmpty,
+      integer,
+    });
+
+    return (
+      <Input
+        ref={ref}
+        type="text"
+        inputMode={inputMode ?? (integer ? 'numeric' : 'decimal')}
+        {...props}
+        value={field.value}
+        onChange={field.onChange}
+        onBlur={e => {
+          field.onBlur();
+          onBlur?.(e);
+        }}
+      />
+    );
+  }
+);
+
+NumberInput.displayName = 'NumberInput';
+
+/**
+ * Bare numeric input — a plain `<input>` (no design-system chrome) with the same
+ * clear-safe numeric behavior. Use this to migrate raw `<input type="number">`
+ * elements that carry bespoke styling: pass their existing `className` and props
+ * through unchanged. Safe to render inside loops (it's a component, not a hook).
+ */
+export interface NumberFieldProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'value' | 'onChange' | 'defaultValue' | 'type'
+  > {
+  value: number | undefined;
+  onChange: (value: number | undefined) => void;
+  allowEmpty?: boolean;
+  integer?: boolean;
+}
+
+export const NumberField = React.forwardRef<HTMLInputElement, NumberFieldProps>(
+  (
+    {
+      value,
+      onChange,
+      min,
+      max,
+      allowEmpty = false,
+      integer = true,
+      inputMode,
+      onBlur,
+      ...props
+    },
+    ref
+  ) => {
+    const field = useNumberField({
+      value,
+      onChange,
+      min: toNumber(min),
+      max: toNumber(max),
+      allowEmpty,
+      integer,
+    });
+
+    return (
+      <input
+        ref={ref}
+        type="text"
+        inputMode={inputMode ?? (integer ? 'numeric' : 'decimal')}
+        {...props}
+        value={field.value}
+        onChange={field.onChange}
+        onBlur={e => {
+          field.onBlur();
+          onBlur?.(e);
+        }}
+      />
+    );
+  }
+);
+
+NumberField.displayName = 'NumberField';

--- a/src/components/ui/forms/__tests__/NumberInput.test.tsx
+++ b/src/components/ui/forms/__tests__/NumberInput.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { useState } from 'react';
+import { NumberInput, NumberField } from '../NumberInput';
+
+afterEach(cleanup);
+
+/**
+ * Controlled harness so tests exercise the real string-buffer behavior
+ * (the parent stores a number, the component owns the editing buffer).
+ */
+function Harness({
+  initial,
+  allowEmpty,
+  integer,
+  min,
+  max,
+  onValue,
+}: {
+  initial: number | undefined;
+  allowEmpty?: boolean;
+  integer?: boolean;
+  min?: number;
+  max?: number;
+  onValue?: (v: number | undefined) => void;
+}) {
+  const [value, setValue] = useState<number | undefined>(initial);
+  return (
+    <NumberInput
+      id="score"
+      label="Score"
+      value={value}
+      onChange={v => {
+        setValue(v);
+        onValue?.(v);
+      }}
+      allowEmpty={allowEmpty}
+      integer={integer}
+      min={min}
+      max={max}
+    />
+  );
+}
+
+describe('NumberInput / useNumberField', () => {
+  it('is not a spinbutton — renders a text input with numeric inputMode', () => {
+    render(<Harness initial={0} />);
+    const input = screen.getByLabelText('Score') as HTMLInputElement;
+    expect(input.type).toBe('text');
+    expect(input.inputMode).toBe('numeric');
+  });
+
+  it('can be cleared and retyped (the core bug fix) — no snap-back to 0', () => {
+    render(<Harness initial={0} />);
+    const input = screen.getByLabelText('Score') as HTMLInputElement;
+
+    // The classic bug: value "0", deleting it must actually empty the field.
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input.value).toBe('');
+
+    fireEvent.change(input, { target: { value: '16' } });
+    expect(input.value).toBe('16');
+  });
+
+  it('emits the parsed number on change', () => {
+    const onValue = vi.fn();
+    render(<Harness initial={0} onValue={onValue} />);
+    const input = screen.getByLabelText('Score');
+    fireEvent.change(input, { target: { value: '16' } });
+    expect(onValue).toHaveBeenLastCalledWith(16);
+  });
+
+  it('required field falls back to min ?? 0 on blur when left empty', () => {
+    const onValue = vi.fn();
+    render(<Harness initial={5} min={1} onValue={onValue} />);
+    const input = screen.getByLabelText('Score') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+    expect(input.value).toBe('1');
+    expect(onValue).toHaveBeenLastCalledWith(1);
+  });
+
+  it('allowEmpty resolves to undefined when cleared', () => {
+    const onValue = vi.fn();
+    render(<Harness initial={5} allowEmpty onValue={onValue} />);
+    const input = screen.getByLabelText('Score');
+    fireEvent.change(input, { target: { value: '' } });
+    expect(onValue).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it('clamps to max on blur, not per keystroke', () => {
+    const onValue = vi.fn();
+    render(<Harness initial={0} max={20} onValue={onValue} />);
+    const input = screen.getByLabelText('Score') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '25' } });
+    expect(input.value).toBe('25'); // not fought while typing
+    fireEvent.blur(input);
+    expect(input.value).toBe('20');
+    expect(onValue).toHaveBeenLastCalledWith(20);
+  });
+
+  it('rejects non-numeric keystrokes for integer fields', () => {
+    render(<Harness initial={3} />);
+    const input = screen.getByLabelText('Score') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '3a' } });
+    expect(input.value).toBe('3');
+  });
+
+  it('supports negative values (modifiers)', () => {
+    const onValue = vi.fn();
+    render(<Harness initial={0} onValue={onValue} />);
+    const input = screen.getByLabelText('Score') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '-2' } });
+    expect(input.value).toBe('-2');
+    expect(onValue).toHaveBeenLastCalledWith(-2);
+  });
+
+  it('supports decimals when integer={false}', () => {
+    const onValue = vi.fn();
+    render(<Harness initial={0} integer={false} onValue={onValue} />);
+    const input = screen.getByLabelText('Score') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '1.5' } });
+    expect(input.value).toBe('1.5');
+    expect(onValue).toHaveBeenLastCalledWith(1.5);
+  });
+
+  it('NumberField preserves a passed className (bare styling)', () => {
+    render(
+      <NumberField
+        value={1}
+        onChange={() => {}}
+        className="custom-cls"
+        aria-label="bare"
+      />
+    );
+    expect(screen.getByLabelText('bare')).toHaveClass('custom-cls');
+  });
+});

--- a/src/components/ui/game/equipment/MagicItemForm.tsx
+++ b/src/components/ui/game/equipment/MagicItemForm.tsx
@@ -5,6 +5,7 @@ import { MagicItemCategory, MagicItemRarity } from '@/types/character';
 import { Plus, Trash2, Sparkles, Zap, Shield } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import { Checkbox } from '@/components/ui/forms/checkbox';
 import RichTextEditor from '@/components/ui/forms/RichTextEditor';
@@ -320,14 +321,13 @@ export function MagicItemForm({
 
                 {/* Max Charges and Rest Type */}
                 <div className="mb-3 grid grid-cols-2 gap-3">
-                  <Input
+                  <NumberInput
                     label="Max Charges"
-                    type="number"
                     min={1}
-                    value={charge.maxCharges.toString()}
-                    onChange={e =>
+                    value={charge.maxCharges}
+                    onChange={v =>
                       updateCharge(index, {
-                        maxCharges: parseInt(e.target.value) || 1,
+                        maxCharges: v ?? 1,
                       })
                     }
                     helperText="Total charges when fully recharged"
@@ -372,16 +372,15 @@ export function MagicItemForm({
 
                   {charge.scaleWithProficiency && (
                     <div className="mt-2 pl-6">
-                      <Input
+                      <NumberInput
                         label="Proficiency Multiplier"
-                        type="number"
+                        integer={false}
                         min={0.5}
                         step={0.5}
-                        value={(charge.proficiencyMultiplier || 1).toString()}
-                        onChange={e =>
+                        value={charge.proficiencyMultiplier || 1}
+                        onChange={v =>
                           updateCharge(index, {
-                            proficiencyMultiplier:
-                              parseFloat(e.target.value) || 1,
+                            proficiencyMultiplier: v ?? 1,
                           })
                         }
                         helperText="Max charges = proficiency bonus × multiplier"
@@ -408,18 +407,17 @@ export function MagicItemForm({
 
           <div className="border-accent-amber-border bg-accent-amber-bg rounded-lg border p-4">
             <div className="mb-4 grid grid-cols-3 gap-3">
-              <Input
+              <NumberInput
                 label="Max Charges"
-                type="number"
                 min={0}
-                value={formData.chargePool.maxCharges.toString()}
-                onChange={e =>
+                value={formData.chargePool.maxCharges}
+                onChange={v =>
                   setFormData(prev => ({
                     ...prev,
                     chargePool: prev.chargePool
                       ? {
                           ...prev.chargePool,
-                          maxCharges: parseInt(e.target.value) || 0,
+                          maxCharges: v ?? 0,
                         }
                       : undefined,
                   }))
@@ -523,37 +521,31 @@ export function MagicItemForm({
             Spell Bonuses
           </h4>
           <div className="grid grid-cols-2 gap-4">
-            <Input
+            <NumberInput
               label="Bonus to Spell Attack"
-              type="number"
               min={0}
               max={5}
-              value={(formData.bonusSpellAttack ?? '').toString()}
-              onChange={e => {
-                const val = e.target.value
-                  ? parseInt(e.target.value)
-                  : undefined;
+              allowEmpty
+              value={formData.bonusSpellAttack}
+              onChange={v => {
                 setFormData(prev => ({
                   ...prev,
-                  bonusSpellAttack: val,
+                  bonusSpellAttack: v,
                 }));
               }}
               placeholder="+0"
               helperText="Added to spell attack rolls"
             />
-            <Input
+            <NumberInput
               label="Bonus to Spell Save DC"
-              type="number"
               min={0}
               max={5}
-              value={(formData.bonusSpellSaveDc ?? '').toString()}
-              onChange={e => {
-                const val = e.target.value
-                  ? parseInt(e.target.value)
-                  : undefined;
+              allowEmpty
+              value={formData.bonusSpellSaveDc}
+              onChange={v => {
                 setFormData(prev => ({
                   ...prev,
-                  bonusSpellSaveDc: val,
+                  bonusSpellSaveDc: v,
                 }));
               }}
               placeholder="+0"

--- a/src/components/ui/game/equipment/WeaponForm.tsx
+++ b/src/components/ui/game/equipment/WeaponForm.tsx
@@ -11,6 +11,7 @@ import {
 import { Plus, Trash2, Sparkles, Zap, Shield } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import { Checkbox } from '@/components/ui/forms/checkbox';
 import RichTextEditor from '@/components/ui/forms/RichTextEditor';
@@ -204,42 +205,42 @@ export function WeaponForm({
             </SelectField>
           </div>
 
-          <Input
+          <NumberInput
             label="Enhancement Bonus"
-            type="number"
-            value={formData.enhancementBonus.toString()}
-            onChange={e =>
+            value={formData.enhancementBonus}
+            onChange={v =>
               setFormData({
                 ...formData,
-                enhancementBonus: parseInt(e.target.value) || 0,
+                enhancementBonus: v ?? 0,
               })
             }
             min={0}
             max={3}
           />
-          <Input
+          <NumberInput
             label="Weight (lb)"
-            type="number"
-            value={(formData.weight ?? '').toString()}
-            onChange={e =>
+            value={formData.weight}
+            onChange={v =>
               setFormData({
                 ...formData,
-                weight: e.target.value ? parseFloat(e.target.value) : undefined,
+                weight: v,
               })
             }
+            allowEmpty
+            integer={false}
             min={0}
             step={0.1}
           />
-          <Input
+          <NumberInput
             label="Value (cp)"
-            type="number"
-            value={(formData.value ?? '').toString()}
-            onChange={e =>
+            value={formData.value}
+            onChange={v =>
               setFormData({
                 ...formData,
-                value: e.target.value ? parseInt(e.target.value) : undefined,
+                value: v,
               })
             }
+            allowEmpty
             min={0}
           />
         </div>
@@ -541,14 +542,13 @@ export function WeaponForm({
 
                 {/* Max Charges and Rest Type */}
                 <div className="mb-3 grid grid-cols-2 gap-3">
-                  <Input
+                  <NumberInput
                     label="Max Charges"
-                    type="number"
                     min={1}
-                    value={charge.maxCharges.toString()}
-                    onChange={e =>
+                    value={charge.maxCharges}
+                    onChange={v =>
                       updateCharge(index, {
-                        maxCharges: parseInt(e.target.value) || 1,
+                        maxCharges: v ?? 1,
                       })
                     }
                     helperText="Total charges when fully recharged"
@@ -592,16 +592,15 @@ export function WeaponForm({
 
                   {charge.scaleWithProficiency && (
                     <div className="mt-2 pl-6">
-                      <Input
+                      <NumberInput
                         label="Proficiency Multiplier"
-                        type="number"
+                        integer={false}
                         min={0.5}
                         step={0.5}
-                        value={(charge.proficiencyMultiplier || 1).toString()}
-                        onChange={e =>
+                        value={charge.proficiencyMultiplier || 1}
+                        onChange={v =>
                           updateCharge(index, {
-                            proficiencyMultiplier:
-                              parseFloat(e.target.value) || 1,
+                            proficiencyMultiplier: v ?? 1,
                           })
                         }
                         helperText="Max charges = proficiency bonus × multiplier"
@@ -628,18 +627,17 @@ export function WeaponForm({
 
           <div className="border-accent-amber-border bg-accent-amber-bg rounded-lg border p-4">
             <div className="mb-4 grid grid-cols-3 gap-3">
-              <Input
+              <NumberInput
                 label="Max Charges"
-                type="number"
                 min={0}
-                value={formData.chargePool.maxCharges.toString()}
-                onChange={e =>
+                value={formData.chargePool.maxCharges}
+                onChange={v =>
                   setFormData(prev => ({
                     ...prev,
                     chargePool: prev.chargePool
                       ? {
                           ...prev.chargePool,
-                          maxCharges: parseInt(e.target.value) || 0,
+                          maxCharges: v ?? 0,
                         }
                       : undefined,
                   }))
@@ -768,32 +766,26 @@ export function WeaponForm({
             Spell Bonuses
           </h4>
           <div className="grid grid-cols-2 gap-4">
-            <Input
+            <NumberInput
               label="Bonus to Spell Attack"
-              type="number"
               min={0}
               max={5}
-              value={(formData.bonusSpellAttack ?? '').toString()}
-              onChange={e => {
-                const val = e.target.value
-                  ? parseInt(e.target.value)
-                  : undefined;
-                setFormData(prev => ({ ...prev, bonusSpellAttack: val }));
+              allowEmpty
+              value={formData.bonusSpellAttack}
+              onChange={v => {
+                setFormData(prev => ({ ...prev, bonusSpellAttack: v }));
               }}
               placeholder="+0"
               helperText="Added to spell attack rolls"
             />
-            <Input
+            <NumberInput
               label="Bonus to Spell Save DC"
-              type="number"
               min={0}
               max={5}
-              value={(formData.bonusSpellSaveDc ?? '').toString()}
-              onChange={e => {
-                const val = e.target.value
-                  ? parseInt(e.target.value)
-                  : undefined;
-                setFormData(prev => ({ ...prev, bonusSpellSaveDc: val }));
+              allowEmpty
+              value={formData.bonusSpellSaveDc}
+              onChange={v => {
+                setFormData(prev => ({ ...prev, bonusSpellSaveDc: v }));
               }}
               placeholder="+0"
               helperText="Added to spell save DC"

--- a/src/components/ui/game/inventory/ItemForm.tsx
+++ b/src/components/ui/game/inventory/ItemForm.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from '@/components/ui/forms/button';
 import { Badge } from '@/components/ui/layout/badge';
 import { Input } from '@/components/ui/forms/input';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { CompactRichTextEditor } from '@/components/ui/forms/CompactRichTextEditor';
 import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import { ProcessedItem, ProcessedMagicItem } from '@/types/items';
@@ -213,19 +214,13 @@ export function ItemForm({
                   </SelectField>
                 </div>
 
-                <Input
+                <NumberInput
                   label="Quantity"
-                  type="number"
-                  value={
-                    formData.quantity > 0 ? formData.quantity.toString() : ''
-                  }
-                  onChange={e =>
+                  value={formData.quantity}
+                  onChange={v =>
                     setFormData({
                       ...formData,
-                      quantity:
-                        e.target.value === ''
-                          ? 0
-                          : parseInt(e.target.value) || 0,
+                      quantity: v ?? 0,
                     })
                   }
                   min={1}
@@ -355,33 +350,30 @@ export function ItemForm({
               </h4>
 
               <div className="grid grid-cols-2 gap-4">
-                <Input
+                <NumberInput
                   label="Weight (lbs)"
-                  type="number"
+                  integer={false}
+                  allowEmpty
                   step="0.001"
-                  value={formData.weight?.toString() || ''}
-                  onChange={e =>
+                  value={formData.weight}
+                  onChange={v =>
                     setFormData({
                       ...formData,
-                      weight: e.target.value
-                        ? parseFloat(e.target.value)
-                        : undefined,
+                      weight: v,
                     })
                   }
                   placeholder="Per item"
                   min={0}
                 />
 
-                <Input
+                <NumberInput
                   label="Value (cp)"
-                  type="number"
-                  value={formData.value?.toString() || ''}
-                  onChange={e =>
+                  allowEmpty
+                  value={formData.value}
+                  onChange={v =>
                     setFormData({
                       ...formData,
-                      value: e.target.value
-                        ? parseInt(e.target.value)
-                        : undefined,
+                      value: v,
                     })
                   }
                   placeholder="Per item"

--- a/src/hooks/useNumberField.ts
+++ b/src/hooks/useNumberField.ts
@@ -1,0 +1,127 @@
+'use client';
+
+import * as React from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseNumberFieldOptions {
+  /** Current numeric value (or undefined when empty). */
+  value: number | undefined;
+  /** Called with the resolved numeric value, or undefined when cleared (only if allowEmpty). */
+  onChange: (value: number | undefined) => void;
+  /** Minimum allowed value; enforced on blur. Also the fallback when a required field is left empty. */
+  min?: number;
+  /** Maximum allowed value; enforced on blur. */
+  max?: number;
+  /**
+   * When true, clearing the field resolves to `undefined`.
+   * When false (default), an emptied field falls back to `min ?? 0` on blur.
+   */
+  allowEmpty?: boolean;
+  /** Parse as an integer (default) or a float. */
+  integer?: boolean;
+}
+
+export interface NumberFieldBindings {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur: () => void;
+}
+
+const clampNumber = (n: number, min?: number, max?: number): number => {
+  let out = n;
+  if (min !== undefined && out < min) out = min;
+  if (max !== undefined && out > max) out = max;
+  return out;
+};
+
+/**
+ * Manages the string buffer for a controlled numeric input so the field can be
+ * emptied mid-edit without snapping back to 0 (the classic `parseInt(v) || 0`
+ * bug). Spread the returned bindings onto any `<input>` (raw or design-system).
+ *
+ * - While typing, the raw string is preserved (empty allowed).
+ * - A parsed number is emitted on every valid keystroke.
+ * - An emptied required field falls back to `min ?? 0` on blur; an emptied
+ *   optional field (`allowEmpty`) resolves to `undefined`.
+ * - Min/max are enforced on blur, not per keystroke, so intermediate values
+ *   while typing aren't fought.
+ */
+export function useNumberField({
+  value,
+  onChange,
+  min,
+  max,
+  allowEmpty = false,
+  integer = true,
+}: UseNumberFieldOptions): NumberFieldBindings {
+  const [text, setText] = useState<string>(value == null ? '' : String(value));
+  // The last value we emitted, so we can detect external (prop-driven) changes.
+  const lastEmitted = useRef<number | undefined>(value);
+
+  useEffect(() => {
+    if (value !== lastEmitted.current) {
+      setText(value == null ? '' : String(value));
+      lastEmitted.current = value;
+    }
+  }, [value]);
+
+  const parse = useCallback(
+    (raw: string): number | undefined => {
+      if (raw === '' || raw === '-') return undefined;
+      const n = integer ? parseInt(raw, 10) : parseFloat(raw);
+      return Number.isNaN(n) ? undefined : n;
+    },
+    [integer]
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      // Only accept a valid (possibly partial) numeric string.
+      const pattern = integer ? /^-?\d*$/ : /^-?\d*\.?\d*$/;
+      if (raw !== '' && !pattern.test(raw)) return;
+      setText(raw);
+
+      const parsed = parse(raw);
+      if (parsed === undefined) {
+        // Empty/partial — only propagate for optional fields; otherwise wait for blur.
+        if (allowEmpty && lastEmitted.current !== undefined) {
+          lastEmitted.current = undefined;
+          onChange(undefined);
+        }
+        return;
+      }
+      // Emit the typed value as-is; clamping happens on blur so typing isn't fought.
+      lastEmitted.current = parsed;
+      onChange(parsed);
+    },
+    [parse, integer, allowEmpty, onChange]
+  );
+
+  const handleBlur = useCallback(() => {
+    const parsed = parse(text);
+    if (parsed === undefined) {
+      if (allowEmpty) {
+        setText('');
+        if (lastEmitted.current !== undefined) {
+          lastEmitted.current = undefined;
+          onChange(undefined);
+        }
+      } else {
+        const fallback = clampNumber(min ?? 0, min, max);
+        setText(String(fallback));
+        lastEmitted.current = fallback;
+        onChange(fallback);
+      }
+      return;
+    }
+    const clamped = clampNumber(parsed, min, max);
+    setText(String(clamped));
+    if (clamped !== lastEmitted.current) {
+      lastEmitted.current = clamped;
+      onChange(clamped);
+    }
+  }, [text, parse, allowEmpty, min, max, onChange]);
+
+  return { value: text, onChange: handleChange, onBlur: handleBlur };
+}


### PR DESCRIPTION
## Problem

Number inputs across the app used `value={n}` + `onChange={e => setX(parseInt(e.target.value) || 0)}`. The `|| 0` snaps an emptied field back to `0`, so you can't delete the `0` and type a new value — you have to select-all and overwrite. ~90% of numeric inputs had this.

## Fix

New shared primitives (`src/components/ui/forms/NumberInput.tsx`, `src/hooks/useNumberField.ts`):

- **`useNumberField`** — holds a string buffer while editing so the field can be emptied; emits a parsed number on each valid keystroke; falls back to `min ?? 0` on blur (or `undefined` when `allowEmpty`); clamps to min/max on blur (not per keystroke, so typing isn't fought).
- **`NumberInput`** — wraps the design-system `Input` with numeric `value`/`onChange`. Drop-in for `<Input type="number">`.
- **`NumberField`** — a bare `<input>` that preserves bespoke `className`, for the compact raw inputs; safe inside `.map()`.

## Migration

~30 files (~70 inputs) migrated off the `|| 0` pattern:
- `<Input type="number">` → `NumberInput`; raw `<input type="number">` → `NumberField` (styling preserved verbatim).
- Optional fields (spell bonuses/overrides, bestiary CR filters, ability "uses", currency) use `allowEmpty` → resolve to `undefined` when cleared.
- Decimal fields (weight, price, proficiency multiplier, CR) use `integer={false}`.
- A few handlers/state converted to `number | undefined` to match.

Inputs that **already** used a local string-buffer + commit-on-blur pattern (ability-score editors, initiative cell, XP/inspiration trackers, add-combatant HP/AC, DefensesAndSenses range) were left as-is — they already clear correctly.

## Notes

- Migrated fields now use `type="text" inputMode="numeric"` (via the new components) instead of `type="number"`, so the browser spinner arrows are gone. This is intentional — cleaner in these dense forms — and the mobile numeric keyboard is preserved. Easy to re-add if you want spinners back.

## Testing

- `npm run type-check` — clean
- `npm run lint` on changed files — clean (one pre-existing `exhaustive-deps` warning in ItemForm, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)