### PR TITLE
fix(battlemap): repair stale annotations lock and dead live-map pointer

### DIFF
--- a/src/app/api/campaign/[code]/battlemaps/[id]/route.ts
+++ b/src/app/api/campaign/[code]/battlemaps/[id]/route.ts
@@ -3,11 +3,14 @@ import {
   getRedis,
   campaignBattleMapsKey,
   campaignBattleMapKey,
+  campaignSharedKey,
   refreshCampaignTTL,
   SLIDING_TTL_SECONDS,
 } from '@/lib/redis';
 import { verifyDmAuthority } from '@/lib/dmAuth';
+import { shouldClearActiveBattleMap } from '@/lib/activeBattleMap';
 import type { BattleMapMetadata, SyncedBattleMap } from '@/types/battlemap';
+import type { SharedBattleMapState } from '@/types/sharedState';
 
 export async function GET(
   _request: NextRequest,
@@ -123,6 +126,16 @@ export async function DELETE(
       );
     }
     await redis.del(campaignBattleMapKey(code, id));
+
+    // The shared "live map" pointer is sticky — never cleared by a relink or
+    // delete. If it still references the map being deleted, clear it so players
+    // don't get stranded opening a dead map (they'd see the old/removed one).
+    const sharedRaw = await redis.get<string | SharedBattleMapState>(
+      campaignSharedKey(code, 'battlemap')
+    );
+    if (shouldClearActiveBattleMap(sharedRaw, id)) {
+      await redis.del(campaignSharedKey(code, 'battlemap'));
+    }
 
     const existingRaw = await redis.get<BattleMapMetadata[]>(
       campaignBattleMapsKey(code)

--- a/src/app/player/campaign/[code]/battlemap/[id]/page.tsx
+++ b/src/app/player/campaign/[code]/battlemap/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { usePlayerStore } from '@/store/playerStore';
 import { useHydration } from '@/hooks/useHydration';
@@ -22,12 +22,42 @@ function PlayerBattleMapPage() {
     if (battleMapId) markBattleMapJoined(battleMapId);
   }, [battleMapId]);
 
+  // Guard stale deep links: a DM can delete the map an old bookmark points at.
+  // The live canvas has no existence check (it syncs an empty relay room), so
+  // validate here. Fail-open — a transient API error must not block a real map.
+  const [mapMissing, setMapMissing] = useState(false);
+  useEffect(() => {
+    if (!code || !battleMapId) return;
+    let cancelled = false;
+    fetch(`/api/campaign/${code}/battlemaps/${battleMapId}`)
+      .then(res => {
+        if (!cancelled && res.status === 404) setMapMissing(true);
+      })
+      .catch(() => {
+        /* network error — fail open, let the canvas try to connect */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [code, battleMapId]);
+
   const hasHydrated = useHydration();
   const character = usePlayerStore(s =>
     s.characters.find(c => c.id === characterId)
   );
 
   if (!hasHydrated) return null;
+
+  if (mapMissing) {
+    return (
+      <div className="bg-surface flex min-h-screen items-center justify-center px-6">
+        <p className="text-body text-center">
+          This battle map is no longer available. Ask your DM for the current
+          map, or head back to your character sheet.
+        </p>
+      </div>
+    );
+  }
 
   if (!characterId || !character) {
     return (

--- a/src/app/player/campaign/[code]/battlemap/[id]/page.tsx
+++ b/src/app/player/campaign/[code]/battlemap/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { usePlayerStore } from '@/store/playerStore';
 import { useHydration } from '@/hooks/useHydration';
@@ -22,42 +22,12 @@ function PlayerBattleMapPage() {
     if (battleMapId) markBattleMapJoined(battleMapId);
   }, [battleMapId]);
 
-  // Guard stale deep links: a DM can delete the map an old bookmark points at.
-  // The live canvas has no existence check (it syncs an empty relay room), so
-  // validate here. Fail-open — a transient API error must not block a real map.
-  const [mapMissing, setMapMissing] = useState(false);
-  useEffect(() => {
-    if (!code || !battleMapId) return;
-    let cancelled = false;
-    fetch(`/api/campaign/${code}/battlemaps/${battleMapId}`)
-      .then(res => {
-        if (!cancelled && res.status === 404) setMapMissing(true);
-      })
-      .catch(() => {
-        /* network error — fail open, let the canvas try to connect */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [code, battleMapId]);
-
   const hasHydrated = useHydration();
   const character = usePlayerStore(s =>
     s.characters.find(c => c.id === characterId)
   );
 
   if (!hasHydrated) return null;
-
-  if (mapMissing) {
-    return (
-      <div className="bg-surface flex min-h-screen items-center justify-center px-6">
-        <p className="text-body text-center">
-          This battle map is no longer available. Ask your DM for the current
-          map, or head back to your character sheet.
-        </p>
-      </div>
-    );
-  }
 
   if (!characterId || !character) {
     return (

--- a/src/components/ui/campaign/NPCFormDialog.tsx
+++ b/src/components/ui/campaign/NPCFormDialog.tsx
@@ -58,6 +58,8 @@ import {
   npcInventoryItemToFormData,
   formDataToNpcInventoryPatch,
 } from '@/utils/npcInventoryItemForm';
+import { NPCSpellListEditor } from './NPCSpellListEditor';
+import type { Spell } from '@/types/character';
 
 interface NamedText {
   name: string;
@@ -322,6 +324,7 @@ export function NPCFormDialog({
   const [spellSlotOverrides, setSpellSlotOverrides] = useState<
     Record<number, number | undefined>
   >({});
+  const [spells, setSpells] = useState<Spell[]>([]);
 
   // ---------- Auto-calc initiative from DEX ----------
 
@@ -389,6 +392,7 @@ export function NPCFormDialog({
           }
         }
         setSpellSlotOverrides(overrides);
+        setSpells(editingNpc.spellcasting.spells ?? []);
       } else {
         setSpellcastingEnabled(false);
         setCasterLevel(1);
@@ -396,6 +400,7 @@ export function NPCFormDialog({
         setSpellAttackOverride(undefined);
         setSpellDCOverride(undefined);
         setSpellSlotOverrides({});
+        setSpells([]);
       }
 
       // Group & tags
@@ -567,6 +572,7 @@ export function NPCFormDialog({
     setSpellAttackOverride(undefined);
     setSpellDCOverride(undefined);
     setSpellSlotOverrides({});
+    setSpells([]);
     resetAbilityScores();
     resetDetailFields();
   }
@@ -876,7 +882,7 @@ export function NPCFormDialog({
                   )
                 : undefined,
             slotsUsed: editingNpc?.spellcasting?.slotsUsed ?? {},
-            spells: editingNpc?.spellcasting?.spells ?? [],
+            spells,
           }
         : undefined,
     };
@@ -1791,6 +1797,15 @@ export function NPCFormDialog({
                               })()}
                             </div>
                           </div>
+                        </div>
+                        <div>
+                          <label className="text-muted mb-1 block text-xs font-medium">
+                            Spell List
+                          </label>
+                          <NPCSpellListEditor
+                            spells={spells}
+                            onChange={setSpells}
+                          />
                         </div>
                       </div>
                     )}

--- a/src/components/ui/campaign/NPCSpellListEditor.tsx
+++ b/src/components/ui/campaign/NPCSpellListEditor.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import { Plus, Pencil, Trash2, Star } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+} from '@/components/ui/feedback/dialog';
+import { Button } from '@/components/ui/forms/button';
+import { Badge } from '@/components/ui/layout/badge';
+import { SpellAutocomplete } from '@/components/ui/forms/SpellAutocomplete';
+import { SpellFormFields } from '@/components/shared/spells';
+import { useSpellsData } from '@/hooks/useSpellsData';
+import {
+  convertProcessedSpellToFormData,
+  convertFormDataToSpell,
+  spellToFormData,
+  createInitialSpellFormData,
+} from '@/utils/spellConversion';
+import type { Spell } from '@/types/character';
+import type { ProcessedSpell } from '@/types/spells';
+import type { SpellFormData } from '@/utils/spellConversion';
+
+const LEVEL_NAMES: Record<number, string> = {
+  0: 'Cantrips',
+  1: 'Level 1',
+  2: 'Level 2',
+  3: 'Level 3',
+  4: 'Level 4',
+  5: 'Level 5',
+  6: 'Level 6',
+  7: 'Level 7',
+  8: 'Level 8',
+  9: 'Level 9',
+};
+
+interface NPCSpellListEditorProps {
+  spells: Spell[];
+  onChange: (spells: Spell[]) => void;
+}
+
+/**
+ * Edit-mode spell list manager for the NPC form. Mirrors the add/edit/remove
+ * flow of the read-mode NPCSpellTab (same SpellAutocomplete + SpellFormFields +
+ * conversion utils) but operates on a local Spell[] array so changes are saved
+ * with the rest of the form (works for new NPCs too), rather than persisting to
+ * the store immediately. Runtime concerns (casting, slot usage) are omitted.
+ */
+export function NPCSpellListEditor({
+  spells,
+  onChange,
+}: NPCSpellListEditorProps) {
+  const { spells: dbSpells, loading } = useSpellsData();
+
+  const [addOpen, setAddOpen] = useState(false);
+  const [addFormData, setAddFormData] = useState<SpellFormData>(
+    createInitialSpellFormData
+  );
+  const [addTags, setAddTags] = useState<string[]>([]);
+
+  const [editingSpell, setEditingSpell] = useState<Spell | null>(null);
+  const [editFormData, setEditFormData] = useState<SpellFormData>(
+    createInitialSpellFormData
+  );
+  const [editTags, setEditTags] = useState<string[]>([]);
+
+  const existingTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const spell of spells) spell.tags?.forEach(t => set.add(t));
+    return Array.from(set).sort();
+  }, [spells]);
+
+  const byLevel = useMemo(() => {
+    const groups: Record<number, Spell[]> = {};
+    for (const spell of spells) (groups[spell.level] ??= []).push(spell);
+    return groups;
+  }, [spells]);
+
+  const levels = useMemo(
+    () =>
+      Object.keys(byLevel)
+        .map(Number)
+        .sort((a, b) => a - b),
+    [byLevel]
+  );
+
+  const closeAdd = () => {
+    setAddOpen(false);
+    setAddFormData(createInitialSpellFormData());
+    setAddTags([]);
+  };
+
+  const handleAddFromDb = (processed: ProcessedSpell) =>
+    setAddFormData(convertProcessedSpellToFormData(processed));
+
+  const handleAdd = () => {
+    if (!addFormData.name.trim()) return;
+    const spell = convertFormDataToSpell(addFormData);
+    if (addTags.length > 0) spell.tags = [...addTags];
+    onChange([...spells, spell]);
+    closeAdd();
+  };
+
+  const openEdit = (spell: Spell) => {
+    setEditingSpell(spell);
+    setEditFormData(spellToFormData(spell));
+    setEditTags(spell.tags ?? []);
+  };
+
+  const handleSaveEdit = () => {
+    if (!editingSpell) return;
+    const updates = convertFormDataToSpell(editFormData, editingSpell.id);
+    // Preserve existing innate-usage count; don't reset when editing.
+    if (updates.freeCastMax !== undefined) {
+      updates.freeCastsUsed = editingSpell.freeCastsUsed ?? 0;
+    }
+    updates.tags = editTags.length > 0 ? editTags : undefined;
+    onChange(
+      spells.map(s =>
+        s.id === editingSpell.id
+          ? // Preserve original createdAt (convertFormDataToSpell makes a new one).
+            { ...s, ...updates, createdAt: s.createdAt }
+          : s
+      )
+    );
+    setEditingSpell(null);
+  };
+
+  const handleRemove = (id: string) =>
+    onChange(spells.filter(s => s.id !== id));
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-heading text-sm font-medium">
+          Spells{spells.length > 0 ? ` (${spells.length})` : ''}
+        </span>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => setAddOpen(true)}
+        >
+          <Plus className="mr-1 h-3.5 w-3.5" />
+          Add Spell
+        </Button>
+      </div>
+
+      {spells.length === 0 ? (
+        <p className="text-muted border-divider rounded-lg border border-dashed px-3 py-4 text-center text-sm">
+          No spells yet. Add spells this NPC can cast.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {levels.map(level => (
+            <div
+              key={level}
+              className="border-divider overflow-hidden rounded-lg border"
+            >
+              <div className="bg-surface-secondary text-heading px-3 py-1.5 text-xs font-semibold">
+                {LEVEL_NAMES[level] ?? `Level ${level}`}{' '}
+                <span className="text-muted">({byLevel[level].length})</span>
+              </div>
+              <div className="divide-y divide-[var(--border-divider)]">
+                {byLevel[level].map(spell => (
+                  <SpellEditRow
+                    key={spell.id}
+                    spell={spell}
+                    onEdit={() => openEdit(spell)}
+                    onRemove={() => handleRemove(spell.id)}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add Spell dialog */}
+      <Dialog
+        open={addOpen}
+        onOpenChange={open => {
+          if (!open) closeAdd();
+        }}
+      >
+        <DialogContent size="lg">
+          <DialogHeader>
+            <DialogTitle>Add Spell</DialogTitle>
+          </DialogHeader>
+          <DialogBody className="space-y-4">
+            <div className="border-accent-purple-border bg-accent-purple-bg/30 rounded-lg border-2 p-4">
+              <SpellAutocomplete
+                spells={dbSpells}
+                onSelect={handleAddFromDb}
+                loading={loading}
+                placeholder="Search spells from database to auto-fill..."
+              />
+            </div>
+            <SpellFormFields
+              formData={addFormData}
+              onChange={setAddFormData}
+              tags={addTags}
+              onTagsChange={setAddTags}
+              existingTags={existingTags}
+            />
+          </DialogBody>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={closeAdd}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              onClick={handleAdd}
+              disabled={!addFormData.name.trim()}
+            >
+              Add Spell
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Spell dialog */}
+      <Dialog
+        open={!!editingSpell}
+        onOpenChange={open => {
+          if (!open) setEditingSpell(null);
+        }}
+      >
+        <DialogContent size="lg">
+          <DialogHeader>
+            <DialogTitle>Edit: {editingSpell?.name}</DialogTitle>
+          </DialogHeader>
+          {editingSpell && (
+            <DialogBody>
+              <SpellFormFields
+                formData={editFormData}
+                onChange={setEditFormData}
+                tags={editTags}
+                onTagsChange={setEditTags}
+                existingTags={existingTags}
+              />
+            </DialogBody>
+          )}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setEditingSpell(null)}
+            >
+              Cancel
+            </Button>
+            <Button type="button" variant="primary" onClick={handleSaveEdit}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function SpellEditRow({
+  spell,
+  onEdit,
+  onRemove,
+}: {
+  spell: Spell;
+  onEdit: () => void;
+  onRemove: () => void;
+}) {
+  const isAtWill = spell.freeCastMax !== undefined && spell.freeCastMax === 0;
+  const isInnate = spell.freeCastMax !== undefined && spell.freeCastMax > 0;
+
+  return (
+    <div className="bg-surface-raised flex items-center gap-2 px-3 py-1.5">
+      {(isAtWill || isInnate) && (
+        <Star className="text-accent-amber-text h-3.5 w-3.5 shrink-0" />
+      )}
+      <span className="text-heading min-w-0 flex-1 truncate text-sm font-medium">
+        {spell.name}
+      </span>
+      <Badge variant={spell.level === 0 ? 'warning' : 'secondary'} size="sm">
+        {spell.level === 0 ? 'C' : `L${spell.level}`}
+      </Badge>
+      {isAtWill && (
+        <Badge variant="warning" size="sm">
+          At Will
+        </Badge>
+      )}
+      {isInnate && (
+        <Badge variant="secondary" size="sm">
+          {spell.freeCastMax}/day
+        </Badge>
+      )}
+      {spell.concentration && (
+        <Badge variant="info" size="sm">
+          C
+        </Badge>
+      )}
+      <div className="flex shrink-0 items-center gap-0.5">
+        <button
+          type="button"
+          onClick={onEdit}
+          className="text-muted hover:text-accent-amber-text rounded p-1 transition-colors"
+          title="Edit spell"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={onRemove}
+          className="text-muted hover:text-accent-red-text rounded p-1 transition-colors"
+          title="Remove spell"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/battle-map/BattleMapPickerDialog.tsx
+++ b/src/components/ui/campaign/battle-map/BattleMapPickerDialog.tsx
@@ -17,6 +17,8 @@ import { Input } from '@/components/ui/forms/input';
 
 import { modeStorageKey } from '@/components/ui/campaign/dm-vtt/useBattleMapMode';
 import { generateBattleMapId, useBattleMapStore } from '@/store/battleMapStore';
+import { useDmStore } from '@/store/dmStore';
+import { useDmBattleMapSync } from '@/hooks/useDmBattleMapSync';
 import { findLinkedBattleMap, planMapLinkSwitch } from '@/utils/battleMapLinks';
 
 import { BattleMapPickerRow } from './BattleMapPickerRow';
@@ -42,16 +44,27 @@ export function BattleMapPickerDialog({
   const router = useRouter();
   const { getBattleMaps, addBattleMap, linkEncounter, unlinkEncounter } =
     useBattleMapStore();
+  const dmId = useDmStore(s => s.dmId);
+  const { pushActive } = useDmBattleMapSync(campaignCode, dmId);
   const [newName, setNewName] = useState('');
 
   const battleMaps = getBattleMaps(campaignCode);
   const current = findLinkedBattleMap(battleMaps, encounterId);
 
-  function applyAndGo(mapId: string) {
+  // `pushLive` moves the campaign's live-map pointer to the chosen map so
+  // players following the "join map" banner land on it without a combat
+  // restart. Skipped for freshly created blank maps — those open in setup for
+  // the DM to build, and pushing one live would strand players on an empty
+  // canvas. See useDmBattleMapSync / EncounterView.pushLinkedMapLive.
+  function applyAndGo(mapId: string, pushLive = true) {
     const plan = planMapLinkSwitch(current?.id ?? null, mapId);
     if (plan.unlinkFrom)
       unlinkEncounter(campaignCode, plan.unlinkFrom, encounterId);
     if (plan.linkTo) linkEncounter(campaignCode, plan.linkTo, encounterId);
+    if (pushLive) {
+      const name = battleMaps.find(m => m.id === mapId)?.name;
+      void pushActive(mapId, name);
+    }
     onOpenChange(false);
     router.push(`/dm/campaign/${campaignCode}/battlemaps/${mapId}`);
   }
@@ -82,7 +95,7 @@ export function BattleMapPickerDialog({
       // Ignore localStorage errors
     }
     setNewName('');
-    applyAndGo(id);
+    applyAndGo(id, false);
   }
 
   return (

--- a/src/components/ui/campaign/battle-map/__tests__/BattleMapPickerDialog.test.tsx
+++ b/src/components/ui/campaign/battle-map/__tests__/BattleMapPickerDialog.test.tsx
@@ -11,6 +11,11 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock }),
 }));
 
+const pushActiveMock = vi.fn();
+vi.mock('@/hooks/useDmBattleMapSync', () => ({
+  useDmBattleMapSync: () => ({ pushActive: pushActiveMock }),
+}));
+
 function map(id: string, linked: string[] = []): BattleMap {
   return {
     id,
@@ -48,6 +53,7 @@ describe('BattleMapPickerDialog', () => {
   beforeEach(() => {
     localStorage.clear();
     pushMock.mockClear();
+    pushActiveMock.mockClear();
     // Reset the persisted store between tests: remove every seeded map.
     const state = useBattleMapStore.getState();
     for (const m of state.getBattleMaps('ABC123')) {
@@ -75,6 +81,22 @@ describe('BattleMapPickerDialog', () => {
       'e1'
     );
     expect(pushMock).toHaveBeenCalledWith('/dm/campaign/ABC123/battlemaps/m2');
+  });
+
+  it('pushes the switched map live so players follow without a combat restart', () => {
+    seed([map('m1', ['e1']), map('m2')]);
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /switch & open/i }));
+    expect(pushActiveMock).toHaveBeenCalledWith('m2', 'Map m2');
+  });
+
+  it('does not push a freshly created blank map live (would strand players on an empty canvas)', () => {
+    renderDialog();
+    fireEvent.change(screen.getByLabelText('New battle map name'), {
+      target: { value: 'Cave of Chaos' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create & open/i }));
+    expect(pushActiveMock).not.toHaveBeenCalled();
   });
 
   it('unlinks the current map without navigating', () => {

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -164,7 +164,12 @@ export function useDmBattleMapCanvas({
       // re-applying remote elements as full updates (including layerId).
       attachUnknownLayerMirror(vp, 'dm', () => vp.requestRender());
       pinUnsubRef.current?.();
-      pinUnsubRef.current = subscribePinCanonicalLayers(vp);
+      // Play canvas never arranges maps — the annotations layer (DM tokens,
+      // notes, text) must stay unlocked, repairing any state persisted locked
+      // by the setup editor's arrange-maps mode.
+      pinUnsubRef.current = subscribePinCanonicalLayers(vp, () => ({
+        annotationsLocked: false,
+      }));
 
       const selectTool = vp.toolManager.getTool<SelectTool>('select');
       selectTool?.onSelectionChange(() => {

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -365,6 +365,9 @@ export function useDmLocationEditor(
       pinUnsubRef.current?.();
       pinUnsubRef.current = subscribePinCanonicalLayers(vp, () => ({
         mapUnlocked: arrangeActiveRef.current,
+        // Annotations is locked only while arranging maps; pinned unlocked
+        // otherwise so the DM is never trapped on a locked annotations layer.
+        annotationsLocked: arrangeActiveRef.current,
       }));
 
       // Live sync — battlemap mode only; resolver reads Zustand LIVE via

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -286,7 +286,10 @@ export function PlayerBattleMapCanvas({
     // player's own layer ends up active.
     ensureCanonicalLayers(vp, 'player');
     ensurePlayerLayer(vp, characterId);
-    subscribePinCanonicalLayers(vp);
+    // Players never edit the DM annotations layer — keep it pinned locked so
+    // their hit-testing and marquee skip DM content (the relay rejects their
+    // writes to it anyway).
+    subscribePinCanonicalLayers(vp, () => ({ annotationsLocked: true }));
 
     // Layers aren't synced: remote elements can reference layer ids that
     // don't exist here (old clients, other players). Mirror each unknown

--- a/src/components/ui/campaign/location-map/__tests__/layerContract.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/layerContract.test.ts
@@ -131,6 +131,64 @@ describe('pinCanonicalLayers', () => {
   });
 });
 
+describe('annotations lock invariant (dm can never be trapped on a locked annotations layer)', () => {
+  it('ensureCanonicalLayers unlocks an already-locked annotations layer for dm (self-heal of corrupt persisted state)', () => {
+    // Simulates loading a canvasState persisted mid-arrange, where the
+    // annotations layer was saved locked=true. A DM must never inherit that.
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'dm');
+    vp.layerManager.updateLayerDirect(ANNOTATIONS_LAYER_ID, { locked: true });
+    ensureCanonicalLayers(vp, 'dm');
+    expect(layer(vp, ANNOTATIONS_LAYER_ID).locked).toBe(false);
+  });
+
+  it('ensureCanonicalLayers keeps annotations locked for player', () => {
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'player');
+    vp.layerManager.updateLayerDirect(ANNOTATIONS_LAYER_ID, { locked: false });
+    ensureCanonicalLayers(vp, 'player');
+    expect(layer(vp, ANNOTATIONS_LAYER_ID).locked).toBe(true);
+  });
+
+  it('migrateCanvasToContract reports change and unlocks annotations for dm when persisted locked (so the heal persists)', () => {
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'dm');
+    migrateCanvasToContract(vp, 'dm');
+    vp.layerManager.updateLayerDirect(ANNOTATIONS_LAYER_ID, { locked: true });
+    const changed = migrateCanvasToContract(vp, 'dm');
+    expect(changed).toBe(true);
+    expect(layer(vp, ANNOTATIONS_LAYER_ID).locked).toBe(false);
+  });
+
+  it('pinCanonicalLayers pins the annotations lock when annotationsLocked is given', () => {
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'dm');
+    vp.layerManager.updateLayerDirect(ANNOTATIONS_LAYER_ID, { locked: true });
+    pinCanonicalLayers(vp, { annotationsLocked: false });
+    expect(layer(vp, ANNOTATIONS_LAYER_ID).locked).toBe(false);
+    pinCanonicalLayers(vp, { annotationsLocked: true });
+    expect(layer(vp, ANNOTATIONS_LAYER_ID).locked).toBe(true);
+  });
+
+  it('pinCanonicalLayers leaves the annotations lock untouched when annotationsLocked is omitted', () => {
+    const vp = makeVp();
+    ensureCanonicalLayers(vp, 'dm');
+    vp.layerManager.updateLayerDirect(ANNOTATIONS_LAYER_ID, { locked: true });
+    pinCanonicalLayers(vp);
+    expect(layer(vp, ANNOTATIONS_LAYER_ID).locked).toBe(true);
+  });
+
+  it('subscribePinCanonicalLayers enforces annotationsLocked from getOpts on change', () => {
+    const vp = makeCleanVp();
+    const unsubscribe = subscribePinCanonicalLayers(vp, () => ({
+      annotationsLocked: false,
+    }));
+    vp.layerManager.updateLayerDirect(ANNOTATIONS_LAYER_ID, { locked: true });
+    expect(layer(vp, ANNOTATIONS_LAYER_ID).locked).toBe(false);
+    unsubscribe();
+  });
+});
+
 describe('subscribePinCanonicalLayers', () => {
   it('pins on layer changes without infinite recursion', () => {
     const vp = makeCleanVp();

--- a/src/components/ui/campaign/location-map/layerContract.ts
+++ b/src/components/ui/campaign/location-map/layerContract.ts
@@ -66,20 +66,24 @@ export function ensureCanonicalLayers(
       opacity: 1,
     });
   }
-  pinCanonicalLayers(vp);
+  pinCanonicalLayers(vp, { annotationsLocked: role === 'player' });
   if (lm.activeLayerId === MAP_LAYER_ID || !lm.getLayer(lm.activeLayerId)) {
     lm.setActiveLayer(ANNOTATIONS_LAYER_ID);
   }
 }
 
 /**
- * Re-assert band invariants. Lock state of annotations/custom/player layers
- * is NOT pinned (role- and user-controlled); only the map lock is, because
- * only arrange-maps mode may relax it (opts.mapUnlocked).
+ * Re-assert band invariants. The map lock is always pinned (only arrange-maps
+ * mode relaxes it via opts.mapUnlocked). The annotations lock is pinned only
+ * when opts.annotationsLocked is supplied — DMs pin it OPEN (a DM must never
+ * be trapped on a locked annotations layer, e.g. one persisted mid-arrange),
+ * players pin it CLOSED, and setup arrange-maps pins it closed for the
+ * duration. Omitted → left user-controlled. Custom/player lock state is never
+ * pinned.
  */
 export function pinCanonicalLayers(
   vp: ViewportLike,
-  opts?: { mapUnlocked?: boolean }
+  opts?: { mapUnlocked?: boolean; annotationsLocked?: boolean }
 ): void {
   const lm = vp.layerManager;
   const map = lm.getLayer(MAP_LAYER_ID);
@@ -92,11 +96,25 @@ export function pinCanonicalLayers(
       });
     }
   }
+  // The annotations lock is pinned only when a lock intent is supplied
+  // (dm → unlocked, player → locked, setup arrange-maps → locked for the
+  // duration). Omitting annotationsLocked leaves it user-controlled — the
+  // caller has no stake in the lock, only the band order.
   const annotations = lm.getLayer(ANNOTATIONS_LAYER_ID);
-  if (annotations && annotations.order !== ANNOTATIONS_LAYER_ORDER) {
-    lm.updateLayerDirect(ANNOTATIONS_LAYER_ID, {
-      order: ANNOTATIONS_LAYER_ORDER,
-    });
+  if (annotations) {
+    const patch: { order?: number; locked?: boolean } = {};
+    if (annotations.order !== ANNOTATIONS_LAYER_ORDER) {
+      patch.order = ANNOTATIONS_LAYER_ORDER;
+    }
+    if (
+      opts?.annotationsLocked !== undefined &&
+      annotations.locked !== opts.annotationsLocked
+    ) {
+      patch.locked = opts.annotationsLocked;
+    }
+    if (patch.order !== undefined || patch.locked !== undefined) {
+      lm.updateLayerDirect(ANNOTATIONS_LAYER_ID, patch);
+    }
   }
   // getLayers() is order-sorted (stable), so renumbering by enumeration
   // index preserves each band's relative order.
@@ -124,7 +142,7 @@ export function pinCanonicalLayers(
  */
 export function subscribePinCanonicalLayers(
   vp: ViewportLike,
-  getOpts?: () => { mapUnlocked?: boolean }
+  getOpts?: () => { mapUnlocked?: boolean; annotationsLocked?: boolean }
 ): () => void {
   let pinning = false;
   return vp.layerManager.on('change', () => {
@@ -204,8 +222,15 @@ export function migrateCanvasToContract(
   role: CanvasRole
 ): boolean {
   const lm = vp.layerManager;
+  // Capture the annotations lock before ensureCanonicalLayers heals it, so a
+  // canvasState persisted with a locked annotations layer (the mid-arrange
+  // save that trapped every DM token/note) is reported as changed and the
+  // caller re-persists the repaired state.
+  const annotationsLockedBefore = lm.getLayer(ANNOTATIONS_LAYER_ID)?.locked;
   ensureCanonicalLayers(vp, role);
-  let changed = false;
+  let changed =
+    annotationsLockedBefore !== undefined &&
+    annotationsLockedBefore !== lm.getLayer(ANNOTATIONS_LAYER_ID)?.locked;
 
   for (const legacy of lm.getLayers()) {
     if (legacy.id === MAP_LAYER_ID || legacy.id === ANNOTATIONS_LAYER_ID) {

--- a/src/lib/__tests__/activeBattleMap.test.ts
+++ b/src/lib/__tests__/activeBattleMap.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { shouldClearActiveBattleMap } from '@/lib/activeBattleMap';
+import type { SharedBattleMapState } from '@/types/sharedState';
+
+describe('shouldClearActiveBattleMap', () => {
+  it('is true when the shared active id matches the deleted map (object form)', () => {
+    const shared: SharedBattleMapState = {
+      activeBattleMapId: 'map-1',
+      updatedAt: 'now',
+    };
+    expect(shouldClearActiveBattleMap(shared, 'map-1')).toBe(true);
+  });
+
+  it('is true when the shared value is the raw JSON string form', () => {
+    const raw = JSON.stringify({
+      activeBattleMapId: 'map-1',
+      updatedAt: 'now',
+    });
+    expect(shouldClearActiveBattleMap(raw, 'map-1')).toBe(true);
+  });
+
+  it('is false when the active id points at a different map', () => {
+    const shared: SharedBattleMapState = {
+      activeBattleMapId: 'map-2',
+      updatedAt: 'now',
+    };
+    expect(shouldClearActiveBattleMap(shared, 'map-1')).toBe(false);
+  });
+
+  it('is false when nothing is shared (null/undefined) or no active id', () => {
+    expect(shouldClearActiveBattleMap(null, 'map-1')).toBe(false);
+    expect(shouldClearActiveBattleMap(undefined, 'map-1')).toBe(false);
+    expect(
+      shouldClearActiveBattleMap(
+        { activeBattleMapId: null, updatedAt: 'now' },
+        'map-1'
+      )
+    ).toBe(false);
+  });
+
+  it('is false on unparseable raw JSON (never throws)', () => {
+    expect(shouldClearActiveBattleMap('{ not json', 'map-1')).toBe(false);
+  });
+});

--- a/src/lib/activeBattleMap.ts
+++ b/src/lib/activeBattleMap.ts
@@ -1,0 +1,27 @@
+import type { SharedBattleMapState } from '@/types/sharedState';
+
+/**
+ * The shared battle-map pointer (`campaign:<code>:battlemap`) is sticky: it is
+ * only ever overwritten by a positive push (manual share toggle or start-combat
+ * with a linked map), never cleared. So deleting the map it references would
+ * strand players on a dead id. Decide whether a delete of `deletedMapId` should
+ * clear that pointer. Redis may hand back the value as an object or a raw JSON
+ * string; unparseable input is treated as "nothing to clear" (never throws).
+ */
+export function shouldClearActiveBattleMap(
+  raw: string | SharedBattleMapState | null | undefined,
+  deletedMapId: string
+): boolean {
+  if (!raw) return false;
+  let parsed: SharedBattleMapState | null;
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw) as SharedBattleMapState;
+    } catch {
+      return false;
+    }
+  } else {
+    parsed = raw;
+  }
+  return parsed?.activeBattleMapId === deletedMapId;
+}


### PR DESCRIPTION
Battle-map bugs surfacing when a DM arranges multiple background maps and switches maps between fights.

## Bug 1 — tokens/notes/text uninteractable in live mode
Arrange-maps mode locks the annotations layer so only maps are draggable. An autosave firing **mid-arrange** persisted that `locked:true` state, and nothing ever unlocked it — so in live (play) mode every DM token, note, and text element (all on the annotations layer) became unselectable. Creation still worked, which is why the layer looked fine but was dead to interaction.

**Fix:** make the annotations lock a pinned invariant.
- `pinCanonicalLayers` gains an `annotationsLocked` opt and pins the lock like it already pins the map lock.
- `ensureCanonicalLayers` forces the lock to match role on load (`dm` open, `player` locked) — **self-heals canvases already persisted locked**.
- `migrateCanvasToContract` reports the heal as `changed` so the play canvas re-persists the repaired state.
- Subscriptions declare intent: DM play → unlocked, player → locked, setup editor → locked only while arranging.

Existing broken maps heal themselves the next time the DM opens them in play mode.

## Bug 2 — player opens the old / removed map
The shared "live map" pointer (`campaign:<code>:battlemap`, Upstash) is sticky: only overwritten by a positive push (manual share or start-combat with a linked map), never cleared. So deleting or switching maps left players pointed at the old one.

Note on architecture: the player's map **data** comes from the relay's own Redis (keyed by room, over WebSocket). The Upstash `campaignBattleMapKey` / `GET /battlemaps/[id]` route is not written by the app — an early attempt to guard the player page on that GET produced a false "no longer available" over live maps and was reverted (see commit history).

**Fix:**
- New pure helper `shouldClearActiveBattleMap` (+tests). The battle-map `DELETE` handler clears the pointer when it references the deleted map, so the player banner href goes null instead of pointing at a dead room.
- The picker's map switch now **pushes the live pointer to the newly linked map** (`pushActive`), so players follow a mid-session map switch without a combat restart. Freshly created blank maps are skipped (they open in setup; pushing one live would strand players on an empty canvas). Relink now overrides a manual share — intended: the DM's current map for the encounter wins.

## Tests
- +6 regression tests in `layerContract.test.ts` (annotations-lock invariant + self-heal).
- +5 tests for `shouldClearActiveBattleMap`.
- +2 tests in `BattleMapPickerDialog.test.tsx` (push on switch, skip on blank create).
- Full suite green, type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)