### PR TITLE
chore(data): update 5etools data to v2.33.1, add Ravenloft: Horrors Within

### DIFF
--- a/json/backgrounds.json
+++ b/json/backgrounds.json
@@ -6,6 +6,114 @@
 	},
 	"background": [
 		{
+			"name": "Aberrant Heir",
+			"source": "EFA",
+			"page": 25,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"con",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"con",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"aberrant dragonmark|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"history": true,
+					"intimidation": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"disguise kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"dagger|xphb",
+						"disguise kit|xphb",
+						"costume|xphb",
+						"traveler's clothes|xphb",
+						{
+							"value": 1600
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Strength, Constitution, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Aberrant Dragonmark|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill History|XPHB} and {@skill Intimidation|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Disguise Kit|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Dagger|XPHB}, {@item Disguise Kit|XPHB}, {@item Costume|XPHB}, {@item Traveler's Clothes|XPHB}, 16 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
 			"name": "Acolyte",
 			"source": "PHB",
 			"page": 127,
@@ -443,7 +551,7 @@
 					"name": "Cultural Chameleon",
 					"type": "entries",
 					"entries": [
-						"Before becoming an adventurer, you spent much of your adult life away from your homeland, living among people different from your kin. You came to understand these foreign cultures and the ways of their people, who eventually treated you as one of their own. One culture had more of an influence on you than any other, shaping your beliefs and customs Choose a race whose culture you've adopted, or roll on the Adopted Culture table.",
+						"Before becoming an adventurer, you spent much of your adult life away from your homeland, living among people different from your kin. You came to understand these foreign cultures and the ways of their people, who eventually treated you as one of their own. One culture had more of an influence on you than any other, shaping your beliefs and customs. Choose a race whose culture you've adopted, or roll on the Adopted Culture table.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -661,8 +769,122 @@
 		},
 		{
 			"name": "Archaeologist",
+			"source": "EFA",
+			"page": 26,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"int",
+								"wis"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"int",
+								"wis"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"skilled|xphb": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"history": true,
+					"survival": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"cartographer's tools": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"cartographer's tools|xphb",
+						"bullseye lantern|xphb",
+						"map|xphb",
+						"map or scroll case|xphb",
+						"shovel|xphb",
+						"tent|xphb",
+						"traveler's clothes|xphb",
+						{
+							"value": 1700
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Dexterity, Intelligence, Wisdom"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Skilled|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill History|XPHB} and {@skill Survival|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Cartographer's Tools|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Cartographer's Tools|XPHB}, {@item Bullseye Lantern|XPHB}, {@item Map|XPHB}, {@item Map or Scroll Case|XPHB}, {@item Shovel|XPHB}, {@item Tent|XPHB}, {@item Traveler's Clothes|XPHB}, 17 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Archaeologist",
 			"source": "ToA",
 			"page": 192,
+			"reprintedAs": [
+				"Archaeologist|EFA"
+			],
 			"skillProficiencies": [
 				{
 					"history": true,
@@ -942,7 +1164,7 @@
 								],
 								[
 									"3",
-									"When I'm not exploring dungeons or ruins. I get jittery and impatient."
+									"When I'm not exploring dungeons or ruins, I get jittery and impatient."
 								],
 								[
 									"4",
@@ -1021,7 +1243,7 @@
 				{
 					"A": [
 						{
-							"item": "artisan's tools|xphb"
+							"equipmentType": "toolArtisan"
 						},
 						{
 							"item": "pouch|xphb",
@@ -1076,301 +1298,6 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true
-		},
-		{
-			"name": "Ashari",
-			"source": "TDCSR",
-			"page": 180,
-			"skillProficiencies": [
-				{
-					"nature": true,
-					"choose": {
-						"from": [
-							"arcana",
-							"survival"
-						],
-						"count": 1
-					}
-				}
-			],
-			"languageProficiencies": [
-				{
-					"primordial": true,
-					"choose": {
-						"from": [
-							"aquan",
-							"auran",
-							"ignan",
-							"terran"
-						],
-						"count": 1
-					}
-				}
-			],
-			"toolProficiencies": [
-				{
-					"herbalism kit": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						{
-							"item": "Traveler's Clothes|phb",
-							"displayName": "A set of traveler's clothes"
-						},
-						{
-							"special": "a staff carved with symbols of your tribe"
-						},
-						"herbalism kit|phb",
-						{
-							"item": "pouch|phb",
-							"containsValue": 1000
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Nature}, plus your choice of {@skill Arcana} or {@skill Survival}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "{@item Herbalism Kit|PHB}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "{@language Primordial} ({@language Primordial|PHB|Aquan}, {@language Primordial|PHB|Auran}, {@language Primordial|PHB|Ignan}, or {@language Primordial|PHB|Terran}, depending on the elemental affinity of your tribe)"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A set of {@item traveler's clothes|phb}, a staff carved with symbols of your tribe, an {@item herbalism kit|PHB}, and a belt {@item pouch|phb} containing 10 gp"
-						}
-					]
-				},
-				{
-					"name": "Feature: Elemental Harmony",
-					"type": "entries",
-					"page": 180,
-					"entries": [
-						"Growing up surrounded by wild elemental magics has attuned your senses to those chaotic forces, enabling you to subtly bend them to your will. As an action, you channel minor magic involving the element of your chosen Ashari order, giving you one of the following abilities:",
-						{
-							"type": "entries",
-							"name": "Pyrah",
-							"page": 180,
-							"entries": [
-								"You instantaneously create and control a burst of flame small enough to light a candle, a torch, or a small campfire. Alternatively, you snuff out a flame of the same size."
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Terrah",
-							"page": 180,
-							"entries": [
-								"You instantaneously create a small rock no larger than a {@item gold (gp)|PHB|gold coin}. The rock appears in your hand, then turns to dust after 1 minute."
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Vesrah",
-							"page": 180,
-							"entries": [
-								"You instantaneously create enough hot or cold water to fill a small drinking vessel."
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Zephrah",
-							"page": 180,
-							"entries": [
-								"You create an instantaneous puff of wind strong enough to blow papers off a desk or mess up someone's hair."
-							]
-						}
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"name": "Suggested Characteristics",
-					"page": 180,
-					"entries": [
-						"{@book The Ashari|TDCSR|2|The Ashari} hold themselves removed from the rest of Tal'Dorei by their own choice. This makes many Ashari naive to the ways of the world beyond their homes\u2014but it can also make them determined, steadfast, and tightly focused on their goals. Ever since {@creature Keyleth, Voice of the Tempest|TDCSR} and leader of the {@book Zephrah|TDCSR|3|Zephrah}, became a world-renowned hero, the Air Ashari at least have become more familiar to Tal'Dorei's other peoples. They are known to welcome outsiders to their mountaintop enclave, and to take on quests that force them to leave their isolated home.",
-						"To learn more about your character's Ashari order, see \"{@book The Ashari|TDCSR|2|The Ashari}\".",
-						{
-							"type": "table",
-							"caption": "Ashari Personality Traits",
-							"colLabels": [
-								"{@dice d8}",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I like to keep my hands busy, no matter where I am."
-								],
-								[
-									"2",
-									"I love to explore new places and meet new people."
-								],
-								[
-									"3",
-									"I meditate at dawn each day\u2014and I can't stand it when my routine is interrupted."
-								],
-								[
-									"4",
-									"I like noticing patterns in the world around me, whether or not they mean anything."
-								],
-								[
-									"5",
-									"I don't let anything\u2014or anyone\u2014stand in the way of my mission."
-								],
-								[
-									"6",
-									"I'm a plain talker, even with people who outrank me."
-								],
-								[
-									"7",
-									"I've always got some of my native element with me in some form. (This might be modeling clay, pure water, special burning incense, or a bottled cloud.)"
-								],
-								[
-									"8",
-									"I talk with everyone like I've known them all my life. Because most people I know, I have known all my life!"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Ashari Ideals",
-							"colLabels": [
-								"{@dice d6}",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"{@b Destiny}. I believe that everyone has a role to play. Now I just have to find mine. (Neutral)"
-								],
-								[
-									"2",
-									"{@b Community}. It's important to surround yourself with people you can count on, and who will support you. (Good)"
-								],
-								[
-									"3",
-									"{@b Knowledge}. I want to learn everything I can about the Elemental Planes\u2014and maybe even visit them myself. (Neutral)"
-								],
-								[
-									"4",
-									"{@b Freedom}. I don't care what anyone says. Even if it causes problems, the elements must be free. And so should I. (Chaotic)"
-								],
-								[
-									"5",
-									"{@b Structure}. The elements are in harmony when they are free to act as they will, within the safe boundaries set by {@book the Ashari|TDCSR|2|The Ashari}. People are much the same. (Lawful)"
-								],
-								[
-									"6",
-									"{@b Virtuous Cycle}. If I see someone who needs help, I feel compelled to assist them. Surely they'll return the favor someday! (Good)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Ashari Bonds",
-							"colLabels": [
-								"{@dice d6}",
-								"Bond"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I have a cousin in another Ashari tribe whom I've never met, but someday I want to visit my extended family."
-								],
-								[
-									"2",
-									"The leader of my tribe thinks I could be their successor, but I worry that I don't have enough experience to lead my people."
-								],
-								[
-									"3",
-									"A mysterious person killed a member of my family. I've left home to discover who the killer was\u2014and to seek vengeance."
-								],
-								[
-									"4",
-									"My older sibling set out on their Aramente a year ago, and I haven't seen them since."
-								],
-								[
-									"5",
-									"When I was a baby, a {@creature giant eagle} brought me to {@book Zephrah|TDCSR|3|Zephrah}. I love my family, but I often wonder who my birth parents are."
-								],
-								[
-									"6",
-									"I trust my animal friends more than any humanoid ally."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Ashari Flaws",
-							"colLabels": [
-								"{@dice d6}",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"Big cities are overwhelming. I get nervous when surrounded by people I don't know."
-								],
-								[
-									"2",
-									"I know all too well that elemental power is dangerous\u2014but I like playing around with it anyway."
-								],
-								[
-									"3",
-									"I get surly if I go too long without being in contact with my native element."
-								],
-								[
-									"4",
-									"I think the mission of my people is a fool's errand. They should abandon isolation, let the elements be, and enjoy the pleasures of the world!"
-								],
-								[
-									"5",
-									"I can't stand it when people say one thing and mean another! Just say what you mean!"
-								],
-								[
-									"6",
-									"Ugh, I know it's not right, but I can't help but look down on people who can't manipulate the elements. It's not like it's hard!"
-								]
-							]
-						}
-					]
-				}
-			],
-			"hasFluff": true
 		},
 		{
 			"name": "Astral Drifter",
@@ -2260,7 +2187,7 @@
 					"name": "How Do I Fit In?",
 					"entries": [
 						"As a member of the Azorius Senate, you are probably engaged in the work of law enforcement (even if your background involved the legislative or judicial aspects of the senate's activities). Legislative aides and judges' clerks find little reason to venture beyond the Azorius guildhalls, but soldiers and lawmages patrol the streets daily.",
-						"An Azorius soldier or lawmage is a force for order, charged with fighting crime on the streets\u2014and in the halls of power. You might spend your time foiling thefts, putting a stop to Orzhov extortion, rooting out Dimir spies, or hunting down Golgari assassins. Perhaps you take your orders from a precognitive mage (or you are one yourself) who receives unpredictable and cryptic visions of future crimes that you and your allies must try to prevent."
+						"An Azorius soldier or lawmage is a force for order, charged with fighting crime on the streets—and in the halls of power. You might spend your time foiling thefts, putting a stop to Orzhov extortion, rooting out Dimir spies, or hunting down Golgari assassins. Perhaps you take your orders from a precognitive mage (or you are one yourself) who receives unpredictable and cryptic visions of future crimes that you and your allies must try to prevent."
 					]
 				}
 			],
@@ -2287,7 +2214,7 @@
 							"name": "Baldur's Gate Feature: Religious Community",
 							"type": "entries",
 							"entries": [
-								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
 								"You're tightly connected with the religious community of Baldur's Gate. You know if a deity has a following in the city and any places that faith openly congregates and the neighborhoods those faithful typically inhabit. While this isn't remarkable for most of the city's larger faiths, keeping track of the hundreds of religions newcomers bring with them is no mean feat."
 							],
 							"data": {
@@ -2320,7 +2247,7 @@
 							"name": "Baldur's Gate Feature: Long-Lost Heir",
 							"type": "entries",
 							"entries": [
-								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
 								"You're well-versed in the mannerisms and idiosyncrasies of Baldurian patriars and other nobles, imitating them smoothly enough to convince even the snootiest family heads of your authenticity. You're skilled at posing as the long-lost heir to some imaginary or extinguished patriar lineage.",
 								"Because of your skill in passing yourself off as a patriar, you have a Watch token that allows you alone into the Upper City of Baldur's Gate. You might be able to bluff others through with you, or even convince members of the Watch that you're a patriar. However, any true test of your authenticity is likely to reveal your deception."
 							],
@@ -2355,8 +2282,8 @@
 								"name": "Baldur's Gate Feature: Criminal Connections",
 								"type": "entries",
 								"entries": [
-									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
-									"In Baldur's Gate, crime is just another business. As a result, you can arrange a meeting with a low-ranking operative of nearly any business, patriar family, crew, government institution, or\u2014certainly\u2014the Guild. This operative will hear you out and, at their discretion, take your information or request up their chain of command. These meetings almost always occur in shady venues."
+									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+									"In Baldur's Gate, crime is just another business. As a result, you can arrange a meeting with a low-ranking operative of nearly any business, patriar family, crew, government institution, or—certainly—the Guild. This operative will hear you out and, at their discretion, take your information or request up their chain of command. These meetings almost always occur in shady venues."
 								],
 								"data": {
 									"isFeature": true
@@ -2389,7 +2316,7 @@
 											],
 											[
 												"3",
-												"It's always been about money. You're not paid what you're worth, working for someone who has more than they deserve. But the Guild offered you a way to fix that. You keep doing what you've always done\u2014guard work, dock labor, business accounting\u2014but what you learn you pass on to the Guild."
+												"It's always been about money. You're not paid what you're worth, working for someone who has more than they deserve. But the Guild offered you a way to fix that. You keep doing what you've always done—guard work, dock labor, business accounting—but what you learn you pass on to the Guild."
 											],
 											[
 												"4",
@@ -2443,8 +2370,8 @@
 							"name": "Baldur's Gate Feature: Backstage Pass",
 							"type": "entries",
 							"entries": [
-								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
-								"You've learned that most of the real business of entertainment (or any other venture) happens behind the scenes. It's easy for you to case what sorts of audiences attend what venue\u2014like how toughs gather at the Blushing Mermaid or how brash patriars congregate at the Helm and Cloak. After a successful performance, you may meet an enthusiastic member of the crowd\u2014someone of an occupation or social class that frequents the establishment. This contact is delighted to talk with you, and to listen."
+								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+								"You've learned that most of the real business of entertainment (or any other venture) happens behind the scenes. It's easy for you to case what sorts of audiences attend what venue—like how toughs gather at the Blushing Mermaid or how brash patriars congregate at the Helm and Cloak. After a successful performance, you may meet an enthusiastic member of the crowd—someone of an occupation or social class that frequents the establishment. This contact is delighted to talk with you, and to listen."
 							],
 							"data": {
 								"isFeature": true
@@ -2477,7 +2404,7 @@
 								"name": "Baldur's Gate Feature: Social Vengeance",
 								"type": "entries",
 								"entries": [
-									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
 									"You've lived your entire life in the Lower or Outer City of Baldur's Gate. You grew up seeing arrogant patriars flaunt their wealth while your hardworking neighbors struggled. As a result, you know how eager commoners in Baldur's Gate are to see any patriar get what they deserve. While in a busy part of the Lower City or Outer City of Baldur's Gate, you can spend {@dice 2d10} minutes to convince {@dice 1d6} {@creature commoner||commoners} to perform a non-illegal act that inconveniences a member of the Watch or Flaming Fist, a patriar, or some other wealthy looking individual."
 								],
 								"data": {
@@ -2556,7 +2483,7 @@
 							"name": "Baldur's Gate Feature: Professional Courtesy",
 							"type": "entries",
 							"entries": [
-								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
 								"You're familiar with the city's crews, their territories, and inter-crew politics. Choose one of the three districts of Baldur's Gate: the Upper City, the Lower City, or the Outer City. This is the district where you conduct most of your business. Whenever you need information about something in one of that district's neighborhoods, you can seek out crew members in that area and learn the local gossip. You can also gain unimpeded entry to nearly any bank, guild hall, place of business, workhouse, or crew meeting place in your district."
 							],
 							"data": {
@@ -2590,8 +2517,8 @@
 								"name": "Baldur's Gate Feature: The Real City",
 								"type": "entries",
 								"entries": [
-									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
-									"You know the Baldur's Gate most Baldurians ignore, the dog-eat-dog world of the homeless and unfortunate. You know where to go in the Lower City and Outer City for anonymity. In these slums and alley camps, you can get a damp bed and a bad meal, but also a degree of privacy and no questions asked. Living here isn't comfortable, but it's unlikely anyone will find you\u2014and you can stay as long as you want."
+									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+									"You know the Baldur's Gate most Baldurians ignore, the dog-eat-dog world of the homeless and unfortunate. You know where to go in the Lower City and Outer City for anonymity. In these slums and alley camps, you can get a damp bed and a bad meal, but also a degree of privacy and no questions asked. Living here isn't comfortable, but it's unlikely anyone will find you—and you can stay as long as you want."
 								],
 								"data": {
 									"isFeature": true
@@ -2636,7 +2563,7 @@
 											],
 											[
 												"6",
-												"You aren't originally from Baldur's Gate. You came here seeking something else, only to learn that the quest that drove you had become impossible to fulfill\u2014its object was destroyed or its purpose was negated by some superseding event. Suddenly directionless and unable to return to your homeland, you have lingered, adrift, in this wretched city."
+												"You aren't originally from Baldur's Gate. You came here seeking something else, only to learn that the quest that drove you had become impossible to fulfill—its object was destroyed or its purpose was negated by some superseding event. Suddenly directionless and unable to return to your homeland, you have lingered, adrift, in this wretched city."
 											]
 										]
 									}
@@ -2669,8 +2596,8 @@
 							"name": "Baldur's Gate Feature: Patriar",
 							"type": "entries",
 							"entries": [
-								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
-								"As a member of one of the elite families of Baldur's Gate, you may pass through city gates without paying tolls, mingle among the Gate's nobility unquestioned, and impress those on the lookout for wealthy patrons. You are welcome in the Upper City and may stay there after dark without being harassed or evicted. Your word is accepted over others' without question, and any corruption among guards or government officials tends to work in your favor, not against you\u2014at least until you make some effort to expose it."
+								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+								"As a member of one of the elite families of Baldur's Gate, you may pass through city gates without paying tolls, mingle among the Gate's nobility unquestioned, and impress those on the lookout for wealthy patrons. You are welcome in the Upper City and may stay there after dark without being harassed or evicted. Your word is accepted over others' without question, and any corruption among guards or government officials tends to work in your favor, not against you—at least until you make some effort to expose it."
 							],
 							"data": {
 								"isFeature": true
@@ -2703,8 +2630,8 @@
 								"name": "Baldur's Gate Feature: Immigrant Experience",
 								"type": "entries",
 								"entries": [
-									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
-									"Even after your short time in Baldur's Gate, you've learned the city holds more walls and gates than those the Watch and Flaming Fist patrols. You are known within the city's immigrant communities. Should you ever need to learn about a foreign land, people, tradition, or history, you know where to find someone with firsthand experience\u2014likely somewhere in the Outer City."
+									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+									"Even after your short time in Baldur's Gate, you've learned the city holds more walls and gates than those the Watch and Flaming Fist patrols. You are known within the city's immigrant communities. Should you ever need to learn about a foreign land, people, tradition, or history, you know where to find someone with firsthand experience—likely somewhere in the Outer City."
 								],
 								"data": {
 									"isFeature": true
@@ -2749,7 +2676,7 @@
 											],
 											[
 												"6",
-												"A peddler once brought something astonishing to your homeland\u2014a Gondan clockwork, shimmering cloth of gold, a trained speaking bird, or some other small wonder\u2014and told you that it came from Baldur's Gate. You've come to see the source of such wonders, and perhaps learn to create them."
+												"A peddler once brought something astonishing to your homeland—a Gondan clockwork, shimmering cloth of gold, a trained speaking bird, or some other small wonder—and told you that it came from Baldur's Gate. You've come to see the source of such wonders, and perhaps learn to create them."
 											]
 										]
 									}
@@ -2782,8 +2709,8 @@
 							"name": "Baldur's Gate Feature: Rumor Monger",
 							"type": "entries",
 							"entries": [
-								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
-								"Via your personal rumor mill and articles published in Baldur's Mouth, you can surmise a great deal about Baldurians' secrets\u2014who's practicing necromancy, who's involved in spying or smuggling, who would purchase or craft dangerous magical wares without batting an eyelash. Whenever a noteworthy crime or mysterious happening occurs in the city, you immediately have a list of {@dice 1d4} suspects who, if they aren't involved, have a strong chance of knowing who is."
+								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+								"Via your personal rumor mill and articles published in Baldur's Mouth, you can surmise a great deal about Baldurians' secrets—who's practicing necromancy, who's involved in spying or smuggling, who would purchase or craft dangerous magical wares without batting an eyelash. Whenever a noteworthy crime or mysterious happening occurs in the city, you immediately have a list of {@dice 1d4} suspects who, if they aren't involved, have a strong chance of knowing who is."
 							],
 							"data": {
 								"isFeature": true
@@ -2815,8 +2742,8 @@
 							"name": "Baldur's Gate Feature: Smuggler's Sense",
 							"type": "entries",
 							"entries": [
-								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
-								"You're familiar with the docks of Baldur's Gate, the movement of inspectors and tax collectors, the way cargo and coin flows. As a result, it's easy for you to hustle a load of cargo ashore or see such a cargo onto a cooperative ship without attracting suspicion or taxation. You also know the movements of the Gray Wavers\u2014the Flaming Fist harbor guards\u2014and have a sense of how to operate the city's mechanized cranes."
+								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+								"You're familiar with the docks of Baldur's Gate, the movement of inspectors and tax collectors, the way cargo and coin flows. As a result, it's easy for you to hustle a load of cargo ashore or see such a cargo onto a cooperative ship without attracting suspicion or taxation. You also know the movements of the Gray Wavers—the Flaming Fist harbor guards—and have a sense of how to operate the city's mechanized cranes."
 							],
 							"data": {
 								"isFeature": true
@@ -2849,13 +2776,13 @@
 								"name": "Baldur's Gate Feature: City Guard",
 								"type": "entries",
 								"entries": [
-									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
 									"You may choose to currently serve in either the Flaming Fist or the Watch. If you do, you have responsibilities related to your post. For as long as you perform these responsibilities, you gain benefits. If you stop performing your responsibilities, though, you lose access to the benefits and might suffer further fallout. Should you lose these benefits, you may regain them by having an unpleasant conversation with your commanding officer and fulfilling your responsibilities for a month.",
 									{
 										"type": "entries",
 										"name": "Flaming Fist",
 										"entries": [
-											"If you serve in the Flaming Fist, once every ten days, you must report to the Seatower of Balduran for training, and you're required to take a regular shift patrolling either the Lower City or the Outer City. In return, you have access to the Flaming Fist's fortresses and a direct line of communication with Flaming Fist officers and other soldiers. You can also pass through the city's gates without question\u2014although you can't bring guests into the Upper City as a member of the Watch might. Additionally, you're always welcome at the Three Old Kegs, where the Three Old Toads are glad to greet you with a smile and a mug of ale."
+											"If you serve in the Flaming Fist, once every ten days, you must report to the Seatower of Balduran for training, and you're required to take a regular shift patrolling either the Lower City or the Outer City. In return, you have access to the Flaming Fist's fortresses and a direct line of communication with Flaming Fist officers and other soldiers. You can also pass through the city's gates without question—although you can't bring guests into the Upper City as a member of the Watch might. Additionally, you're always welcome at the Three Old Kegs, where the Three Old Toads are glad to greet you with a smile and a mug of ale."
 										]
 									},
 									{
@@ -2874,7 +2801,7 @@
 								"type": "entries",
 								"name": "Baldur's Gate Feature: Loyalty Test",
 								"entries": [
-									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+									"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
 									"You've had enough dealings with crooked soldiers that you can spot the behaviors common to corrupt guards and military officers a mile away. While awareness of such corruption doesn't equate to evidence of it, and your sense certainly isn't foolproof, your instinct proves a useful starting point when determining who might take a bribe, who might turn a blind eye to a crime, or who might have criminal connections. You can also use this sense to get a feeling about who might fulfill their duties strictly by the book."
 								],
 								"data": {
@@ -2908,7 +2835,7 @@
 							"name": "Baldur's Gate Feature: Gateguide Connection",
 							"type": "entries",
 							"entries": [
-								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate\u2014though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
+								"{@note The effects of a Baldur's Gate feature can be used only while the character is in Baldur's Gate—though, at the DM's discretion, they might have applicable effects in situations similar to those in Baldur's Gate.}",
 								"Even though you might not be a member of the Gateguides crew, you've associated with enough of them that you know their torch-based code. From the lighting, placement, and type of torch arranged on or near a structure, you can gather a great deal of information about those who live or do business there, particularly if they deal fairly with strangers, have Guild or government connections, or have either helped or denied the Gateguides in the past."
 							],
 							"data": {
@@ -2918,271 +2845,6 @@
 					}
 				}
 			},
-			"hasFluff": true
-		},
-		{
-			"name": "Black Fist Double Agent",
-			"source": "ALCurseOfStrahd",
-			"page": 2,
-			"skillProficiencies": [
-				{
-					"deception": true,
-					"insight": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"disguise kit": true,
-					"choose": {
-						"from": [
-							"anyArtisansTool",
-							"gaming set"
-						]
-					}
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						"disguise kit|phb",
-						"common clothes|phb",
-						{
-							"item": "emblem|phb",
-							"displayName": "Tears of Virulence emblem"
-						},
-						{
-							"special": "writ of free agency signed by the Lord Regent"
-						},
-						{
-							"item": "pouch|phb",
-							"containsValue": 1500
-						}
-					]
-				},
-				{
-					"a": [
-						{
-							"equipmentType": "toolArtisan"
-						}
-					],
-					"b": [
-						{
-							"equipmentType": "setGaming"
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Deception}, {@skill Insight}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "{@item Disguise kit|phb}, and one type of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} or {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set}"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "{@item Disguise kit|phb}, {@item common clothes|phb}, a Tears of Virulence {@item emblem|phb}, a writ of free agency signed by the Lord Regent, a set of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} or {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set} you are proficient with, and a {@item pouch|phb} with 15 gp (payment for services rendered)."
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Moderate"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"You are an informant for the Tears of Virulence who now lord over Phlan, but are also a double agent for original town guard of Phlan, the Black Fists. For the Tears you've been tasked with ferreting out the secrets of Phlan's criminal underworld, insurgency, and the common peoples of Phlan. In exchange for reporting on the activities of dissenters, criminals, and other rebel elements, the Tears of Virulence leave you alone to conduct your affairs in peace.",
-						"In reality you work for the deposed Black Fists, sharing misinformation with the Tears of Virulence that often helps the Black Fists and other Phlan insurgents.",
-						"Since the evacuation of Phlan, you are even busier today than you ever were previously, as the number of dissenters among the refugees grows daily, while you are afforded many opportunities to spy on the peoples of Mulmaster and Elventree, to the pleasure of your contact(s) within the Tears of Virulence."
-					]
-				},
-				{
-					"name": "Feature: Double Agent",
-					"type": "entries",
-					"entries": [
-						"You have a reliable and trusty contact within the Tears of Virulence garrison in Phlan to whom you pass information and secrets. In exchange, you can get away with minor criminal offenses within the town of Phlan. In addition, your Black Fists contacts can help you secure an audience with the Lord Regent, the Lord Sage, members of the Black Fists, or deposed nobles and authority figures who are sympathetic to the Phlan refugees and insurgents. Note: This feature is a variant of the Noble feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"name": "Suggested Characteristics",
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"People are only as trustworthy as you are valuable to them. Always strive to be the most valuable person around."
-								],
-								[
-									"2",
-									"My eloquence and sophistication are tools I use to avoid arousing suspicion myself."
-								],
-								[
-									"3",
-									"I am a thrill-seeker, excited by covert and dangerous missions."
-								],
-								[
-									"4",
-									"I live by my wits and always check every lock twice, just to be certain."
-								],
-								[
-									"5",
-									"I never admit to my mistakes lest they be used against me."
-								],
-								[
-									"6",
-									"I take every effort to be unnoticeable and blend into the crowd. Passersby rarely give me a second look."
-								],
-								[
-									"7",
-									"I am prepared for any eventuality; including the day my usefulness as a spy comes to an end."
-								],
-								[
-									"8",
-									"I always make certain to know my enemy before acting, lest I bite off more than I can chew."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Suspicious. In my experience, everybody has something to hide, and what they hide can usually hurt me. (Any)"
-								],
-								[
-									"2",
-									"Secretive. I trade in secrets, and am not about to let any of mine slip. (Any)"
-								],
-								[
-									"3",
-									"Hedonist. Life is short. I live my life to the fullest, as I know any day could be my last. (Chaotic)"
-								],
-								[
-									"4",
-									"Selfless. I use my position to help the downtrodden avoid persecution from the authorities. (Good)"
-								],
-								[
-									"5",
-									"Patriotic. I am a loyal supporter of Phlan and its leaders, and see my role as a solemn duty and necessary evil to prevent anarchy. (Lawful)"
-								],
-								[
-									"6",
-									"Manipulative. I use my knowledge to blackmail and manipulate others to my own benefit. (Evil)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I was framed for a crime I did not commit, and seek to bring the true culprit to justice."
-								],
-								[
-									"2",
-									"I am a part of an underground network that smuggles innocent civilians out of the city prior to being raided by the authorities."
-								],
-								[
-									"3",
-									"I miss the glory days of Phlan, before the coming of the dragon."
-								],
-								[
-									"4",
-									"I seek to prove myself worthy of joining the Black Fist as a member of their order."
-								],
-								[
-									"5",
-									"My sister was killed by a Tear of Virulence, and now I feed them false information whenever possible."
-								],
-								[
-									"6",
-									"My family was wrongly imprisoned, and I act as an informant in order to secure their release."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I think too highly of myself, and have an exaggerated sense of self-importance."
-								],
-								[
-									"2",
-									"I have difficulty trusting strangers. I see spies and informants everywhere."
-								],
-								[
-									"3",
-									"Years of getting away with minor crimes has left me believing that I am above the law, and have diplomatic immunity above my station."
-								],
-								[
-									"4",
-									"Years of seeing innocent people suffer have left me despondent and pessimistic for the future."
-								],
-								[
-									"5",
-									"My desire for vengeance often gets me into trouble."
-								],
-								[
-									"6",
-									"I am spendthrift, and share my wealth with the patrons of my favorite tavern."
-								]
-							]
-						}
-					]
-				}
-			],
 			"hasFluff": true
 		},
 		{
@@ -3498,7 +3160,7 @@
 								],
 								[
 									"4",
-									"I trust the chain of command more than anything\u2014more even than my closest friends."
+									"I trust the chain of command more than anything—more even than my closest friends."
 								],
 								[
 									"5",
@@ -3516,7 +3178,7 @@
 					"type": "entries",
 					"name": "Contacts",
 					"entries": [
-						"The ordered structure of the Boros Legion offers abundant opportunities to make friends\u2014and rivals\u2014in higher places. You might have close friends in other guilds that share the Boros emphasis on order and community, or bitter enemies among the guilds that represent chaos and destruction.",
+						"The ordered structure of the Boros Legion offers abundant opportunities to make friends—and rivals—in higher places. You might have close friends in other guilds that share the Boros emphasis on order and community, or bitter enemies among the guilds that represent chaos and destruction.",
 						"Roll twice on the Boros Contacts table (for an ally and a rival) and once on the Non-Boros Contacts table.",
 						{
 							"type": "table",
@@ -3630,259 +3292,7 @@
 							"type": "inset",
 							"name": "Tajic, Blade of the Legion",
 							"entries": [
-								"Tajic is a firefist who carries the exalted title of Blade of the Legion, putting him just below the angels in rank. He maintains close communication with Aurelia, though recent events in the city have set them at odds. Tajic believes that the Boros can trust only the Boros. He is convinced that any effort at peace among the guilds is doomed to failure without the Guildpact. The Boros, he argues, would be better off spending their energy to make themselves stronger so they can uphold the fragile balance that exists now\u2014and protect the innocent when the balance tilts. Aurelia feels that his negative attitude runs the risk of poisoning the hearts of the other Boros and undermining any peace efforts. For the most part, in deference to the angel, Tajic keeps his views to himself."
-							]
-						}
-					]
-				}
-			],
-			"hasFluff": true
-		},
-		{
-			"name": "Caravan Specialist",
-			"source": "ALElementalEvil",
-			"page": 2,
-			"skillProficiencies": [
-				{
-					"animal handling": true,
-					"survival": true
-				}
-			],
-			"languageProficiencies": [
-				{
-					"anyStandard": 1
-				}
-			],
-			"toolProficiencies": [
-				{
-					"vehicles (land)": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						"whip|phb",
-						"two-person tent|phb",
-						{
-							"special": "regional map"
-						},
-						"traveler's clothes|phb",
-						{
-							"item": "pouch|phb",
-							"containsValue": 1000
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Animal Handling}, {@skill Survival}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "{@filter Vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "One of your choice"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A {@item whip|phb}, a {@item two-person tent|phb}, a regional map, a set of {@item traveler's clothes|phb}, and a belt {@item pouch|phb} containing 10 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Poor"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"You are used to life on the road. You pride yourself at having traveled every major trade way in the Moonsea region, including the best backroads and shortcuts. When traveling these roads, you know where the best inns, campsites, and water sources are located, as well as potential locations of danger such as ambush. Having worked the roads as long as you have, you have made many acquaintances and find it easy to pick up information and rumors floating from town to town. You are skilled with beasts of burden and handling and repairing wagons of all kinds."
-					]
-				},
-				{
-					"name": "Feature: Wagonmaster",
-					"type": "entries",
-					"entries": [
-						"You are used to being in charge of the operation and your reputation for reliability has you on a short list when the job is critical. Experience has taught you to rely on your gut. Others recognize this and look to you for direction when a situation gets serious. You are able to identify the most defensible locations for camping. If you are part of a caravan outfit, you are able to attract two additional workers that are loyal to you based on your reputation. You have an excellent memory for maps and geography and can always determine your cardinal directions while traveling. Note: This feature is a variant of the Outlander feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"name": "Suggested Characteristics",
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Any group is only as strong as its weakest link. Everyone has to pull their own weight. "
-								],
-								[
-									"2",
-									"There's always someone out there trying to take what I've got. Always be vigilant."
-								],
-								[
-									"3",
-									"Anything can be learned if you have the right teacher. Most folks just need a chance."
-								],
-								[
-									"4",
-									"Early to bed and early to rise; this much at least is under my control."
-								],
-								[
-									"5",
-									"You can listen to me or don't and wish you had. Everyone ends up on one side of that fence."
-								],
-								[
-									"6",
-									"Eventually my hard work will be rewarded. Maybe that time has finally come."
-								],
-								[
-									"7",
-									"A strong ox or horse is more reliable than most people I've met."
-								],
-								[
-									"8",
-									"I never had time for books, but wish I had. I admire folks who have taken the time to learn."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Service. Using my talents to help others is the best way of helping myself. (Good)"
-								],
-								[
-									"2",
-									"Selfish. What people don't know WILL hurt them, but why is that my problem? (Evil)"
-								],
-								[
-									"3",
-									"Wanderer. I go where the road takes me. Sometimes that's a good thing... (Chaotic)"
-								],
-								[
-									"4",
-									"Fittest. On the open road, the law of nature wins. Victims are the unprepared. (Lawful)"
-								],
-								[
-									"5",
-									"Focused. I simply have a job to do, and I'm going to do it. (Neutral)"
-								],
-								[
-									"6",
-									"Motivated. There's a reason I'm good at what I do, I pay attention to the details. (Any) "
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"My brother has a farm in Elmwood and I've helped him and his neighbors move their goods to Mulmaster and other surrounding towns. Those are good people."
-								],
-								[
-									"2",
-									"A caravan I lead was attacked by bandits and many innocents died. I swear that I will avenge them by killing any bandits I encounter."
-								],
-								[
-									"3",
-									"The Soldiery are mostly good guys who understand the importance of protecting the roads. The City Watch is who you have to look out for. If they are inspecting your goods, get ready to pay a fine."
-								],
-								[
-									"4",
-									"The new commander of Southroad Tower, Capt. Holke, understands the importance of safe roads. He's hired me for several jobs and I'm grateful."
-								],
-								[
-									"5",
-									"There's always a road I haven't traveled before. I'm always looking for new places to explore."
-								],
-								[
-									"6",
-									"Wealth and power mean little without the freedom to go where and when you want."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I have trouble trusting people I've just met."
-								],
-								[
-									"2",
-									"I enjoy the open road. Underground and tight spaces make me very nervous."
-								],
-								[
-									"3",
-									"I expect others to heed my orders and have little respect or sympathy if they don't."
-								],
-								[
-									"4",
-									"I am very prideful and have trouble admitting when I'm wrong."
-								],
-								[
-									"5",
-									"Once I decide on a course of action, I do not waiver."
-								],
-								[
-									"6",
-									"I like to explore, and my curiosity will sometimes get me into trouble."
-								]
+								"Tajic is a firefist who carries the exalted title of Blade of the Legion, putting him just below the angels in rank. He maintains close communication with Aurelia, though recent events in the city have set them at odds. Tajic believes that the Boros can trust only the Boros. He is convinced that any effort at peace among the guilds is doomed to failure without the Guildpact. The Boros, he argues, would be better off spending their energy to make themselves stronger so they can uphold the fragile balance that exists now—and protect the innocent when the balance tilts. Aurelia feels that his negative attitude runs the risk of poisoning the hearts of the other Boros and undermining any peace efforts. For the most part, in deference to the angel, Tajic keeps his views to himself."
 							]
 						}
 					]
@@ -4067,7 +3477,7 @@
 					"name": "Feature: Name Dropping",
 					"type": "entries",
 					"entries": [
-						"You know and have met any number of powerful people across the land\u2014and some of them might even remember you. You might be able to wrangle minor assistance from a major figure in the campaign, at the DM's discretion. Additionally, the common folk treat you with deference, and your heritage and the stories you tell might be good for a free meal or a place to sleep."
+						"You know and have met any number of powerful people across the land—and some of them might even remember you. You might be able to wrangle minor assistance from a major figure in the campaign, at the DM's discretion. Additionally, the common folk treat you with deference, and your heritage and the stories you tell might be good for a free meal or a place to sleep."
 					],
 					"data": {
 						"isFeature": true
@@ -4077,7 +3487,7 @@
 					"name": "Suggested Characteristics",
 					"type": "entries",
 					"entries": [
-						"Scions of celebrity adventurers must deal with fame that's not theirs, wealth they didn't earn, and expectations they can never hope to meet. These hardships can have adverse effects, but those who cope with them can arrive at a decent attitude and a grounded worldview. Those who fail become bitter\u2014or worse.",
+						"Scions of celebrity adventurers must deal with fame that's not theirs, wealth they didn't earn, and expectations they can never hope to meet. These hardships can have adverse effects, but those who cope with them can arrive at a decent attitude and a grounded worldview. Those who fail become bitter—or worse.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -4148,7 +3558,7 @@
 								],
 								[
 									"4",
-									"Training. Hard work, sacrifice, and training lead to success\u2014and eventually to perfection. (Any)"
+									"Training. Hard work, sacrifice, and training lead to success—and eventually to perfection. (Any)"
 								],
 								[
 									"5",
@@ -4433,7 +3843,7 @@
 							"rows": [
 								[
 									"1",
-									"Independence. I am a free spirit\u2014no one tells me what to do. (Chaotic)"
+									"Independence. I am a free spirit—no one tells me what to do. (Chaotic)"
 								],
 								[
 									"2",
@@ -4474,7 +3884,7 @@
 								],
 								[
 									"2",
-									"I owe everything to my mentor\u2014a horrible person who's probably rotting in jail somewhere."
+									"I owe everything to my mentor—a horrible person who's probably rotting in jail somewhere."
 								],
 								[
 									"3",
@@ -4936,268 +4346,6 @@
 			"hasFluff": true
 		},
 		{
-			"name": "Clasp Member",
-			"source": "TDCSR",
-			"page": 181,
-			"skillProficiencies": [
-				{
-					"deception": true,
-					"choose": {
-						"from": [
-							"sleight of hand",
-							"stealth"
-						],
-						"count": 1
-					}
-				}
-			],
-			"languageProficiencies": [
-				{
-					"thieves' cant": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"choose": {
-						"from": [
-							"disguise kit",
-							"forgery kit",
-							"thieves' tools"
-						],
-						"count": 1
-					}
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						{
-							"item": "common clothes|phb",
-							"displayName": "A set of inconspicuous common clothes"
-						},
-						{
-							"equipmentType": "toolArtisan"
-						},
-						{
-							"item": "pouch|phb",
-							"containsValue": 1000
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Deception}, plus your choice of {@skill Sleight of Hand} or {@skill Stealth}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "{@item Disguise Kit|PHB}, {@item forgery kit|PHB}, or {@item thieves' tools|PHB} (one of your choice)"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "{@language Thieves' Cant}"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A set of inconspicuous {@item common clothes|phb}, a set of {@filter tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} with which you're proficient, and a belt {@item pouch|PHB} containing 10 gp"
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Feature: A Favor in Turn",
-					"page": 182,
-					"entries": [
-						"You have gained enough clout in the {@book Clasp|TDCSR|2|The Clasp} that you can call in a favor from your contacts whenever you're close enough to a center of syndicate activity. A request for a favor can be no longer than 20 words, and is passed up the chain to an undisclosed Spireling for approval. This favor can take on any form subject to the approval of the GM, who decides how it is fulfilled. If muscle is requested, an NPC member of the {@book Clasp|TDCSR|2|The Clasp} can temporarily aid your party. If money is needed, a small loan can be provided. If you've been imprisoned, {@book Clasp|TDCSR|2|The Clasp} operatives can look into breaking you out or paying off the jailer.",
-						"At some point, the favor will be called in for repayment, often without warning. Refusing the call will result in your termination\u2014literally. You might be called on to commit a specific burglary, or to pressure an {@book Emonian|TDCSR|3|Emon, the City of Fellowship} dignitary to reveal a secret at an upcoming ball. The {@book Clasp|TDCSR|2|The Clasp} might even demand that you assassinate a specific person, with no questions asked or answered. It's the GM's prerogative to ensure that the syndicate's request is proportionate to the favor they bestowed\u2014or that they compensate you in other ways for a service that goes beyond the scope of repaying the initial favor."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"name": "Suggested Characteristics",
-					"page": 182,
-					"entries": [
-						"The {@book Clasp|TDCSR|2|The Clasp} enjoys a strange status in Tal'Dorei. The syndicate is a feared group of thieves and killers, whose name is often invoked only in whispers. But at the same time, the organization has a reputation for guerilla heroism, in response to its members having saved countless lives when the {@book Chroma Conclave|TDCSR|1|The Chroma Conclave} attacked {@book Emon|TDCSR|3|Emon, the City of Fellowship}. And so like every {@book Clasp|TDCSR|2|The Clasp} member, your own reputation often swings between these two poles.",
-						"Your bond is likely associated with your fellow {@book Clasp|TDCSR|2|The Clasp} members or the individual who introduced you to the syndicate. Your ideal probably involves establishing your importance and indispensability to the {@book Clasp|TDCSR|2|The Clasp}.",
-						{
-							"type": "table",
-							"caption": "Clasp Member Personality Traits",
-							"colLabels": [
-								"{@dice d8}",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"What's life without risk? I'm always willing to take a risk if the reward seems worth it."
-								],
-								[
-									"2",
-									"I only show my emotions around people I really trust."
-								],
-								[
-									"3",
-									"I don't need friends; I need allies. When I do make \"friends,\" I only consider what they can do for me."
-								],
-								[
-									"4",
-									"I look for simple solutions. The world's full of tough problems, but a well-placed knife is a one-size-fits-all answer."
-								],
-								[
-									"5",
-									"Money talks. I don't. We've got an efficient relationship."
-								],
-								[
-									"6",
-									"I used to have one rule\u2014don't get involved in other people's problems. Why are things so complicated now?"
-								],
-								[
-									"7",
-									"Crime is a game, and I play to win. I have no sympathy for players who don't get that."
-								],
-								[
-									"8",
-									"This organization has a lot of folks who cling to ugly, brutal practices. I'm not like that. I'm a professional, and professionals have standards."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Clasp Member Ideals",
-							"colLabels": [
-								"{@dice d6}",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"{@b By Any Means}. I complete jobs. Collateral damage isn't my problem. (Chaotic)"
-								],
-								[
-									"2",
-									"{@b Ambition}. I will climb to the top of the ladder. Everything I do is a stepping-stone to a Spireling's position. (Neutral)"
-								],
-								[
-									"3",
-									"{@b Decisiveness}. It's important to make up your mind so you can act swiftly and without delay. (Neutral)"
-								],
-								[
-									"4",
-									"{@b Honor}. There's room in the {@book Clasp|TDCSR|2|The Clasp} for both good and evil. Every day, I awake and choose to do what's right. (Good)"
-								],
-								[
-									"5",
-									"{@b Family}. The {@book Clasp|TDCSR|2|The Clasp} is family. Anything that's good for the family is good for me. (Lawful)"
-								],
-								[
-									"6",
-									"{@b Self-Interest}. There are too many bleeding hearts in the {@book Clasp|TDCSR|2|The Clasp} these days. Doing the right thing means doing the thing that makes my life better. (Evil)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Clasp Member Bonds",
-							"colLabels": [
-								"{@dice d6}",
-								"Bond"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I'd do anything\u2014anything\u2014to protect my comrades."
-								],
-								[
-									"2",
-									"I'll always be grateful to the Spireling who took me in when I was an orphaned kid."
-								],
-								[
-									"3",
-									"I was inspired to join the {@book Clasp|TDCSR|2|The Clasp} by the stories my parents told of being saved from the {@book Chroma Conclave's|TDCSR|1|The Chroma Conclave} attack on {@book Emon|TDCSR|3|Emon, the City of Fellowship}. I can look past the organization's flaws."
-								],
-								[
-									"4",
-									"I was nearly killed by the {@book Myriad|TDCSR|2|The Myriad}. If the {@book Clasp|TDCSR|2|The Clasp} is the enemy of those villains, then the {@book Clasp|TDCSR|2|The Clasp} is my friend."
-								],
-								[
-									"5",
-									"I've got family back in the old town who are counting on me for money. They don't know how I get it, but they don't need to know."
-								],
-								[
-									"6",
-									"I joined the {@book Clasp|TDCSR|2|The Clasp} to become rich, powerful, and beloved. That's all there is to it."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Clasp Member Flaws",
-							"colLabels": [
-								"{@dice d6}",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I'm hopeless at organizing my belongings, and I'm always losing things."
-								],
-								[
-									"2",
-									"I get bored whenever a plan is going too smoothly. A win is always more fun when it's by the skin of my teeth!"
-								],
-								[
-									"3",
-									"I've seen Spirelings walk out among cheering crowds of thousands. Gods, I wish that were me. I need that to be me."
-								],
-								[
-									"4",
-									"I'm rubbish with money, and never seem to leave town with a full purse. Keeps me coming back to the life, I suppose."
-								],
-								[
-									"5",
-									"I can't work with shoddy, makeshift {@item thieves' tools|PHB}. I need everything involving my work to be perfect."
-								],
-								[
-									"6",
-									"Any slight against me, no matter how small, is cause for revenge."
-								]
-							]
-						}
-					]
-				}
-			],
-			"hasFluff": true,
-			"hasFluffImages": true
-		},
-		{
 			"name": "Cloistered Scholar",
 			"source": "SCAG",
 			"page": 146,
@@ -5302,253 +4450,6 @@
 				"name": "Sage",
 				"source": "PHB"
 			},
-			"hasFluff": true
-		},
-		{
-			"name": "Cormanthor Refugee",
-			"source": "ALRageOfDemons",
-			"page": 5,
-			"skillProficiencies": [
-				{
-					"nature": true,
-					"survival": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"anyArtisansTool": 1
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						"two-person tent|phb",
-						{
-							"equipmentType": "toolArtisan"
-						},
-						"holy symbol|phb",
-						"traveler's clothes|phb",
-						{
-							"item": "pouch|phb",
-							"containsValue": 500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Nature}, {@skill Survival}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "One type of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "Elven"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A {@item two-person tent|phb}, {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}, a {@item holy symbol|phb}, a set of {@item traveler's clothes|phb}, a belt {@item pouch|phb} containing 5 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Poor"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"You are one of hundreds of refugees that were driven from Hillsfar or that fled the destruction of Myth Drannor and who now shelter in hidden camps under the northern eaves of the Cormanthor Forest. If you up grew in the camps, you have never been to a settlement other than the village of Elventree. As a guest of the elves, you have learned their ways and the ways of the forest. You are also a traumatized, as residual wild magic, energies released by the fall of Thultanthar upon Myth Drannor, and the constant fear of raids hunting for non-humans to fight in Hillsfar's Arena have taken their toll on you, as they have on everyone in the camps."
-					]
-				},
-				{
-					"name": "Feature: Shelter of the Elven Clergy",
-					"type": "entries",
-					"entries": [
-						"The clerics of Elventree have vowed to care for the Cormanthor refugees. They will help you when they can, including providing you and your companions with free healing and care at temples, shrines, and other established presences in Elventree. They will also provide you (but only you) with a poor lifestyle. Note: This feature is a variant of the Acolyte feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I long for a home that never really existed, whether in the camps, Hillsfar, or Myth Drannor."
-								],
-								[
-									"2",
-									"Though I am not an elf, I am a fervent, radical worshipper of the elven gods."
-								],
-								[
-									"3",
-									"I live in the moment, knowing my life could be turned upside down any day."
-								],
-								[
-									"4",
-									"I appreciate beauty in all of its forms."
-								],
-								[
-									"5",
-									"I hate the dark elves and the Netherese for each driving the elves out of Cormanthyr in the past."
-								],
-								[
-									"6",
-									"I am a forest bumpkin who grew up in a tent in the woods and is wholly ignorant of city life."
-								],
-								[
-									"7",
-									"I was raised alongside children of many other races. I harbor no racial prejudices at all."
-								],
-								[
-									"8",
-									"The elves have just the right word for so many things that cannot be expressed as well in other languages. I pepper my speech with elven words, phrases, and sayings."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Patient. The elves have taught me to think and plan for the long-term. (Lawful)"
-								],
-								[
-									"2",
-									"Rebellious. Governments and politicians drove my family to the camps. I subtly defy authority whenever I think I can get away with it. (Chaotic)"
-								],
-								[
-									"3",
-									"Self - Absorbed. I've had to look out for number one so long that it has become second nature. (Any)"
-								],
-								[
-									"4",
-									"Wanderlust. I want to see as much of the world beyond the camps as I can. (Any)"
-								],
-								[
-									"5",
-									"Generous. I give everything I can to help those in need, regardless of who they are. (Good)"
-								],
-								[
-									"6",
-									"To the Abyss with Them. The people of Hillsfar cast me out. I won't risk my hide to help them. (Evil)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"The elves took me in when I had nowhere else to go. In return, I do what I can to help elves in need."
-								],
-								[
-									"2",
-									"I seek revenge against the people of Hillsfar for driving my family into the forest."
-								],
-								[
-									"3",
-									"My family lost everything when they were driven from Hillsfar. I strive to rebuild that fortune."
-								],
-								[
-									"4",
-									"The forest has provided me with food and shelter. In return, I protect forests and those who dwell within."
-								],
-								[
-									"5",
-									"I am deeply, tragically in love with someone whose racial lifespan is far longer or shorter than mine."
-								],
-								[
-									"6",
-									"Members of my extended family did not make it to the camps or have been kidnapped to fight in the Arena. I search for them tirelessly."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I am very uncomfortable indoors and underground."
-								],
-								[
-									"2",
-									"I am haughty. I grew up among the elves and emulate them. Other races are crude in comparison."
-								],
-								[
-									"3",
-									"Elf this, elf that. I am sick and tired of the elves."
-								],
-								[
-									"4",
-									"I am a miser. Having lost everything once before, I clutch my possessions and wealth very tightly."
-								],
-								[
-									"5",
-									"I am a moocher. I am so used to others providing for me that I have come to expect everyone to do it."
-								],
-								[
-									"6",
-									"I believe the gods have cursed me, my family, and all of the Cormanthor refugees. We are all doomed, doomed I tell you!"
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
-				}
-			],
 			"hasFluff": true
 		},
 		{
@@ -5765,7 +4666,7 @@
 								],
 								[
 									"3",
-									"The first thing I do in a new place is note the locations of everything valuable\u2014or where such things could be hidden."
+									"The first thing I do in a new place is note the locations of everything valuable—or where such things could be hidden."
 								],
 								[
 									"4",
@@ -5909,6 +4810,7 @@
 			"name": "Criminal",
 			"source": "XPHB",
 			"page": 180,
+			"srd52": true,
 			"basicRules2024": true,
 			"edition": "one",
 			"ability": [
@@ -6523,7 +5425,7 @@
 							"rows": [
 								[
 									"1",
-									"I discovered a secret I can't let anyone else uncover\u2014including my guild superiors."
+									"I discovered a secret I can't let anyone else uncover—including my guild superiors."
 								],
 								[
 									"2",
@@ -6653,417 +5555,6 @@
 			"hasFluff": true
 		},
 		{
-			"name": "Dragon Casualty",
-			"source": "ALCurseOfStrahd",
-			"page": 3,
-			"skillProficiencies": [
-				{
-					"intimidation": true,
-					"survival": true
-				}
-			],
-			"languageProficiencies": [
-				{
-					"draconic": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"vehicles (water)": true
-				},
-				{
-					"anyArtisansTool": 1
-				},
-				{
-					"choose": {
-						"from": [
-							"gaming set",
-							"vehicles (land)"
-						]
-					}
-				},
-				{
-					"vehicles (land)": true
-				},
-				{
-					"anyMusicalInstrument": 1
-				},
-				{
-					"choose": {
-						"from": [
-							"alchemist's supplies",
-							"herbalism kit"
-						]
-					}
-				},
-				{
-					"choose": {
-						"from": [
-							"thieves' tools",
-							"forgery kit",
-							"disguise kit"
-						]
-					}
-				},
-				{
-					"anyGamingSet": 1
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						"dagger|phb",
-						{
-							"special": "tattered rags"
-						},
-						{
-							"special": "loaf of moldy bread"
-						},
-						{
-							"special": "small cast-off scale belonging to Vorgansharax\u2014the Maimed Virulence"
-						},
-						{
-							"item": "pouch|phb",
-							"displayName": "pouch of various coins (salvaged during your escape from Phlan)",
-							"containsValue": 500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Intimidation}, {@skill Survival}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "Special (see origin below)"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "Draconic"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A {@item dagger|phb}, tattered rags, a loaf of moldy bread, a small cast-off scale belonging to Vorgansharax\u2014the Maimed Virulence, and a {@item pouch|phb} with 5 gp of various coins (salvaged during your escape from Phlan)."
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Wretched"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"When the Maimed Virulence descended upon Phlan, you were one of the unfortunate casualties of war. Captured during the initial assault, you have spent the last year of your life as a plaything of a capricious and malevolent overlord.",
-						"While many of your fellow prisoners fell to the dragon's insatiable fury over the coming months, you and your fellow \"survivors\" were spared only for a worse fate as one of the dragon's magical experiments, leaving you and those who survived the torture scarred and disfigured.",
-						"What reasons the dragon had for releasing you few survivors, nobody knows. You only fear that those who died under his terrible claw were the lucky ones, and you and your fellow Dragonscarred are doomed for a fate worse than death."
-					]
-				},
-				{
-					"name": "Origin",
-					"type": "entries",
-					"entries": [
-						"Prior to the coordinated attack by the Maimed Virulence and her rebel Black Fist supporters, you were once a citizen or visitor to Phlan. While the trauma of your recent ordeal has greatly altered your motivations and perception of the world, your former life still clings to you and colors your mannerisms, behaviors, and outlook on life. Choose one entry on the following table (or roll randomly) to determine your former occupation prior to your incarceration and torture. Your choice determines your tool proficiency from this background.",
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Origin (Occupation)",
-								"Tool Proficiency"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-5",
-								"col-6"
-							],
-							"rows": [
-								[
-									"1",
-									"Dockworker/Fisherman",
-									"{@filter Vehicles (water)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (water)}"
-								],
-								[
-									"2",
-									"Tradesperson/Merchant",
-									"{@filter Artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}"
-								],
-								[
-									"3",
-									"Black Fist Soldier",
-									"{@filter Gaming set|items|source=phb|miscellaneous=mundane|type=gaming set} or {@filter Vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)}"
-								],
-								[
-									"4",
-									"Adventurer/Visitor",
-									"{@filter Vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)}"
-								],
-								[
-									"5",
-									"Entertainer",
-									"{@filter Musical Instrument|items|source=phb|miscellaneous=mundane|type=instrument}"
-								],
-								[
-									"6",
-									"Scholar/Healer",
-									"{@item Alchemist's Supplies|phb} or {@item Herbalism kit|phb}"
-								],
-								[
-									"7",
-									"Criminal",
-									"{@item thieves' tools|phb}, {@item forgery kit|phb}, or {@item Disguise kit|phb}"
-								],
-								[
-									"8",
-									"Unskilled Laborer",
-									"{@filter Gaming set|items|source=phb|miscellaneous=mundane|type=gaming set}"
-								]
-							]
-						}
-					]
-				},
-				{
-					"name": "Feature: Dragonscarred",
-					"type": "entries",
-					"entries": [
-						"Over a period of several months you were subject to magical and mundane torture at the claws of Vorgansharax and his minions. These experiments have left you horribly disfigured but mark you as a survivor of the Maimed Virulence. This affords you a measure of fame and notoriety, for those who know of your harrowing ordeal are keen to hear the tale personally but makes it difficult to disguise your appearance and hide from prying eyes.",
-						"You can parlay this attention into access to people and places you might not otherwise have, for you and your companions. Nobles, scholars, mages, and those who seek to ferret out the secrets of the Maimed Virulence would all be keen to hear your tale of survival, and learn what secrets (if any) you might possess, and/or study your affliction with great interest. However, you fear that your afflictions are not completely mundane and that the Maimed Virulence may as yet have some nefarious reason for allowing your escape, as your scars burn with acidic fury and seem to writhe beneath your skin at times. Note: This feature is a variant of the Far Traveler feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"name": "Disfigurement (Optional)",
-					"type": "entries",
-					"entries": [
-						"In addition to extensive scarring, you may choose one of the following options to represent your disfigurement. This disfigurement is purely cosmetic, misshapen, and horrific to look upon.",
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Disfigurement"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Small non-functional wing(s)."
-								],
-								[
-									"2",
-									"Misshapen, wing-like membranes along one or both arms."
-								],
-								[
-									"3",
-									"Elongated, claw-like hand(s)."
-								],
-								[
-									"4",
-									"Elongated, claw-like feet."
-								],
-								[
-									"5",
-									"Painful green scales randomly embedded in skin."
-								],
-								[
-									"6",
-									"Bulbous, reptilian eye(s)."
-								],
-								[
-									"7",
-									"Enlarged dorsal spines."
-								],
-								[
-									"8",
-									"Hair replaced with small irregular spines."
-								]
-							]
-						}
-					]
-				},
-				{
-					"name": "Suggested Characteristics",
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I am driven to escape my past, and rarely stay in one place long."
-								],
-								[
-									"2",
-									"I know secrets of the Maimed Virulence, but fear the harm that may befall me should others learn them."
-								],
-								[
-									"3",
-									"Speaking of my ordeal helps sooth the still open wounds in my soul."
-								],
-								[
-									"4",
-									"My former life is meaningless, and was ripped to shreds by the claws of Vorgansharax. All that matters now is what I do with the future."
-								],
-								[
-									"5",
-									"I have faced the worst a dragon can deliver and survived. I am fearless, and my resolve unshakable."
-								],
-								[
-									"6",
-									"I am haunted my tortured past, and wake at night screaming at half-remembered horrors."
-								],
-								[
-									"7",
-									"I sleep with my back to a wall or tree, and a weapon within arm's reach."
-								],
-								[
-									"8",
-									"I am slow to trust, but incredibly loyal to those who have earned it."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Survivor. No matter the cost, I will take any action necessary to survive. (Any)"
-								],
-								[
-									"2",
-									"Independence. When in trouble, the only person I can rely on is myself. (Chaotic)"
-								],
-								[
-									"3",
-									"Compassionate. I have suffered long at the hands of a Dragon, and take pity and compassion on the suffering of others. (Good)"
-								],
-								[
-									"4",
-									"Secretive. I am withdrawn, and hide my monstrous appearance for fear of drawing unwanted attention. (Chaotic)"
-								],
-								[
-									"5",
-									"Justice. I have been wronged, and will not allow the same fate to befall others. (Lawful)"
-								],
-								[
-									"6",
-									"Sycophant. During my ordeal, I became a willing servant of the Maimed Virulence, and spy on his behalf. (Evil)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I have sworn vengeance on the Maimed Virulence and those that follow him."
-								],
-								[
-									"2",
-									"I long to reunite with friends and family who may dwell among the Phlan Refugees, and protect them."
-								],
-								[
-									"3",
-									"While a prisoner of the Maimed Virulence, I overheard rumors of an item or treasure the Dragon seeks. I will have that treasure for myself!"
-								],
-								[
-									"4",
-									"I seek to reclaim and rebuild my former life to the best of my ability."
-								],
-								[
-									"5",
-									"I have been reborn as a child of Vorgansharax. I will claim my birthright as his chosen heir and successor."
-								],
-								[
-									"6",
-									"I attribute my survival to the work of the divine, and seek to prove myself worthy of the honor."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I have been touched with dragon-greed, and have a lust for wealth which can never be satisfied."
-								],
-								[
-									"2",
-									"I secretly believe others are plotting to harm me."
-								],
-								[
-									"3",
-									"I no longer enjoy the simple pleasures in life. Food is but ashes and bile in my throat."
-								],
-								[
-									"4",
-									"Anyone who refuses to celebrate my celebrity does not deserve my company."
-								],
-								[
-									"5",
-									"I am paranoid and overly suspicious of others. Anyone may be an agent of the Maimed Virulence."
-								],
-								[
-									"6",
-									"Once I make up my mind, I follow my chosen course of action regardless of the consequences."
-								]
-							]
-						}
-					]
-				}
-			],
-			"hasFluff": true
-		},
-		{
 			"name": "Dragon Cultist",
 			"source": "FRHoF",
 			"page": 29,
@@ -7184,254 +5675,6 @@
 			"hasFluffImages": true
 		},
 		{
-			"name": "Earthspur Miner",
-			"source": "ALElementalEvil",
-			"page": 3,
-			"skillProficiencies": [
-				{
-					"athletics": true,
-					"survival": true
-				}
-			],
-			"languageProficiencies": [
-				{
-					"dwarvish": true,
-					"undercommon": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"a": [
-						"shovel|phb"
-					],
-					"b": [
-						"miner's pick|phb"
-					]
-				},
-				{
-					"_": [
-						"block and tackle|phb",
-						"climber's kit|phb",
-						"common clothes|phb",
-						{
-							"item": "pouch|phb",
-							"containsValue": 500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Athletics}, {@skill Survival}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "Dwarvish and Undercommon "
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A {@item shovel|phb} or a {@item miner's pick|phb}, a {@item block and tackle|phb}, a {@item climber's kit|phb}, a set of {@item common clothes|phb}, and a belt {@item pouch|phb} containing 5 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Poor"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"You are a down-on your luck miner from the Earthspur Mountains who is no stranger to hardship. You have spent a great deal of time living among the dwarves, goliaths, and denizens of the Underdark that also work mines in the area. At this point, you're just as comfortable working underground as above. You know how to read a seam, dicker for supplies with the deep gnomes, party with dwarves, and find your way back to the surface afterwards. Unfortunately, you haven't struck it rich...yet. Although you've come to Mulmaster looking for work, the tall peaks and deep mines of the Earthspurs still call to you."
-					]
-				},
-				{
-					"name": "Feature: Deep Miner",
-					"type": "entries",
-					"entries": [
-						"You are used to navigating the deep places of the earth. You never get lost in caves or mines if you have either seen an accurate map of them or have been through them before. Furthermore, you are able to scrounge fresh water and food for yourself and as many as five other people each day if you are in a mine or natural caves. Note: This feature is a variant of the Outlander feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Nothing bothers me for long."
-								],
-								[
-									"2",
-									"I hate the horrors of the Underdark with a passion. They took my friends and family and almost got me."
-								],
-								[
-									"3",
-									"Anything worth doing takes time and patience. I have learned to plan and wait for the things I want and to be patient to achieve my goals."
-								],
-								[
-									"4",
-									"I can party with everyone. Whether with dwarves, or goliaths, or deep gnomes, I can find a way to have a good time."
-								],
-								[
-									"5",
-									"I'd rather be mining. This is okay; mining is better."
-								],
-								[
-									"6",
-									"I think that I will stumble upon great riches if I just keep looking."
-								],
-								[
-									"7",
-									"People who don't work with their hands and who live in houses are soft and weak."
-								],
-								[
-									"8",
-									"I wish I were more educated. I look up to people who are."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Generosity. The riches of the earth are to be shared by all. (Good)"
-								],
-								[
-									"2",
-									"Greed. Gems and precious metals, I want them all for myself. (Evil)"
-								],
-								[
-									"3",
-									"Mooch. Property, schmoperty. If I need it, I take and use it. If I don't, I leave it for someone else. (Chaotic)"
-								],
-								[
-									"4",
-									"Boundaries. Everything and everyone has its prescribed place; I respect that and expect others to do the same. (Lawful)"
-								],
-								[
-									"5",
-									"Let it Be. I don't meddle in the affairs of others if I can avoid it. They're none of my business. (Neutral)"
-								],
-								[
-									"6",
-									"Materialist. I want riches to improve my life. (Any)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"The people of the Earthspur mines are my family. I will do anything to protect them."
-								],
-								[
-									"2",
-									"A deep gnome saved my life when I was injured and alone. I owe his people a great debt."
-								],
-								[
-									"3",
-									"I must behold and preserve the natural beauty of places below the earth."
-								],
-								[
-									"4",
-									"Gems hold a special fascination for me, more than gold, land, magic, or power."
-								],
-								[
-									"5",
-									"I want to explore new depths and scale new heights."
-								],
-								[
-									"6",
-									"Someday I'm going to find the mother lode, then I'll spend the rest of my life in luxury."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I'm uncomfortable spending time under the open sky. I'd rather be indoors or underground."
-								],
-								[
-									"2",
-									"I'm not used to being around other people much and sometimes get grouchy about it."
-								],
-								[
-									"3",
-									"Good tools are more reliable than people. In a cave in, I would save a sturdy pick before a stranger."
-								],
-								[
-									"4",
-									"I jealously guard my secrets, because I think others will take advantage of me if they learn what I know."
-								],
-								[
-									"5",
-									"I am obsessed with getting rich. I always have a scheme brewing for making it big."
-								],
-								[
-									"6",
-									"I'm afraid of the dark."
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
-				}
-			],
-			"hasFluff": true
-		},
-		{
 			"name": "Emerald Enclave Caretaker",
 			"source": "FRHoF",
 			"page": 29,
@@ -7535,7 +5778,7 @@
 						{
 							"type": "item",
 							"name": "Equipment:",
-							"entry": "Choose A or B: (A) {@item Shortbow|XPHB}, 20 Arrows, {@item Herbalism Kit|XPHB}, {@item Bedroll|XPHB}, {@item Blanket|XPHB}, {@item Pouch|XPHB}, {@item Tent|XPHB}, {@item Traveler's Clothes|XPHB}, 13 GP; or (B) 50 GP"
+							"entry": "Choose A or B: (A) {@item Shortbow|XPHB}, {@item Arrow|XPHB|20 Arrows}, {@item Herbalism Kit|XPHB}, {@item Bedroll|XPHB}, {@item Blanket|XPHB}, {@item Pouch|XPHB}, {@item Tent|XPHB}, {@item Traveler's Clothes|XPHB}, 13 GP; or (B) 50 GP"
 						}
 					]
 				}
@@ -7895,7 +6138,7 @@
 				{
 					"A": [
 						{
-							"item": "musical instrument|xphb"
+							"equipmentType": "instrumentMusical"
 						},
 						{
 							"item": "costume|xphb",
@@ -8081,7 +6324,7 @@
 					"name": "Feature: Dual Personalities",
 					"type": "entries",
 					"entries": [
-						"Most of your fellow adventurers and the world know you as your persona. Those who seek to learn more about you\u2014your weaknesses, your origins, your purpose\u2014find themselves stymied by your disguise. Upon donning a disguise and behaving as your persona, you are unidentifiable as your true self. By removing your disguise and revealing your true face, you are no longer identifiable as your persona. This allows you to change appearances between your two personalities as often as you wish, using one to hide the other or serve as convenient camouflage. However, should someone realize the connection between your persona and your true self, your deception might lose its effectiveness."
+						"Most of your fellow adventurers and the world know you as your persona. Those who seek to learn more about you—your weaknesses, your origins, your purpose—find themselves stymied by your disguise. Upon donning a disguise and behaving as your persona, you are unidentifiable as your true self. By removing your disguise and revealing your true face, you are no longer identifiable as your persona. This allows you to change appearances between your two personalities as often as you wish, using one to hide the other or serve as convenient camouflage. However, should someone realize the connection between your persona and your true self, your deception might lose its effectiveness."
 					],
 					"data": {
 						"isFeature": true
@@ -8091,7 +6334,7 @@
 					"name": "Suggested Characteristics",
 					"type": "entries",
 					"entries": [
-						"A faceless character usually plays their persona\u2014the hero or extraordinary person they are every day. That's all a facade, though, or a part of them expressed to an extreme. To define a persona, feel free to choose characteristics from other backgrounds, particularly folk hero, hermit, or noble. For the person behind the persona, the one who truly strives to be faceless, consider a distinct set of faceless characteristics. As a result, those with this background have two sets of characteristics, one for their persona, and one for their faceless selves.",
+						"A faceless character usually plays their persona—the hero or extraordinary person they are every day. That's all a facade, though, or a part of them expressed to an extreme. To define a persona, feel free to choose characteristics from other backgrounds, particularly folk hero, hermit, or noble. For the person behind the persona, the one who truly strives to be faceless, consider a distinct set of faceless characteristics. As a result, those with this background have two sets of characteristics, one for their persona, and one for their faceless selves.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -8109,7 +6352,7 @@
 								],
 								[
 									2,
-									"I strive to have no personality\u2014it's easier to forget what's hardly there."
+									"I strive to have no personality—it's easier to forget what's hardly there."
 								],
 								[
 									3,
@@ -8129,7 +6372,7 @@
 								],
 								[
 									7,
-									"I am ever learning how to be among others\u2014when to stay quiet, when to laugh."
+									"I am ever learning how to be among others—when to stay quiet, when to laugh."
 								],
 								[
 									8,
@@ -8454,7 +6697,7 @@
 								],
 								[
 									"6",
-									"When I get an idea, I am single-minded in its execution\u2014even if it's a terrible idea."
+									"When I get an idea, I am single-minded in its execution—even if it's a terrible idea."
 								],
 								[
 									"7",
@@ -8990,7 +7233,7 @@
 						{
 							"type": "item",
 							"name": "Equipment:",
-							"entry": "Choose A or B: (A) {@item Sickle|XPHB}, {@item Carpenter's Tools|XPHB}, {@item Healer's Kit|XPHB}, {@item Iron Pot|XPHB}, {@item Shovel|XPHB}, 30 GP; or (B) 50 GP"
+							"entry": "Choose A or B: (A) {@item Sickle|XPHB}, {@item Carpenter's Tools|XPHB}, {@item Healer's Kit|XPHB}, {@item Iron Pot|XPHB}, {@item Shovel|XPHB}, {@item Traveler's Clothes|XPHB}, 30 GP; or (B) 50 GP"
 						}
 					]
 				}
@@ -9373,7 +7616,7 @@
 								],
 								[
 									"8",
-									"I'm always changing my mind\u2014well, almost always."
+									"I'm always changing my mind—well, almost always."
 								]
 							]
 						}
@@ -9576,7 +7819,7 @@
 								],
 								[
 									"2",
-									"{@b Luck.} Our luck depends on respecting its rules\u2014now throw this salt over your shoulder. (Lawful)"
+									"{@b Luck.} Our luck depends on respecting its rules—now throw this salt over your shoulder. (Lawful)"
 								],
 								[
 									"3",
@@ -9986,7 +8229,7 @@
 								],
 								[
 									"4",
-									"Might. If I become strong, I can take what I want\u2014what I deserve. (Evil)"
+									"Might. If I become strong, I can take what I want—what I deserve. (Evil)"
 								],
 								[
 									"5",
@@ -10226,7 +8469,7 @@
 								],
 								[
 									"4",
-									"Survival. You can't win if you're dead. Live to fight another day\u2014when the odds might be more in your favor. (Any)"
+									"Survival. You can't win if you're dead. Live to fight another day—when the odds might be more in your favor. (Any)"
 								],
 								[
 									"5",
@@ -10313,270 +8556,6 @@
 							]
 						}
 					]
-				}
-			],
-			"hasFluff": true
-		},
-		{
-			"name": "Gate Urchin",
-			"source": "ALRageOfDemons",
-			"page": 6,
-			"skillProficiencies": [
-				{
-					"deception": true,
-					"sleight of hand": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"thieves' tools": true,
-					"anyMusicalInstrument": 1
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						{
-							"special": "battered alms box"
-						},
-						{
-							"equipmentType": "instrumentMusical"
-						},
-						"common clothes|phb",
-						{
-							"item": "pouch|phb",
-							"displayName": "belt pouch"
-						},
-						{
-							"value": 1000
-						}
-					]
-				},
-				{
-					"a": [
-						{
-							"special": "cast-off military jacket"
-						}
-					],
-					"b": [
-						{
-							"special": "cap"
-						}
-					],
-					"c": [
-						{
-							"special": "scarf"
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Deception}, {@skill Sleight of Hand}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "{@item Thieves' tools|phb}, one type of {@filter musical instrument|items|source=phb|miscellaneous=mundane|type=instrument}"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A battered alms box, a {@filter musical instrument|items|source=phb|miscellaneous=mundane|type=instrument}, a cast-off military jacket, cap, or scarf, a set of {@item common clothes|phb}, a belt {@item pouch|phb}, and 10 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Poor"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"All traffic into and out of the City of Trade passes through the Hillsfar Gate, making it the ideal place for the destitute to gather to panhandle, busk, gossip, and pick pockets. You grew up on the streets in the shadow of that great steel edifice, which houses both Red Plumes and Guild Mages. Though you may have moved on, you still have friends among them, and that life has had a lasting impact on you."
-					]
-				},
-				{
-					"name": "Feature: Red Plume and Mage Guild Contacts",
-					"type": "entries",
-					"entries": [
-						"You made a number of friends among the Red Plumes and the Mage's Guild when you lived at the Hillsfar Gate. They remember you fondly and help you in little ways when they can. You can invoke their assistance in and around Hillsfar to obtain food, as well as simple equipment for temporary use. You can also invoke it to gain access to the low-security areas of their garrisons, halls, and encampments. Note: This feature is a variant of the Soldier feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I appreciate the simple things in life. a song, a warm meal, a sunny day. I don't need any more."
-								],
-								[
-									"2",
-									"My problems are always caused by others. I'm never to blame."
-								],
-								[
-									"3",
-									"I am afraid I could wind up back on the streets any day."
-								],
-								[
-									"4",
-									"I get along with everyone."
-								],
-								[
-									"5",
-									"I see people as marks for a con and have difficulty feeling true empathy for them."
-								],
-								[
-									"6",
-									"I have a real flair for matchmaking. I can find anyone a spouse!"
-								],
-								[
-									"7",
-									"I think money is the true measure of appreciation and affection. Everything else is talk or an act."
-								],
-								[
-									"8",
-									"I don't like having a lot of stuff, just a few simple things I need. I don't like being tied down and tend to leave things behind when I don't need them anymore."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Loyal. I never rat out any of my friends, even when the Red Plumes or the Rogues Guild ask. (Lawful)"
-								],
-								[
-									"2",
-									"Adventurous. I don't like doing the same thing every day. I crave variety. (Chaotic)"
-								],
-								[
-									"3",
-									"Strong. Only the strong survive. I respect those who are strong and powerful. (Any)"
-								],
-								[
-									"4",
-									"Witty. Brains are better than brawn. I rely on my wits and respect others who do the same. (Any)"
-								],
-								[
-									"5",
-									"Honest. Others can do what they want, but I won't lie or steal, even to feed my family. (Good)"
-								],
-								[
-									"6",
-									"Ungrateful. Those who give, only do it to make themselves feel better. I steal from them. (Evil)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"The Joydancers of Lliira gave me my instrument when I really needed food. I hate them for that."
-								],
-								[
-									"2",
-									"Busking has taught me to love music above all else."
-								],
-								[
-									"3",
-									"The Rogues Guild spared me when I did a job without cutting them in. I owe them a great debt."
-								],
-								[
-									"4",
-									"I know people hate the Red Plumes, but some of them were really good to me. I help Red Plumes whenever I can, and I respect them. They're just doing what they have to do to get by in this world."
-								],
-								[
-									"5",
-									"I will be wealthy some day. My descendants will live in comfort and style."
-								],
-								[
-									"6",
-									"I know how hard life on the streets is. I do everything I can for those who have less than me."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Though I no longer live at the Gate, I am still always concerned about where I will get my next meal."
-								],
-								[
-									"2",
-									"Years of thieving have become habit. I sometimes steal from strangers without thinking about it."
-								],
-								[
-									"3",
-									"I am ashamed of my origins. I pretend I am higher-born and fear others will find out the truth."
-								],
-								[
-									"4",
-									"I think people who grew up in houses are soft, spoiled, and ungrateful. I frequently tell them so."
-								],
-								[
-									"5",
-									"I am still very uncomfortable wearing nice clothes, sleeping in a warm bed, and eating fine food."
-								],
-								[
-									"6",
-									"I do not trust anyone who has not had a hard life. "
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
 				}
 			],
 			"hasFluff": true
@@ -11006,7 +8985,7 @@
 								],
 								[
 									"4",
-									"I embrace my shorter stature. It helps me stay unnoticed\u2014and underestimated."
+									"I embrace my shorter stature. It helps me stay unnoticed—and underestimated."
 								],
 								[
 									"5",
@@ -11239,7 +9218,7 @@
 								],
 								[
 									"8",
-									"Like a wild animal, I lash out viciously when I'm provoked\u2014and I'm easily provoked."
+									"Like a wild animal, I lash out viciously when I'm provoked—and I'm easily provoked."
 								]
 							]
 						},
@@ -11395,7 +9374,7 @@
 								],
 								[
 									"5",
-									"There's a troll in a remote area of the undercity who seems to find me interesting\u2014and who knows more than you'd think."
+									"There's a troll in a remote area of the undercity who seems to find me interesting—and who knows more than you'd think."
 								],
 								[
 									"6",
@@ -11472,7 +9451,7 @@
 					"name": "How Do I Fit In?",
 					"entries": [
 						"As part of the Golgari Swarm, you are a specialized instrument of the greater body. Your orders, when you have such, come from the guildmaster by way of his chancellors, who carry his messages throughout the guild. The swarm relies on you to advance the greater good by protecting some part, however small, of its teeming existence. That responsibility doesn't mean you're indispensable; your eventual death is part of your purpose and function, too, and you'll be replaced even as your body provides nutrients to further the swarm's growth.",
-						"A classic adventuring role for a member of the Golgari involves crawling through dungeon-like environments\u2014the sewers and ancient vaults of the undercity\u2014in search of treasures left behind by the dead. Sometimes you might be sent to find a specific item believed lost in a dangerous part of the undercity. At other times, you could be asked to collect samples of a specific fungus, retrieve a body floating in the muck of the sewers, or bring back whatever booty you can to help fill the swarm's coffers.",
+						"A classic adventuring role for a member of the Golgari involves crawling through dungeon-like environments—the sewers and ancient vaults of the undercity—in search of treasures left behind by the dead. Sometimes you might be sent to find a specific item believed lost in a dangerous part of the undercity. At other times, you could be asked to collect samples of a specific fungus, retrieve a body floating in the muck of the sewers, or bring back whatever booty you can to help fill the swarm's coffers.",
 						"You might gain enough renown to become a member of the Ochran, assigned to a variety of tasks concerning thievery, assassination, or the protection of important figures in your guild. You might steal something because the guild needs it, or because its loss will bring harm to another guild, hastening that group's decline. You could be assigned to kill an outspoken and active enemy of the Golgari, such as an overzealous Boros captain whose raids into the undercity have approached dangerously close to the swarm's inner sanctum. Or you could serve as a bodyguard to one of Guildmaster Jarad's high chancellors, escorting this figure through the undercity while being ready to intervene at a moment's notice if things go wrong.",
 						"The shamans of the Golgari use their magic to accelerate the cycle of decay and regrowth. You might be sent to spread spores throughout an area that the Golgari want to claim as their territory or to convince the inhabitants of such a territory to abandon it. You might also contend with the ever-present threat of hostile monsters encroaching into Golgari-controlled regions."
 					]
@@ -11900,7 +9879,7 @@
 								],
 								[
 									"2",
-									"Go ahead and insult me\u2014I dare you."
+									"Go ahead and insult me—I dare you."
 								],
 								[
 									"3",
@@ -11980,7 +9959,7 @@
 							"rows": [
 								[
 									"1",
-									"I am determined that one day I will lead my clan\u2014or a new one."
+									"I am determined that one day I will lead my clan—or a new one."
 								],
 								[
 									"2",
@@ -12597,7 +10576,7 @@
 					"name": "Suggested Characteristics",
 					"type": "entries",
 					"entries": [
-						"Guild artisans are among the most ordinary people in the world\u2014until they set down their tools and take up an adventuring career. They understand the value of hard work and the importance of community, but they're vulnerable to sins of greed and covetousness.",
+						"Guild artisans are among the most ordinary people in the world—until they set down their tools and take up an adventuring career. They understand the value of hard work and the importance of community, but they're vulnerable to sins of greed and covetousness.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -12611,7 +10590,7 @@
 							"rows": [
 								[
 									"1",
-									"I believe that anything worth doing is worth doing right. I can't help it\u2014I'm a perfectionist."
+									"I believe that anything worth doing is worth doing right. I can't help it—I'm a perfectionist."
 								],
 								[
 									"2",
@@ -12742,7 +10721,7 @@
 								],
 								[
 									"4",
-									"I'm never satisfied with what I have\u2014I always want more."
+									"I'm never satisfied with what I have—I always want more."
 								],
 								[
 									"5",
@@ -12755,252 +10734,6 @@
 							]
 						}
 					]
-				}
-			],
-			"hasFluff": true
-		},
-		{
-			"name": "Harborfolk",
-			"source": "ALElementalEvil",
-			"page": 4,
-			"skillProficiencies": [
-				{
-					"athletics": true,
-					"sleight of hand": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"anyGamingSet": 1,
-					"vehicles (water)": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						"fishing tackle|phb",
-						"dice set|phb",
-						"playing card set|phb",
-						{
-							"item": "three-dragon ante set|phb",
-							"displayName": "or Three-Dragon Ante set"
-						},
-						"common clothes|phb",
-						"rowboat",
-						{
-							"item": "pouch|phb",
-							"containsValue": 500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Athletics}, {@skill Sleight of Hand}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "One type of {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set}, {@filter vehicles (water)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (water)}"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "{@item Fishing tackle|phb}, {@item dice set|phb}, {@item playing card set|phb}, or {@item Three-Dragon Ante set|phb}, a set of {@item common clothes|phb}, {@item rowboat}, and a belt {@item pouch|phb} containing 5 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Poor"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"You are one of the hundreds of small-time fishermen and women who haul the bounty of Mulmaster's freshwater harbor to the city's markets each morning. You have spent countless days rowing in the waters in and around Mulmaster and know them and the other fisherfolk, dockworkers, and port inhabitants better than anyone. Though you have left that life behind, you still visit once in a while."
-					]
-				},
-				{
-					"name": "Feature: Harborfolk",
-					"type": "entries",
-					"entries": [
-						"You grew up on the docks and waters of Mulmaster Harbor. The harborfolk remember you and still treat you as one of them. They welcome you and your companions. While they might charge you for it, they'll always offer what food and shelter they have; they'll even hide you if the City Watch is after you (but not if the Hawks are). Note: This feature is a variant of the Folk Hero feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I am curious. I want to know why things are the way they are and why people do the things that they do."
-								],
-								[
-									"2",
-									"I can't sing, but that never stops me from doing it, loudly. Everyone loves a good sea chanty!"
-								],
-								[
-									"3",
-									"I think the High Blade is doing a terrific job, don't you?"
-								],
-								[
-									"4",
-									"I'm very excited that the House Built on Gold is being restored. I am a zealous worshipper of Waukeen."
-								],
-								[
-									"5",
-									"I am quite superstitious. I see portents in everyday occurrences."
-								],
-								[
-									"6",
-									"I resent the rich and enjoy thwarting their plans and spoiling their fun in small ways."
-								],
-								[
-									"7",
-									"I have a sea story to fit every occasion."
-								],
-								[
-									"8",
-									"I'm a fisher, but I secretly detest eating fish. I will do anything to avoid it."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Calm. For all things, there is a tide. I set sail when it is right, and mend my nets when it is not. (Lawful)"
-								],
-								[
-									"2",
-									"Windblown. I go where the winds blow. No man or woman tells me where or when to sail. (Chaotic)"
-								],
-								[
-									"3",
-									"Aspiring. I will gain the favor of a Zor or Zora patron, maybe even one of the Blades! (Any)"
-								],
-								[
-									"4",
-									"Salty. I want people to look to me as an expert on plying Mulmaster Harbor. (Any)"
-								],
-								[
-									"5",
-									"Selfless. We are all children of the sea. I help everyone in peril afloat and ashore. (Good)"
-								],
-								[
-									"6",
-									"Let them Drown. I refuse to risk my hide to help others. They wouldn't help me if roles were reversed. (Evil)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I once lost everything but my rowboat. I'll do anything to protect it."
-								],
-								[
-									"2",
-									"My brother was in the Soldiery, but he was killed. I really look up to the men and women who serve."
-								],
-								[
-									"3",
-									"The Cloaks killed my friend for spellcasting. I'll get them back somehow, someday."
-								],
-								[
-									"4",
-									"The High House of Hurting helped me when I was hurt and asked nothing in return. I owe them my life."
-								],
-								[
-									"5",
-									"I was robbed in the Zhent ghetto once. It will not happen again."
-								],
-								[
-									"6",
-									"I would do anything to protect the other harborfolk. They are my family."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I drink too much, which causes me to miss the tide."
-								],
-								[
-									"2",
-									"I killed a drunk member of the City Watch in a brawl. I am terrified that they might find out."
-								],
-								[
-									"3",
-									"I oversell myself and make promises I can't keep when I want to impress someone."
-								],
-								[
-									"4",
-									"Book learning is a waste of time. I have no patience for people who don't speak from experience."
-								],
-								[
-									"5",
-									"I almost always cheat. I can't help myself."
-								],
-								[
-									"6",
-									"I am a secret informant for the Hawks. I send them reports about everything I see and hear, even what my friends and allies are up to."
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
 				}
 			],
 			"hasFluff": true
@@ -13117,6 +10850,139 @@
 		},
 		{
 			"name": "Haunted One",
+			"source": "RHW",
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"con",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"con",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"survivor|rhw": true
+				},
+				{
+					"anyFromCategory": {
+						"category": [
+							"DG"
+						]
+					}
+				}
+			],
+			"skillProficiencies": [
+				{
+					"arcana": true,
+					"survival": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyGamingSet": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						{
+							"equipmentType": "setGaming",
+							"displayName": "Gaming Set (same as above)"
+						},
+						"crowbar|xphb",
+						{
+							"item": "holy water|xphb",
+							"displayName": "Holy Water (1 flask)"
+						},
+						"mirror|xphb",
+						{
+							"item": "oil|xphb",
+							"displayName": "Oil (2 flasks)"
+						},
+						"signal whistle|xphb",
+						"tinderbox|xphb",
+						"traveler's clothes|xphb",
+						{
+							"item": "torch|xphb",
+							"displayName": "Torches",
+							"quantity": 5
+						},
+						"waterskin|xphb",
+						{
+							"value": 1400
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Constitution, Wisdom, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Survivor|RHW} or a {@filter Dark Gift feat of your choice|feats|category=DG}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Arcana|XPHB} and {@skill Survival|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "Choose one kind of {@item Gaming Set|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Gaming Set|XPHB} (same as above), {@item Crowbar|XPHB}, {@item Holy Water|XPHB} (1 {@item flask|XPHB}), {@item Mirror|XPHB}, {@item Oil|XPHB}(2 {@item flask|XPHB|flasks}), {@item Signal Whistle|XPHB}, {@item Tinderbox|XPHB}, {@item Traveler's Clothes|XPHB}, 5 {@item Torch|XPHB|Torches}, {@item Waterskin|XPHB}, and 14 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Haunted One",
 			"source": "VRGR",
 			"page": 34,
 			"otherSources": [
@@ -13124,6 +10990,9 @@
 					"source": "CoS",
 					"page": 209
 				}
+			],
+			"reprintedAs": [
+				"Haunted One|RHW"
 			],
 			"skillProficiencies": [
 				{
@@ -13241,7 +11110,7 @@
 								],
 								[
 									"6",
-									"You were cursed with lycanthropy and later cured. You are now haunted by the innocents you slaughtered."
+									"You were cursed with {@variantrule Player Characters as Lycanthropes|MM|lycanthropy} and later cured. You are now haunted by the innocents you slaughtered."
 								],
 								[
 									"7",
@@ -13419,7 +11288,7 @@
 								],
 								[
 									"4",
-									"I've seen great darkness, and I'm committed to being a light against it\u2014the light of all lights."
+									"I've seen great darkness, and I'm committed to being a light against it—the light of all lights."
 								],
 								[
 									"5",
@@ -13501,7 +11370,7 @@
 								],
 								[
 									"9",
-									"I've seen the evil of a type of place\u2014like forests, cities, or graveyards\u2014and resist going there."
+									"I've seen the evil of a type of place—like forests, cities, or graveyards—and resist going there."
 								],
 								[
 									"10",
@@ -13948,32 +11817,73 @@
 			"hasFluffImages": true
 		},
 		{
-			"name": "Hillsfar Merchant",
-			"source": "ALRageOfDemons",
-			"page": 7,
+			"name": "House Agent",
+			"source": "EFA",
+			"page": 26,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"int",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"int",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"lucky|xphb": true
+				}
+			],
 			"skillProficiencies": [
 				{
-					"insight": true,
+					"investigation": true,
 					"persuasion": true
 				}
 			],
 			"toolProficiencies": [
 				{
-					"vehicles (land)": true,
-					"vehicles (water)": true
+					"anyArtisansTool": 1
 				}
 			],
 			"startingEquipment": [
 				{
-					"_": [
-						"fine clothes|phb",
-						"signet ring|phb",
+					"a": [
 						{
-							"special": "letter of introduction from your family's trading house"
+							"equipmentType": "toolArtisan"
 						},
+						"fine clothes|xphb",
 						{
-							"special": "purse",
-							"containsValue": 2500
+							"value": 2000
+						}
+					],
+					"b": [
+						{
+							"value": 5000
 						}
 					]
 				}
@@ -13985,478 +11895,42 @@
 					"items": [
 						{
 							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Strength, Intelligence, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Lucky|XPHB}"
+						},
+						{
+							"type": "item",
 							"name": "Skill Proficiencies:",
-							"entry": "{@skill Insight}, {@skill Persuasion}"
+							"entry": "{@skill Investigation|XPHB} and {@skill Persuasion|XPHB}"
 						},
 						{
 							"type": "item",
 							"name": "Tool Proficiencies:",
-							"entry": "{@filter Vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)} and {@filter vehicles (water)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (water)}"
+							"entry": "Choose one kind of {@item Artisan's Tools|XPHB}"
 						},
 						{
 							"type": "item",
 							"name": "Equipment:",
-							"entry": "A set of {@item fine clothes|phb}, a {@item signet ring|phb}, a letter of introduction from your family's trading house, and a purse containing 25 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Wealthy"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"Before becoming an adventurer, you were a successful merchant operating out Hillsfar, the City of Trade. Your family operated warehouses, organized caravans, managed stores, or owned a ship and has trade contacts throughout the Moonsea region, as well as up and down the length of the Sword Coast. Perhaps they import ore, uncut gems, untreated furs, or grain into the City of Trade, or they export fine cloth, faceted gems, fine furs, or Dragon's Breath, a brandy-like liquor. Regardless, you've largely given that life up for some reason and have chosen to seek adventure instead. Nevertheless, the training you received then, and perhaps the contacts you made, serve you well as an adventurer.",
-						"Choose one of the following features:"
-					]
-				},
-				{
-					"name": "Feature: Factor",
-					"type": "entries",
-					"entries": [
-						"Although you've left the day-to-day life of a merchant behind, your family has assigned you the services of a loyal retainer from the business, a factor, husbanding agent, seafarer, caravan guard, or clerk. This individual is a commoner who can perform mundane tasks for you such as making purchases, delivering messages, and running errands. He or she will not fight for you and will not follow you into obviously dangerous areas (such as dungeons), and will leave if frequently endangered or abused. If he or she is killed, the family assigns you another within a few days. Note: This feature is a variant of the Noble Knight's Retainers feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"name": "Alternate Feature: Trade Contact",
-					"type": "entries",
-					"entries": [
-						"You and your family have trade contacts such as caravan masters, shopkeepers, sailors, artisans, and farmers throughout the Moonsea region and all along the Sword Coast. Once per game session, when adventuring in either of those areas, you can use those contacts to get information about the local area or to pass a message to someone in those areas, even across the great distance between the two areas. Note: This feature is a variant of the Criminal Contact and Researcher features."
-					],
-					"data": {
-						"isFeature": true,
-						"isAlternateFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I fill my evenings with wine or mead and song."
-								],
-								[
-									"2",
-									"I greatly admire gladiators and enjoy the Arena."
-								],
-								[
-									"3",
-									"I take my wealth for granted. It seldom occurs to me that others aren't rich themselves."
-								],
-								[
-									"4",
-									"I leave broken hearts all around the Moonsea and up and down the Sword Coast."
-								],
-								[
-									"5",
-									"I work hard and seldom make time for fun."
-								],
-								[
-									"6",
-									"I am a particularly devout and pray often."
-								],
-								[
-									"7",
-									"The Red Plumes caught me once. I hate them."
-								],
-								[
-									"8",
-									"I ask a lot of questions to get information about those with whom I am working and dealing."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Frugal. I spend my money very carefully. (Lawful)"
-								],
-								[
-									"2",
-									"Profligate. I tend to spend extravagantly. (Chaotic)"
-								],
-								[
-									"3",
-									"Honest. I deal with others above board. (Any)"
-								],
-								[
-									"4",
-									"Sharp. I seek to make the best deal possible. (Any)"
-								],
-								[
-									"5",
-									"Charitable. I give generously to others. (Good)"
-								],
-								[
-									"6",
-									"Greedy. I do not share my wealth with others. (Evil)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I am fiercely loyal to those with whom I work."
-								],
-								[
-									"2",
-									"I must uphold the good name of my family."
-								],
-								[
-									"3",
-									"I will prove myself to my family as an adventurer."
-								],
-								[
-									"4",
-									"Deals are sacrosanct. I never go back on my word."
-								],
-								[
-									"5",
-									"I love making deals and negotiating agreements."
-								],
-								[
-									"6",
-									"I guard my wealth jealously."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I am a braggart. I promote myself shamelessly."
-								],
-								[
-									"2",
-									"I am vain. I always wear the latest fashions."
-								],
-								[
-									"3",
-									"I am a glutton. I eat and drink to excess."
-								],
-								[
-									"4",
-									"I am a snob. I want only the finest things in life."
-								],
-								[
-									"5",
-									"I am lazy. I want others to take care of everything."
-								],
-								[
-									"6",
-									"I am overconfident. I overestimate my abilities."
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
-				}
-			],
-			"hasFluff": true
-		},
-		{
-			"name": "Hillsfar Smuggler",
-			"source": "ALRageOfDemons",
-			"page": 8,
-			"skillProficiencies": [
-				{
-					"perception": true,
-					"stealth": true
-				}
-			],
-			"languageProficiencies": [
-				{
-					"anyStandard": 1
-				}
-			],
-			"toolProficiencies": [
-				{
-					"forgery kit": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						"forgery kit|phb",
-						"common clothes|phb",
-						{
-							"item": "pouch|phb",
-							"displayName": "belt pouch"
-						},
-						{
-							"value": 500
+							"entry": "Choose A or B: (A) {@item Artisan's Tools|XPHB} (same as above), {@item Fine Clothes|XPHB}, 20 GP; or (B) 50 GP"
 						}
 					]
 				}
 			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Perception}, {@skill Stealth}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "One racial language"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "{@item Forgery kit|phb}"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A {@item forgery kit|phb}, a set of {@item common clothes|phb}, a belt {@item pouch|phb}, and 5 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Modest"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"Hillsfar is the City of Trade. However, the Great Law of Trade only protects \"legitimate\" trade, trade that passes through the city's sole gate, which the Red Plumes monitor and tax. And the Great Law of Humanity banishes non-humans from the city altogether. The two Great Laws create great demand and great risk for smugglers, who shepherd illicit goods and non-humans into and out of the city by secret routes. The Rogues Guild tightly controls all of this activity, taking its cut from sanctioned jobs and exacting punishment for independent jobs.",
-						"Perhaps you trafficked Dragon's Breath (a brandy-like liquor) to avoid tariffs or contraband to avoid seizure, or maybe you are a human who sympathizes with the non-humans and worked as part of the network of secret routes and safe houses that helps them pass through Hillsfar. Either way, you have contacts in the smuggling community who can help you slip into and out of the city unnoticed, for a price."
-					]
-				},
-				{
-					"name": "Feature: Secret Passage",
-					"type": "entries",
-					"entries": [
-						"You can call on your contacts within the smuggling community to secure secret passage into or out of Hillsfar for yourself and your adventuring companions, no questions asked, and no Red Plume entanglements. Because you're calling in a favor, you can't be certain they will be able to help on your timetable or at all. Your Dungeon Master will determine whether you can be smuggled into or out of the city. In return for your passage, you and your companions may owe the Rouges Guild a favor and/or may have to pay bribes. Note: This feature is a variant of the Sailor feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"When I'm not smuggling, I gamble."
-								],
-								[
-									"2",
-									"I just love Halfling cooking and baking!"
-								],
-								[
-									"3",
-									"I party with dwarves whenever I can."
-								],
-								[
-									"4",
-									"I'm a terrible singer, but I love to do it."
-								],
-								[
-									"5",
-									"I was raised to honor Chauntea and still do."
-								],
-								[
-									"6",
-									"The blood sports of the Arena sicken me."
-								],
-								[
-									"7",
-									"I think non-humans are really interesting."
-								],
-								[
-									"8",
-									"I exaggerate the tales of my exploits."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Fair. I think everyone deserves to be treated fairly. I don't play favorites. (Lawful)"
-								],
-								[
-									"2",
-									"Impulsive. Planning is often a waste of time. No plan survives contact with reality. It's easier to dive in and deal with the consequences. (Chaotic)"
-								],
-								[
-									"3",
-									"Curious. I want to learn as much as I can about the people and places I encounter. (Any)"
-								],
-								[
-									"4",
-									"Prepared. I think success depends on preparing as much as possible in advance. (Any)"
-								],
-								[
-									"5",
-									"Respectful. I think everyone deserves to be treated with respect and dignity, regardless of their race, creed, color, or origin. (Good)"
-								],
-								[
-									"6",
-									"Corrupt. I will break the law or act dishonestly if the money is right. (Evil)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I am loyal to the Rogues Guild and would do anything for them."
-								],
-								[
-									"2",
-									"I love the city of Hillsfar and my fellow Hillsfarians, despite the recent problems."
-								],
-								[
-									"3",
-									"I admire the elves. I help them whenever I can."
-								],
-								[
-									"4",
-									"A gnome helped me once. I pay the favor forward."
-								],
-								[
-									"5",
-									"I enjoy tricking the Red Plumes at every opportunity."
-								],
-								[
-									"6",
-									"I smuggled agricultural goods for non-human farmers. I try to help them when I can."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"My hatred for the Red Plumes burns so brightly that I have difficulty suppressing It around them."
-								],
-								[
-									"2",
-									"The Red Plumes caught me once before, and I was branded for my crime. If they catch me again, for any offense, the punishment will be dire."
-								],
-								[
-									"3",
-									"I treat all Hillsfarians poorly. I am disgusted with their failure to revolt against the Great Law of Humanity."
-								],
-								[
-									"4",
-									"I have difficulty trusting strangers. Anyone could be a spy for the authorities."
-								],
-								[
-									"5",
-									"I am greedy. There Isn't much I won't do for money."
-								],
-								[
-									"6",
-									"I'm an informant for the Red Plumes. They let me continue my activities, so long as I pass them information about illegal activity in Hillsfar."
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
-				}
-			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "House Agent",
 			"source": "ERLW",
 			"page": 53,
+			"reprintedAs": [
+				"House Agent|EFA"
+			],
 			"skillProficiencies": [
 				{
 					"investigation": true,
@@ -14848,6 +12322,1425 @@
 			"hasFluff": true
 		},
 		{
+			"name": "House Cannith Heir",
+			"source": "EFA",
+			"page": 27,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"dex",
+								"int"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"dex",
+								"int"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of making|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"investigation": true,
+					"sleight of hand": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyArtisansTool": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						{
+							"equipmentType": "toolArtisan"
+						},
+						"crowbar|xphb",
+						"fine clothes|xphb",
+						{
+							"item": "pouch|xphb",
+							"displayName": "Pouches",
+							"quantity": 2
+						},
+						{
+							"value": 1700
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Strength, Dexterity, Intelligence"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Making|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Investigation|XPHB} and {@skill Sleight of Hand|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "Choose one kind of {@item Artisan's Tools|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Artisan's Tools|XPHB} (same as above), {@item Crowbar|XPHB}, {@item Fine Clothes|XPHB}, 2 {@item Pouch|XPHB|Pouches}, 17 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Deneith Heir",
+			"source": "EFA",
+			"page": 27,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"con",
+								"wis"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"con",
+								"wis"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of sentinel|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"insight": true,
+					"perception": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyGamingSet": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"spear|xphb",
+						"shortbow|xphb",
+						"arrows (20)|xphb",
+						"gaming set|xphb",
+						"fine clothes|xphb",
+						"healer's kit|xphb",
+						"quiver|xphb",
+						{
+							"value": 100
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Strength, Constitution, Wisdom"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Sentinel|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Insight|XPHB} and {@skill Perception|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "Choose one kind of {@item Gaming Set|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Spear|XPHB}, {@item Shortbow|XPHB}, {@item Arrow|XPHB|20 Arrows}, {@item Gaming Set|XPHB} (same as above), {@item Fine Clothes|XPHB}, {@item Healer's Kit|XPHB}, {@item Quiver|XPHB}, 1 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Ghallanda Heir",
+			"source": "EFA",
+			"page": 28,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of hospitality|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"insight": true,
+					"persuasion": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"cook's utensils": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"cook's utensils|xphb",
+						"fine clothes|xphb",
+						"iron pot|xphb",
+						"lamp|xphb",
+						{
+							"item": "oil|xphb",
+							"quantity": 5
+						},
+						"perfume|xphb",
+						{
+							"value": 2600
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Dexterity, Wisdom, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Hospitality|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Insight|XPHB} and {@skill Persuasion|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Cook's Utensils|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Cook's Utensils|XPHB}, {@item Fine Clothes|XPHB}, {@item Iron Pot|XPHB}, {@item Lamp|XPHB}, {@item Oil|XPHB} (5 flasks), {@item Perfume|XPHB}, 26 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Jorasco Heir",
+			"source": "EFA",
+			"page": 28,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"con",
+								"wis"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"con",
+								"wis"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of healing|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"medicine": true,
+					"stealth": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"herbalism kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"herbalism kit|xphb",
+						"fine clothes|xphb",
+						"healer's kit|xphb",
+						{
+							"value": 2500
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Dexterity, Constitution, Wisdom"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Healing|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Medicine|XPHB} and {@skill Stealth|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Herbalism Kit|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Herbalism Kit|XPHB}, {@item Fine Clothes|XPHB}, {@item Healer's Kit|XPHB}, 25 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Kundarak Heir",
+			"source": "EFA",
+			"page": 29,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"con",
+								"int"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"con",
+								"int"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of warding|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"arcana": true,
+					"investigation": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"thieves' tools": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"thieves' tools|xphb",
+						"fine clothes|xphb",
+						{
+							"value": 1000
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Strength, Constitution, Intelligence"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Warding|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Arcana|XPHB} and {@skill Investigation|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Thieves' Tools|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Thieves' Tools|XPHB}, {@item Fine Clothes|XPHB}, 10 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Lyrandar Heir",
+			"source": "EFA",
+			"page": 29,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"dex",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"str",
+								"dex",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of storm|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"acrobatics": true,
+					"nature": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"navigator's tools": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"navigator's tools|xphb",
+						"fine clothes|xphb",
+						{
+							"value": 1000
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Strength, Dexterity, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Storm|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Acrobatics|XPHB} and {@skill Nature|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Navigator's Tools|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Navigator's Tools|XPHB}, {@item Fine Clothes|XPHB}, 10 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Medani Heir",
+			"source": "EFA",
+			"page": 30,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"int",
+								"wis"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"int",
+								"wis"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of detection|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"insight": true,
+					"investigation": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"disguise kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"disguise kit|xphb",
+						"fine clothes|xphb",
+						{
+							"value": 1000
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Dexterity, Intelligence, Wisdom"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Detection|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Insight|XPHB} and {@skill Investigation|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Disguise Kit|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Disguise Kit|XPHB}, {@item Fine Clothes|XPHB}, 10 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Orien Heir",
+			"source": "EFA",
+			"page": 30,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"con",
+								"int"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"con",
+								"int"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of passage|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"acrobatics": true,
+					"athletics": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"cartographer's tools": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"cartographer's tools|xphb",
+						"fine clothes|xphb",
+						"map|xphb",
+						"map or scroll case|xphb",
+						{
+							"value": 1800
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Dexterity, Constitution, Intelligence"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Passage|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Acrobatics|XPHB} and {@skill Athletics|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Cartographer's Tools|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Cartographer's Tools|XPHB}, {@item Fine Clothes|XPHB}, {@item Map|XPHB}, {@item Map or Scroll Case|XPHB}, 18 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Phiarlan Heir",
+			"source": "EFA",
+			"page": 31,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of shadow|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"deception": true,
+					"stealth": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"disguise kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"disguise kit|xphb",
+						"fine clothes|xphb",
+						{
+							"value": 1000
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Dexterity, Wisdom, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Shadow|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Deception|XPHB} and {@skill Stealth|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Disguise Kit|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Disguise Kit|XPHB}, {@item Fine Clothes|XPHB}, 10 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Sivis Heir",
+			"source": "EFA",
+			"page": 31,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"int",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"int",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of scribing|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"history": true,
+					"perception": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"calligrapher's supplies": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"calligrapher's supplies|xphb",
+						"fine clothes|xphb",
+						"ink|xphb",
+						{
+							"item": "ink pen|xphb",
+							"quantity": 5
+						},
+						{
+							"item": "paper|xphb",
+							"quantity": 30
+						},
+						{
+							"item": "parchment|xphb",
+							"quantity": 9
+						},
+						{
+							"value": 800
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Intelligence, Wisdom, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Scribing|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill History|XPHB} and {@skill Perception|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Calligrapher's Supplies|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Calligrapher's Supplies|XPHB}, {@item Fine Clothes|XPHB}, {@item Ink|XPHB}, 5 {@item Ink Pen|XPHB|Ink Pens}, {@item Paper|XPHB} (30 sheets), {@item Parchment|XPHB} (9 sheets), 8 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Tharashk Heir",
+			"source": "EFA",
+			"page": 32,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"con",
+								"int",
+								"wis"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"con",
+								"int",
+								"wis"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of finding|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"perception": true,
+					"survival": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyGamingSet": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"gaming set|xphb",
+						"climber's kit|xphb",
+						"fine clothes|xphb",
+						"hunting trap|xphb",
+						"manacles|xphb",
+						{
+							"value": 200
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Constitution, Intelligence, Wisdom"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Finding|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Perception|XPHB} and {@skill Survival|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "Choose one kind of {@item Gaming Set|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Gaming Set|XPHB} (same as above), {@item Climber's Kit|XPHB}, {@item Fine Clothes|XPHB}, {@item Hunting Trap|XPHB}, {@item Manacles|XPHB}, 2 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Thuranni Heir",
+			"source": "EFA",
+			"page": 32,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"int",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"int",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of shadow|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"performance": true,
+					"stealth": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyMusicalInstrument": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"musical instrument|xphb",
+						"costume|xphb",
+						"fine clothes|xphb",
+						{
+							"value": 1300
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Dexterity, Intelligence, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Shadow|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Performance|XPHB} and {@skill Stealth|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "Choose one kind of {@item Musical Instrument|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Musical Instrument|XPHB} (same as above), {@item Costume|XPHB}, {@item Fine Clothes|XPHB}, 13 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "House Vadalis Heir",
+			"source": "EFA",
+			"page": 33,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"con",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"con",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"mark of handling|efa": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"animal handling": true,
+					"nature": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"herbalism kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"herbalism kit|xphb",
+						"fine clothes|xphb",
+						"net|xphb",
+						{
+							"value": 2900
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Constitution, Wisdom, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Mark of Handling|EFA}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Animal Handling|XPHB} and {@skill Nature|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Herbalism Kit|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Herbalism Kit|XPHB}, {@item Fine Clothes|XPHB}, {@item Net|XPHB}, 29 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
 			"name": "Ice Fisher",
 			"source": "FRHoF",
 			"page": 31,
@@ -15177,7 +14070,7 @@
 					"name": "Feature: Trials of the Five Gods",
 					"type": "entries",
 					"entries": [
-						"Your life is oriented around your participation in the five trials that will determine your worthiness in the afterlife. While you prepare for and undergo those trials, you have constant access to training. A comfortable place to live and regular meals are provided to you by servitor mummies (the anointed) under the supervision of viziers. You can enjoy these benefits only as long as you obey the societal norms of Naktamun\u2014training for the trials (with or without your crop), obeying the orders of the gods, and following the instructions of their viziers. If you violate these norms, you risk being treated as a dissenter. See \"{@book Trials of the Five Gods|PS-A|3}\" for more information about undertaking the trials and their rewards."
+						"Your life is oriented around your participation in the five trials that will determine your worthiness in the afterlife. While you prepare for and undergo those trials, you have constant access to training. A comfortable place to live and regular meals are provided to you by servitor mummies (the anointed) under the supervision of viziers. You can enjoy these benefits only as long as you obey the societal norms of Naktamun—training for the trials (with or without your crop), obeying the orders of the gods, and following the instructions of their viziers. If you violate these norms, you risk being treated as a dissenter. See \"{@book Trials of the Five Gods|PS-A|3}\" for more information about undertaking the trials and their rewards."
 					],
 					"data": {
 						"isFeature": true
@@ -15187,7 +14080,7 @@
 					"name": "Suggested Characteristics",
 					"type": "entries",
 					"entries": [
-						"An initiate's life is focused on the trials, but it doesn't need to be all about the trials. Though some initiates are highly focused on their training, most undergo that training while also experiencing joy, sorrow, love, loss, anger, jealousy, hope, faith, delight\u2014the whole range of mortal emotions and experience. The afterlife might be a constant presence in every initiate's mind, but it is the culmination of a life well-lived\u2014not a replacement for it.",
+						"An initiate's life is focused on the trials, but it doesn't need to be all about the trials. Though some initiates are highly focused on their training, most undergo that training while also experiencing joy, sorrow, love, loss, anger, jealousy, hope, faith, delight—the whole range of mortal emotions and experience. The afterlife might be a constant presence in every initiate's mind, but it is the culmination of a life well-lived—not a replacement for it.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -15209,7 +14102,7 @@
 								],
 								[
 									"3",
-									"I'll settle for nothing less than perfection\u2014in myself, in my cropmates, in everything."
+									"I'll settle for nothing less than perfection—in myself, in my cropmates, in everything."
 								],
 								[
 									"4",
@@ -15250,7 +14143,7 @@
 								],
 								[
 									"2",
-									"{@b Knowledge.} The world is a puzzle\u2014a mystery waiting to be solved. (Neutral)"
+									"{@b Knowledge.} The world is a puzzle—a mystery waiting to be solved. (Neutral)"
 								],
 								[
 									"3",
@@ -15258,7 +14151,7 @@
 								],
 								[
 									"4",
-									"{@b Ambition.} I'm going to prove that I deserve only the best\u2014of everything. (Evil)"
+									"{@b Ambition.} I'm going to prove that I deserve only the best—of everything. (Evil)"
 								],
 								[
 									"5",
@@ -15378,6 +14271,118 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Inquisitive",
+			"source": "EFA",
+			"page": 33,
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"con",
+								"int",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"con",
+								"int",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"alert|xphb": true
+				}
+			],
+			"skillProficiencies": [
+				{
+					"insight": true,
+					"investigation": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"thieves' tools": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"thieves' tools|xphb",
+						"bullseye lantern|xphb",
+						"crowbar|xphb",
+						{
+							"item": "oil|xphb",
+							"quantity": 10
+						},
+						"traveler's clothes|xphb",
+						{
+							"value": 1000
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Constitution, Intelligence, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Alert|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Insight|XPHB} and {@skill Investigation|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Thieves' Tools|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Thieves' Tools|XPHB}, {@item Bullseye Lantern|XPHB}, {@item Crowbar|XPHB}, {@item Oil|XPHB} (10 flasks), {@item Traveler's Clothes|XPHB}, 10 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
 			"name": "Inquisitor",
 			"source": "PSI",
 			"page": 12,
@@ -15443,8 +14448,130 @@
 		},
 		{
 			"name": "Investigator",
+			"source": "RHW",
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"int",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"int",
+								"wis",
+								"cha"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"sharp eye|rhw": true
+				},
+				{
+					"anyFromCategory": {
+						"category": [
+							"DG"
+						]
+					}
+				}
+			],
+			"skillProficiencies": [
+				{
+					"insight": true,
+					"investigation": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"disguise kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"disguise kit|xphb",
+						"manacles|xphb",
+						"shovel|xphb",
+						"traveler's clothes|xphb",
+						{
+							"displayName": "Vials",
+							"item": "vial|xphb",
+							"quantity": 3
+						},
+						{
+							"value": 1600
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Intelligence, Wisdom, Charisma"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "{@feat Sharp Eye|RHW} or a {@filter Dark Gift feat of your choice|feats|category=DG}"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Insight|XPHB} and {@skill Investigation|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Disguise Kit|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Disguise Kit|XPHB}, {@item Manacles|XPHB}, {@item Shovel|XPHB}, {@item Traveler's Clothes|XPHB}, 3 {@item Vial|XPHB|Vials}, and 16 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Investigator",
 			"source": "VRGR",
 			"page": 35,
+			"reprintedAs": [
+				"Investigator|RHW"
+			],
 			"skillProficiencies": [
 				{
 					"choose": {
@@ -15719,7 +14846,7 @@
 								],
 								[
 									"4",
-									"I've seen great darkness, and I'm committed to being a light against it\u2014the light of all lights."
+									"I've seen great darkness, and I'm committed to being a light against it—the light of all lights."
 								],
 								[
 									"5",
@@ -15801,7 +14928,7 @@
 								],
 								[
 									"9",
-									"I've seen the evil of a type of place\u2014like forests, cities, or graveyards\u2014and resist going there."
+									"I've seen the evil of a type of place—like forests, cities, or graveyards—and resist going there."
 								],
 								[
 									"10",
@@ -15822,249 +14949,6 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true
-		},
-		{
-			"name": "Iron Route Bandit",
-			"source": "ALCurseOfStrahd",
-			"page": 5,
-			"skillProficiencies": [
-				{
-					"animal handling": true,
-					"stealth": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"anyGamingSet": 1,
-					"vehicles (land)": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						{
-							"item": "common clothes|phb",
-							"displayName": "dark common clothes"
-						},
-						"pack saddle|phb",
-						"burglar's pack|phb",
-						{
-							"item": "pouch|phb",
-							"containsValue": 500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Animal Handling}, {@skill Stealth}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "One type of {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set}, {@filter vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)}"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A set of dark {@item common clothes|phb}, {@item pack saddle|phb}, {@item burglar's pack|phb}, and a belt {@item pouch|phb} containing 5 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Poor"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"The Iron Route, once the primary trade route between Phlan and Zhentil Keep, used to be a site of extensive banditry until the Phlan's recent occupation. Your time as an erstwhile bandit has given you plenty of experience in the saddle and a knack for acquiring and appraising other people's mounts, pets, and vehicles among other things. This particular set of skills has become very lucrative for you by working for the underground as a horse thief for a local guild of thieves and other shadowy organizations."
-					]
-				},
-				{
-					"name": "Feature: Black-Market Breeder",
-					"type": "entries",
-					"entries": [
-						"You know how to find people who are always looking for stolen animals & vehicles, whether to provide for animal pit fights, or to supply some desperate rogues the means to get away faster on mounts during an illegal job. This contact not only provides you with information of what such animals & vehicles are in high demand in the area, but also offer to give you favors and information (DM choice) if you bring such animals & vehicles to them. Note: This is a variant of the Criminal Contact feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"name": "Suggested Characteristics",
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"If people leave their gear unsecured, they must not want it very much."
-								],
-								[
-									"2",
-									"I feel more comfortable sleeping under the open sky."
-								],
-								[
-									"3",
-									"I always pre-plan my escape should things go bad; I always like to have an exit strategy."
-								],
-								[
-									"4",
-									"I tend to give animal owners breeding and care advice whether or not they want it."
-								],
-								[
-									"5",
-									"I lost a pet as a child and sadly reflect on it to this day."
-								],
-								[
-									"6",
-									"I always form a powerful, emotional bond with my mount."
-								],
-								[
-									"7",
-									"I recoil at the thought of killing someone else's pet or mount."
-								],
-								[
-									"8",
-									"I prefer to hang to the back of a scuffle or discussion. Better to have my enemies in front of me."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Loyalty. Never bite the hand that feeds. (Good)"
-								],
-								[
-									"2",
-									"Unpredictability. Keep your enemy guessing and off-balance like a confused deer. (Chaotic)"
-								],
-								[
-									"3",
-									"Power. I strive to become leader of the pack at all costs. (Lawful)"
-								],
-								[
-									"4",
-									"Freedom. I bow to no one I don't respect. (Chaotic)"
-								],
-								[
-									"5",
-									"Resourcefulness. Our wits are our most valuable resource in troubled times. (Any)"
-								],
-								[
-									"6",
-									"Unity. Lone wolves fail where the pack succeeds. (Any)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I cannot leave a harmed animal behind; I must save it or put it out of its misery."
-								],
-								[
-									"2",
-									"I leave behind my own personal calling cards when I do a job."
-								],
-								[
-									"3",
-									"I do not trust people who do not have a pet, mount, or furry companion."
-								],
-								[
-									"4",
-									"The pelt I wear on my back was from an animal that died saving my life, I will always cherish it."
-								],
-								[
-									"5",
-									"If my pet does not like you, I do not like you!"
-								],
-								[
-									"6",
-									"Once you've ridden with me and fought by my side, I'll be there for you odds be damned."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I talk to animals; I believe they understand me, even if they do not."
-								],
-								[
-									"2",
-									"I growl at and bite anyone who gets too close to my food while I am eating."
-								],
-								[
-									"3",
-									"I strongly dislike enclosed spaces and require intoxication or firm encouragement to enter them."
-								],
-								[
-									"4",
-									"I robbed the wrong caravan once. The owner is a powerful merchant who holds a grudge."
-								],
-								[
-									"5",
-									"I'm an inveterate gambler."
-								],
-								[
-									"6",
-									"I judge people based on how well they stand their ground in a fight. I got not time for cowards..."
-								]
-							]
-						}
-					]
-				}
-			],
-			"hasFluff": true
 		},
 		{
 			"name": "Izzet Engineer",
@@ -16178,7 +15062,7 @@
 					"type": "entries",
 					"name": "Feature: Urban Infrastructure",
 					"entries": [
-						"The popular conception of the Izzet League is based on mad inventions, dangerous experiments, and explosive blasts. Much of that perception is accurate, but the league is also involved with mundane tasks of construction and architecture\u2014primarily in crafting the infrastructure that allows Ravnicans to enjoy running water, levitating platforms, and other magical and technological wonders.",
+						"The popular conception of the Izzet League is based on mad inventions, dangerous experiments, and explosive blasts. Much of that perception is accurate, but the league is also involved with mundane tasks of construction and architecture—primarily in crafting the infrastructure that allows Ravnicans to enjoy running water, levitating platforms, and other magical and technological wonders.",
 						"You have a basic knowledge of the structure of buildings, including the stuff behind the walls. You can also find blueprints of a specific building in order to learn the details of its construction. Such blueprints might provide knowledge of entry points, structural weaknesses, or secret spaces. Your access to such information isn't unlimited. If obtaining or using the information gets you in trouble with the law, the guild can't shield you from the repercussions."
 					],
 					"data": {
@@ -16261,7 +15145,7 @@
 								],
 								[
 									"3",
-									"It's not magic\u2014or anything, really\u2014if you do it only halfway. Whatever I do, I give it all I've got."
+									"It's not magic—or anything, really—if you do it only halfway. Whatever I do, I give it all I've got."
 								],
 								[
 									"4",
@@ -16638,7 +15522,7 @@
 										],
 										[
 											"5",
-											"A meaningful favor from someone you defended\u2014perhaps a handkerchief or glove"
+											"A meaningful favor from someone you defended—perhaps a handkerchief or glove"
 										],
 										[
 											"6",
@@ -16846,7 +15730,7 @@
 					"name": "Feature: Knightly Regard",
 					"type": "entries",
 					"entries": [
-						"You receive shelter and succor from members of your knightly order and those who are sympathetic to its aims. If your order is a religious one, you can gain aid from temples and other religious communities of your deity. Knights of civic orders can get help from the community\u2014whether a lone settlement or a great nation\u2014that they serve, and knights of philosophical orders can find help from those they have aided in pursuit of their ideals, and those who share their ideals.",
+						"You receive shelter and succor from members of your knightly order and those who are sympathetic to its aims. If your order is a religious one, you can gain aid from temples and other religious communities of your deity. Knights of civic orders can get help from the community—whether a lone settlement or a great nation—that they serve, and knights of philosophical orders can find help from those they have aided in pursuit of their ideals, and those who share their ideals.",
 						"This help comes in the form of shelter and meals, and healing when appropriate, as well as occasionally risky assistance, such as a band of local citizens rallying to aid a sorely pressed knight, or those who support the order helping to smuggle a knight out of town when he or she is being hunted unjustly."
 					],
 					"data": {
@@ -16930,7 +15814,7 @@
 						"fine clothes|xphb",
 						"ink|xphb",
 						{
-							"item": "ink|xphb",
+							"item": "ink pen|xphb",
 							"quantity": 5
 						},
 						{
@@ -16976,7 +15860,7 @@
 						{
 							"type": "item",
 							"name": "Equipment:",
-							"entry": "Choose A or B: (A) 2 {@item Javelin|XPHB|Javelins}, {@item Calligrapher's Supplies|XPHB}, {@item Fine Clothes|XPHB}, {@item Ink|XPHB}, 5 {@item Ink|XPHB} Pens, {@item Parchment|XPHB} (9 sheets), 13 GP; or (B) 50 GP"
+							"entry": "Choose A or B: (A) 2 {@item Javelin|XPHB|Javelins}, {@item Calligrapher's Supplies|XPHB}, {@item Fine Clothes|XPHB}, {@item Ink|XPHB}, 5 {@item Ink Pen|XPHB|Ink Pens}, {@item Parchment|XPHB} (9 sheets), 13 GP; or (B) 50 GP"
 						}
 					]
 				}
@@ -17311,254 +16195,6 @@
 			"hasFluff": true
 		},
 		{
-			"name": "Lyceum Scholar",
-			"source": "TDCSR",
-			"page": 183,
-			"skillProficiencies": [
-				{
-					"choose": {
-						"from": [
-							"arcana",
-							"history",
-							"persuasion"
-						],
-						"count": 2
-					}
-				}
-			],
-			"languageProficiencies": [
-				{
-					"any": 2
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						{
-							"item": "fine clothes|phb",
-							"displayName": "A set of fine clothes"
-						},
-						{
-							"special": "student uniform"
-						},
-						{
-							"item": "writing kit|TDCSR"
-						},
-						{
-							"item": "pouch|phb",
-							"containsValue": 1000
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "Your choice of two of the following: {@skill Arcana}, {@skill History}, or {@skill Persuasion}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "Two of your choice"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A set of {@item fine clothes|phb}, a student uniform, a {@item writing kit|TDCSR} ({@item pouch|PHB|small pouch} with a quill, {@item Ink (1-ounce bottle)|PHB|ink}, {@item Parchment (one sheet)|PHB|folded parchment} and a penknife), and a belt {@item pouch|PHB} containing 10 gp"
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Feature: Academic Requisition",
-					"page": 184,
-					"entries": [
-						"You've cleared enough lessons\u2014and have gained an ally or two among the staff\u2014to enable access to certain private areas within the {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} and other allied universities. Whenever you're on {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} grounds or at another major academic institution, you can requisition any set of {@filter tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} found in the fifth edition rules. Each set of {@filter tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} is magically marked to sound an alarm if they are removed from the university's grounds.",
-						"When you seek services such as spellcasting from an NPC at the {@book Alabaster Lyceum|TDCSR|3|5. Alabaster Lyceum} or a related institution, you can use those services at a 25 percent discount, at the GM's discretion."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"name": "Suggested Characteristics",
-					"page": 184,
-					"entries": [
-						"The {@book Alabaster Lyceum|TDCSR|3|5. Alabaster Lyceum} accepts students of all major trades, the fine arts, and the magical arts. Pupils talented and privileged enough to be accepted travel to {@book Emon|TDCSR|3|Emon, the City of Fellowship} from all over Tal'Dorei, seeking to study among some of the greatest minds and most talented arcanists in the land. If you came from a smaller city, a rural area, or Tal'Dorei's relatively uncharted wilderness, studying at the {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} might have left you with a sense of culture shock, for good or for ill.",
-						"Your bond is likely associated with your goals as a student or graduate. Your ideal probably involves your hopes in using the knowledge you've gained at the {@book Lyceum|TDCSR|3|5. Alabaster Lyceum}, and your travels as an adventurer, to tailor the world to your liking.",
-						{
-							"type": "table",
-							"caption": "Lyceum Scholar Personality Traits",
-							"colLabels": [
-								"{@dice d8}",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I can't believe I'm here! At the {@book Alabaster Lyceum|TDCSR|3|5. Alabaster Lyceum}. Oh, gods, I've dreamed of this my whole life, and now I'm here!"
-								],
-								[
-									"2",
-									"I can't believe I squandered all the opportunities I had at school. I was supposed to be learning good stuff, but I wasted it all daydreaming about fighting monsters."
-								],
-								[
-									"3",
-									"Every night at school, I'd knock back a couple of meads and read with my pals! Just a bunch of nerds having fun, and I loved it."
-								],
-								[
-									"4",
-									"Everyone at school was such a stick in the mud. Dressing the same, listening to the same bards...ugh, it's sad. Just be yourself."
-								],
-								[
-									"5",
-									"I'm happiest when I've got my little party with me. At school, it was like we were a squad of heroes, slaying projects like monsters."
-								],
-								[
-									"6",
-									"I'd really rather you didn't bother me. Can't you see I'm studying here?"
-								],
-								[
-									"7",
-									"I don't care. I just don't care about it all. The dates I had to memorize, the formulae I learned...I just want to run away and live!"
-								],
-								[
-									"8",
-									"I'm just...tired. All the time. Oh, adventuring, sure, that's fine, as long as I can find time to...nap...goodnight."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Lyceum Scholar Ideals",
-							"colLabels": [
-								"{@dice d6}",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"{@b Preparedness}. I can't go out into the world unless I know what I'm up against. Study first, act later. (Neutral)"
-								],
-								[
-									"2",
-									"{@b Stardom}. Having a team is good and all, but you can't win a game of ball without the star charger, and you know that's me. (Evil)"
-								],
-								[
-									"3",
-									"{@b Individuality}. The world keeps us down by trying to put us all into little boxes. I'm tired of living in my box, and I don't care what you think about it. (Chaotic)"
-								],
-								[
-									"4",
-									"{@b Purpose}. I study because there are things I need to know. I'll find my place in the world, and I'll make the world better. (Good)"
-								],
-								[
-									"5",
-									"{@b Code of Conduct}. The student code is there to benefit all students, you know. It's the same for laws! (Lawful)"
-								],
-								[
-									"6",
-									"{@b Recreation}. All this studying crap wasn't worth anything if you weren't partying when you were done. Meet me down at the tavern, okay? (Chaotic)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Lyceum Scholar Bonds",
-							"colLabels": [
-								"{@dice d6}",
-								"Bond"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I came to the {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} with no one, but I fell in love with the city of {@book Emon|TDCSR|3|Emon, the City of Fellowship}. I've finally found a place that feels like home!"
-								],
-								[
-									"2",
-									"Most of my professors drove me to frustration, but there's one who was kind and wise. I know they'll always have my back."
-								],
-								[
-									"3",
-									"My family saved every copper piece to give me the opportunities I have now. I can't let them down."
-								],
-								[
-									"4",
-									"I came to the {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} with a childhood friend, but we've long been drifting apart."
-								],
-								[
-									"5",
-									"Discovery is the only thing that matters to me. The topic doesn't matter. Books keep me company on my loneliest days."
-								],
-								[
-									"6",
-									"The {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} is my life. I'd give up anything\u2014everything\u2014to protect it from harm."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Lyceum Scholar Flaws",
-							"colLabels": [
-								"{@dice d6}",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"The {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} taught me to never want to leave my room. The campus was so huge, and the crowds were so horrible."
-								],
-								[
-									"2",
-									"You think you're so great just because you've got muscles, and endurance, and...shut up! Read a book sometime!"
-								],
-								[
-									"3",
-									"Huh? What? Sorry, I was thinking about a test I need to retake when I get back to school...."
-								],
-								[
-									"4",
-									"I spent too much time studying. Now I don't have any friends."
-								],
-								[
-									"5",
-									"If you don't match my aesthetic, I'm not interested in you. We can work together, but we won't be friends. Got it?"
-								],
-								[
-									"6",
-									"I'm always striving for perfection. I got top of my class, sure, but only with a 98 average. And that's. Not. Perfect."
-								]
-							]
-						}
-					]
-				}
-			],
-			"hasFluff": true,
-			"hasFluffImages": true
-		},
-		{
 			"name": "Mage of High Sorcery",
 			"source": "DSotDQ",
 			"page": 30,
@@ -17881,7 +16517,7 @@
 								],
 								[
 									"5",
-									"{@b Bravery.} To act when others quake in fear\u2014this is the essence of the warrior. (Any)"
+									"{@b Bravery.} To act when others quake in fear—this is the essence of the warrior. (Any)"
 								],
 								[
 									"6",
@@ -18164,6 +16800,126 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Mist Wanderer",
+			"source": "RHW",
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"con",
+								"wis"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"dex",
+								"con",
+								"wis"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"anyFromCategory": {
+						"category": [
+							"DG"
+						]
+					}
+				}
+			],
+			"skillProficiencies": [
+				{
+					"survival": true,
+					"stealth": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyArtisansTool": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						{
+							"equipmentType": "toolArtisan",
+							"displayName": "Artisan's Tools (same as above)"
+						},
+						"lamp|xphb",
+						{
+							"item": "oil|xphb",
+							"displayName": "Oil (5 flasks)"
+						},
+						"pouch|xphb",
+						"rope|xphb",
+						"tinderbox|xphb",
+						"traveler's clothes|xphb",
+						{
+							"value": 3000
+						}
+					],
+					"b": [
+						{
+							"value": 5000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Dexterity, Constitution, Wisdom"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "A {@filter Dark Gift feat of your choice|feats|category=DG} ({@feat Mist Walker|RHW} is recommended)"
+						},
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Survival|XPHB} and {@skill Stealth|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "Choose one kind of {@item Artisan's Tools|XPHB}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Choose A or B: (A) {@item Artisan's Tools|XPHB} (same as above), {@item Lamp|XPHB}, {@item Oil|XPHB} (5 flasks), {@item Pouch|XPHB}, {@item Rope|XPHB}, {@item Tinderbox|XPHB}, {@item Traveler's Clothes|XPHB}, and 30 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
 			"name": "Moonwell Pilgrim",
 			"source": "FRHoF",
 			"page": 33,
@@ -18404,256 +17160,6 @@
 			"hasFluffImages": true
 		},
 		{
-			"name": "Mulmaster Aristocrat",
-			"source": "ALElementalEvil",
-			"page": 5,
-			"skillProficiencies": [
-				{
-					"deception": true,
-					"performance": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"anyArtisansTool": 1,
-					"anyMusicalInstrument": 1
-				}
-			],
-			"startingEquipment": [
-				{
-					"a": [
-						{
-							"equipmentType": "toolArtisan"
-						}
-					],
-					"b": [
-						{
-							"equipmentType": "instrumentMusical"
-						}
-					]
-				},
-				{
-					"_": [
-						"fine clothes|phb",
-						{
-							"special": "purse",
-							"containsValue": 1000
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Deception}, {@skill Performance}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "One type of artistic {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} and one {@filter musical instrument|items|source=phb|miscellaneous=mundane|type=instrument}"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "One set of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} or {@filter musical instrument|items|source=phb|miscellaneous=mundane|type=instrument}, a set of {@item fine clothes|phb}, and a purse containing 10 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Wealthy"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"From your hilltop home, you have looked down (literally and perhaps figuratively) on the unwashed masses of Mulmaster for your entire life. Your fur-trimmed robes and training in the visual and performing arts mark you as wealthy and perhaps well-born; you are a member of the City of Danger's aristocracy. None of your immediate family members sits on the Council of Blades or is even a Zor or Zora...yet. Nevertheless, you are one of Mulmaster's elite, and whether you personally covet a higher standing or not, you are at home in the dance halls where the aristocracy gathers to plot, to scheme, to do business, to discuss the arts, and, above all, to see, and to be seen."
-					]
-				},
-				{
-					"name": "Feature: Highborn",
-					"type": "entries",
-					"entries": [
-						"Mulmaster is run by and for its aristocracy. Every other class of citizen in the city defers to you, and even the priesthood, Soldiery, Hawks, and Cloaks treat you with deference. Other aristocrats and nobles accept you in their circles and likely know you or of you. Your connections can get you the ear of a Zor or Zora under the right circumstances. Note: This feature is a variant of the Noble feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"My ambitions are boundless. I will be a Zor or Zora one day!"
-								],
-								[
-									"2",
-									"I must always look my best."
-								],
-								[
-									"3",
-									"Beauty is everywhere. I can find it in even the homeliest person and the most horrible tragedy."
-								],
-								[
-									"4",
-									"Decorum must be preserved at all costs."
-								],
-								[
-									"5",
-									"I will not admit I am wrong if I can avoid it."
-								],
-								[
-									"6",
-									"I am extremely well-educated and frequently remind others of that fact."
-								],
-								[
-									"7",
-									"I take what I can today, because I do not know what tomorrow holds."
-								],
-								[
-									"8",
-									"My life is full of dance, song, drink, and love."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Generous. I have a responsibility to help and protect the less fortunate. (Good)"
-								],
-								[
-									"2",
-									"Loyal. My word, once given, is my bond. (Lawful)"
-								],
-								[
-									"3",
-									"Callous. I am unconcerned with any negative effects my actions may have on the lives and fortunes of others. (Evil)"
-								],
-								[
-									"4",
-									"Impulsive. I follow my heart. (Chaotic)"
-								],
-								[
-									"5",
-									"Ignorant. Explanations bore me. (Neutral)"
-								],
-								[
-									"6",
-									"Isolationist. I am concerned with the fortunes of my friends and family. Others must see to themselves. (Any)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I have dedicated my wealth and my talents to the service of one of the city's many temples."
-								],
-								[
-									"2",
-									"My family and I are loyal supporters of High Blade Jaseen Drakehorn. Our fortunes are inexorably tied to hers. I would do anything to support her."
-								],
-								[
-									"3",
-									"Like many families who were close to High Blade Selfaril Uoumdolphin, mine has suffered greatly since his fall. We honor his memory in secret."
-								],
-								[
-									"4",
-									"My family plotted with Rassendyll Uoumdolphin brother usurped brother as High Blade. Betrayal is the quickest route to power."
-								],
-								[
-									"5",
-									"Wealth and power are nothing. Fulfillment can only be found in artistic expression."
-								],
-								[
-									"6",
-									"It's not how you feel, who you know, or what you can do - it's how you look, and I look fabulous."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I have difficulty caring about anyone or anything other than myself."
-								],
-								[
-									"2",
-									"Having grown up with wealth, I am careless with my finances. I overspend and am overly generous."
-								],
-								[
-									"3",
-									"The ends (my advancement) justify any means."
-								],
-								[
-									"4",
-									"I must have what I want and will brook no delay."
-								],
-								[
-									"5",
-									"My family has lost everything. I must keep up appearances, lest we become a laughingstock."
-								],
-								[
-									"6",
-									"I have no artistic sense. I hide that fact behind extreme opinions and have become a trendsetter. "
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
-				}
-			],
-			"hasFluff": true
-		},
-		{
 			"name": "Myriad Operative (Criminal)",
 			"source": "EGW",
 			"page": 203,
@@ -18855,7 +17361,7 @@
 					"name": "Suggested Characteristics",
 					"type": "entries",
 					"entries": [
-						"Nobles are born and raised to a very different lifestyle than most people ever experience, and their personalities reflect that upbringing. A noble title comes with a plethora of bonds\u2014responsibilities to family, to other nobles (including the sovereign), to the people entrusted to the family's care, or even to the title itself. But this responsibility is often a good way to undermine a noble.",
+						"Nobles are born and raised to a very different lifestyle than most people ever experience, and their personalities reflect that upbringing. A noble title comes with a plethora of bonds—responsibilities to family, to other nobles (including the sovereign), to the people entrusted to the family's care, or even to the title itself. But this responsibility is often a good way to undermine a noble.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -19361,7 +17867,7 @@
 								],
 								[
 									"6",
-									"{@b Eternity}. I want to live forever\u2014in the flesh as long as possible, and as a spirit afterward. (Any)"
+									"{@b Eternity}. I want to live forever—in the flesh as long as possible, and as a spirit afterward. (Any)"
 								]
 							]
 						},
@@ -19417,7 +17923,7 @@
 							"rows": [
 								[
 									"1",
-									"I hold a scandalous secret that could ruin my family forever\u2014but could also earn me the favor of the Ghost Council."
+									"I hold a scandalous secret that could ruin my family forever—but could also earn me the favor of the Ghost Council."
 								],
 								[
 									"2",
@@ -19721,7 +18227,7 @@
 								],
 								[
 									"3",
-									"I once ran twenty-five miles without stopping to warn to my clan of an approaching orc horde. I'd do it again if I had to."
+									"I once ran twenty-five miles without stopping to warn my clan of an approaching orc horde. I'd do it again if I had to."
 								],
 								[
 									"4",
@@ -19857,573 +18363,6 @@
 							]
 						}
 					]
-				}
-			],
-			"hasFluff": true
-		},
-		{
-			"name": "Phlan Insurgent",
-			"source": "ALCurseOfStrahd",
-			"page": 6,
-			"skillProficiencies": [
-				{
-					"stealth": true,
-					"survival": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"anyArtisansTool": 1,
-					"vehicles (land)": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						{
-							"item": "caltrops (bag of 20)|phb",
-							"displayName": "bag of caltrops (bag of 20)"
-						},
-						{
-							"item": "trinket|phb",
-							"displayName": "small trinket that connects you to the life you once had before the occupation of Phlan"
-						},
-						"healer's kit|phb",
-						{
-							"item": "common clothes|phb",
-							"displayName": "dark common clothes that includes a cloak and hood"
-						},
-						{
-							"item": "pouch|phb",
-							"containsValue": 500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Stealth}, {@skill Survival}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "One type of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}, {@filter vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)}"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A bag of {@item caltrops (bag of 20)|phb}, a small {@item trinket|phb} that connects you to the life you once had before the occupation of Phlan, a {@item healer's kit|phb}, a set of dark {@item common clothes|phb} that includes a cloak and hood, and a belt {@item pouch|phb} containing 5 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Poor"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"The taking of Phlan by Vorgansharax is a clear memory in your mind. You were going about your everyday business when the green dragon's forces spilled out of the sewers and assailed your home. Many of Phlan's citizens, young and old alike, were captured, killed, or offered as tribute to the Maimed Virulence. You, yourself were one of those captured. But, either with the help of adventurers or through your own wits and sheer determination, you escaped.",
-						"Rather than flee the region, you've chosen to stay and fight. Finding refuge outside the town and the deadly thicket surrounding it, you strike out against the Tears of the Virulence and their monstrous allies. You've learned to survive in dire and desperate circumstances, with supplies running low and the arrival of reinforcements uncertain. You've grown accustomed to acting under the cover of night, dealing what blows you can to avenge the friends and family you lost within the currently occupied Phlan. You will drive Vorgansharax out, or you die trying."
-					]
-				},
-				{
-					"name": "Origin",
-					"type": "entries",
-					"entries": [
-						"Removed from your life as a townsperson, you've adapted to rough life in the wilds surrounding Phlan. The trade you practiced still influences your outlook, the manner in which you approach situations, and the way you contribute to the resistance movement against the Maimed Virulence. You can roll on the following table to determine what your occupation was before the fall, or choose one that best fits your character (select from either the general column or the specific column, but not both).",
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Origin (General)",
-								"Origin (Specific)"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-4",
-								"col-7"
-							],
-							"rows": [
-								[
-									"1",
-									"Fisher",
-									"Stojanow River Worker"
-								],
-								[
-									"2",
-									"Hunter",
-									"Twilight Marsh Worker"
-								],
-								[
-									"3",
-									"Craftsperson",
-									"Mantor's Library Scribe"
-								],
-								[
-									"4",
-									"Priest/Priestess",
-									"Clergy of Ilmater"
-								],
-								[
-									"5",
-									"Cook",
-									"Laughing Goblin Server"
-								],
-								[
-									"6",
-									"City Watch",
-									"Black Fist Guard"
-								],
-								[
-									"7",
-									"Servant",
-									"House Sokol Retainer"
-								],
-								[
-									"8",
-									"Unskilled Laborer",
-									"Bay of Phlan Dockworker"
-								]
-							]
-						}
-					]
-				},
-				{
-					"name": "Feature: Guerrilla",
-					"type": "entries",
-					"entries": [
-						"You've come to know the surrounding forests, streams, caves, and other natural features in which you can take refuge\u2014or set up ambushes. You can quickly survey your environment for advantageous features. Additionally, you can scavenge around your natural surroundings to cobble together simple supplies (such as improvised torches, rope, patches of fabric, etc.) that are consumed after use. Note: This feature is a variant of the Outlander feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"name": "Suggested Characteristics",
-					"type": "entries",
-					"entries": [
-						"You have given up the life you knew as a citizen of Phlan. However, the Maimed Virulence's invasion resonates deep inside you. Perhaps you have a few friends or family members who were able to escape with you. Or, perhaps, everyone you held dear either perished or went missing during the fall. You may know of someone who is, against all odds, surviving within the thicket and you long to liberate them from a life of peril within the town.",
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"My patience knows no bounds, so long as my goal is in sight."
-								],
-								[
-									"2",
-									"In life and in struggle, the ends justify my actions."
-								],
-								[
-									"3",
-									"If you aren't helping me, you'd best at least stay out of my way."
-								],
-								[
-									"4",
-									"I long for the life that was taken away from me."
-								],
-								[
-									"5",
-									"Friends and family perished, tragically, before my eyes. I hope never to undergo that again."
-								],
-								[
-									"6",
-									"Making the right choices in life are important to me. The choices I make might save not just my life, but the lives of others as well."
-								],
-								[
-									"7",
-									"I can never allow my foes to get the drop on me."
-								],
-								[
-									"8",
-									"Time is a precious resource that I must spend wisely."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Leadership. The oppressed need someone to inspire them to courageous acts. (Good)"
-								],
-								[
-									"2",
-									"Unpredictability. Keeping the enemy guessing and off-balance is my tactical strength. (Chaos)"
-								],
-								[
-									"3",
-									"Determination. Threats to my home must be eliminated at all costs. (Any)"
-								],
-								[
-									"4",
-									"Freedom. Those who are enslaved and unjustly imprisoned deserve my aid. (Good)"
-								],
-								[
-									"5",
-									"Resourcefulness. Our wits are our most valuable resource in troubled times. (Any)"
-								],
-								[
-									"6",
-									"Unity. Working together, we can overcome all obstacles, even the most seemingly insurmountable ones. (Any)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I'll never let my fellow insurgents down. They are my only remaining friends."
-								],
-								[
-									"2",
-									"I was separated from a loved one during my escape from town. I will find them."
-								],
-								[
-									"3",
-									"One of the Tears of the Virulence was a trusted friend, until the day they betrayed the city. They will pay harshly for their transgressions."
-								],
-								[
-									"4",
-									"An item I hold close is my last remaining connection to the family I lost during the fall."
-								],
-								[
-									"5",
-									"The dragon who took my past life away from me will feel the full extent of my vengeance."
-								],
-								[
-									"6",
-									"The knowledge in Mantor's Library is an irreplaceable treasure that must be protected."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I have no respect for those who flee. I harbor a deep grudge against the citizens who abandoned Phlan."
-								],
-								[
-									"2",
-									"Ale is the only way I can escape the desperation of my circumstances."
-								],
-								[
-									"3",
-									"It doesn't take much to get me into a fight."
-								],
-								[
-									"4",
-									"Being an insurgent means doing things that aren't always ethical. I'm still learning to live with that."
-								],
-								[
-									"5",
-									"My desire to liberate Phlan oftentimes clouds my judgment, despite my best efforts."
-								],
-								[
-									"6",
-									"I relentlessly despise the Maimed Virulence and his allies. I'd abandon other goals in order to strike out at them."
-								]
-							]
-						}
-					]
-				}
-			],
-			"hasFluff": true
-		},
-		{
-			"name": "Phlan Refugee",
-			"source": "ALElementalEvil",
-			"page": 6,
-			"skillProficiencies": [
-				{
-					"insight": true,
-					"athletics": true
-				}
-			],
-			"languageProficiencies": [
-				{
-					"anyStandard": 1
-				}
-			],
-			"toolProficiencies": [
-				{
-					"anyArtisansTool": 1
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						{
-							"equipmentType": "toolArtisan"
-						},
-						{
-							"special": "token of the life you once knew"
-						},
-						"traveler's clothes|phb",
-						{
-							"item": "pouch|phb",
-							"containsValue": 1500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Insight}, {@skill Athletics}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "One type of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "One of your choice"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A set of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} (one of your choice), a token of the life you once knew, a set of {@item traveler's clothes|phb}, and a belt {@item pouch|phb} containing 15 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Modest"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"Gone are the happier days of walking into the Laughing Goblin Inn after a hard day's labor. Everything has changed, and you are lucky to be alive. Back in Phlan you could count yourself among those street-wise folks who knew when to pay a bribe and who to work with to make a living. Your ability to listen to the winds of change have saved you before, and this time they allowed you to be one of the lucky few who escaped Phlan with something more than just the shirt on your back."
-					]
-				},
-				{
-					"name": "Feature: Phlan Survivor",
-					"type": "entries",
-					"entries": [
-						"Whatever your prior standing was, you are now one of the many refugees that have come to Mulmaster. You are able to find refuge with others from Phlan and those who sympathize with your plight. Within Mulmaster this means that you can find a place to bed down, recover, and hide from the watch with either other refugees from Phlan, or the Zhents within the ghettos. Note: This feature is a variant of the Folk Hero feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I may have lost everything I worked for most of my life, but there's work to be done, no time to linger on the past."
-								],
-								[
-									"2",
-									"I worked hard to get where I am and I refuse to let a little hardship stop me from succeeding."
-								],
-								[
-									"3",
-									"I protect those around me, you never know when one of them will be useful."
-								],
-								[
-									"4",
-									"I have always gotten ahead by giving, why change now?"
-								],
-								[
-									"5",
-									"I prepare for everything, it paid off in Phlan and it will pay off again."
-								],
-								[
-									"6",
-									"I will reclaim my home, though the path may be long, I will never give up hope."
-								],
-								[
-									"7",
-									"I never cared for personal hygiene, and am amazed that It bothers others."
-								],
-								[
-									"8",
-									"I am always willing to volunteer my services, just as long as don't have to do anything."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Justice. Corruption brought Phlan down, I will not tolerate that any longer. (Lawful)"
-								],
-								[
-									"2",
-									"Acceptance. Stability is a myth, to think you can control your future is futile. (Chaotic)"
-								],
-								[
-									"3",
-									"Hope. I am guided by a higher power and I trust that everything will be right in the end. (Good)"
-								],
-								[
-									"4",
-									"Restraint. I hate those who caused my loss. It is all I can do not to lash out at them. (Any)"
-								],
-								[
-									"5",
-									"Strength. As shown in Phlan, the strong survive. If you are weak you deserve what you get (Evil)"
-								],
-								[
-									"6",
-									"Openness. I am always willing to share my life story with anyone who will listen. (Any)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I have the chance at a new life and this time I am going to do things right."
-								],
-								[
-									"2",
-									"The Lord Regent brought this suffering upon his people. I will see him brought to justice."
-								],
-								[
-									"3",
-									"I await the day I will be able to return to my home in Phlan."
-								],
-								[
-									"4",
-									"I will never forget the debt owed to Glevith of the Welcomers. I will be ready to repay that debt when called upon."
-								],
-								[
-									"5",
-									"There was someone I cared about in Phlan, I will find out what happened to them."
-								],
-								[
-									"6",
-									"Some say my life wasn't worth saving, I will prove them wrong."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I used the lives of children to facilitate my escape from Phlan."
-								],
-								[
-									"2",
-									"I am a sucker for the underdog, and always bet on the loosing team."
-								],
-								[
-									"3",
-									"I am incapable of standing up for myself."
-								],
-								[
-									"4",
-									"I will borrow money from friends with no intention to repay it."
-								],
-								[
-									"5",
-									"I am unable to keep secrets. A secret is just an untold story."
-								],
-								[
-									"6",
-									"When something goes wrong, it's never my fault."
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
 				}
 			],
 			"hasFluff": true
@@ -21146,7 +19085,7 @@
 								]
 							]
 						},
-						"Consider customizing how your spells look when you cast them. You might wield your Prismari spells with dynamic, gestural movement\u2014as much dance as somatic component. Even a blast of fire in your hands is a sculpted work of art; elemental forces make grand designs as you hurl spells. These forces might linger on your body or in your clothes as decorative elements after your spells are dissipated, as sparks dance in your hair and your touch leaves tracings of frost on whatever you touch."
+						"Consider customizing how your spells look when you cast them. You might wield your Prismari spells with dynamic, gestural movement—as much dance as somatic component. Even a blast of fire in your hands is a sculpted work of art; elemental forces make grand designs as you hurl spells. These forces might linger on your body or in your clothes as decorative elements after your spells are dissipated, as sparks dance in your hair and your touch leaves tracings of frost on whatever you touch."
 					],
 					"data": {
 						"isFeature": true
@@ -21833,7 +19772,7 @@
 								],
 								[
 									"3",
-									"{@b Creativity}. I strive to find more ways to express my art through pain\u2014my own as well as others'. (Chaotic)"
+									"{@b Creativity}. I strive to find more ways to express my art through pain—my own as well as others'. (Chaotic)"
 								],
 								[
 									"4",
@@ -22161,244 +20100,6 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true
-		},
-		{
-			"name": "Reformed Cultist",
-			"source": "TDCSR",
-			"page": 185,
-			"skillProficiencies": [
-				{
-					"deception": true,
-					"religion": true
-				}
-			],
-			"languageProficiencies": [
-				{
-					"any": 1
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						{
-							"special": "vestments"
-						},
-						{
-							"item": "holy symbol|phb",
-							"displayName": "a holy symbol of your previous cult"
-						},
-						"common clothes|phb",
-						{
-							"item": "pouch|phb",
-							"containsValue": 1500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Deception} and {@skill Religion}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "One of your choice"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "Vestments and a {@item holy symbol|phb} of your previous cult, a set of {@item common clothes|phb}, a belt {@item pouch|PHB} containing 15 gp"
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Feature: Fell Teachings",
-					"page": 186,
-					"entries": [
-						"You were inundated with knowledge about one of the {@book Betrayer Gods|TDCSR|2|Betrayer Gods}, and know by heart everything from their basic commandments to some of their most esoteric secrets. Choose one of the {@book Betrayer Gods|TDCSR|2|Betrayer Gods}. You have {@quickref Advantage and Disadvantage|PHB|2|0|advantage} on Intelligence ({@skill Religion}) checks to know information about their faith, including obscure secrets unknown to most worshipers.",
-						"Additionally, you can work with your GM to create a secret that you learned during your time in the cult. This secret might be the seed of a conspiracy, a myth of a legendary hero whose true meaning has mutated over the years, or even the location of a fabled artifact of the gods."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"name": "Suggested Characteristics",
-					"page": 186,
-					"entries": [
-						"The life of every former cultist is defined to some degree by the process of fleeing the past, and of trying to make a future away from the beliefs that once claimed them. Your bond is likely associated with those who gave you the insight and strength to flee your old ways. Your ideal might involve your desire to take down and destroy those who promote the evil you escaped, and perhaps finding new faith in a forgiving god.",
-						{
-							"type": "table",
-							"caption": "Reformed Cultist Personality Traits",
-							"colLabels": [
-								"{@dice d8}",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I need a {@item dagger|phb} close at hand at all times. Just in case they find me."
-								],
-								[
-									"2",
-									"I can't believe I'm out here fighting monsters. After everything I've been through, why can't I find a normal life?"
-								],
-								[
-									"3",
-									"I need a stiff drink before I do anything stressful these days. I know it's a problem. Just...let me have this."
-								],
-								[
-									"4",
-									"Murder is okay when it's for a good cause! I didn't tear my past out by the roots so I could let evil people cause more harm."
-								],
-								[
-									"5",
-									"My past is filled with stories like you wouldn't believe. Ones that'll really make your skin crawl. Do you want to hear...?"
-								],
-								[
-									"6",
-									"Yeah, I'm crying. I do that. Get over yourself."
-								],
-								[
-									"7",
-									"I know you've told me your name twice already, but that's not good enough. How can I be sure you are who you say you are?"
-								],
-								[
-									"8",
-									"My mind is always racing. I can't...I just need to...you have to give me a second\u2014or else I can't...organize my thoughts."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Reformed Cultist Ideals",
-							"colLabels": [
-								"{@dice d6}",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"{@b Life}. I've spent too long shackled to an evil master. No matter what happened before, I deserve my freedom now. (Chaotic)"
-								],
-								[
-									"2",
-									"{@b Redemption}. People can change, but redemption must be something they choose for themselves. If they do, it is my duty to help them along that path. (Good)"
-								],
-								[
-									"3",
-									"{@b Power}. When I abandoned the cult, it wasn't out of some misguided sense of righteousness. That pathetic organization was merely a shackle on my potential. (Evil)"
-								],
-								[
-									"4",
-									"{@b Vengeance}. The cult has poisoned my life. I will see all its followers suffer. (Any)"
-								],
-								[
-									"5",
-									"{@b Hierarchy}. The cult was vile, but its strength was in stability and organization. As long as good folk lack unity, evil will always triumph. (Lawful)"
-								],
-								[
-									"6",
-									"{@b Reparations}. As a cultist, I harmed people whose names I'll never know. I feel obligated to repay my debt by aiding others. (Good)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Reformed Cultist Bonds",
-							"colLabels": [
-								"{@dice d6}",
-								"Bond"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"My cousin escaped the cult with me. I lost track of them when we fled, but I know they're alive. I can feel it."
-								],
-								[
-									"2",
-									"I was saved from the cult by a priest of one of the {@book Prime Deities|TDCSR|2|Prime Deities}. If not for that sign of faith, I would surely be lost."
-								],
-								[
-									"3",
-									"I was told by the person who saved me that a sage once said: \"Life needs things to live.\" I don't know what that means, but I've dedicated my existence to finding out."
-								],
-								[
-									"4",
-									"One of my cultist parents had a change of heart when I was a teenager, and we fled together in the dark of night. I didn't want to leave, but I understand now that their courage saved my life."
-								],
-								[
-									"5",
-									"I was bested by a warrior when I fumbled a cult-ordered assassination. I don't know why that person took pity on me, but they gave me purpose when I was lost."
-								],
-								[
-									"6",
-									"Now that I've saved myself, the only person important to me is my former cult leader\u2014because I've sworn that they'll die by my hand."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Reformed Cultist Flaws",
-							"colLabels": [
-								"{@dice d6}",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I'm haunted by what I saw in those ritual chambers. Every time I see blood, I...oh, gods, I can't bear to even think about it."
-								],
-								[
-									"2",
-									"I ran from the cult long ago. But deep down, there's a part of me that still thinks they were right about certain things."
-								],
-								[
-									"3",
-									"I can't help but feel a rush whenever I see a life snuffed out before me. Just one more kill... just one more."
-								],
-								[
-									"4",
-									"Organized religion terrifies me. {@book Betrayer Gods|TDCSR|2|Betrayer Gods} or {@book Prime Deities|TDCSR|2|Prime Deities}...it doesn't matter. The sight of the faithful freezes my blood cold."
-								],
-								[
-									"5",
-									"Oh, I always tell the truth. Always. I've never had to keep a secret from anyone, so of course I'll be open with you."
-								],
-								[
-									"6",
-									"I don't trust easily. If you grew up being lied to about every little thing? The fundamental nature of the world? You wouldn't, either."
-								]
-							]
-						}
-					]
-				}
-			],
-			"hasFluff": true
 		},
 		{
 			"name": "Revelry Pirate (Sailor)",
@@ -22995,8 +20696,8 @@
 					"type": "entries",
 					"name": "Building a Ruined Character",
 					"entries": [
-						"Ruined characters were on top of the world before misfortune struck. Many were wealthy. Others come from modest backgrounds, but they were surrounded by friends, family, and loved ones. They might have been famous, or simply never encountered serious hardship before. Some were born to privilege or rose to prominence through trickery or a false reputation. Now a {@item Deck of Many Things}\u2014or another calamity\u2014has knocked them down like a house of cards.",
-						"If your character's life was ruined by a {@item Deck of Many Things}, consider which card was responsible. Perhaps your character was imprisoned for years by the Donjon or Void card, and now everyone they knew has died. Maybe your character drew the Rogue card, and the person closest to them\u2014a spouse, child, or parent\u2014turned against them. A devil unleashed by the Flames card might have destroyed their life. The Ruin or Talons card might have stolen the character's material goods or saddled them with vast debt."
+						"Ruined characters were on top of the world before misfortune struck. Many were wealthy. Others come from modest backgrounds, but they were surrounded by friends, family, and loved ones. They might have been famous, or simply never encountered serious hardship before. Some were born to privilege or rose to prominence through trickery or a false reputation. Now a {@item Deck of Many Things}—or another calamity—has knocked them down like a house of cards.",
+						"If your character's life was ruined by a {@item Deck of Many Things}, consider which card was responsible. Perhaps your character was imprisoned for years by the Donjon or Void card, and now everyone they knew has died. Maybe your character drew the Rogue card, and the person closest to them—a spouse, child, or parent—turned against them. A devil unleashed by the Flames card might have destroyed their life. The Ruin or Talons card might have stolen the character's material goods or saddled them with vast debt."
 					]
 				},
 				{
@@ -23358,7 +21059,7 @@
 					"name": "Suggested Characteristics",
 					"type": "entries",
 					"entries": [
-						"Sages are defined by their extensive studies, and their characteristics reflect this life of study. Devoted to scholarly pursuits, a sage values knowledge highly\u2014sometimes in its own right, sometimes as a means toward other ideals.",
+						"Sages are defined by their extensive studies, and their characteristics reflect this life of study. Devoted to scholarly pursuits, a sage values knowledge highly—sometimes in its own right, sometimes as a means toward other ideals.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -23376,7 +21077,7 @@
 								],
 								[
 									"2",
-									"I've read every book in the world's greatest libraries\u2014or I like to boast that I have."
+									"I've read every book in the world's greatest libraries—or I like to boast that I have."
 								],
 								[
 									"3",
@@ -23524,6 +21225,7 @@
 			"name": "Sage",
 			"source": "XPHB",
 			"page": 183,
+			"srd52": true,
 			"basicRules2024": true,
 			"edition": "one",
 			"ability": [
@@ -23783,7 +21485,7 @@
 								],
 								[
 									"3",
-									"Freedom. The sea is freedom\u2014the freedom to go anywhere and do anything. (Chaotic)"
+									"Freedom. The sea is freedom—the freedom to go anywhere and do anything. (Chaotic)"
 								],
 								[
 									"4",
@@ -23816,7 +21518,7 @@
 								],
 								[
 									"2",
-									"The ship is most important\u2014crewmates and captains come and go."
+									"The ship is most important—crewmates and captains come and go."
 								],
 								[
 									"3",
@@ -24114,249 +21816,6 @@
 			"hasFluffImages": true
 		},
 		{
-			"name": "Secret Identity",
-			"source": "ALRageOfDemons",
-			"page": 9,
-			"skillProficiencies": [
-				{
-					"deception": true,
-					"stealth": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"disguise kit": true,
-					"forgery kit": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						"disguise kit|phb",
-						"forgery kit|phb",
-						"common clothes|phb",
-						{
-							"item": "pouch|phb",
-							"displayName": "belt pouch"
-						},
-						{
-							"value": 500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Deception}, {@skill Stealth}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "{@item Disguise kit|phb}, {@item Forgery kit|phb}"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A {@item disguise kit|phb}, a {@item forgery kit|phb}, a set of {@item common clothes|phb}, a belt {@item pouch|phb}, 5 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Modest"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"Even though you are a non-human, despite Hillsfar's Great Law of Humanity, you continue to live in the City of Trade. You do so by maintaining a secret identity, forging documents, and wearing a disguise. Few, if any, know you aren't human. If you're a halfling or gnome, you pass as a little person or a child. If you're a half-elf, half-orc, or genasi, you disguise your non-human features. Other races use a combination of disguise and concealing clothing to hide. Your reasons for doing so are your own. Perhaps you're a dissident or the agent of a foreign power. Maybe you have a relationship with someone you cannot bear to leave. Regardless, this way of life has taken a heavy toll on you."
-					]
-				},
-				{
-					"name": "Feature: Secret Identity",
-					"type": "entries",
-					"entries": [
-						"You have created a secret identity that you use to conceal your true race and that offers a covering explanation for your presence in Hillsfar. In addition, you can forge documents, including official papers and personal letters, as long as you have seen an example of the kind of document or the handwriting you are trying to copy Note: This feature is a variant of the Charlatan feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Despite its problems, I love Hillsfar, it's the greatest city in the world. The only one for me."
-								],
-								[
-									"2",
-									"I move from place to place, never staying anywhere long and leaving nothing behind."
-								],
-								[
-									"3",
-									"I think flattery is the best way to direct attention away from me."
-								],
-								[
-									"4",
-									"I don't make friends easily. They're a liability I cannot afford."
-								],
-								[
-									"5",
-									"Risk and danger are exhilarate me. Pulling off schemes and deceptions is a rush."
-								],
-								[
-									"6",
-									"The First Lord is right, humans are superior. I really admire them, despite the atrocities."
-								],
-								[
-									"7",
-									"I avoid people of my own race, as well as things associated with my race, lest they give me away."
-								],
-								[
-									"8",
-									"I live for the Arena. I admire gladiators and enjoy the thrill of blood on the sands!"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Quisling. Supporting the rulers of the land and following the laws is the road to salvation. (Lawful)"
-								],
-								[
-									"2",
-									"Scoflaw. The laws and lawmakers are corrupt. I follow laws only when it suits me. (Chaotic)"
-								],
-								[
-									"3",
-									"Optimist. Everyone Is basically good. Though the government is misguided it will all be okay. (Any)"
-								],
-								[
-									"4",
-									"Secretive. I am in the habit of not talking about myself. My business is none of yours. (Any)"
-								],
-								[
-									"5",
-									"Heroic. I do everything I can to help non-humans, regardless of the personal cost to me. (Good)"
-								],
-								[
-									"6",
-									"Depraved. I have lost my moral compass. The ends justify most any means. (Evil)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"The humans of Hillsfar have inflicted terrible harm on me, my family, and my race. I will have revenge."
-								],
-								[
-									"2",
-									"I am part of an underground network that smuggles non-humans into and out of the city."
-								],
-								[
-									"3",
-									"I am a partisan. I commit minor acts of defiance against the First Lord and Red Plumes when I can."
-								],
-								[
-									"4",
-									"I am a spy. I report on events in and around Hillsfar."
-								],
-								[
-									"5",
-									"My secret identity is the only thing protecting me from the Arena. I will stop at nothing to maintain it."
-								],
-								[
-									"6",
-									"I am madly in love with a human who does not know my true identity, and I fear rejection if I reveal it."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"After years of denying who I am, I now despise myself and other members of my pathetic race."
-								],
-								[
-									"2",
-									"Years of hiding have made me somewhat paranoid. I trust no one."
-								],
-								[
-									"3",
-									"I've been lying so often and for so long that I can't help it anymore. I frequently lie for no reason at all."
-								],
-								[
-									"4",
-									"I am ashamed. I failed to protect a member of my family who was seized and thrown into the Area."
-								],
-								[
-									"5",
-									"I am struggling with maintaining my secret identity. I subconsciously want to get caught and therefore sometimes let my secret identity slip."
-								],
-								[
-									"6",
-									"Years of successfully deceiving others have made me cocky. I think no one can see through my lies."
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
-				}
-			],
-			"hasFluff": true
-		},
-		{
 			"name": "Selesnya Initiate",
 			"source": "GGR",
 			"page": 86,
@@ -24524,7 +21983,7 @@
 					"type": "entries",
 					"name": "Suggested Characteristics",
 					"entries": [
-						"Most members of the Selesnya Conclave are true believers\u2014the tight-knit community allows little room for the cynical or disillusioned. They are spiritual, empathetic, and generally peaceful\u2014unless roused to action. Their flaws and bonds alike grow naturally from their close ties to the community.",
+						"Most members of the Selesnya Conclave are true believers—the tight-knit community allows little room for the cynical or disillusioned. They are spiritual, empathetic, and generally peaceful—unless roused to action. Their flaws and bonds alike grow naturally from their close ties to the community.",
 						{
 							"type": "table",
 							"caption": "Personality Traits",
@@ -24800,260 +22259,8 @@
 					"name": "How Do I Fit In?",
 					"entries": [
 						"Although the guild teaches the importance of subjugating the individual will to the good of the conclave, it also celebrates the diversity of individuals, in the same sense that a field that produces different crops is healthier than one that yields a single crop. That principle applies to your skills as an adventurer. As long as your efforts are directed toward advancing the goals of the guild rather than your private agenda, you're allowed to put your talents to work in your unique way.",
-						"That said, you must never lose sight of the fact that you are part of a larger community. That includes the whole guild, of course, but your ties to community start with your vernadi (enclave) and its voda (dryad leader). The dryads want to know what you're doing and what purpose it serves, and they act to curtail your actions\u2014or even expel you from the guild\u2014if they determine that you aren't serving Selesnya's best interests."
+						"That said, you must never lose sight of the fact that you are part of a larger community. That includes the whole guild, of course, but your ties to community start with your vernadi (enclave) and its voda (dryad leader). The dryads want to know what you're doing and what purpose it serves, and they act to curtail your actions—or even expel you from the guild—if they determine that you aren't serving Selesnya's best interests."
 					]
-				}
-			],
-			"hasFluff": true
-		},
-		{
-			"name": "Shade Fanatic",
-			"source": "ALRageOfDemons",
-			"page": 10,
-			"skillProficiencies": [
-				{
-					"deception": true,
-					"intimidation": true
-				}
-			],
-			"languageProficiencies": [
-				{
-					"other": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"forgery kit": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						"forgery kit|phb",
-						{
-							"special": "transparent cylinder of shadow that has no opening"
-						},
-						"signet ring|phb",
-						"fine clothes|phb",
-						{
-							"value": 1500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Deception}, {@skill Intimidation}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "{@item Forgery kit|phb}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "Netherese"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "A {@item forgery kit|phb}, a transparent cylinder of shadow that has no opening, a {@item signet ring|phb}, a set of {@item fine clothes|phb}, and 15 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Modest"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"You grew up at a time when the wizards of Netheril were at war with the elves of Cormanthor. You recall sitting cross-legged hearing the stories of the glorious Thultanthar, also called the Shade Enclave and the City of Shade, and aspired to study there and maybe even did, for a time. Your dreams came crashing down a few years ago when Thultanthar fell from the sky upon Myth Drannor.",
-						"You know that there was a Netherese Garrison stationed near Hillsfar and have heard rumors that its downfall came from traitors within the ranks. You remain loyal to Netheril and seek other Shade loyalists and fanatics in the Cormanthor forest and the areas surrounding Hillsfar."
-					]
-				},
-				{
-					"name": "Feature: Secret Society",
-					"type": "entries",
-					"entries": [
-						"You have a special way of communicating with others who feel the same way you do about the Shade. When you enter a village or larger city you can identify contact who will give you information on those that would hinder your goals and those would help you simply because of your desire to see the Shade Enclave return in all its glory. Note: This feature is a variant of the Criminal feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I am a bully; I try to hide it though."
-								],
-								[
-									"2",
-									"I let my actions speak for themselves"
-								],
-								[
-									"3",
-									"I am important; I will not let anyone forget that."
-								],
-								[
-									"4",
-									"You are either with me or against me."
-								],
-								[
-									"5",
-									"I know it is only a time before I am betrayed by those I care for."
-								],
-								[
-									"6",
-									"I never understand why people get so emotional."
-								],
-								[
-									"7",
-									"They are out to get me. It is only my cunning that keeps me ahead of them"
-								],
-								[
-									"8",
-									"Everyone has a choice, the one I make is always right though."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Hope. I know even if I need do evil acts, history will be my redemption. (Chaos)"
-								],
-								[
-									"2",
-									"Dedicated. I can do anything I put my mind to (Lawful)"
-								],
-								[
-									"3",
-									"Exciting. I have found the truth of the Shadovar and want to share it with everyone. (Any)"
-								],
-								[
-									"4",
-									"Frugal. I horde my possessions knowing that someday I will be called upon to give everything I have to the cause (Any)"
-								],
-								[
-									"5",
-									"Eloquent. I use my words to sway others to my beliefs. (Any)"
-								],
-								[
-									"6",
-									"Compassionate. It is through love that others will join in our cause. (Good)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"They say the Shade broke the bonds of mortality; I want to find out how."
-								],
-								[
-									"2",
-									"The whispers in my head remind me that there is power to be found in the shadows."
-								],
-								[
-									"3",
-									"For the glory of Netheril, I will grow in power."
-								],
-								[
-									"4",
-									"I once lived in Hillsfar, I was chased out before I was able to say farewell."
-								],
-								[
-									"5",
-									"My true love was a killed by the Red Plumes; I plot to make them suffer."
-								],
-								[
-									"6",
-									"I had a loved one die in the arena at Hillsfar; I am out to prove I am stronger than them!"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I always over exaggerate my abilities."
-								],
-								[
-									"2",
-									"I cannot bear to let those I care for out of my sight."
-								],
-								[
-									"3",
-									"I am incapable of standing up for myself."
-								],
-								[
-									"4",
-									"The group I am with has committed atrocities; I am always worried their actions will become public."
-								],
-								[
-									"5",
-									"I always enjoy a good mug of ale... or five."
-								],
-								[
-									"6",
-									"I know what I do is wrong, but am afraid to speak up about it."
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
 				}
 			],
 			"hasFluff": true
@@ -25443,7 +22650,7 @@
 								],
 								[
 									"5",
-									"I'm not afraid of hard work\u2014in fact, I prefer it."
+									"I'm not afraid of hard work—in fact, I prefer it."
 								],
 								[
 									"6",
@@ -25708,7 +22915,7 @@
 								]
 							]
 						},
-						"Consider customizing how your spells look when you cast them. Your Silverquill spells might be accompanied by visual effects resembling splotches of ink or radiating ripples of golden light. Any auditory effects of your spells often sound like amplified echoes of your own voice speaking the spells' verbal components\u2014even amid the crash of lightning or a fiery eruption."
+						"Consider customizing how your spells look when you cast them. Your Silverquill spells might be accompanied by visual effects resembling splotches of ink or radiating ripples of golden light. Any auditory effects of your spells often sound like amplified echoes of your own voice speaking the spells' verbal components—even amid the crash of lightning or a fiery eruption."
 					],
 					"data": {
 						"isFeature": true
@@ -25890,7 +23097,7 @@
 					"type": "entries",
 					"name": "Clades and Projects",
 					"entries": [
-						"As a Simic researcher, you are part of a clade\u2014a diverse group of individuals combining disparate talents in pursuit of a common goal\u2014or a researcher on a specialized, short-term project focused on addressing an immediate need. You can roll a {@dice d6} or choose from the options in the Research Options table to determine your area of research.",
+						"As a Simic researcher, you are part of a clade—a diverse group of individuals combining disparate talents in pursuit of a common goal—or a researcher on a specialized, short-term project focused on addressing an immediate need. You can roll a {@dice d6} or choose from the options in the Research Options table to determine your area of research.",
 						{
 							"type": "table",
 							"caption": "Research Options",
@@ -25993,7 +23200,7 @@
 					"type": "entries",
 					"name": "Suggested Characteristics",
 					"entries": [
-						"The bizarre science of the Simic Combine attracts a certain type of personality and encompasses a set of beliefs about the nature of life. Simic members' bonds and flaws derive from their scientific research\u2014including their creation of new life forms, which they can become very attached to.",
+						"The bizarre science of the Simic Combine attracts a certain type of personality and encompasses a set of beliefs about the nature of life. Simic members' bonds and flaws derive from their scientific research—including their creation of new life forms, which they can become very attached to.",
 						{
 							"type": "table",
 							"caption": "Personality Traits",
@@ -26058,7 +23265,7 @@
 								],
 								[
 									"2",
-									"{@b Change}. All life is meant to progress toward perfection, and our work is to hurry it along\u2014no matter what must be upended along the way. (Chaotic)"
+									"{@b Change}. All life is meant to progress toward perfection, and our work is to hurry it along—no matter what must be upended along the way. (Chaotic)"
 								],
 								[
 									"3",
@@ -26100,7 +23307,7 @@
 								],
 								[
 									"3",
-									"The other researchers in my clade are my family\u2014a big, eccentric family including members and parts of many species."
+									"The other researchers in my clade are my family—a big, eccentric family including members and parts of many species."
 								],
 								[
 									"4",
@@ -26254,7 +23461,7 @@
 								],
 								[
 									"9",
-									"I left the Selesnya\u2014and a lover\u2014behind when I joined the Simic."
+									"I left the Selesnya—and a lover—behind when I joined the Simic."
 								],
 								[
 									"10",
@@ -26269,7 +23476,7 @@
 					"name": "How Do I Fit In?",
 					"entries": [
 						"As a Simic adventurer, your mission likely aligns with the Adaptationist philosophy; the disagreements and tensions among the guilds will soon erupt into open conflict, and your guild needs your help to ensure that the Simic survive. That help might come in the form of defending against Golgari incursions into Simic zonots or shielding Simic research from Azorius intrusion. It could also involve more subtle, diplomatic work to maintain balance among the guilds, or subterfuge aimed at undermining another guild's grab for power.",
-						"Self-improvement is also an important part of your mission. Anything you can do to make yourself more capable\u2014whether learning a new spell or adopting a new hybridizing mutation\u2014gives the Simic a stronger weapon in its arsenal. The combine must change to survive, and that means individual members of the guild must grow and adapt as well."
+						"Self-improvement is also an important part of your mission. Anything you can do to make yourself more capable—whether learning a new spell or adopting a new hybridizing mutation—gives the Simic a stronger weapon in its arsenal. The combine must change to survive, and that means individual members of the guild must grow and adapt as well."
 					]
 				}
 			],
@@ -26349,7 +23556,7 @@
 					"type": "entries",
 					"name": "Claim to Fame",
 					"entries": [
-						"Every smuggler has that one tale that sets them apart from common criminals. By wits, sailing skill, or a silver tongue, you lived to tell the story\u2014and you tell it often. You can roll on the following table to determine your claim or choose one that best fits your character.",
+						"Every smuggler has that one tale that sets them apart from common criminals. By wits, sailing skill, or a silver tongue, you lived to tell the story—and you tell it often. You can roll on the following table to determine your claim or choose one that best fits your character.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -26836,7 +24043,7 @@
 								],
 								[
 									"3",
-									"I made a terrible mistake in battle that cost many lives\u2014and I would do anything to keep that mistake secret."
+									"I made a terrible mistake in battle that cost many lives—and I would do anything to keep that mistake secret."
 								],
 								[
 									"4",
@@ -26861,6 +24068,7 @@
 			"name": "Soldier",
 			"source": "XPHB",
 			"page": 185,
+			"srd52": true,
 			"basicRules2024": true,
 			"edition": "one",
 			"ability": [
@@ -27102,35 +24310,92 @@
 			"hasFluffImages": true
 		},
 		{
-			"name": "Stojanow Prisoner",
-			"source": "ALCurseOfStrahd",
-			"page": 8,
+			"name": "Spirit Medium",
+			"source": "RHW",
+			"edition": "one",
+			"ability": [
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"con",
+								"int",
+								"wis"
+							],
+							"weights": [
+								2,
+								1
+							]
+						}
+					}
+				},
+				{
+					"choose": {
+						"weighted": {
+							"from": [
+								"con",
+								"int",
+								"wis"
+							],
+							"weights": [
+								1,
+								1,
+								1
+							]
+						}
+					}
+				}
+			],
+			"feats": [
+				{
+					"anyFromCategory": {
+						"category": [
+							"DG"
+						]
+					}
+				}
+			],
 			"skillProficiencies": [
 				{
-					"deception": true,
-					"perception": true
+					"insight": true,
+					"religion": true
 				}
 			],
 			"toolProficiencies": [
 				{
-					"anyGamingSet": 1,
-					"thieves' tools": true
+					"anyGamingSet": 1
 				}
 			],
 			"startingEquipment": [
 				{
-					"_": [
+					"a": [
+						"dagger|xphb",
 						{
-							"special": "small knife"
+							"equipmentType": "setGaming",
+							"displayName": "Gaming Set (same as above)"
 						},
-						"common clothes|phb",
+						"basket|xphb",
+						"bell|xphb",
 						{
-							"item": "trinket|phb",
-							"displayName": "trinket from the life you stayed behind to defend"
+							"displayName": "Candles",
+							"item": "candle|xphb",
+							"quantity": 8
 						},
+						"ink|xphb",
+						"ink pen|xphb",
 						{
-							"item": "pouch|phb",
-							"containsValue": 1000
+							"item": "paper|xphb",
+							"displayName": "Paper (5 sheets)"
+						},
+						"tinderbox|xphb",
+						"traveler's clothes|xphb",
+						{
+							"value": 3200
+						}
+					],
+					"b": [
+						{
+							"value": 5000
 						}
 					]
 				}
@@ -27142,718 +24407,34 @@
 					"items": [
 						{
 							"type": "item",
+							"name": "Ability Scores:",
+							"entry": "Constitution, Intelligence, Wisdom"
+						},
+						{
+							"type": "item",
+							"name": "Feat:",
+							"entry": "A {@filter Dark Gift feat of your choice|feats|category=DG} ({@feat Gathered Whispers|RHW} is recommended)"
+						},
+						{
+							"type": "item",
 							"name": "Skill Proficiencies:",
-							"entry": "{@skill Deception}, {@skill Perception}"
+							"entry": "{@skill Insight|XPHB} and {@skill Religion|XPHB}"
 						},
 						{
 							"type": "item",
 							"name": "Tool Proficiencies:",
-							"entry": "One type of {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set}, thieves' tools"
+							"entry": "Choose one kind of {@item Gaming Set|XPHB}"
 						},
 						{
 							"type": "item",
 							"name": "Equipment:",
-							"entry": "A small knife, a set of {@item common clothes|phb}, a {@item trinket|phb} from the life you stayed behind to defend, a belt {@item pouch|phb} with 10 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Poor"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"\"We need to leave, now!\" Those words still haunt your dreams at night. When everyone was fleeing Phlan, you choose to stay. Whether out of an emotional attachment, or pursuit of riches, you made the decision that would affect the rest of your life.",
-						"Food became scarcer for those without connections. You became a beggar and to stay alive you bartered information to any interested party with food or gold to spare. You were good at what you did, and thought you were invincible. That changed when you were captured by the Tears of Virulence, the soldiers of Vorgansharax, the Maimed Virulence, for selling secrets to those bent on overthrowing the dragon. They locked you in the cells of Stojanow Gate. The first weeks you hoped to stay alive. As the weeks turned into months, and the interrogations continued you began to pray for death."
-					]
-				},
-				{
-					"name": "Feature: Ex-Convict",
-					"type": "entries",
-					"entries": [
-						"The knowledge gained during your incarceration lets you gain insight into local guards and jailors. You know which will accept bribes, or look the other way for you. You can also seek shelter for yourself from authorities with other criminals in the area. Note: This feature is a variant of the Courtier feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"name": "Suggested Characteristics",
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I am a bully; others will suffer as I have."
-								],
-								[
-									"2",
-									"I always say yes even when I mean no; it's just easier."
-								],
-								[
-									"3",
-									"I aim to misbehave."
-								],
-								[
-									"4",
-									"I go out of my way to frustrate or anger those in power."
-								],
-								[
-									"5",
-									"I strive to obey the law. I will never again make the mistake of going against authority."
-								],
-								[
-									"6",
-									"I always plan everything out. The one time I let others plan things it did not end well for me."
-								],
-								[
-									"7",
-									"I take blame to protect others from pain."
-								],
-								[
-									"8",
-									"I hoard information, you never know what may come in handy."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Loss. I freely give those who offend me what was so brutally denied me, death. (Chaos)"
-								],
-								[
-									"2",
-									"Dedication. I never betray those who trust me. (Law)"
-								],
-								[
-									"3",
-									"Vengeance. I use any means to get information I need; I have been well taught. (Evil)"
-								],
-								[
-									"4",
-									"Redemption. Everyone deserves a second chance. (Good)"
-								],
-								[
-									"5",
-									"Resilience. I can survive any challenge (Any)"
-								],
-								[
-									"6",
-									"Leadership. The best teams are made up of those that society has discarded."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I take up arms to help establish a free Phlan."
-								],
-								[
-									"2",
-									"The horrors of my time in Stojanow haunt my dreams, only after a day of hard work can I find sleep."
-								],
-								[
-									"3",
-									"I am indebted to those who freed me from prison, I will repay this debt."
-								],
-								[
-									"4",
-									"My torturer survived the attack that set me free, I will find him/her."
-								],
-								[
-									"5",
-									"I will not rest while others suffer fates similar to mine."
-								],
-								[
-									"6",
-									"I am searching for a way to heal the scars of Stojanow, both physical and emotional."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"During stressful times, I find myself crying for no reason."
-								],
-								[
-									"2",
-									"My nerve endings are shot from the interrogations; I am numb to all but the harshest touch."
-								],
-								[
-									"3",
-									"I am incapable of standing up for myself."
-								],
-								[
-									"4",
-									"I folded under the torture, and gave information that I promised would be kept secret. My life would be in jeopardy if others found out."
-								],
-								[
-									"5",
-									"Survival is worth more than friendship."
-								],
-								[
-									"6",
-									"The ghosts from my past hinder my actions."
-								]
-							]
+							"entry": "Choose A or B: (A) {@item Dagger|XPHB}, {@item Gaming Set|XPHB} (same as above), {@item Basket|XPHB}, {@item Bell|XPHB}, 8 Candles, {@item Ink|XPHB}, {@item Ink Pen|XPHB}, {@item Paper|XPHB} (5 sheets), {@item Tinderbox|XPHB}, {@item Traveler's Clothes|XPHB}, and 32 GP; or (B) 50 GP"
 						}
 					]
 				}
 			],
-			"hasFluff": true
-		},
-		{
-			"name": "Ticklebelly Nomad",
-			"source": "ALCurseOfStrahd",
-			"page": 9,
-			"skillProficiencies": [
-				{
-					"animal handling": true,
-					"nature": true
-				}
-			],
-			"languageProficiencies": [
-				{
-					"giant": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"herbalism kit": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						"herbalism kit|phb",
-						{
-							"special": "small article of jewelry that is distinct to your tribe"
-						},
-						"hunting trap|phb",
-						"common clothes|phb",
-						{
-							"item": "pouch|phb",
-							"containsValue": 500
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Animal Handling}, {@skill Nature}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "{@item Herbalism kit|phb}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "Giant"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "{@item Herbalism kit|phb}, a small article of jewelry that is distinct to your tribe, a {@item hunting trap|phb}, a set of {@item common clothes|phb}, and a belt {@item pouch|phb} containing 5 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Poor"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"You were born into a nomadic tribe that called the Ticklebelly Hills home. You migrated from location to location, living off the land with your tribe. The tribe would seasonally travel south into the Grass Sea and the Giant's Cairn, north into the Dragonspine Mountains, and even occasionally east across the Stojanow River to the borders of the Quivering forest.",
-						"In your migrations, your people have come to know the stone giant tribes that populate the Giant's Cairn. The dragon cultists came to the hills one day\u2014magic-users wearing purple and riding horrid beasts, black-clad warriors wearing wicked masks, and even soldiers from the nearby town of Phlan. Then the dragon called Vorgansharax arrived and laired in the hills, causing horrid thickets to grow and animals to act unusually. The cultists began raiding nomad camps for victims to offer to the wyrm. Eventually, the dragon moved on to attack Phlan, but life was never again the same for the nomads of the Ticklebelly Hills."
-					]
-				},
-				{
-					"name": "Feature: At Home in the Wild",
-					"type": "entries",
-					"entries": [
-						"The wilderness is your home and you are comfortable dwelling in it. You can find a place to hide, rest, or recuperate when out in the wild. This place of rest is secure enough to conceal you from most natural threats. Threats that are supernatural, magical, or are actively seeking you out might do so with difficulty depending on the nature of the threat (as determined by the DM). However, this feature doesn't shield or conceal you from scrying, mental probing, nor from threats that don't necessarily require the five senses to find you. Note: This feature is a variant of the Folk Hero feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"name": "Suggested Characteristics",
-					"type": "entries",
-					"entries": [
-						"Ticklebelly nomads only venture into civilization when necessary. You are social within your tribe, with tribes of other nomads, and even with the stone giant tribes that populate the Giant's Cairn. However, other communities tend to either put you on your guard or put you in a state of wonder. Was it this wonder that enticed you into a life of adventuring? On the other hand, you are fiercely protective of and dedicated to your tribe. Perhaps it was this dedication that led you to venture out; either of your own will or at the behest of your tribe's leaders.",
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I eagerly inject myself into the unknown."
-								],
-								[
-									"2",
-									"Villages, towns, and cities do not suit me. I'd rather be out in the wilderness any day."
-								],
-								[
-									"3",
-									"I accomplish my tasks efficiently, using as few resources as possible."
-								],
-								[
-									"4",
-									"It's difficult for me to remain in one place for long."
-								],
-								[
-									"5",
-									"I loudly brag about my tribe every chance I get."
-								],
-								[
-									"6",
-									"Having walked among giants, I am fearless in the face of bigger creatures."
-								],
-								[
-									"7",
-									"I am quiet and reserved, but observant. Nothing escapes my attention."
-								],
-								[
-									"8",
-									"My word is my bond. I see a promise to completion, even if it conflicts with my beliefs."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Kinship. Family is most important in life. Though I may be far from my own, the bonds of family must be protected in others' lives as well. (Good)"
-								],
-								[
-									"2",
-									"Preservation. Nature must not be despoiled by encroaching civilization. (Any)"
-								],
-								[
-									"3",
-									"Wanderlust. One must expand their horizons by seeing the world and exploring. (Chaos)"
-								],
-								[
-									"4",
-									"Isolation. My tribe and its ways must be protected and shielded from outside influence. (Neutral)"
-								],
-								[
-									"5",
-									"Protection. Threats to the land and to the people must be dealt with at any and all costs. (Law)"
-								],
-								[
-									"6",
-									"Belonging: All creatures have a place in the world, so I strive to help others find theirs. (Good)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I ache to return to my tribe and the family I left, but cannot until my obligations are fulfilled."
-								],
-								[
-									"2",
-									"The dragon cultists that invaded my homeland stole away one of my tribe's people. I will not know rest until I've found them."
-								],
-								[
-									"3",
-									"The dragon's presence in the hills destroyed valuable territory and resulted in deaths within my tribe. The creature must pay for what it has done."
-								],
-								[
-									"4",
-									"I carry a trinket that spiritually and emotionally ties me to my people and my home."
-								],
-								[
-									"5",
-									"I discovered a strange relic in the hills during my tribe's wanderings. I must discover what it is."
-								],
-								[
-									"6",
-									"One of the stone giant clans from the Giant's Cairn has graced me with a mark of kinship."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I throw myself and my friends into situations rarely ever thinking about consequences."
-								],
-								[
-									"2",
-									"Unfamiliar people and surroundings put me on edge."
-								],
-								[
-									"3",
-									"I have absolutely no patience for slowpokes and those who prove indecisive."
-								],
-								[
-									"4",
-									"My desire to experience new things causes me to make unsafe choices."
-								],
-								[
-									"5",
-									"I am overly protective of nature, sometimes to the detriment of my companions and myself."
-								],
-								[
-									"6",
-									"My lack of worldliness often proves my undoing in social, commercial, and hostile situations."
-								]
-							]
-						}
-					]
-				}
-			],
-			"hasFluff": true
-		},
-		{
-			"name": "Trade Sheriff",
-			"source": "ALRageOfDemons",
-			"page": 11,
-			"skillProficiencies": [
-				{
-					"investigation": true,
-					"persuasion": true
-				}
-			],
-			"languageProficiencies": [
-				{
-					"elvish": true
-				}
-			],
-			"toolProficiencies": [
-				{
-					"thieves' tools": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"_": [
-						"thieves' tools|phb",
-						{
-							"special": "gray cloak"
-						},
-						{
-							"item": "fine clothes|phb",
-							"displayName": "Sheriff's insignia (badge) a set of fine clothes"
-						},
-						{
-							"value": 1700
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "{@skill Investigation}, {@skill Persuasion}"
-						},
-						{
-							"type": "item",
-							"name": "Tool Proficiencies:",
-							"entry": "{@item Thieves' tools|phb}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "Elvish"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "{@item Thieves' tools|phb}, a gray cloak, Sheriff's insignia (badge) a set of {@item fine clothes|phb}, and 17 gp"
-						}
-					]
-				},
-				{
-					"name": "Lifestyle",
-					"type": "entries",
-					"entries": [
-						"Modest"
-					]
-				},
-				{
-					"name": "Overview",
-					"type": "entries",
-					"entries": [
-						"You are one of the many people that make sure the trade routes are clear at ALL times. You assure that the Great Law of Trade is followed at all costs. You work by yourself or in groups to quell bandits and brigands who might stop trade routes from going through. You investigate potential ambushes and possible rumors as to someone wanting to rob or stop caravans. You are as much an investigator as you are law enforcement.",
-						"You are able to go into a town/village around the Hillsfar area and find a contact that is willing to give you information from rumor to fact. This sometimes comes at a cost of a minor bribe of 1-9 silver pieces."
-					]
-				},
-				{
-					"name": "Feature: Investigative Services",
-					"type": "entries",
-					"entries": [
-						"You are part of a small force outside of Hillsfar. You have a special way of communicating with others and they seem to be at ease around you. You can invoke your rank to allow you access to a crime scene or to requisition equipment or horses on a temporary basis. When you enter a town or village around Hillsfar you can identify a contact who will give you information on the local rumors and would help you simply because of your desire to get answers and information for anyone wanting to disrupt trade. Note: This feature is a variant of the soldier feature."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "table",
-							"colLabels": [
-								"d8",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I am always polite and respectful"
-								],
-								[
-									"2",
-									"I let my actions speak for themselves"
-								],
-								[
-									"3",
-									"I am haunted by my past having seen the murder of a close friend or family member and it is the one case I always needed to solve but have not been able to."
-								],
-								[
-									"4",
-									"I am quick to judge and slow to vindicate"
-								],
-								[
-									"5",
-									"I can be very persuasive and am able to ask quest ions where others might not be able to."
-								],
-								[
-									"6",
-									"I have a quirky personality that seems to take others off their guard."
-								],
-								[
-									"7",
-									"My sense of humor is considered by most to be awkward."
-								],
-								[
-									"8",
-									"Everyone has a choice, and they can always make the right choice, mine!"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"Hope. my job is to speak for the victim (Good)"
-								],
-								[
-									"2",
-									"Dedicated. Once I start an investigation, until told to do so, I do not quit, not matter where it leads. (Lawful)"
-								],
-								[
-									"3",
-									"Nation. My city, nation, or people are all that matter. (Any)"
-								],
-								[
-									"4",
-									"Mercenary. When I do investigations, I expect answers immediately. (Any)"
-								],
-								[
-									"5",
-									"Eloquent. I use my words to sway others to give me answers. (Good)"
-								],
-								[
-									"6",
-									"Might. It is through threats and force that I get my answers. (Lawful)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Bond"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"To this day an unsolved case will always leave me haunted and bother me."
-								],
-								[
-									"2",
-									"Through the might of my personality I will solve an investigation or puzzle."
-								],
-								[
-									"3",
-									"It is my right to believe what I will, just try and stop me."
-								],
-								[
-									"4",
-									"I need to prove my worth to my fellow Sheriffs"
-								],
-								[
-									"5",
-									"Someone I cared for died under suspicious circumstances. I will find out what happened to them and bring their killer to justice."
-								],
-								[
-									"6",
-									"I speak for those that cannot speak for themselves."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"colLabels": [
-								"d6",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-1 text-center",
-								"col-11"
-							],
-							"rows": [
-								[
-									"1",
-									"I always over exaggerate my abilities."
-								],
-								[
-									"2",
-									"I cannot bear to let those I care for out of my sight."
-								],
-								[
-									"3",
-									"I took a bribe to tank an investigation and I would do anything to keep it secret."
-								],
-								[
-									"4",
-									"I have little respect for those that are of \"low\" intelligence/race."
-								],
-								[
-									"5",
-									"I always enjoy a good mug of ale... or five to cover up my past."
-								],
-								[
-									"6",
-									"I speak for the First Lord of Hillsfar and make sure everyone knows it."
-								]
-							]
-						}
-					],
-					"name": "Suggested Characteristics"
-				}
-			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Urban Bounty Hunter",
@@ -28012,7 +24593,7 @@
 					"name": "Suggested Characteristics",
 					"type": "entries",
 					"entries": [
-						"Urchins are shaped by lives of desperate poverty, for good and for ill. They tend to be driven either by a commitment to the people with whom they shared life on the street or by a burning desire to find a better life\u2014and maybe get some payback on all the rich people who treated them badly.",
+						"Urchins are shaped by lives of desperate poverty, for good and for ill. They tend to be driven either by a commitment to the people with whom they shared life on the street or by a burning desire to find a better life—and maybe get some payback on all the rich people who treated them badly.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -28087,7 +24668,7 @@
 								],
 								[
 									"5",
-									"People. I help the people who help me\u2014that's what keeps us alive. (Neutral)"
+									"People. I help the people who help me—that's what keeps us alive. (Neutral)"
 								],
 								[
 									"6",
@@ -28591,31 +25172,6 @@
 			"hasFluff": true
 		},
 		{
-			"name": "Variant Clasp Member (Myriad Operative)",
-			"source": "TDCSR",
-			"page": 182,
-			"_copy": {
-				"name": "Clasp Member",
-				"source": "TDCSR",
-				"_mod": {
-					"entries": [
-						{
-							"mode": "insertArr",
-							"index": 1,
-							"items": {
-								"type": "entries",
-								"name": "Variant: Myriad Operative",
-								"page": 182,
-								"entries": [
-									"Your skill set might be similar to that of many members of the {@book Clasp|TDCSR|2|The Clasp}, but you work for a criminal organization that is far more sophisticated\u2014and even less scrupulous. As a {@book Myriad|TDCSR|2|The Myriad} operative in Tal'Dorei, you might have been given a specific task that furthers that syndicate's hunger to expand beyond Wildemount, or which gives them an edge in their rivalry with the {@book Clasp|TDCSR|2|The Clasp}. Moreover, you understand the wisdom of keeping your activities secret from fellow criminals as well as law enforcement, since the agents of the {@book Clasp|TDCSR|2|The Clasp} will show you no mercy if your true identity is ever revealed."
-								]
-							}
-						}
-					]
-				}
-			}
-		},
-		{
 			"name": "Variant Criminal (Spy)",
 			"source": "PHB",
 			"page": 130,
@@ -28687,7 +25243,7 @@
 								"name": "Feature: By Popular Demand",
 								"type": "entries",
 								"entries": [
-									"You can always find a place to perform in any place that features combat for entertainment\u2014perhaps a gladiatorial arena or secret pit fighting club. At such a place, you receive free lodging and food of a modest or comfortable standard (depending on the quality of the establishment), as long as you perform each night. In addition, your performance makes you something of a local figure. When strangers recognize you in a town where you have performed, they typically take a liking to you."
+									"You can always find a place to perform in any place that features combat for entertainment—perhaps a gladiatorial arena or secret pit fighting club. At such a place, you receive free lodging and food of a modest or comfortable standard (depending on the quality of the establishment), as long as you perform each night. In addition, your performance makes you something of a local figure. When strangers recognize you in a town where you have performed, they typically take a liking to you."
 								],
 								"data": {
 									"isFeature": true
@@ -28816,7 +25372,7 @@
 								"name": "Feature: Retainers",
 								"type": "entries",
 								"entries": [
-									"You have the service of three retainers loyal to your family. These retainers can be attendants or messengers, and one might be a majordomo. Your retainers are commoners who can perform mundane tasks for you, but they do not fight for you, will not follow you into obviously dangerous areas (such as dungeons), and will leave if they are frequently endangered or abused."
+									"You have the service of three retainers loyal to your family. These retainers can be attendants or messengers, and one might be a majordomo. Your retainers are {@creature commoner||commoners} who can perform mundane tasks for you, but they do not fight for you, will not follow you into obviously dangerous areas (such as dungeons), and will leave if they are frequently endangered or abused."
 								],
 								"data": {
 									"isFeature": true
@@ -28853,35 +25409,6 @@
 				}
 			},
 			"hasFluff": true
-		},
-		{
-			"name": "Variant Whitestone Rifle Corps (Grey Hunter)",
-			"source": "TDCSR",
-			"page": 182,
-			"_copy": {
-				"name": "Whitestone Rifle Corps",
-				"source": "TDCSR",
-				"_mod": {
-					"entries": [
-						{
-							"mode": "insertArr",
-							"index": 1,
-							"items": {
-								"type": "entries",
-								"name": "Variant: Grey Hunter",
-								"page": 189,
-								"entries": [
-									"As elite as they are, the members of the {@book Whitestone Rifle Corps|TDCSR|3|Whitestone Rifle Corps} do not represent the apex of firearms skill in {@book Whitestone|TDCSR|3|Whitestone}. A clandestine group of elite soldiers and survivalists is drawn secretly from the Rifle Corps ranks. Called the {@book Grey Hunters|TDCSR|3|Grey Hunters}, these soldiers are special operatives of the de Rolo family, and loyally serve as spies, bodyguards, and even assassins when the job requires it. Though few officially know of them, rumors of the {@book Grey Hunters'|TDCSR|3|Grey Hunters} existence swirl constantly throughout the city-state, often in response to their activities after having been loaned out to protect {@book Whitestone's|TDCSR|3|Whitestone} allies.",
-									"You are one of these {@book Grey Hunters|TDCSR|3|Grey Hunters}, even if just a trainee (if you're starting your campaign at low levels). You have the ear of the lord and lady of {@book Whitestone|TDCSR|3|Whitestone}, though you must exercise this privilege graciously lest you lose it."
-								],
-								"data": {
-									"isFeature": true
-								}
-							}
-						}
-					]
-				}
-			}
 		},
 		{
 			"name": "Vizier",
@@ -29080,7 +25607,7 @@
 								],
 								[
 									"4",
-									"I am committed to the service of my god\u2014because it's my sure ticket into the afterlife. (Bontu)"
+									"I am committed to the service of my god—because it's my sure ticket into the afterlife. (Bontu)"
 								],
 								[
 									"5",
@@ -29239,7 +25766,7 @@
 					"name": "Suggested Characteristics",
 					"type": "entries",
 					"entries": [
-						"Agents of the Volstrucker are groomed to follow orders without question and to kill without mercy. The trauma that brings one into the order can fester even more strongly against the darkness of a Volstrucker agent's assignments. Officially, no one ever leaves the order\u2014but those desperate enough do whatever it takes to gain some measure of freedom.",
+						"Agents of the Volstrucker are groomed to follow orders without question and to kill without mercy. The trauma that brings one into the order can fester even more strongly against the darkness of a Volstrucker agent's assignments. Officially, no one ever leaves the order—but those desperate enough do whatever it takes to gain some measure of freedom.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -29269,7 +25796,7 @@
 								],
 								[
 									"5",
-									"I always keep my word\u2014except when I'm commanded to break it."
+									"I always keep my word—except when I'm commanded to break it."
 								],
 								[
 									"6",
@@ -29462,7 +25989,7 @@
 					"type": "entries",
 					"entries": [
 						"While you are in Waterdeep or elsewhere in the North, your house sees to your everyday needs. Your name and signet are sufficient to cover most of your expenses; the inns, taverns, and festhalls you frequent are glad to record your debt and send an accounting to your family's estate in Waterdeep to settle what you owe.",
-						"This advantage enables you to live a comfortable lifestyle without having to pay 2 gp a day for it, or reduces the cost of a wealthy or aristocratic lifestyle by that amount. You may not maintain a less affluent lifestyle and use the difference as income\u2014the benefit is a line of credit, not an actual monetary reward."
+						"This advantage enables you to live a comfortable lifestyle without having to pay 2 gp a day for it, or reduces the cost of a wealthy or aristocratic lifestyle by that amount. You may not maintain a less affluent lifestyle and use the difference as income—the benefit is a line of credit, not an actual monetary reward."
 					],
 					"data": {
 						"isFeature": true
@@ -29596,312 +26123,6 @@
 							"type": "item",
 							"name": "Equipment:",
 							"entry": "Choose A or B: (A) {@item Dagger|XPHB|2 Daggers}, {@item Thieves' Tools|XPHB}, {@item Gaming Set|XPHB} (any), {@item Bedroll|XPHB}, {@item Pouch|XPHB|2 Pouches}, {@item Traveler's Clothes|XPHB}, 16 GP; or (B) 50 GP"
-						}
-					]
-				}
-			],
-			"hasFluff": true,
-			"hasFluffImages": true
-		},
-		{
-			"name": "Whitestone Rifle Corps",
-			"source": "TDCSR",
-			"page": 187,
-			"skillProficiencies": [
-				{
-					"choose": {
-						"from": [
-							"athletics",
-							"perception",
-							"survival"
-						],
-						"count": 2
-					}
-				}
-			],
-			"languageProficiencies": [
-				{
-					"any": 1
-				}
-			],
-			"weaponProficiencies": [
-				{
-					"firearms": true
-				}
-			],
-			"startingEquipment": [
-				{
-					"a": [
-						"musket|dmg"
-					],
-					"b": [
-						"pistol|dmg"
-					]
-				},
-				{
-					"_": [
-						"common clothes|phb",
-						{
-							"item": "pouch|phb",
-							"containsValue": 1000
-						}
-					]
-				}
-			],
-			"entries": [
-				{
-					"type": "list",
-					"style": "list-hang-notitle",
-					"items": [
-						{
-							"type": "item",
-							"name": "Skill Proficiencies:",
-							"entry": "Your choice of two of the following: {@skill Athletics}, {@skill Perception}, or {@skill Survival}"
-						},
-						{
-							"type": "item",
-							"name": "Weapon Proficiencies:",
-							"entry": "{@filter Firearms|items|source=null|type=firearm}"
-						},
-						{
-							"type": "item",
-							"name": "Languages:",
-							"entry": "One of your choice"
-						},
-						{
-							"type": "item",
-							"name": "Equipment:",
-							"entry": "Your choice of a {@item musket} or a {@item pistol}, a set of {@item common clothes|phb}, and a {@item pouch|PHB} containing 10 gp"
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Feature: Legacy of Secrecy",
-					"page": 187,
-					"entries": [
-						"You have been entrusted with the use and care of a weapon both powerful and terrifying. The rifle you wield might transform the face of warfare and life in Tal'Dorei. It is a weapon that haunts the mind of its creator, {@creature Percival de Rolo|TDCSR}, manifesting as a pain that lives always behind his kind eyes.",
-						"You were granted a {@item musket} or a {@item pistol} by your commander in the {@book Whitestone Rifle Corps|TDCSR|3|Whitestone Rifle Corps}. This weapon is a symbol of your status, and when you display it, other folk around you\u2014particularly adventurers, mercenaries, guards, engineers, and weapons enthusiasts\u2014treat you differently. You might be seen as a noble defender of the people, a selfish hoarder of power, or anything in between, at the GM's discretion."
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"name": "Feature: Rifle Corps Relationship",
-					"page": 187,
-					"entries": [
-						"You are\u2014or were\u2014a member of an elite and trusted band of {@book Whitestone's|TDCSR|3|Whitestone} staunchest defenders. Work with your GM to determine your current relationship with the Rifle Corps. If your campaign starts in {@book Whitestone|TDCSR|3|Whitestone}, you might be an active member of that unit. Otherwise, you can use the Rifle Corps Relationships table for suggestions.",
-						{
-							"type": "table",
-							"caption": "Rifle Corps Relationships",
-							"colLabels": [
-								"{@dice d6}",
-								"Current Relationship"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I retired honorably from the Rifle Corps\u2014and now it's time for me to pursue my own adventures."
-								],
-								[
-									"2",
-									"I'm on an important mission to protect {@book Whitestone|TDCSR|3|Whitestone} or guard one of our allies."
-								],
-								[
-									"3",
-									"{@book Whitestone|TDCSR|3|Whitestone} is in trouble, and I was sent away to seek help."
-								],
-								[
-									"4",
-									"I don't think firearms technology should be kept secret, so I escaped from the Rifle Corps with my weapon and am on the run."
-								],
-								[
-									"5",
-									"I was on a mission with my company when I got separated from them. Now I need to find my way back home."
-								],
-								[
-									"6",
-									"My weapon was stolen. I built a new one, but I can't return home until I've tracked down the thief and recovered the original. ({@book Whitestone Hunter|TDCSR|3|Grey Hunters} variant only)"
-								]
-							]
-						}
-					],
-					"data": {
-						"isFeature": true
-					}
-				},
-				{
-					"type": "entries",
-					"name": "Suggested Characteristics",
-					"page": 188,
-					"entries": [
-						"Those who join the {@book Whitestone Rifle Corps|TDCSR|3|Whitestone Rifle Corps} become members of an elite and trusted band known as the city-state's staunchest defenders. But this means working with your GM to determine why you're not at home protecting {@book Whitestone|TDCSR|3|Whitestone}. Perhaps you took on a mission to guard someone on behalf of the de Rolo family, or you might have been separated from your company while on an assignment. Either way, you find yourself embroiled now in a series of new adventures as you try to make your way back home.",
-						"Your bond is likely associated with your comrades-in-arms or with {@book Whitestone|TDCSR|3|Whitestone} itself. Your ideal could be tied to justice or protection, but could also be a secretive, selfish perversion of those virtues.",
-						{
-							"type": "table",
-							"caption": "Rifle Corps Personality Traits",
-							"colLabels": [
-								"{@dice d8}",
-								"Personality Trait"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I want to make a good impression at all times. That means keeping my clothes and gear clean and in top condition."
-								],
-								[
-									"2",
-									"I don't like being the center of attention. I'd rather let someone else do the talking while I watch their back."
-								],
-								[
-									"3",
-									"I feel safe only if I'm carrying my trusty rifle. And my dagger. And my concealed pistol. Oh, and of course my...."
-								],
-								[
-									"4",
-									"I don't trust people with my secrets easily, so it feels like a big deal when someone else shares a secret with me."
-								],
-								[
-									"5",
-									"I like coming up with solutions to problems using my esoteric knowledge of natural philosophy."
-								],
-								[
-									"6",
-									"Everyone around me takes things so seriously. Sometimes I just want to let loose and have fun!"
-								],
-								[
-									"7",
-									"Knowing things that other people don't know makes me feel special and important."
-								],
-								[
-									"8",
-									"I'm most at home in woods and mountains, where everything feels at once familiar, always growing and changing."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Rifle Corps Ideals",
-							"colLabels": [
-								"{@dice d6}",
-								"Ideal"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"{@b Responsibility}. I have a duty to protect the people of {@book Whitestone|TDCSR|3|Whitestone} and to uphold the trust placed in me by the de Rolos. (Lawful)"
-								],
-								[
-									"2",
-									"{@b Militarization}. Everyone should have access to the most powerful weapons available, so they can defend themselves effectively. (Evil)"
-								],
-								[
-									"3",
-									"{@b Cooperation}. Any problem can be solved as long as people are willing to work together. (Good)"
-								],
-								[
-									"4",
-									"{@b Camaraderie}. It's important to have people you can trust to help out in a fight\u2014and to uncork a bottle together afterward. (Any)"
-								],
-								[
-									"5",
-									"{@b Context}. There are no universal rights or wrongs. Every choice depends on the details of the situation. (Chaotic)"
-								],
-								[
-									"6",
-									"{@b Secrecy}. Information is valuable, but it can also be dangerous. I'll keep my mouth shut and gather as much intel as I can. (Neutral)"
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Rifle Corps Bons",
-							"colLabels": [
-								"{@dice d6}",
-								"Bond"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"I never knew what to do with myself until I joined the Rifle Corps. Now I have a purpose and comrades to give me direction."
-								],
-								[
-									"2",
-									"One of my fellow Rifle Corps soldiers saved my life\u2014and then I saved theirs. That kind of bond lasts forever."
-								],
-								[
-									"3",
-									"{@book Whitestone|TDCSR|3|Whitestone} is the best city in all of Tal'Dorei. Nowhere else has been blessed by the {@deity The Dawnfather|Exandria|TDCSR|Dawnfather} and has a clock that tracks the movement of the stars!"
-								],
-								[
-									"4",
-									"My quick thinking saved a noble from assassination, and she showed me great kindness in return. I daren't say it, but I'm more loyal to her than I am to the de Rolos."
-								],
-								[
-									"5",
-									"My weapon is my life. I clean it, repair it, and care for it\u2014and it serves me loyally in return."
-								],
-								[
-									"6",
-									"The people of {@book Whitestone|TDCSR|3|Whitestone} cared for my family when we had nothing. I promise to repay their compassion with my service."
-								]
-							]
-						},
-						{
-							"type": "table",
-							"caption": "Rifle Corps Flaws",
-							"colLabels": [
-								"{@dice d6}",
-								"Flaw"
-							],
-							"colStyles": [
-								"col-2 text-center",
-								"col-10"
-							],
-							"rows": [
-								[
-									"1",
-									"Who cares about keeping this gun safe? \"Don't let it fall into the wrong hands!\" Ha! It's only a matter of time before someone slips up and these weapons are everywhere."
-								],
-								[
-									"2",
-									"I think being part of the Rifle Corps is so cool. I love telling people about my position so I can impress them."
-								],
-								[
-									"3",
-									"My weapon was stolen. I built a new one, but I can't return home until I've tracked down the thief and recovered the original."
-								],
-								[
-									"4",
-									"I'm tired of protecting spoiled people who don't know how to protect themselves."
-								],
-								[
-									"5",
-									"I shoot first and ask questions later."
-								],
-								[
-									"6",
-									"The first and only time I killed someone, it changed my life. I still dream about it, and I'll never be the carefree person I was before."
-								]
-							]
 						}
 					]
 				}
@@ -30374,7 +26595,7 @@
 								],
 								[
 									"8",
-									"I'm always changing my mind\u2014well, almost always."
+									"I'm always changing my mind—well, almost always."
 								]
 							]
 						}
@@ -30708,6 +26929,6157 @@
 							"type": "item",
 							"name": "Equipment:",
 							"entry": "Choose A or B: (A) {@item Club|XPHB}, {@item Dagger|XPHB}, {@item Forgery Kit|XPHB}, {@item Fine Clothes|XPHB}, {@item Hooded Lantern|XPHB}, {@item Oil|XPHB} (3 flasks), 2 {@item Pouch|XPHB|Pouches}, {@item String|XPHB}, {@item Tinderbox|XPHB}, 11 GP; or (B) 50 GP"
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Black Fist Double Agent",
+			"source": "ALCurseOfStrahd",
+			"page": 2,
+			"skillProficiencies": [
+				{
+					"deception": true,
+					"insight": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"disguise kit": true,
+					"choose": {
+						"from": [
+							"anyArtisansTool",
+							"gaming set"
+						]
+					}
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"disguise kit|phb",
+						"common clothes|phb",
+						{
+							"item": "emblem|phb",
+							"displayName": "Tears of Virulence emblem"
+						},
+						{
+							"special": "writ of free agency signed by the Lord Regent"
+						},
+						{
+							"item": "pouch|phb",
+							"containsValue": 1500
+						}
+					]
+				},
+				{
+					"a": [
+						{
+							"equipmentType": "toolArtisan"
+						}
+					],
+					"b": [
+						{
+							"equipmentType": "setGaming"
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Deception}, {@skill Insight}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Disguise kit|phb}, and one type of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} or {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "{@item Disguise kit|phb}, {@item common clothes|phb}, a Tears of Virulence {@item emblem|phb}, a writ of free agency signed by the Lord Regent, a set of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} or {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set} you are proficient with, and a {@item pouch|phb} with 15 gp (payment for services rendered)."
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Moderate"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"You are an informant for the Tears of Virulence who now lord over Phlan, but are also a double agent for original town guard of Phlan, the Black Fists. For the Tears you've been tasked with ferreting out the secrets of Phlan's criminal underworld, insurgency, and the common peoples of Phlan. In exchange for reporting on the activities of dissenters, criminals, and other rebel elements, the Tears of Virulence leave you alone to conduct your affairs in peace.",
+						"In reality you work for the deposed Black Fists, sharing misinformation with the Tears of Virulence that often helps the Black Fists and other Phlan insurgents.",
+						"Since the evacuation of Phlan, you are even busier today than you ever were previously, as the number of dissenters among the refugees grows daily, while you are afforded many opportunities to spy on the peoples of Mulmaster and Elventree, to the pleasure of your contact(s) within the Tears of Virulence."
+					]
+				},
+				{
+					"name": "Feature: Double Agent",
+					"type": "entries",
+					"entries": [
+						"You have a reliable and trusty contact within the Tears of Virulence garrison in Phlan to whom you pass information and secrets. In exchange, you can get away with minor criminal offenses within the town of Phlan. In addition, your Black Fists contacts can help you secure an audience with the Lord Regent, the Lord Sage, members of the Black Fists, or deposed nobles and authority figures who are sympathetic to the Phlan refugees and insurgents. Note: This feature is a variant of the Noble feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"People are only as trustworthy as you are valuable to them. Always strive to be the most valuable person around."
+								],
+								[
+									"2",
+									"My eloquence and sophistication are tools I use to avoid arousing suspicion myself."
+								],
+								[
+									"3",
+									"I am a thrill-seeker, excited by covert and dangerous missions."
+								],
+								[
+									"4",
+									"I live by my wits and always check every lock twice, just to be certain."
+								],
+								[
+									"5",
+									"I never admit to my mistakes lest they be used against me."
+								],
+								[
+									"6",
+									"I take every effort to be unnoticeable and blend into the crowd. Passersby rarely give me a second look."
+								],
+								[
+									"7",
+									"I am prepared for any eventuality; including the day my usefulness as a spy comes to an end."
+								],
+								[
+									"8",
+									"I always make certain to know my enemy before acting, lest I bite off more than I can chew."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Suspicious. In my experience, everybody has something to hide, and what they hide can usually hurt me. (Any)"
+								],
+								[
+									"2",
+									"Secretive. I trade in secrets, and am not about to let any of mine slip. (Any)"
+								],
+								[
+									"3",
+									"Hedonist. Life is short. I live my life to the fullest, as I know any day could be my last. (Chaotic)"
+								],
+								[
+									"4",
+									"Selfless. I use my position to help the downtrodden avoid persecution from the authorities. (Good)"
+								],
+								[
+									"5",
+									"Patriotic. I am a loyal supporter of Phlan and its leaders, and see my role as a solemn duty and necessary evil to prevent anarchy. (Lawful)"
+								],
+								[
+									"6",
+									"Manipulative. I use my knowledge to blackmail and manipulate others to my own benefit. (Evil)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I was framed for a crime I did not commit, and seek to bring the true culprit to justice."
+								],
+								[
+									"2",
+									"I am a part of an underground network that smuggles innocent civilians out of the city prior to being raided by the authorities."
+								],
+								[
+									"3",
+									"I miss the glory days of Phlan, before the coming of the dragon."
+								],
+								[
+									"4",
+									"I seek to prove myself worthy of joining the Black Fist as a member of their order."
+								],
+								[
+									"5",
+									"My sister was killed by a Tear of Virulence, and now I feed them false information whenever possible."
+								],
+								[
+									"6",
+									"My family was wrongly imprisoned, and I act as an informant in order to secure their release."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I think too highly of myself, and have an exaggerated sense of self-importance."
+								],
+								[
+									"2",
+									"I have difficulty trusting strangers. I see spies and informants everywhere."
+								],
+								[
+									"3",
+									"Years of getting away with minor crimes has left me believing that I am above the law, and have diplomatic immunity above my station."
+								],
+								[
+									"4",
+									"Years of seeing innocent people suffer have left me despondent and pessimistic for the future."
+								],
+								[
+									"5",
+									"My desire for vengeance often gets me into trouble."
+								],
+								[
+									"6",
+									"I am spendthrift, and share my wealth with the patrons of my favorite tavern."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Caravan Specialist",
+			"source": "ALElementalEvil",
+			"page": 2,
+			"skillProficiencies": [
+				{
+					"animal handling": true,
+					"survival": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"anyStandard": 1
+				}
+			],
+			"toolProficiencies": [
+				{
+					"vehicles (land)": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"whip|phb",
+						"two-person tent|phb",
+						{
+							"special": "regional map"
+						},
+						"traveler's clothes|phb",
+						{
+							"item": "pouch|phb",
+							"containsValue": 1000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Animal Handling}, {@skill Survival}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@filter Vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "One of your choice"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A {@item whip|phb}, a {@item two-person tent|phb}, a regional map, a set of {@item traveler's clothes|phb}, and a belt {@item pouch|phb} containing 10 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Poor"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"You are used to life on the road. You pride yourself at having traveled every major trade way in the Moonsea region, including the best backroads and shortcuts. When traveling these roads, you know where the best inns, campsites, and water sources are located, as well as potential locations of danger such as ambush. Having worked the roads as long as you have, you have made many acquaintances and find it easy to pick up information and rumors floating from town to town. You are skilled with beasts of burden and handling and repairing wagons of all kinds."
+					]
+				},
+				{
+					"name": "Feature: Wagonmaster",
+					"type": "entries",
+					"entries": [
+						"You are used to being in charge of the operation and your reputation for reliability has you on a short list when the job is critical. Experience has taught you to rely on your gut. Others recognize this and look to you for direction when a situation gets serious. You are able to identify the most defensible locations for camping. If you are part of a caravan outfit, you are able to attract two additional workers that are loyal to you based on your reputation. You have an excellent memory for maps and geography and can always determine your cardinal directions while traveling. Note: This feature is a variant of the Outlander feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Any group is only as strong as its weakest link. Everyone has to pull their own weight. "
+								],
+								[
+									"2",
+									"There's always someone out there trying to take what I've got. Always be vigilant."
+								],
+								[
+									"3",
+									"Anything can be learned if you have the right teacher. Most folks just need a chance."
+								],
+								[
+									"4",
+									"Early to bed and early to rise; this much at least is under my control."
+								],
+								[
+									"5",
+									"You can listen to me or don't and wish you had. Everyone ends up on one side of that fence."
+								],
+								[
+									"6",
+									"Eventually my hard work will be rewarded. Maybe that time has finally come."
+								],
+								[
+									"7",
+									"A strong ox or horse is more reliable than most people I've met."
+								],
+								[
+									"8",
+									"I never had time for books, but wish I had. I admire folks who have taken the time to learn."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Service. Using my talents to help others is the best way of helping myself. (Good)"
+								],
+								[
+									"2",
+									"Selfish. What people don't know WILL hurt them, but why is that my problem? (Evil)"
+								],
+								[
+									"3",
+									"Wanderer. I go where the road takes me. Sometimes that's a good thing... (Chaotic)"
+								],
+								[
+									"4",
+									"Fittest. On the open road, the law of nature wins. Victims are the unprepared. (Lawful)"
+								],
+								[
+									"5",
+									"Focused. I simply have a job to do, and I'm going to do it. (Neutral)"
+								],
+								[
+									"6",
+									"Motivated. There's a reason I'm good at what I do, I pay attention to the details. (Any) "
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"My brother has a farm in Elmwood and I've helped him and his neighbors move their goods to Mulmaster and other surrounding towns. Those are good people."
+								],
+								[
+									"2",
+									"A caravan I lead was attacked by bandits and many innocents died. I swear that I will avenge them by killing any bandits I encounter."
+								],
+								[
+									"3",
+									"The Soldiery are mostly good guys who understand the importance of protecting the roads. The City Watch is who you have to look out for. If they are inspecting your goods, get ready to pay a fine."
+								],
+								[
+									"4",
+									"The new commander of Southroad Tower, Capt. Holke, understands the importance of safe roads. He's hired me for several jobs and I'm grateful."
+								],
+								[
+									"5",
+									"There's always a road I haven't traveled before. I'm always looking for new places to explore."
+								],
+								[
+									"6",
+									"Wealth and power mean little without the freedom to go where and when you want."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I have trouble trusting people I've just met."
+								],
+								[
+									"2",
+									"I enjoy the open road. Underground and tight spaces make me very nervous."
+								],
+								[
+									"3",
+									"I expect others to heed my orders and have little respect or sympathy if they don't."
+								],
+								[
+									"4",
+									"I am very prideful and have trouble admitting when I'm wrong."
+								],
+								[
+									"5",
+									"Once I decide on a course of action, I do not waiver."
+								],
+								[
+									"6",
+									"I like to explore, and my curiosity will sometimes get me into trouble."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Cormanthor Refugee",
+			"source": "ALRageOfDemons",
+			"page": 5,
+			"skillProficiencies": [
+				{
+					"nature": true,
+					"survival": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyArtisansTool": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"two-person tent|phb",
+						{
+							"equipmentType": "toolArtisan"
+						},
+						"holy symbol|phb",
+						"traveler's clothes|phb",
+						{
+							"item": "pouch|phb",
+							"containsValue": 500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Nature}, {@skill Survival}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "One type of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "Elven"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A {@item two-person tent|phb}, {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}, a {@item holy symbol|phb}, a set of {@item traveler's clothes|phb}, a belt {@item pouch|phb} containing 5 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Poor"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"You are one of hundreds of refugees that were driven from Hillsfar or that fled the destruction of Myth Drannor and who now shelter in hidden camps under the northern eaves of the Cormanthor Forest. If you up grew in the camps, you have never been to a settlement other than the village of Elventree. As a guest of the elves, you have learned their ways and the ways of the forest. You are also a traumatized, as residual wild magic, energies released by the fall of Thultanthar upon Myth Drannor, and the constant fear of raids hunting for non-humans to fight in Hillsfar's Arena have taken their toll on you, as they have on everyone in the camps."
+					]
+				},
+				{
+					"name": "Feature: Shelter of the Elven Clergy",
+					"type": "entries",
+					"entries": [
+						"The clerics of Elventree have vowed to care for the Cormanthor refugees. They will help you when they can, including providing you and your companions with free healing and care at temples, shrines, and other established presences in Elventree. They will also provide you (but only you) with a poor lifestyle. Note: This feature is a variant of the Acolyte feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I long for a home that never really existed, whether in the camps, Hillsfar, or Myth Drannor."
+								],
+								[
+									"2",
+									"Though I am not an elf, I am a fervent, radical worshipper of the elven gods."
+								],
+								[
+									"3",
+									"I live in the moment, knowing my life could be turned upside down any day."
+								],
+								[
+									"4",
+									"I appreciate beauty in all of its forms."
+								],
+								[
+									"5",
+									"I hate the dark elves and the Netherese for each driving the elves out of Cormanthyr in the past."
+								],
+								[
+									"6",
+									"I am a forest bumpkin who grew up in a tent in the woods and is wholly ignorant of city life."
+								],
+								[
+									"7",
+									"I was raised alongside children of many other races. I harbor no racial prejudices at all."
+								],
+								[
+									"8",
+									"The elves have just the right word for so many things that cannot be expressed as well in other languages. I pepper my speech with elven words, phrases, and sayings."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Patient. The elves have taught me to think and plan for the long-term. (Lawful)"
+								],
+								[
+									"2",
+									"Rebellious. Governments and politicians drove my family to the camps. I subtly defy authority whenever I think I can get away with it. (Chaotic)"
+								],
+								[
+									"3",
+									"Self - Absorbed. I've had to look out for number one so long that it has become second nature. (Any)"
+								],
+								[
+									"4",
+									"Wanderlust. I want to see as much of the world beyond the camps as I can. (Any)"
+								],
+								[
+									"5",
+									"Generous. I give everything I can to help those in need, regardless of who they are. (Good)"
+								],
+								[
+									"6",
+									"To the Abyss with Them. The people of Hillsfar cast me out. I won't risk my hide to help them. (Evil)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"The elves took me in when I had nowhere else to go. In return, I do what I can to help elves in need."
+								],
+								[
+									"2",
+									"I seek revenge against the people of Hillsfar for driving my family into the forest."
+								],
+								[
+									"3",
+									"My family lost everything when they were driven from Hillsfar. I strive to rebuild that fortune."
+								],
+								[
+									"4",
+									"The forest has provided me with food and shelter. In return, I protect forests and those who dwell within."
+								],
+								[
+									"5",
+									"I am deeply, tragically in love with someone whose racial lifespan is far longer or shorter than mine."
+								],
+								[
+									"6",
+									"Members of my extended family did not make it to the camps or have been kidnapped to fight in the Arena. I search for them tirelessly."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am very uncomfortable indoors and underground."
+								],
+								[
+									"2",
+									"I am haughty. I grew up among the elves and emulate them. Other races are crude in comparison."
+								],
+								[
+									"3",
+									"Elf this, elf that. I am sick and tired of the elves."
+								],
+								[
+									"4",
+									"I am a miser. Having lost everything once before, I clutch my possessions and wealth very tightly."
+								],
+								[
+									"5",
+									"I am a moocher. I am so used to others providing for me that I have come to expect everyone to do it."
+								],
+								[
+									"6",
+									"I believe the gods have cursed me, my family, and all of the Cormanthor refugees. We are all doomed, doomed I tell you!"
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Dragon Casualty",
+			"source": "ALCurseOfStrahd",
+			"page": 3,
+			"skillProficiencies": [
+				{
+					"intimidation": true,
+					"survival": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"draconic": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"vehicles (water)": true
+				},
+				{
+					"anyArtisansTool": 1
+				},
+				{
+					"choose": {
+						"from": [
+							"gaming set",
+							"vehicles (land)"
+						]
+					}
+				},
+				{
+					"vehicles (land)": true
+				},
+				{
+					"anyMusicalInstrument": 1
+				},
+				{
+					"choose": {
+						"from": [
+							"alchemist's supplies",
+							"herbalism kit"
+						]
+					}
+				},
+				{
+					"choose": {
+						"from": [
+							"thieves' tools",
+							"forgery kit",
+							"disguise kit"
+						]
+					}
+				},
+				{
+					"anyGamingSet": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"dagger|phb",
+						{
+							"special": "tattered rags"
+						},
+						{
+							"special": "loaf of moldy bread"
+						},
+						{
+							"special": "small cast-off scale belonging to Vorgansharax—the Maimed Virulence"
+						},
+						{
+							"item": "pouch|phb",
+							"displayName": "pouch of various coins (salvaged during your escape from Phlan)",
+							"containsValue": 500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Intimidation}, {@skill Survival}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "Special (see origin below)"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "Draconic"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A {@item dagger|phb}, tattered rags, a loaf of moldy bread, a small cast-off scale belonging to Vorgansharax—the Maimed Virulence, and a {@item pouch|phb} with 5 gp of various coins (salvaged during your escape from Phlan)."
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Wretched"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"When the Maimed Virulence descended upon Phlan, you were one of the unfortunate casualties of war. Captured during the initial assault, you have spent the last year of your life as a plaything of a capricious and malevolent overlord.",
+						"While many of your fellow prisoners fell to the dragon's insatiable fury over the coming months, you and your fellow \"survivors\" were spared only for a worse fate as one of the dragon's magical experiments, leaving you and those who survived the torture scarred and disfigured.",
+						"What reasons the dragon had for releasing you few survivors, nobody knows. You only fear that those who died under his terrible claw were the lucky ones, and you and your fellow Dragonscarred are doomed for a fate worse than death."
+					]
+				},
+				{
+					"name": "Origin",
+					"type": "entries",
+					"entries": [
+						"Prior to the coordinated attack by the Maimed Virulence and her rebel Black Fist supporters, you were once a citizen or visitor to Phlan. While the trauma of your recent ordeal has greatly altered your motivations and perception of the world, your former life still clings to you and colors your mannerisms, behaviors, and outlook on life. Choose one entry on the following table (or roll randomly) to determine your former occupation prior to your incarceration and torture. Your choice determines your tool proficiency from this background.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Origin (Occupation)",
+								"Tool Proficiency"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-5",
+								"col-6"
+							],
+							"rows": [
+								[
+									"1",
+									"Dockworker/Fisherman",
+									"{@filter Vehicles (water)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (water)}"
+								],
+								[
+									"2",
+									"Tradesperson/Merchant",
+									"{@filter Artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}"
+								],
+								[
+									"3",
+									"Black Fist Soldier",
+									"{@filter Gaming set|items|source=phb|miscellaneous=mundane|type=gaming set} or {@filter Vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)}"
+								],
+								[
+									"4",
+									"Adventurer/Visitor",
+									"{@filter Vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)}"
+								],
+								[
+									"5",
+									"Entertainer",
+									"{@filter Musical Instrument|items|source=phb|miscellaneous=mundane|type=instrument}"
+								],
+								[
+									"6",
+									"Scholar/Healer",
+									"{@item Alchemist's Supplies|phb} or {@item Herbalism kit|phb}"
+								],
+								[
+									"7",
+									"Criminal",
+									"{@item thieves' tools|phb}, {@item forgery kit|phb}, or {@item Disguise kit|phb}"
+								],
+								[
+									"8",
+									"Unskilled Laborer",
+									"{@filter Gaming set|items|source=phb|miscellaneous=mundane|type=gaming set}"
+								]
+							]
+						}
+					]
+				},
+				{
+					"name": "Feature: Dragonscarred",
+					"type": "entries",
+					"entries": [
+						"Over a period of several months you were subject to magical and mundane torture at the claws of Vorgansharax and his minions. These experiments have left you horribly disfigured but mark you as a survivor of the Maimed Virulence. This affords you a measure of fame and notoriety, for those who know of your harrowing ordeal are keen to hear the tale personally but makes it difficult to disguise your appearance and hide from prying eyes.",
+						"You can parlay this attention into access to people and places you might not otherwise have, for you and your companions. Nobles, scholars, mages, and those who seek to ferret out the secrets of the Maimed Virulence would all be keen to hear your tale of survival, and learn what secrets (if any) you might possess, and/or study your affliction with great interest. However, you fear that your afflictions are not completely mundane and that the Maimed Virulence may as yet have some nefarious reason for allowing your escape, as your scars burn with acidic fury and seem to writhe beneath your skin at times. Note: This feature is a variant of the Far Traveler feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Disfigurement (Optional)",
+					"type": "entries",
+					"entries": [
+						"In addition to extensive scarring, you may choose one of the following options to represent your disfigurement. This disfigurement is purely cosmetic, misshapen, and horrific to look upon.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Disfigurement"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Small non-functional wing(s)."
+								],
+								[
+									"2",
+									"Misshapen, wing-like membranes along one or both arms."
+								],
+								[
+									"3",
+									"Elongated, claw-like hand(s)."
+								],
+								[
+									"4",
+									"Elongated, claw-like feet."
+								],
+								[
+									"5",
+									"Painful green scales randomly embedded in skin."
+								],
+								[
+									"6",
+									"Bulbous, reptilian eye(s)."
+								],
+								[
+									"7",
+									"Enlarged dorsal spines."
+								],
+								[
+									"8",
+									"Hair replaced with small irregular spines."
+								]
+							]
+						}
+					]
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am driven to escape my past, and rarely stay in one place long."
+								],
+								[
+									"2",
+									"I know secrets of the Maimed Virulence, but fear the harm that may befall me should others learn them."
+								],
+								[
+									"3",
+									"Speaking of my ordeal helps sooth the still open wounds in my soul."
+								],
+								[
+									"4",
+									"My former life is meaningless, and was ripped to shreds by the claws of Vorgansharax. All that matters now is what I do with the future."
+								],
+								[
+									"5",
+									"I have faced the worst a dragon can deliver and survived. I am fearless, and my resolve unshakable."
+								],
+								[
+									"6",
+									"I am haunted my tortured past, and wake at night screaming at half-remembered horrors."
+								],
+								[
+									"7",
+									"I sleep with my back to a wall or tree, and a weapon within arm's reach."
+								],
+								[
+									"8",
+									"I am slow to trust, but incredibly loyal to those who have earned it."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Survivor. No matter the cost, I will take any action necessary to survive. (Any)"
+								],
+								[
+									"2",
+									"Independence. When in trouble, the only person I can rely on is myself. (Chaotic)"
+								],
+								[
+									"3",
+									"Compassionate. I have suffered long at the hands of a Dragon, and take pity and compassion on the suffering of others. (Good)"
+								],
+								[
+									"4",
+									"Secretive. I am withdrawn, and hide my monstrous appearance for fear of drawing unwanted attention. (Chaotic)"
+								],
+								[
+									"5",
+									"Justice. I have been wronged, and will not allow the same fate to befall others. (Lawful)"
+								],
+								[
+									"6",
+									"Sycophant. During my ordeal, I became a willing servant of the Maimed Virulence, and spy on his behalf. (Evil)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I have sworn vengeance on the Maimed Virulence and those that follow him."
+								],
+								[
+									"2",
+									"I long to reunite with friends and family who may dwell among the Phlan Refugees, and protect them."
+								],
+								[
+									"3",
+									"While a prisoner of the Maimed Virulence, I overheard rumors of an item or treasure the Dragon seeks. I will have that treasure for myself!"
+								],
+								[
+									"4",
+									"I seek to reclaim and rebuild my former life to the best of my ability."
+								],
+								[
+									"5",
+									"I have been reborn as a child of Vorgansharax. I will claim my birthright as his chosen heir and successor."
+								],
+								[
+									"6",
+									"I attribute my survival to the work of the divine, and seek to prove myself worthy of the honor."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I have been touched with dragon-greed, and have a lust for wealth which can never be satisfied."
+								],
+								[
+									"2",
+									"I secretly believe others are plotting to harm me."
+								],
+								[
+									"3",
+									"I no longer enjoy the simple pleasures in life. Food is but ashes and bile in my throat."
+								],
+								[
+									"4",
+									"Anyone who refuses to celebrate my celebrity does not deserve my company."
+								],
+								[
+									"5",
+									"I am paranoid and overly suspicious of others. Anyone may be an agent of the Maimed Virulence."
+								],
+								[
+									"6",
+									"Once I make up my mind, I follow my chosen course of action regardless of the consequences."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Earthspur Miner",
+			"source": "ALElementalEvil",
+			"page": 3,
+			"skillProficiencies": [
+				{
+					"athletics": true,
+					"survival": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"dwarvish": true,
+					"undercommon": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"shovel|phb"
+					],
+					"b": [
+						"miner's pick|phb"
+					]
+				},
+				{
+					"_": [
+						"block and tackle|phb",
+						"climber's kit|phb",
+						"common clothes|phb",
+						{
+							"item": "pouch|phb",
+							"containsValue": 500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Athletics}, {@skill Survival}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "Dwarvish and Undercommon "
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A {@item shovel|phb} or a {@item miner's pick|phb}, a {@item block and tackle|phb}, a {@item climber's kit|phb}, a set of {@item common clothes|phb}, and a belt {@item pouch|phb} containing 5 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Poor"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"You are a down-on your luck miner from the Earthspur Mountains who is no stranger to hardship. You have spent a great deal of time living among the dwarves, goliaths, and denizens of the Underdark that also work mines in the area. At this point, you're just as comfortable working underground as above. You know how to read a seam, dicker for supplies with the deep gnomes, party with dwarves, and find your way back to the surface afterwards. Unfortunately, you haven't struck it rich...yet. Although you've come to Mulmaster looking for work, the tall peaks and deep mines of the Earthspurs still call to you."
+					]
+				},
+				{
+					"name": "Feature: Deep Miner",
+					"type": "entries",
+					"entries": [
+						"You are used to navigating the deep places of the earth. You never get lost in caves or mines if you have either seen an accurate map of them or have been through them before. Furthermore, you are able to scrounge fresh water and food for yourself and as many as five other people each day if you are in a mine or natural caves. Note: This feature is a variant of the Outlander feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Nothing bothers me for long."
+								],
+								[
+									"2",
+									"I hate the horrors of the Underdark with a passion. They took my friends and family and almost got me."
+								],
+								[
+									"3",
+									"Anything worth doing takes time and patience. I have learned to plan and wait for the things I want and to be patient to achieve my goals."
+								],
+								[
+									"4",
+									"I can party with everyone. Whether with dwarves, or goliaths, or deep gnomes, I can find a way to have a good time."
+								],
+								[
+									"5",
+									"I'd rather be mining. This is okay; mining is better."
+								],
+								[
+									"6",
+									"I think that I will stumble upon great riches if I just keep looking."
+								],
+								[
+									"7",
+									"People who don't work with their hands and who live in houses are soft and weak."
+								],
+								[
+									"8",
+									"I wish I were more educated. I look up to people who are."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Generosity. The riches of the earth are to be shared by all. (Good)"
+								],
+								[
+									"2",
+									"Greed. Gems and precious metals, I want them all for myself. (Evil)"
+								],
+								[
+									"3",
+									"Mooch. Property, schmoperty. If I need it, I take and use it. If I don't, I leave it for someone else. (Chaotic)"
+								],
+								[
+									"4",
+									"Boundaries. Everything and everyone has its prescribed place; I respect that and expect others to do the same. (Lawful)"
+								],
+								[
+									"5",
+									"Let it Be. I don't meddle in the affairs of others if I can avoid it. They're none of my business. (Neutral)"
+								],
+								[
+									"6",
+									"Materialist. I want riches to improve my life. (Any)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"The people of the Earthspur mines are my family. I will do anything to protect them."
+								],
+								[
+									"2",
+									"A deep gnome saved my life when I was injured and alone. I owe his people a great debt."
+								],
+								[
+									"3",
+									"I must behold and preserve the natural beauty of places below the earth."
+								],
+								[
+									"4",
+									"Gems hold a special fascination for me, more than gold, land, magic, or power."
+								],
+								[
+									"5",
+									"I want to explore new depths and scale new heights."
+								],
+								[
+									"6",
+									"Someday I'm going to find the mother lode, then I'll spend the rest of my life in luxury."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I'm uncomfortable spending time under the open sky. I'd rather be indoors or underground."
+								],
+								[
+									"2",
+									"I'm not used to being around other people much and sometimes get grouchy about it."
+								],
+								[
+									"3",
+									"Good tools are more reliable than people. In a cave in, I would save a sturdy pick before a stranger."
+								],
+								[
+									"4",
+									"I jealously guard my secrets, because I think others will take advantage of me if they learn what I know."
+								],
+								[
+									"5",
+									"I am obsessed with getting rich. I always have a scheme brewing for making it big."
+								],
+								[
+									"6",
+									"I'm afraid of the dark."
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Gate Urchin",
+			"source": "ALRageOfDemons",
+			"page": 6,
+			"skillProficiencies": [
+				{
+					"deception": true,
+					"sleight of hand": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"thieves' tools": true,
+					"anyMusicalInstrument": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"special": "battered alms box"
+						},
+						{
+							"equipmentType": "instrumentMusical"
+						},
+						"common clothes|phb",
+						{
+							"item": "pouch|phb",
+							"displayName": "belt pouch"
+						},
+						{
+							"value": 1000
+						}
+					]
+				},
+				{
+					"a": [
+						{
+							"special": "cast-off military jacket"
+						}
+					],
+					"b": [
+						{
+							"special": "cap"
+						}
+					],
+					"c": [
+						{
+							"special": "scarf"
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Deception}, {@skill Sleight of Hand}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Thieves' tools|phb}, one type of {@filter musical instrument|items|source=phb|miscellaneous=mundane|type=instrument}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A battered alms box, a {@filter musical instrument|items|source=phb|miscellaneous=mundane|type=instrument}, a cast-off military jacket, cap, or scarf, a set of {@item common clothes|phb}, a belt {@item pouch|phb}, and 10 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Poor"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"All traffic into and out of the City of Trade passes through the Hillsfar Gate, making it the ideal place for the destitute to gather to panhandle, busk, gossip, and pick pockets. You grew up on the streets in the shadow of that great steel edifice, which houses both Red Plumes and Guild Mages. Though you may have moved on, you still have friends among them, and that life has had a lasting impact on you."
+					]
+				},
+				{
+					"name": "Feature: Red Plume and Mage Guild Contacts",
+					"type": "entries",
+					"entries": [
+						"You made a number of friends among the Red Plumes and the Mage's Guild when you lived at the Hillsfar Gate. They remember you fondly and help you in little ways when they can. You can invoke their assistance in and around Hillsfar to obtain food, as well as simple equipment for temporary use. You can also invoke it to gain access to the low-security areas of their garrisons, halls, and encampments. Note: This feature is a variant of the Soldier feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I appreciate the simple things in life. a song, a warm meal, a sunny day. I don't need any more."
+								],
+								[
+									"2",
+									"My problems are always caused by others. I'm never to blame."
+								],
+								[
+									"3",
+									"I am afraid I could wind up back on the streets any day."
+								],
+								[
+									"4",
+									"I get along with everyone."
+								],
+								[
+									"5",
+									"I see people as marks for a con and have difficulty feeling true empathy for them."
+								],
+								[
+									"6",
+									"I have a real flair for matchmaking. I can find anyone a spouse!"
+								],
+								[
+									"7",
+									"I think money is the true measure of appreciation and affection. Everything else is talk or an act."
+								],
+								[
+									"8",
+									"I don't like having a lot of stuff, just a few simple things I need. I don't like being tied down and tend to leave things behind when I don't need them anymore."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Loyal. I never rat out any of my friends, even when the Red Plumes or the Rogues Guild ask. (Lawful)"
+								],
+								[
+									"2",
+									"Adventurous. I don't like doing the same thing every day. I crave variety. (Chaotic)"
+								],
+								[
+									"3",
+									"Strong. Only the strong survive. I respect those who are strong and powerful. (Any)"
+								],
+								[
+									"4",
+									"Witty. Brains are better than brawn. I rely on my wits and respect others who do the same. (Any)"
+								],
+								[
+									"5",
+									"Honest. Others can do what they want, but I won't lie or steal, even to feed my family. (Good)"
+								],
+								[
+									"6",
+									"Ungrateful. Those who give, only do it to make themselves feel better. I steal from them. (Evil)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"The Joydancers of Lliira gave me my instrument when I really needed food. I hate them for that."
+								],
+								[
+									"2",
+									"Busking has taught me to love music above all else."
+								],
+								[
+									"3",
+									"The Rogues Guild spared me when I did a job without cutting them in. I owe them a great debt."
+								],
+								[
+									"4",
+									"I know people hate the Red Plumes, but some of them were really good to me. I help Red Plumes whenever I can, and I respect them. They're just doing what they have to do to get by in this world."
+								],
+								[
+									"5",
+									"I will be wealthy some day. My descendants will live in comfort and style."
+								],
+								[
+									"6",
+									"I know how hard life on the streets is. I do everything I can for those who have less than me."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Though I no longer live at the Gate, I am still always concerned about where I will get my next meal."
+								],
+								[
+									"2",
+									"Years of thieving have become habit. I sometimes steal from strangers without thinking about it."
+								],
+								[
+									"3",
+									"I am ashamed of my origins. I pretend I am higher-born and fear others will find out the truth."
+								],
+								[
+									"4",
+									"I think people who grew up in houses are soft, spoiled, and ungrateful. I frequently tell them so."
+								],
+								[
+									"5",
+									"I am still very uncomfortable wearing nice clothes, sleeping in a warm bed, and eating fine food."
+								],
+								[
+									"6",
+									"I do not trust anyone who has not had a hard life. "
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Harborfolk",
+			"source": "ALElementalEvil",
+			"page": 4,
+			"skillProficiencies": [
+				{
+					"athletics": true,
+					"sleight of hand": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyGamingSet": 1,
+					"vehicles (water)": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"fishing tackle|phb",
+						"dice set|phb",
+						"playing card set|phb",
+						{
+							"item": "three-dragon ante set|phb",
+							"displayName": "or Three-Dragon Ante set"
+						},
+						"common clothes|phb",
+						"rowboat",
+						{
+							"item": "pouch|phb",
+							"containsValue": 500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Athletics}, {@skill Sleight of Hand}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "One type of {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set}, {@filter vehicles (water)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (water)}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "{@item Fishing tackle|phb}, {@item dice set|phb}, {@item playing card set|phb}, or {@item Three-Dragon Ante set|phb}, a set of {@item common clothes|phb}, {@item rowboat}, and a belt {@item pouch|phb} containing 5 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Poor"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"You are one of the hundreds of small-time fishermen and women who haul the bounty of Mulmaster's freshwater harbor to the city's markets each morning. You have spent countless days rowing in the waters in and around Mulmaster and know them and the other fisherfolk, dockworkers, and port inhabitants better than anyone. Though you have left that life behind, you still visit once in a while."
+					]
+				},
+				{
+					"name": "Feature: Harborfolk",
+					"type": "entries",
+					"entries": [
+						"You grew up on the docks and waters of Mulmaster Harbor. The harborfolk remember you and still treat you as one of them. They welcome you and your companions. While they might charge you for it, they'll always offer what food and shelter they have; they'll even hide you if the City Watch is after you (but not if the Hawks are). Note: This feature is a variant of the Folk Hero feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am curious. I want to know why things are the way they are and why people do the things that they do."
+								],
+								[
+									"2",
+									"I can't sing, but that never stops me from doing it, loudly. Everyone loves a good sea chanty!"
+								],
+								[
+									"3",
+									"I think the High Blade is doing a terrific job, don't you?"
+								],
+								[
+									"4",
+									"I'm very excited that the House Built on Gold is being restored. I am a zealous worshipper of Waukeen."
+								],
+								[
+									"5",
+									"I am quite superstitious. I see portents in everyday occurrences."
+								],
+								[
+									"6",
+									"I resent the rich and enjoy thwarting their plans and spoiling their fun in small ways."
+								],
+								[
+									"7",
+									"I have a sea story to fit every occasion."
+								],
+								[
+									"8",
+									"I'm a fisher, but I secretly detest eating fish. I will do anything to avoid it."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Calm. For all things, there is a tide. I set sail when it is right, and mend my nets when it is not. (Lawful)"
+								],
+								[
+									"2",
+									"Windblown. I go where the winds blow. No man or woman tells me where or when to sail. (Chaotic)"
+								],
+								[
+									"3",
+									"Aspiring. I will gain the favor of a Zor or Zora patron, maybe even one of the Blades! (Any)"
+								],
+								[
+									"4",
+									"Salty. I want people to look to me as an expert on plying Mulmaster Harbor. (Any)"
+								],
+								[
+									"5",
+									"Selfless. We are all children of the sea. I help everyone in peril afloat and ashore. (Good)"
+								],
+								[
+									"6",
+									"Let them Drown. I refuse to risk my hide to help others. They wouldn't help me if roles were reversed. (Evil)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I once lost everything but my rowboat. I'll do anything to protect it."
+								],
+								[
+									"2",
+									"My brother was in the Soldiery, but he was killed. I really look up to the men and women who serve."
+								],
+								[
+									"3",
+									"The Cloaks killed my friend for spellcasting. I'll get them back somehow, someday."
+								],
+								[
+									"4",
+									"The High House of Hurting helped me when I was hurt and asked nothing in return. I owe them my life."
+								],
+								[
+									"5",
+									"I was robbed in the Zhent ghetto once. It will not happen again."
+								],
+								[
+									"6",
+									"I would do anything to protect the other harborfolk. They are my family."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I drink too much, which causes me to miss the tide."
+								],
+								[
+									"2",
+									"I killed a drunk member of the City Watch in a brawl. I am terrified that they might find out."
+								],
+								[
+									"3",
+									"I oversell myself and make promises I can't keep when I want to impress someone."
+								],
+								[
+									"4",
+									"Book learning is a waste of time. I have no patience for people who don't speak from experience."
+								],
+								[
+									"5",
+									"I almost always cheat. I can't help myself."
+								],
+								[
+									"6",
+									"I am a secret informant for the Hawks. I send them reports about everything I see and hear, even what my friends and allies are up to."
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Hillsfar Merchant",
+			"source": "ALRageOfDemons",
+			"page": 7,
+			"skillProficiencies": [
+				{
+					"insight": true,
+					"persuasion": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"vehicles (land)": true,
+					"vehicles (water)": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"fine clothes|phb",
+						"signet ring|phb",
+						{
+							"special": "letter of introduction from your family's trading house"
+						},
+						{
+							"special": "purse",
+							"containsValue": 2500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Insight}, {@skill Persuasion}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@filter Vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)} and {@filter vehicles (water)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (water)}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A set of {@item fine clothes|phb}, a {@item signet ring|phb}, a letter of introduction from your family's trading house, and a purse containing 25 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Wealthy"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"Before becoming an adventurer, you were a successful merchant operating out Hillsfar, the City of Trade. Your family operated warehouses, organized caravans, managed stores, or owned a ship and has trade contacts throughout the Moonsea region, as well as up and down the length of the Sword Coast. Perhaps they import ore, uncut gems, untreated furs, or grain into the City of Trade, or they export fine cloth, faceted gems, fine furs, or Dragon's Breath, a brandy-like liquor. Regardless, you've largely given that life up for some reason and have chosen to seek adventure instead. Nevertheless, the training you received then, and perhaps the contacts you made, serve you well as an adventurer.",
+						"Choose one of the following features:"
+					]
+				},
+				{
+					"name": "Feature: Factor",
+					"type": "entries",
+					"entries": [
+						"Although you've left the day-to-day life of a merchant behind, your family has assigned you the services of a loyal retainer from the business, a factor, husbanding agent, seafarer, caravan guard, or clerk. This individual is a commoner who can perform mundane tasks for you such as making purchases, delivering messages, and running errands. He or she will not fight for you and will not follow you into obviously dangerous areas (such as dungeons), and will leave if frequently endangered or abused. If he or she is killed, the family assigns you another within a few days. Note: This feature is a variant of the Noble Knight's Retainers feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Alternate Feature: Trade Contact",
+					"type": "entries",
+					"entries": [
+						"You and your family have trade contacts such as caravan masters, shopkeepers, sailors, artisans, and farmers throughout the Moonsea region and all along the Sword Coast. Once per game session, when adventuring in either of those areas, you can use those contacts to get information about the local area or to pass a message to someone in those areas, even across the great distance between the two areas. Note: This feature is a variant of the Criminal Contact and Researcher features."
+					],
+					"data": {
+						"isFeature": true,
+						"isAlternateFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I fill my evenings with wine or mead and song."
+								],
+								[
+									"2",
+									"I greatly admire gladiators and enjoy the Arena."
+								],
+								[
+									"3",
+									"I take my wealth for granted. It seldom occurs to me that others aren't rich themselves."
+								],
+								[
+									"4",
+									"I leave broken hearts all around the Moonsea and up and down the Sword Coast."
+								],
+								[
+									"5",
+									"I work hard and seldom make time for fun."
+								],
+								[
+									"6",
+									"I am a particularly devout and pray often."
+								],
+								[
+									"7",
+									"The Red Plumes caught me once. I hate them."
+								],
+								[
+									"8",
+									"I ask a lot of questions to get information about those with whom I am working and dealing."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Frugal. I spend my money very carefully. (Lawful)"
+								],
+								[
+									"2",
+									"Profligate. I tend to spend extravagantly. (Chaotic)"
+								],
+								[
+									"3",
+									"Honest. I deal with others above board. (Any)"
+								],
+								[
+									"4",
+									"Sharp. I seek to make the best deal possible. (Any)"
+								],
+								[
+									"5",
+									"Charitable. I give generously to others. (Good)"
+								],
+								[
+									"6",
+									"Greedy. I do not share my wealth with others. (Evil)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am fiercely loyal to those with whom I work."
+								],
+								[
+									"2",
+									"I must uphold the good name of my family."
+								],
+								[
+									"3",
+									"I will prove myself to my family as an adventurer."
+								],
+								[
+									"4",
+									"Deals are sacrosanct. I never go back on my word."
+								],
+								[
+									"5",
+									"I love making deals and negotiating agreements."
+								],
+								[
+									"6",
+									"I guard my wealth jealously."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am a braggart. I promote myself shamelessly."
+								],
+								[
+									"2",
+									"I am vain. I always wear the latest fashions."
+								],
+								[
+									"3",
+									"I am a glutton. I eat and drink to excess."
+								],
+								[
+									"4",
+									"I am a snob. I want only the finest things in life."
+								],
+								[
+									"5",
+									"I am lazy. I want others to take care of everything."
+								],
+								[
+									"6",
+									"I am overconfident. I overestimate my abilities."
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Hillsfar Smuggler",
+			"source": "ALRageOfDemons",
+			"page": 8,
+			"skillProficiencies": [
+				{
+					"perception": true,
+					"stealth": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"anyStandard": 1
+				}
+			],
+			"toolProficiencies": [
+				{
+					"forgery kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"forgery kit|phb",
+						"common clothes|phb",
+						{
+							"item": "pouch|phb",
+							"displayName": "belt pouch"
+						},
+						{
+							"value": 500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Perception}, {@skill Stealth}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "One racial language"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Forgery kit|phb}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A {@item forgery kit|phb}, a set of {@item common clothes|phb}, a belt {@item pouch|phb}, and 5 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Modest"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"Hillsfar is the City of Trade. However, the Great Law of Trade only protects \"legitimate\" trade, trade that passes through the city's sole gate, which the Red Plumes monitor and tax. And the Great Law of Humanity banishes non-humans from the city altogether. The two Great Laws create great demand and great risk for smugglers, who shepherd illicit goods and non-humans into and out of the city by secret routes. The Rogues Guild tightly controls all of this activity, taking its cut from sanctioned jobs and exacting punishment for independent jobs.",
+						"Perhaps you trafficked Dragon's Breath (a brandy-like liquor) to avoid tariffs or contraband to avoid seizure, or maybe you are a human who sympathizes with the non-humans and worked as part of the network of secret routes and safe houses that helps them pass through Hillsfar. Either way, you have contacts in the smuggling community who can help you slip into and out of the city unnoticed, for a price."
+					]
+				},
+				{
+					"name": "Feature: Secret Passage",
+					"type": "entries",
+					"entries": [
+						"You can call on your contacts within the smuggling community to secure secret passage into or out of Hillsfar for yourself and your adventuring companions, no questions asked, and no Red Plume entanglements. Because you're calling in a favor, you can't be certain they will be able to help on your timetable or at all. Your Dungeon Master will determine whether you can be smuggled into or out of the city. In return for your passage, you and your companions may owe the Rouges Guild a favor and/or may have to pay bribes. Note: This feature is a variant of the Sailor feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"When I'm not smuggling, I gamble."
+								],
+								[
+									"2",
+									"I just love Halfling cooking and baking!"
+								],
+								[
+									"3",
+									"I party with dwarves whenever I can."
+								],
+								[
+									"4",
+									"I'm a terrible singer, but I love to do it."
+								],
+								[
+									"5",
+									"I was raised to honor Chauntea and still do."
+								],
+								[
+									"6",
+									"The blood sports of the Arena sicken me."
+								],
+								[
+									"7",
+									"I think non-humans are really interesting."
+								],
+								[
+									"8",
+									"I exaggerate the tales of my exploits."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Fair. I think everyone deserves to be treated fairly. I don't play favorites. (Lawful)"
+								],
+								[
+									"2",
+									"Impulsive. Planning is often a waste of time. No plan survives contact with reality. It's easier to dive in and deal with the consequences. (Chaotic)"
+								],
+								[
+									"3",
+									"Curious. I want to learn as much as I can about the people and places I encounter. (Any)"
+								],
+								[
+									"4",
+									"Prepared. I think success depends on preparing as much as possible in advance. (Any)"
+								],
+								[
+									"5",
+									"Respectful. I think everyone deserves to be treated with respect and dignity, regardless of their race, creed, color, or origin. (Good)"
+								],
+								[
+									"6",
+									"Corrupt. I will break the law or act dishonestly if the money is right. (Evil)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am loyal to the Rogues Guild and would do anything for them."
+								],
+								[
+									"2",
+									"I love the city of Hillsfar and my fellow Hillsfarians, despite the recent problems."
+								],
+								[
+									"3",
+									"I admire the elves. I help them whenever I can."
+								],
+								[
+									"4",
+									"A gnome helped me once. I pay the favor forward."
+								],
+								[
+									"5",
+									"I enjoy tricking the Red Plumes at every opportunity."
+								],
+								[
+									"6",
+									"I smuggled agricultural goods for non-human farmers. I try to help them when I can."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"My hatred for the Red Plumes burns so brightly that I have difficulty suppressing It around them."
+								],
+								[
+									"2",
+									"The Red Plumes caught me once before, and I was branded for my crime. If they catch me again, for any offense, the punishment will be dire."
+								],
+								[
+									"3",
+									"I treat all Hillsfarians poorly. I am disgusted with their failure to revolt against the Great Law of Humanity."
+								],
+								[
+									"4",
+									"I have difficulty trusting strangers. Anyone could be a spy for the authorities."
+								],
+								[
+									"5",
+									"I am greedy. There Isn't much I won't do for money."
+								],
+								[
+									"6",
+									"I'm an informant for the Red Plumes. They let me continue my activities, so long as I pass them information about illegal activity in Hillsfar."
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Iron Route Bandit",
+			"source": "ALCurseOfStrahd",
+			"page": 5,
+			"skillProficiencies": [
+				{
+					"animal handling": true,
+					"stealth": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyGamingSet": 1,
+					"vehicles (land)": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"item": "common clothes|phb",
+							"displayName": "dark common clothes"
+						},
+						"pack saddle|phb",
+						"burglar's pack|phb",
+						{
+							"item": "pouch|phb",
+							"containsValue": 500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Animal Handling}, {@skill Stealth}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "One type of {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set}, {@filter vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A set of dark {@item common clothes|phb}, {@item pack saddle|phb}, {@item burglar's pack|phb}, and a belt {@item pouch|phb} containing 5 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Poor"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"The Iron Route, once the primary trade route between Phlan and Zhentil Keep, used to be a site of extensive banditry until the Phlan's recent occupation. Your time as an erstwhile bandit has given you plenty of experience in the saddle and a knack for acquiring and appraising other people's mounts, pets, and vehicles among other things. This particular set of skills has become very lucrative for you by working for the underground as a horse thief for a local guild of thieves and other shadowy organizations."
+					]
+				},
+				{
+					"name": "Feature: Black-Market Breeder",
+					"type": "entries",
+					"entries": [
+						"You know how to find people who are always looking for stolen animals & vehicles, whether to provide for animal pit fights, or to supply some desperate rogues the means to get away faster on mounts during an illegal job. This contact not only provides you with information of what such animals & vehicles are in high demand in the area, but also offer to give you favors and information (DM choice) if you bring such animals & vehicles to them. Note: This is a variant of the Criminal Contact feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"If people leave their gear unsecured, they must not want it very much."
+								],
+								[
+									"2",
+									"I feel more comfortable sleeping under the open sky."
+								],
+								[
+									"3",
+									"I always pre-plan my escape should things go bad; I always like to have an exit strategy."
+								],
+								[
+									"4",
+									"I tend to give animal owners breeding and care advice whether or not they want it."
+								],
+								[
+									"5",
+									"I lost a pet as a child and sadly reflect on it to this day."
+								],
+								[
+									"6",
+									"I always form a powerful, emotional bond with my mount."
+								],
+								[
+									"7",
+									"I recoil at the thought of killing someone else's pet or mount."
+								],
+								[
+									"8",
+									"I prefer to hang to the back of a scuffle or discussion. Better to have my enemies in front of me."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Loyalty. Never bite the hand that feeds. (Good)"
+								],
+								[
+									"2",
+									"Unpredictability. Keep your enemy guessing and off-balance like a confused deer. (Chaotic)"
+								],
+								[
+									"3",
+									"Power. I strive to become leader of the pack at all costs. (Lawful)"
+								],
+								[
+									"4",
+									"Freedom. I bow to no one I don't respect. (Chaotic)"
+								],
+								[
+									"5",
+									"Resourcefulness. Our wits are our most valuable resource in troubled times. (Any)"
+								],
+								[
+									"6",
+									"Unity. Lone wolves fail where the pack succeeds. (Any)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I cannot leave a harmed animal behind; I must save it or put it out of its misery."
+								],
+								[
+									"2",
+									"I leave behind my own personal calling cards when I do a job."
+								],
+								[
+									"3",
+									"I do not trust people who do not have a pet, mount, or furry companion."
+								],
+								[
+									"4",
+									"The pelt I wear on my back was from an animal that died saving my life, I will always cherish it."
+								],
+								[
+									"5",
+									"If my pet does not like you, I do not like you!"
+								],
+								[
+									"6",
+									"Once you've ridden with me and fought by my side, I'll be there for you odds be damned."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I talk to animals; I believe they understand me, even if they do not."
+								],
+								[
+									"2",
+									"I growl at and bite anyone who gets too close to my food while I am eating."
+								],
+								[
+									"3",
+									"I strongly dislike enclosed spaces and require intoxication or firm encouragement to enter them."
+								],
+								[
+									"4",
+									"I robbed the wrong caravan once. The owner is a powerful merchant who holds a grudge."
+								],
+								[
+									"5",
+									"I'm an inveterate gambler."
+								],
+								[
+									"6",
+									"I judge people based on how well they stand their ground in a fight. I got not time for cowards..."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Mulmaster Aristocrat",
+			"source": "ALElementalEvil",
+			"page": 5,
+			"skillProficiencies": [
+				{
+					"deception": true,
+					"performance": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyArtisansTool": 1,
+					"anyMusicalInstrument": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						{
+							"equipmentType": "toolArtisan"
+						}
+					],
+					"b": [
+						{
+							"equipmentType": "instrumentMusical"
+						}
+					]
+				},
+				{
+					"_": [
+						"fine clothes|phb",
+						{
+							"special": "purse",
+							"containsValue": 1000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Deception}, {@skill Performance}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "One type of artistic {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} and one {@filter musical instrument|items|source=phb|miscellaneous=mundane|type=instrument}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "One set of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} or {@filter musical instrument|items|source=phb|miscellaneous=mundane|type=instrument}, a set of {@item fine clothes|phb}, and a purse containing 10 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Wealthy"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"From your hilltop home, you have looked down (literally and perhaps figuratively) on the unwashed masses of Mulmaster for your entire life. Your fur-trimmed robes and training in the visual and performing arts mark you as wealthy and perhaps well-born; you are a member of the City of Danger's aristocracy. None of your immediate family members sits on the Council of Blades or is even a Zor or Zora...yet. Nevertheless, you are one of Mulmaster's elite, and whether you personally covet a higher standing or not, you are at home in the dance halls where the aristocracy gathers to plot, to scheme, to do business, to discuss the arts, and, above all, to see, and to be seen."
+					]
+				},
+				{
+					"name": "Feature: Highborn",
+					"type": "entries",
+					"entries": [
+						"Mulmaster is run by and for its aristocracy. Every other class of citizen in the city defers to you, and even the priesthood, Soldiery, Hawks, and Cloaks treat you with deference. Other aristocrats and nobles accept you in their circles and likely know you or of you. Your connections can get you the ear of a Zor or Zora under the right circumstances. Note: This feature is a variant of the Noble feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"My ambitions are boundless. I will be a Zor or Zora one day!"
+								],
+								[
+									"2",
+									"I must always look my best."
+								],
+								[
+									"3",
+									"Beauty is everywhere. I can find it in even the homeliest person and the most horrible tragedy."
+								],
+								[
+									"4",
+									"Decorum must be preserved at all costs."
+								],
+								[
+									"5",
+									"I will not admit I am wrong if I can avoid it."
+								],
+								[
+									"6",
+									"I am extremely well-educated and frequently remind others of that fact."
+								],
+								[
+									"7",
+									"I take what I can today, because I do not know what tomorrow holds."
+								],
+								[
+									"8",
+									"My life is full of dance, song, drink, and love."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Generous. I have a responsibility to help and protect the less fortunate. (Good)"
+								],
+								[
+									"2",
+									"Loyal. My word, once given, is my bond. (Lawful)"
+								],
+								[
+									"3",
+									"Callous. I am unconcerned with any negative effects my actions may have on the lives and fortunes of others. (Evil)"
+								],
+								[
+									"4",
+									"Impulsive. I follow my heart. (Chaotic)"
+								],
+								[
+									"5",
+									"Ignorant. Explanations bore me. (Neutral)"
+								],
+								[
+									"6",
+									"Isolationist. I am concerned with the fortunes of my friends and family. Others must see to themselves. (Any)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I have dedicated my wealth and my talents to the service of one of the city's many temples."
+								],
+								[
+									"2",
+									"My family and I are loyal supporters of High Blade Jaseen Drakehorn. Our fortunes are inexorably tied to hers. I would do anything to support her."
+								],
+								[
+									"3",
+									"Like many families who were close to High Blade Selfaril Uoumdolphin, mine has suffered greatly since his fall. We honor his memory in secret."
+								],
+								[
+									"4",
+									"My family plotted with Rassendyll Uoumdolphin brother usurped brother as High Blade. Betrayal is the quickest route to power."
+								],
+								[
+									"5",
+									"Wealth and power are nothing. Fulfillment can only be found in artistic expression."
+								],
+								[
+									"6",
+									"It's not how you feel, who you know, or what you can do - it's how you look, and I look fabulous."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I have difficulty caring about anyone or anything other than myself."
+								],
+								[
+									"2",
+									"Having grown up with wealth, I am careless with my finances. I overspend and am overly generous."
+								],
+								[
+									"3",
+									"The ends (my advancement) justify any means."
+								],
+								[
+									"4",
+									"I must have what I want and will brook no delay."
+								],
+								[
+									"5",
+									"My family has lost everything. I must keep up appearances, lest we become a laughingstock."
+								],
+								[
+									"6",
+									"I have no artistic sense. I hide that fact behind extreme opinions and have become a trendsetter. "
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Phlan Insurgent",
+			"source": "ALCurseOfStrahd",
+			"page": 6,
+			"skillProficiencies": [
+				{
+					"stealth": true,
+					"survival": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyArtisansTool": 1,
+					"vehicles (land)": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"item": "caltrops (bag of 20)|phb",
+							"displayName": "bag of caltrops (bag of 20)"
+						},
+						{
+							"item": "trinket|phb",
+							"displayName": "small trinket that connects you to the life you once had before the occupation of Phlan"
+						},
+						"healer's kit|phb",
+						{
+							"item": "common clothes|phb",
+							"displayName": "dark common clothes that includes a cloak and hood"
+						},
+						{
+							"item": "pouch|phb",
+							"containsValue": 500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Stealth}, {@skill Survival}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "One type of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}, {@filter vehicles (land)|items|source=phb;dmg|miscellaneous=mundane|type=vehicle (land)}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A bag of {@item caltrops (bag of 20)|phb}, a small {@item trinket|phb} that connects you to the life you once had before the occupation of Phlan, a {@item healer's kit|phb}, a set of dark {@item common clothes|phb} that includes a cloak and hood, and a belt {@item pouch|phb} containing 5 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Poor"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"The taking of Phlan by Vorgansharax is a clear memory in your mind. You were going about your everyday business when the green dragon's forces spilled out of the sewers and assailed your home. Many of Phlan's citizens, young and old alike, were captured, killed, or offered as tribute to the Maimed Virulence. You, yourself were one of those captured. But, either with the help of adventurers or through your own wits and sheer determination, you escaped.",
+						"Rather than flee the region, you've chosen to stay and fight. Finding refuge outside the town and the deadly thicket surrounding it, you strike out against the Tears of the Virulence and their monstrous allies. You've learned to survive in dire and desperate circumstances, with supplies running low and the arrival of reinforcements uncertain. You've grown accustomed to acting under the cover of night, dealing what blows you can to avenge the friends and family you lost within the currently occupied Phlan. You will drive Vorgansharax out, or you die trying."
+					]
+				},
+				{
+					"name": "Origin",
+					"type": "entries",
+					"entries": [
+						"Removed from your life as a townsperson, you've adapted to rough life in the wilds surrounding Phlan. The trade you practiced still influences your outlook, the manner in which you approach situations, and the way you contribute to the resistance movement against the Maimed Virulence. You can roll on the following table to determine what your occupation was before the fall, or choose one that best fits your character (select from either the general column or the specific column, but not both).",
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Origin (General)",
+								"Origin (Specific)"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-4",
+								"col-7"
+							],
+							"rows": [
+								[
+									"1",
+									"Fisher",
+									"Stojanow River Worker"
+								],
+								[
+									"2",
+									"Hunter",
+									"Twilight Marsh Worker"
+								],
+								[
+									"3",
+									"Craftsperson",
+									"Mantor's Library Scribe"
+								],
+								[
+									"4",
+									"Priest/Priestess",
+									"Clergy of Ilmater"
+								],
+								[
+									"5",
+									"Cook",
+									"Laughing Goblin Server"
+								],
+								[
+									"6",
+									"City Watch",
+									"Black Fist Guard"
+								],
+								[
+									"7",
+									"Servant",
+									"House Sokol Retainer"
+								],
+								[
+									"8",
+									"Unskilled Laborer",
+									"Bay of Phlan Dockworker"
+								]
+							]
+						}
+					]
+				},
+				{
+					"name": "Feature: Guerrilla",
+					"type": "entries",
+					"entries": [
+						"You've come to know the surrounding forests, streams, caves, and other natural features in which you can take refuge—or set up ambushes. You can quickly survey your environment for advantageous features. Additionally, you can scavenge around your natural surroundings to cobble together simple supplies (such as improvised torches, rope, patches of fabric, etc.) that are consumed after use. Note: This feature is a variant of the Outlander feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						"You have given up the life you knew as a citizen of Phlan. However, the Maimed Virulence's invasion resonates deep inside you. Perhaps you have a few friends or family members who were able to escape with you. Or, perhaps, everyone you held dear either perished or went missing during the fall. You may know of someone who is, against all odds, surviving within the thicket and you long to liberate them from a life of peril within the town.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"My patience knows no bounds, so long as my goal is in sight."
+								],
+								[
+									"2",
+									"In life and in struggle, the ends justify my actions."
+								],
+								[
+									"3",
+									"If you aren't helping me, you'd best at least stay out of my way."
+								],
+								[
+									"4",
+									"I long for the life that was taken away from me."
+								],
+								[
+									"5",
+									"Friends and family perished, tragically, before my eyes. I hope never to undergo that again."
+								],
+								[
+									"6",
+									"Making the right choices in life are important to me. The choices I make might save not just my life, but the lives of others as well."
+								],
+								[
+									"7",
+									"I can never allow my foes to get the drop on me."
+								],
+								[
+									"8",
+									"Time is a precious resource that I must spend wisely."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Leadership. The oppressed need someone to inspire them to courageous acts. (Good)"
+								],
+								[
+									"2",
+									"Unpredictability. Keeping the enemy guessing and off-balance is my tactical strength. (Chaos)"
+								],
+								[
+									"3",
+									"Determination. Threats to my home must be eliminated at all costs. (Any)"
+								],
+								[
+									"4",
+									"Freedom. Those who are enslaved and unjustly imprisoned deserve my aid. (Good)"
+								],
+								[
+									"5",
+									"Resourcefulness. Our wits are our most valuable resource in troubled times. (Any)"
+								],
+								[
+									"6",
+									"Unity. Working together, we can overcome all obstacles, even the most seemingly insurmountable ones. (Any)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I'll never let my fellow insurgents down. They are my only remaining friends."
+								],
+								[
+									"2",
+									"I was separated from a loved one during my escape from town. I will find them."
+								],
+								[
+									"3",
+									"One of the Tears of the Virulence was a trusted friend, until the day they betrayed the city. They will pay harshly for their transgressions."
+								],
+								[
+									"4",
+									"An item I hold close is my last remaining connection to the family I lost during the fall."
+								],
+								[
+									"5",
+									"The dragon who took my past life away from me will feel the full extent of my vengeance."
+								],
+								[
+									"6",
+									"The knowledge in Mantor's Library is an irreplaceable treasure that must be protected."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I have no respect for those who flee. I harbor a deep grudge against the citizens who abandoned Phlan."
+								],
+								[
+									"2",
+									"Ale is the only way I can escape the desperation of my circumstances."
+								],
+								[
+									"3",
+									"It doesn't take much to get me into a fight."
+								],
+								[
+									"4",
+									"Being an insurgent means doing things that aren't always ethical. I'm still learning to live with that."
+								],
+								[
+									"5",
+									"My desire to liberate Phlan oftentimes clouds my judgment, despite my best efforts."
+								],
+								[
+									"6",
+									"I relentlessly despise the Maimed Virulence and his allies. I'd abandon other goals in order to strike out at them."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Phlan Refugee",
+			"source": "ALElementalEvil",
+			"page": 6,
+			"skillProficiencies": [
+				{
+					"insight": true,
+					"athletics": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"anyStandard": 1
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyArtisansTool": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"equipmentType": "toolArtisan"
+						},
+						{
+							"special": "token of the life you once knew"
+						},
+						"traveler's clothes|phb",
+						{
+							"item": "pouch|phb",
+							"containsValue": 1500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Insight}, {@skill Athletics}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "One type of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "One of your choice"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A set of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} (one of your choice), a token of the life you once knew, a set of {@item traveler's clothes|phb}, and a belt {@item pouch|phb} containing 15 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Modest"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"Gone are the happier days of walking into the Laughing Goblin Inn after a hard day's labor. Everything has changed, and you are lucky to be alive. Back in Phlan you could count yourself among those street-wise folks who knew when to pay a bribe and who to work with to make a living. Your ability to listen to the winds of change have saved you before, and this time they allowed you to be one of the lucky few who escaped Phlan with something more than just the shirt on your back."
+					]
+				},
+				{
+					"name": "Feature: Phlan Survivor",
+					"type": "entries",
+					"entries": [
+						"Whatever your prior standing was, you are now one of the many refugees that have come to Mulmaster. You are able to find refuge with others from Phlan and those who sympathize with your plight. Within Mulmaster this means that you can find a place to bed down, recover, and hide from the watch with either other refugees from Phlan, or the Zhents within the ghettos. Note: This feature is a variant of the Folk Hero feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I may have lost everything I worked for most of my life, but there's work to be done, no time to linger on the past."
+								],
+								[
+									"2",
+									"I worked hard to get where I am and I refuse to let a little hardship stop me from succeeding."
+								],
+								[
+									"3",
+									"I protect those around me, you never know when one of them will be useful."
+								],
+								[
+									"4",
+									"I have always gotten ahead by giving, why change now?"
+								],
+								[
+									"5",
+									"I prepare for everything, it paid off in Phlan and it will pay off again."
+								],
+								[
+									"6",
+									"I will reclaim my home, though the path may be long, I will never give up hope."
+								],
+								[
+									"7",
+									"I never cared for personal hygiene, and am amazed that It bothers others."
+								],
+								[
+									"8",
+									"I am always willing to volunteer my services, just as long as don't have to do anything."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Justice. Corruption brought Phlan down, I will not tolerate that any longer. (Lawful)"
+								],
+								[
+									"2",
+									"Acceptance. Stability is a myth, to think you can control your future is futile. (Chaotic)"
+								],
+								[
+									"3",
+									"Hope. I am guided by a higher power and I trust that everything will be right in the end. (Good)"
+								],
+								[
+									"4",
+									"Restraint. I hate those who caused my loss. It is all I can do not to lash out at them. (Any)"
+								],
+								[
+									"5",
+									"Strength. As shown in Phlan, the strong survive. If you are weak you deserve what you get (Evil)"
+								],
+								[
+									"6",
+									"Openness. I am always willing to share my life story with anyone who will listen. (Any)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I have the chance at a new life and this time I am going to do things right."
+								],
+								[
+									"2",
+									"The Lord Regent brought this suffering upon his people. I will see him brought to justice."
+								],
+								[
+									"3",
+									"I await the day I will be able to return to my home in Phlan."
+								],
+								[
+									"4",
+									"I will never forget the debt owed to Glevith of the Welcomers. I will be ready to repay that debt when called upon."
+								],
+								[
+									"5",
+									"There was someone I cared about in Phlan, I will find out what happened to them."
+								],
+								[
+									"6",
+									"Some say my life wasn't worth saving, I will prove them wrong."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I used the lives of children to facilitate my escape from Phlan."
+								],
+								[
+									"2",
+									"I am a sucker for the underdog, and always bet on the loosing team."
+								],
+								[
+									"3",
+									"I am incapable of standing up for myself."
+								],
+								[
+									"4",
+									"I will borrow money from friends with no intention to repay it."
+								],
+								[
+									"5",
+									"I am unable to keep secrets. A secret is just an untold story."
+								],
+								[
+									"6",
+									"When something goes wrong, it's never my fault."
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Secret Identity",
+			"source": "ALRageOfDemons",
+			"page": 9,
+			"skillProficiencies": [
+				{
+					"deception": true,
+					"stealth": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"disguise kit": true,
+					"forgery kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"disguise kit|phb",
+						"forgery kit|phb",
+						"common clothes|phb",
+						{
+							"item": "pouch|phb",
+							"displayName": "belt pouch"
+						},
+						{
+							"value": 500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Deception}, {@skill Stealth}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Disguise kit|phb}, {@item Forgery kit|phb}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A {@item disguise kit|phb}, a {@item forgery kit|phb}, a set of {@item common clothes|phb}, a belt {@item pouch|phb}, 5 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Modest"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"Even though you are a non-human, despite Hillsfar's Great Law of Humanity, you continue to live in the City of Trade. You do so by maintaining a secret identity, forging documents, and wearing a disguise. Few, if any, know you aren't human. If you're a halfling or gnome, you pass as a little person or a child. If you're a half-elf, half-orc, or genasi, you disguise your non-human features. Other races use a combination of disguise and concealing clothing to hide. Your reasons for doing so are your own. Perhaps you're a dissident or the agent of a foreign power. Maybe you have a relationship with someone you cannot bear to leave. Regardless, this way of life has taken a heavy toll on you."
+					]
+				},
+				{
+					"name": "Feature: Secret Identity",
+					"type": "entries",
+					"entries": [
+						"You have created a secret identity that you use to conceal your true race and that offers a covering explanation for your presence in Hillsfar. In addition, you can forge documents, including official papers and personal letters, as long as you have seen an example of the kind of document or the handwriting you are trying to copy Note: This feature is a variant of the Charlatan feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Despite its problems, I love Hillsfar, it's the greatest city in the world. The only one for me."
+								],
+								[
+									"2",
+									"I move from place to place, never staying anywhere long and leaving nothing behind."
+								],
+								[
+									"3",
+									"I think flattery is the best way to direct attention away from me."
+								],
+								[
+									"4",
+									"I don't make friends easily. They're a liability I cannot afford."
+								],
+								[
+									"5",
+									"Risk and danger are exhilarate me. Pulling off schemes and deceptions is a rush."
+								],
+								[
+									"6",
+									"The First Lord is right, humans are superior. I really admire them, despite the atrocities."
+								],
+								[
+									"7",
+									"I avoid people of my own race, as well as things associated with my race, lest they give me away."
+								],
+								[
+									"8",
+									"I live for the Arena. I admire gladiators and enjoy the thrill of blood on the sands!"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Quisling. Supporting the rulers of the land and following the laws is the road to salvation. (Lawful)"
+								],
+								[
+									"2",
+									"Scoflaw. The laws and lawmakers are corrupt. I follow laws only when it suits me. (Chaotic)"
+								],
+								[
+									"3",
+									"Optimist. Everyone Is basically good. Though the government is misguided it will all be okay. (Any)"
+								],
+								[
+									"4",
+									"Secretive. I am in the habit of not talking about myself. My business is none of yours. (Any)"
+								],
+								[
+									"5",
+									"Heroic. I do everything I can to help non-humans, regardless of the personal cost to me. (Good)"
+								],
+								[
+									"6",
+									"Depraved. I have lost my moral compass. The ends justify most any means. (Evil)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"The humans of Hillsfar have inflicted terrible harm on me, my family, and my race. I will have revenge."
+								],
+								[
+									"2",
+									"I am part of an underground network that smuggles non-humans into and out of the city."
+								],
+								[
+									"3",
+									"I am a partisan. I commit minor acts of defiance against the First Lord and Red Plumes when I can."
+								],
+								[
+									"4",
+									"I am a spy. I report on events in and around Hillsfar."
+								],
+								[
+									"5",
+									"My secret identity is the only thing protecting me from the Arena. I will stop at nothing to maintain it."
+								],
+								[
+									"6",
+									"I am madly in love with a human who does not know my true identity, and I fear rejection if I reveal it."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"After years of denying who I am, I now despise myself and other members of my pathetic race."
+								],
+								[
+									"2",
+									"Years of hiding have made me somewhat paranoid. I trust no one."
+								],
+								[
+									"3",
+									"I've been lying so often and for so long that I can't help it anymore. I frequently lie for no reason at all."
+								],
+								[
+									"4",
+									"I am ashamed. I failed to protect a member of my family who was seized and thrown into the Area."
+								],
+								[
+									"5",
+									"I am struggling with maintaining my secret identity. I subconsciously want to get caught and therefore sometimes let my secret identity slip."
+								],
+								[
+									"6",
+									"Years of successfully deceiving others have made me cocky. I think no one can see through my lies."
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Shade Fanatic",
+			"source": "ALRageOfDemons",
+			"page": 10,
+			"skillProficiencies": [
+				{
+					"deception": true,
+					"intimidation": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"other": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"forgery kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"forgery kit|phb",
+						{
+							"special": "transparent cylinder of shadow that has no opening"
+						},
+						"signet ring|phb",
+						"fine clothes|phb",
+						{
+							"value": 1500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Deception}, {@skill Intimidation}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Forgery kit|phb}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "Netherese"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A {@item forgery kit|phb}, a transparent cylinder of shadow that has no opening, a {@item signet ring|phb}, a set of {@item fine clothes|phb}, and 15 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Modest"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"You grew up at a time when the wizards of Netheril were at war with the elves of Cormanthor. You recall sitting cross-legged hearing the stories of the glorious Thultanthar, also called the Shade Enclave and the City of Shade, and aspired to study there and maybe even did, for a time. Your dreams came crashing down a few years ago when Thultanthar fell from the sky upon Myth Drannor.",
+						"You know that there was a Netherese Garrison stationed near Hillsfar and have heard rumors that its downfall came from traitors within the ranks. You remain loyal to Netheril and seek other Shade loyalists and fanatics in the Cormanthor forest and the areas surrounding Hillsfar."
+					]
+				},
+				{
+					"name": "Feature: Secret Society",
+					"type": "entries",
+					"entries": [
+						"You have a special way of communicating with others who feel the same way you do about the Shade. When you enter a village or larger city you can identify contact who will give you information on those that would hinder your goals and those would help you simply because of your desire to see the Shade Enclave return in all its glory. Note: This feature is a variant of the Criminal feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am a bully; I try to hide it though."
+								],
+								[
+									"2",
+									"I let my actions speak for themselves"
+								],
+								[
+									"3",
+									"I am important; I will not let anyone forget that."
+								],
+								[
+									"4",
+									"You are either with me or against me."
+								],
+								[
+									"5",
+									"I know it is only a time before I am betrayed by those I care for."
+								],
+								[
+									"6",
+									"I never understand why people get so emotional."
+								],
+								[
+									"7",
+									"They are out to get me. It is only my cunning that keeps me ahead of them"
+								],
+								[
+									"8",
+									"Everyone has a choice, the one I make is always right though."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Hope. I know even if I need do evil acts, history will be my redemption. (Chaos)"
+								],
+								[
+									"2",
+									"Dedicated. I can do anything I put my mind to (Lawful)"
+								],
+								[
+									"3",
+									"Exciting. I have found the truth of the Shadovar and want to share it with everyone. (Any)"
+								],
+								[
+									"4",
+									"Frugal. I horde my possessions knowing that someday I will be called upon to give everything I have to the cause (Any)"
+								],
+								[
+									"5",
+									"Eloquent. I use my words to sway others to my beliefs. (Any)"
+								],
+								[
+									"6",
+									"Compassionate. It is through love that others will join in our cause. (Good)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"They say the Shade broke the bonds of mortality; I want to find out how."
+								],
+								[
+									"2",
+									"The whispers in my head remind me that there is power to be found in the shadows."
+								],
+								[
+									"3",
+									"For the glory of Netheril, I will grow in power."
+								],
+								[
+									"4",
+									"I once lived in Hillsfar, I was chased out before I was able to say farewell."
+								],
+								[
+									"5",
+									"My true love was a killed by the Red Plumes; I plot to make them suffer."
+								],
+								[
+									"6",
+									"I had a loved one die in the arena at Hillsfar; I am out to prove I am stronger than them!"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I always over exaggerate my abilities."
+								],
+								[
+									"2",
+									"I cannot bear to let those I care for out of my sight."
+								],
+								[
+									"3",
+									"I am incapable of standing up for myself."
+								],
+								[
+									"4",
+									"The group I am with has committed atrocities; I am always worried their actions will become public."
+								],
+								[
+									"5",
+									"I always enjoy a good mug of ale... or five."
+								],
+								[
+									"6",
+									"I know what I do is wrong, but am afraid to speak up about it."
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Stojanow Prisoner",
+			"source": "ALCurseOfStrahd",
+			"page": 8,
+			"skillProficiencies": [
+				{
+					"deception": true,
+					"perception": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyGamingSet": 1,
+					"thieves' tools": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"special": "small knife"
+						},
+						"common clothes|phb",
+						{
+							"item": "trinket|phb",
+							"displayName": "trinket from the life you stayed behind to defend"
+						},
+						{
+							"item": "pouch|phb",
+							"containsValue": 1000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Deception}, {@skill Perception}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "One type of {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set}, thieves' tools"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A small knife, a set of {@item common clothes|phb}, a {@item trinket|phb} from the life you stayed behind to defend, a belt {@item pouch|phb} with 10 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Poor"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"\"We need to leave, now!\" Those words still haunt your dreams at night. When everyone was fleeing Phlan, you choose to stay. Whether out of an emotional attachment, or pursuit of riches, you made the decision that would affect the rest of your life.",
+						"Food became scarcer for those without connections. You became a beggar and to stay alive you bartered information to any interested party with food or gold to spare. You were good at what you did, and thought you were invincible. That changed when you were captured by the Tears of Virulence, the soldiers of Vorgansharax, the Maimed Virulence, for selling secrets to those bent on overthrowing the dragon. They locked you in the cells of Stojanow Gate. The first weeks you hoped to stay alive. As the weeks turned into months, and the interrogations continued you began to pray for death."
+					]
+				},
+				{
+					"name": "Feature: Ex-Convict",
+					"type": "entries",
+					"entries": [
+						"The knowledge gained during your incarceration lets you gain insight into local guards and jailors. You know which will accept bribes, or look the other way for you. You can also seek shelter for yourself from authorities with other criminals in the area. Note: This feature is a variant of the Courtier feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am a bully; others will suffer as I have."
+								],
+								[
+									"2",
+									"I always say yes even when I mean no; it's just easier."
+								],
+								[
+									"3",
+									"I aim to misbehave."
+								],
+								[
+									"4",
+									"I go out of my way to frustrate or anger those in power."
+								],
+								[
+									"5",
+									"I strive to obey the law. I will never again make the mistake of going against authority."
+								],
+								[
+									"6",
+									"I always plan everything out. The one time I let others plan things it did not end well for me."
+								],
+								[
+									"7",
+									"I take blame to protect others from pain."
+								],
+								[
+									"8",
+									"I hoard information, you never know what may come in handy."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Loss. I freely give those who offend me what was so brutally denied me, death. (Chaos)"
+								],
+								[
+									"2",
+									"Dedication. I never betray those who trust me. (Law)"
+								],
+								[
+									"3",
+									"Vengeance. I use any means to get information I need; I have been well taught. (Evil)"
+								],
+								[
+									"4",
+									"Redemption. Everyone deserves a second chance. (Good)"
+								],
+								[
+									"5",
+									"Resilience. I can survive any challenge (Any)"
+								],
+								[
+									"6",
+									"Leadership. The best teams are made up of those that society has discarded."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I take up arms to help establish a free Phlan."
+								],
+								[
+									"2",
+									"The horrors of my time in Stojanow haunt my dreams, only after a day of hard work can I find sleep."
+								],
+								[
+									"3",
+									"I am indebted to those who freed me from prison, I will repay this debt."
+								],
+								[
+									"4",
+									"My torturer survived the attack that set me free, I will find him/her."
+								],
+								[
+									"5",
+									"I will not rest while others suffer fates similar to mine."
+								],
+								[
+									"6",
+									"I am searching for a way to heal the scars of Stojanow, both physical and emotional."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"During stressful times, I find myself crying for no reason."
+								],
+								[
+									"2",
+									"My nerve endings are shot from the interrogations; I am numb to all but the harshest touch."
+								],
+								[
+									"3",
+									"I am incapable of standing up for myself."
+								],
+								[
+									"4",
+									"I folded under the torture, and gave information that I promised would be kept secret. My life would be in jeopardy if others found out."
+								],
+								[
+									"5",
+									"Survival is worth more than friendship."
+								],
+								[
+									"6",
+									"The ghosts from my past hinder my actions."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Ticklebelly Nomad",
+			"source": "ALCurseOfStrahd",
+			"page": 9,
+			"skillProficiencies": [
+				{
+					"animal handling": true,
+					"nature": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"giant": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"herbalism kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"herbalism kit|phb",
+						{
+							"special": "small article of jewelry that is distinct to your tribe"
+						},
+						"hunting trap|phb",
+						"common clothes|phb",
+						{
+							"item": "pouch|phb",
+							"containsValue": 500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Animal Handling}, {@skill Nature}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Herbalism kit|phb}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "Giant"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "{@item Herbalism kit|phb}, a small article of jewelry that is distinct to your tribe, a {@item hunting trap|phb}, a set of {@item common clothes|phb}, and a belt {@item pouch|phb} containing 5 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Poor"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"You were born into a nomadic tribe that called the Ticklebelly Hills home. You migrated from location to location, living off the land with your tribe. The tribe would seasonally travel south into the Grass Sea and the Giant's Cairn, north into the Dragonspine Mountains, and even occasionally east across the Stojanow River to the borders of the Quivering forest.",
+						"In your migrations, your people have come to know the stone giant tribes that populate the Giant's Cairn. The dragon cultists came to the hills one day—magic-users wearing purple and riding horrid beasts, black-clad warriors wearing wicked masks, and even soldiers from the nearby town of Phlan. Then the dragon called Vorgansharax arrived and laired in the hills, causing horrid thickets to grow and animals to act unusually. The cultists began raiding nomad camps for victims to offer to the wyrm. Eventually, the dragon moved on to attack Phlan, but life was never again the same for the nomads of the Ticklebelly Hills."
+					]
+				},
+				{
+					"name": "Feature: At Home in the Wild",
+					"type": "entries",
+					"entries": [
+						"The wilderness is your home and you are comfortable dwelling in it. You can find a place to hide, rest, or recuperate when out in the wild. This place of rest is secure enough to conceal you from most natural threats. Threats that are supernatural, magical, or are actively seeking you out might do so with difficulty depending on the nature of the threat (as determined by the DM). However, this feature doesn't shield or conceal you from scrying, mental probing, nor from threats that don't necessarily require the five senses to find you. Note: This feature is a variant of the Folk Hero feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						"Ticklebelly nomads only venture into civilization when necessary. You are social within your tribe, with tribes of other nomads, and even with the stone giant tribes that populate the Giant's Cairn. However, other communities tend to either put you on your guard or put you in a state of wonder. Was it this wonder that enticed you into a life of adventuring? On the other hand, you are fiercely protective of and dedicated to your tribe. Perhaps it was this dedication that led you to venture out; either of your own will or at the behest of your tribe's leaders.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I eagerly inject myself into the unknown."
+								],
+								[
+									"2",
+									"Villages, towns, and cities do not suit me. I'd rather be out in the wilderness any day."
+								],
+								[
+									"3",
+									"I accomplish my tasks efficiently, using as few resources as possible."
+								],
+								[
+									"4",
+									"It's difficult for me to remain in one place for long."
+								],
+								[
+									"5",
+									"I loudly brag about my tribe every chance I get."
+								],
+								[
+									"6",
+									"Having walked among giants, I am fearless in the face of bigger creatures."
+								],
+								[
+									"7",
+									"I am quiet and reserved, but observant. Nothing escapes my attention."
+								],
+								[
+									"8",
+									"My word is my bond. I see a promise to completion, even if it conflicts with my beliefs."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Kinship. Family is most important in life. Though I may be far from my own, the bonds of family must be protected in others' lives as well. (Good)"
+								],
+								[
+									"2",
+									"Preservation. Nature must not be despoiled by encroaching civilization. (Any)"
+								],
+								[
+									"3",
+									"Wanderlust. One must expand their horizons by seeing the world and exploring. (Chaos)"
+								],
+								[
+									"4",
+									"Isolation. My tribe and its ways must be protected and shielded from outside influence. (Neutral)"
+								],
+								[
+									"5",
+									"Protection. Threats to the land and to the people must be dealt with at any and all costs. (Law)"
+								],
+								[
+									"6",
+									"Belonging: All creatures have a place in the world, so I strive to help others find theirs. (Good)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I ache to return to my tribe and the family I left, but cannot until my obligations are fulfilled."
+								],
+								[
+									"2",
+									"The dragon cultists that invaded my homeland stole away one of my tribe's people. I will not know rest until I've found them."
+								],
+								[
+									"3",
+									"The dragon's presence in the hills destroyed valuable territory and resulted in deaths within my tribe. The creature must pay for what it has done."
+								],
+								[
+									"4",
+									"I carry a trinket that spiritually and emotionally ties me to my people and my home."
+								],
+								[
+									"5",
+									"I discovered a strange relic in the hills during my tribe's wanderings. I must discover what it is."
+								],
+								[
+									"6",
+									"One of the stone giant clans from the Giant's Cairn has graced me with a mark of kinship."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I throw myself and my friends into situations rarely ever thinking about consequences."
+								],
+								[
+									"2",
+									"Unfamiliar people and surroundings put me on edge."
+								],
+								[
+									"3",
+									"I have absolutely no patience for slowpokes and those who prove indecisive."
+								],
+								[
+									"4",
+									"My desire to experience new things causes me to make unsafe choices."
+								],
+								[
+									"5",
+									"I am overly protective of nature, sometimes to the detriment of my companions and myself."
+								],
+								[
+									"6",
+									"My lack of worldliness often proves my undoing in social, commercial, and hostile situations."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Trade Sheriff",
+			"source": "ALRageOfDemons",
+			"page": 11,
+			"skillProficiencies": [
+				{
+					"investigation": true,
+					"persuasion": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"elvish": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"thieves' tools": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						"thieves' tools|phb",
+						{
+							"special": "gray cloak"
+						},
+						{
+							"item": "fine clothes|phb",
+							"displayName": "Sheriff's insignia (badge) a set of fine clothes"
+						},
+						{
+							"value": 1700
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Investigation}, {@skill Persuasion}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Thieves' tools|phb}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "Elvish"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "{@item Thieves' tools|phb}, a gray cloak, Sheriff's insignia (badge) a set of {@item fine clothes|phb}, and 17 gp"
+						}
+					]
+				},
+				{
+					"name": "Lifestyle",
+					"type": "entries",
+					"entries": [
+						"Modest"
+					]
+				},
+				{
+					"name": "Overview",
+					"type": "entries",
+					"entries": [
+						"You are one of the many people that make sure the trade routes are clear at ALL times. You assure that the Great Law of Trade is followed at all costs. You work by yourself or in groups to quell bandits and brigands who might stop trade routes from going through. You investigate potential ambushes and possible rumors as to someone wanting to rob or stop caravans. You are as much an investigator as you are law enforcement.",
+						"You are able to go into a town/village around the Hillsfar area and find a contact that is willing to give you information from rumor to fact. This sometimes comes at a cost of a minor bribe of 1-9 silver pieces."
+					]
+				},
+				{
+					"name": "Feature: Investigative Services",
+					"type": "entries",
+					"entries": [
+						"You are part of a small force outside of Hillsfar. You have a special way of communicating with others and they seem to be at ease around you. You can invoke your rank to allow you access to a crime scene or to requisition equipment or horses on a temporary basis. When you enter a town or village around Hillsfar you can identify a contact who will give you information on the local rumors and would help you simply because of your desire to get answers and information for anyone wanting to disrupt trade. Note: This feature is a variant of the soldier feature."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am always polite and respectful"
+								],
+								[
+									"2",
+									"I let my actions speak for themselves"
+								],
+								[
+									"3",
+									"I am haunted by my past having seen the murder of a close friend or family member and it is the one case I always needed to solve but have not been able to."
+								],
+								[
+									"4",
+									"I am quick to judge and slow to vindicate"
+								],
+								[
+									"5",
+									"I can be very persuasive and am able to ask quest ions where others might not be able to."
+								],
+								[
+									"6",
+									"I have a quirky personality that seems to take others off their guard."
+								],
+								[
+									"7",
+									"My sense of humor is considered by most to be awkward."
+								],
+								[
+									"8",
+									"Everyone has a choice, and they can always make the right choice, mine!"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Hope. my job is to speak for the victim (Good)"
+								],
+								[
+									"2",
+									"Dedicated. Once I start an investigation, until told to do so, I do not quit, not matter where it leads. (Lawful)"
+								],
+								[
+									"3",
+									"Nation. My city, nation, or people are all that matter. (Any)"
+								],
+								[
+									"4",
+									"Mercenary. When I do investigations, I expect answers immediately. (Any)"
+								],
+								[
+									"5",
+									"Eloquent. I use my words to sway others to give me answers. (Good)"
+								],
+								[
+									"6",
+									"Might. It is through threats and force that I get my answers. (Lawful)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"To this day an unsolved case will always leave me haunted and bother me."
+								],
+								[
+									"2",
+									"Through the might of my personality I will solve an investigation or puzzle."
+								],
+								[
+									"3",
+									"It is my right to believe what I will, just try and stop me."
+								],
+								[
+									"4",
+									"I need to prove my worth to my fellow Sheriffs"
+								],
+								[
+									"5",
+									"Someone I cared for died under suspicious circumstances. I will find out what happened to them and bring their killer to justice."
+								],
+								[
+									"6",
+									"I speak for those that cannot speak for themselves."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I always over exaggerate my abilities."
+								],
+								[
+									"2",
+									"I cannot bear to let those I care for out of my sight."
+								],
+								[
+									"3",
+									"I took a bribe to tank an investigation and I would do anything to keep it secret."
+								],
+								[
+									"4",
+									"I have little respect for those that are of \"low\" intelligence/race."
+								],
+								[
+									"5",
+									"I always enjoy a good mug of ale... or five to cover up my past."
+								],
+								[
+									"6",
+									"I speak for the First Lord of Hillsfar and make sure everyone knows it."
+								]
+							]
+						}
+					],
+					"name": "Suggested Characteristics"
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Ashari",
+			"source": "TDCSR",
+			"page": 180,
+			"skillProficiencies": [
+				{
+					"nature": true,
+					"choose": {
+						"from": [
+							"arcana",
+							"survival"
+						],
+						"count": 1
+					}
+				}
+			],
+			"languageProficiencies": [
+				{
+					"primordial": true,
+					"choose": {
+						"from": [
+							"aquan",
+							"auran",
+							"ignan",
+							"terran"
+						],
+						"count": 1
+					}
+				}
+			],
+			"toolProficiencies": [
+				{
+					"herbalism kit": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"item": "Traveler's Clothes|phb",
+							"displayName": "A set of traveler's clothes"
+						},
+						{
+							"special": "a staff carved with symbols of your tribe"
+						},
+						"herbalism kit|phb",
+						{
+							"item": "pouch|phb",
+							"containsValue": 1000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Nature}, plus your choice of {@skill Arcana} or {@skill Survival}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Herbalism Kit|PHB}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "{@language Primordial} ({@language Primordial|PHB|Aquan}, {@language Primordial|PHB|Auran}, {@language Primordial|PHB|Ignan}, or {@language Primordial|PHB|Terran}, depending on the elemental affinity of your tribe)"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A set of {@item traveler's clothes|phb}, a staff carved with symbols of your tribe, an {@item herbalism kit|PHB}, and a belt {@item pouch|phb} containing 10 gp"
+						}
+					]
+				},
+				{
+					"name": "Feature: Elemental Harmony",
+					"type": "entries",
+					"page": 180,
+					"entries": [
+						"Growing up surrounded by wild elemental magics has attuned your senses to those chaotic forces, enabling you to subtly bend them to your will. As an action, you channel minor magic involving the element of your chosen Ashari order, giving you one of the following abilities:",
+						{
+							"type": "entries",
+							"name": "Pyrah",
+							"page": 180,
+							"entries": [
+								"You instantaneously create and control a burst of flame small enough to light a candle, a torch, or a small campfire. Alternatively, you snuff out a flame of the same size."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Terrah",
+							"page": 180,
+							"entries": [
+								"You instantaneously create a small rock no larger than a {@item gold (gp)|PHB|gold coin}. The rock appears in your hand, then turns to dust after 1 minute."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Vesrah",
+							"page": 180,
+							"entries": [
+								"You instantaneously create enough hot or cold water to fill a small drinking vessel."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Zephrah",
+							"page": 180,
+							"entries": [
+								"You create an instantaneous puff of wind strong enough to blow papers off a desk or mess up someone's hair."
+							]
+						}
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"name": "Suggested Characteristics",
+					"page": 180,
+					"entries": [
+						"{@book The Ashari|TDCSR|2|The Ashari} hold themselves removed from the rest of Tal'Dorei by their own choice. This makes many Ashari naive to the ways of the world beyond their homes—but it can also make them determined, steadfast, and tightly focused on their goals. Ever since {@creature Keyleth, Voice of the Tempest|TDCSR} and leader of the {@book Zephrah|TDCSR|3|Zephrah}, became a world-renowned hero, the Air Ashari at least have become more familiar to Tal'Dorei's other peoples. They are known to welcome outsiders to their mountaintop enclave, and to take on quests that force them to leave their isolated home.",
+						"To learn more about your character's Ashari order, see \"{@book The Ashari|TDCSR|2|The Ashari}\".",
+						{
+							"type": "table",
+							"caption": "Ashari Personality Traits",
+							"colLabels": [
+								"{@dice d8}",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I like to keep my hands busy, no matter where I am."
+								],
+								[
+									"2",
+									"I love to explore new places and meet new people."
+								],
+								[
+									"3",
+									"I meditate at dawn each day—and I can't stand it when my routine is interrupted."
+								],
+								[
+									"4",
+									"I like noticing patterns in the world around me, whether or not they mean anything."
+								],
+								[
+									"5",
+									"I don't let anything—or anyone—stand in the way of my mission."
+								],
+								[
+									"6",
+									"I'm a plain talker, even with people who outrank me."
+								],
+								[
+									"7",
+									"I've always got some of my native element with me in some form. (This might be modeling clay, pure water, special burning incense, or a bottled cloud.)"
+								],
+								[
+									"8",
+									"I talk with everyone like I've known them all my life. Because most people I know, I have known all my life!"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Ashari Ideals",
+							"colLabels": [
+								"{@dice d6}",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"{@b Destiny}. I believe that everyone has a role to play. Now I just have to find mine. (Neutral)"
+								],
+								[
+									"2",
+									"{@b Community}. It's important to surround yourself with people you can count on, and who will support you. (Good)"
+								],
+								[
+									"3",
+									"{@b Knowledge}. I want to learn everything I can about the Elemental Planes—and maybe even visit them myself. (Neutral)"
+								],
+								[
+									"4",
+									"{@b Freedom}. I don't care what anyone says. Even if it causes problems, the elements must be free. And so should I. (Chaotic)"
+								],
+								[
+									"5",
+									"{@b Structure}. The elements are in harmony when they are free to act as they will, within the safe boundaries set by {@book the Ashari|TDCSR|2|The Ashari}. People are much the same. (Lawful)"
+								],
+								[
+									"6",
+									"{@b Virtuous Cycle}. If I see someone who needs help, I feel compelled to assist them. Surely they'll return the favor someday! (Good)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Ashari Bonds",
+							"colLabels": [
+								"{@dice d6}",
+								"Bond"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I have a cousin in another Ashari tribe whom I've never met, but someday I want to visit my extended family."
+								],
+								[
+									"2",
+									"The leader of my tribe thinks I could be their successor, but I worry that I don't have enough experience to lead my people."
+								],
+								[
+									"3",
+									"A mysterious person killed a member of my family. I've left home to discover who the killer was—and to seek vengeance."
+								],
+								[
+									"4",
+									"My older sibling set out on their Aramente a year ago, and I haven't seen them since."
+								],
+								[
+									"5",
+									"When I was a baby, a {@creature giant eagle} brought me to {@book Zephrah|TDCSR|3|Zephrah}. I love my family, but I often wonder who my birth parents are."
+								],
+								[
+									"6",
+									"I trust my animal friends more than any humanoid ally."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Ashari Flaws",
+							"colLabels": [
+								"{@dice d6}",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"Big cities are overwhelming. I get nervous when surrounded by people I don't know."
+								],
+								[
+									"2",
+									"I know all too well that elemental power is dangerous—but I like playing around with it anyway."
+								],
+								[
+									"3",
+									"I get surly if I go too long without being in contact with my native element."
+								],
+								[
+									"4",
+									"I think the mission of my people is a fool's errand. They should abandon isolation, let the elements be, and enjoy the pleasures of the world!"
+								],
+								[
+									"5",
+									"I can't stand it when people say one thing and mean another! Just say what you mean!"
+								],
+								[
+									"6",
+									"Ugh, I know it's not right, but I can't help but look down on people who can't manipulate the elements. It's not like it's hard!"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Clasp Member",
+			"source": "TDCSR",
+			"page": 181,
+			"skillProficiencies": [
+				{
+					"deception": true,
+					"choose": {
+						"from": [
+							"sleight of hand",
+							"stealth"
+						],
+						"count": 1
+					}
+				}
+			],
+			"languageProficiencies": [
+				{
+					"thieves' cant": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"disguise kit",
+							"forgery kit",
+							"thieves' tools"
+						],
+						"count": 1
+					}
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"item": "common clothes|phb",
+							"displayName": "A set of inconspicuous common clothes"
+						},
+						{
+							"equipmentType": "toolArtisan"
+						},
+						{
+							"item": "pouch|phb",
+							"containsValue": 1000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Deception}, plus your choice of {@skill Sleight of Hand} or {@skill Stealth}"
+						},
+						{
+							"type": "item",
+							"name": "Tool Proficiencies:",
+							"entry": "{@item Disguise Kit|PHB}, {@item forgery kit|PHB}, or {@item thieves' tools|PHB} (one of your choice)"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "{@language Thieves' Cant}"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A set of inconspicuous {@item common clothes|phb}, a set of {@filter tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} with which you're proficient, and a belt {@item pouch|PHB} containing 10 gp"
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Feature: A Favor in Turn",
+					"page": 182,
+					"entries": [
+						"You have gained enough clout in the {@book Clasp|TDCSR|2|The Clasp} that you can call in a favor from your contacts whenever you're close enough to a center of syndicate activity. A request for a favor can be no longer than 20 words, and is passed up the chain to an undisclosed Spireling for approval. This favor can take on any form subject to the approval of the GM, who decides how it is fulfilled. If muscle is requested, an NPC member of the {@book Clasp|TDCSR|2|The Clasp} can temporarily aid your party. If money is needed, a small loan can be provided. If you've been imprisoned, {@book Clasp|TDCSR|2|The Clasp} operatives can look into breaking you out or paying off the jailer.",
+						"At some point, the favor will be called in for repayment, often without warning. Refusing the call will result in your termination—literally. You might be called on to commit a specific burglary, or to pressure an {@book Emonian|TDCSR|3|Emon, the City of Fellowship} dignitary to reveal a secret at an upcoming ball. The {@book Clasp|TDCSR|2|The Clasp} might even demand that you assassinate a specific person, with no questions asked or answered. It's the GM's prerogative to ensure that the syndicate's request is proportionate to the favor they bestowed—or that they compensate you in other ways for a service that goes beyond the scope of repaying the initial favor."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"name": "Suggested Characteristics",
+					"page": 182,
+					"entries": [
+						"The {@book Clasp|TDCSR|2|The Clasp} enjoys a strange status in Tal'Dorei. The syndicate is a feared group of thieves and killers, whose name is often invoked only in whispers. But at the same time, the organization has a reputation for guerilla heroism, in response to its members having saved countless lives when the {@book Chroma Conclave|TDCSR|1|The Chroma Conclave} attacked {@book Emon|TDCSR|3|Emon, the City of Fellowship}. And so like every {@book Clasp|TDCSR|2|The Clasp} member, your own reputation often swings between these two poles.",
+						"Your bond is likely associated with your fellow {@book Clasp|TDCSR|2|The Clasp} members or the individual who introduced you to the syndicate. Your ideal probably involves establishing your importance and indispensability to the {@book Clasp|TDCSR|2|The Clasp}.",
+						{
+							"type": "table",
+							"caption": "Clasp Member Personality Traits",
+							"colLabels": [
+								"{@dice d8}",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"What's life without risk? I'm always willing to take a risk if the reward seems worth it."
+								],
+								[
+									"2",
+									"I only show my emotions around people I really trust."
+								],
+								[
+									"3",
+									"I don't need friends; I need allies. When I do make \"friends,\" I only consider what they can do for me."
+								],
+								[
+									"4",
+									"I look for simple solutions. The world's full of tough problems, but a well-placed knife is a one-size-fits-all answer."
+								],
+								[
+									"5",
+									"Money talks. I don't. We've got an efficient relationship."
+								],
+								[
+									"6",
+									"I used to have one rule—don't get involved in other people's problems. Why are things so complicated now?"
+								],
+								[
+									"7",
+									"Crime is a game, and I play to win. I have no sympathy for players who don't get that."
+								],
+								[
+									"8",
+									"This organization has a lot of folks who cling to ugly, brutal practices. I'm not like that. I'm a professional, and professionals have standards."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Clasp Member Ideals",
+							"colLabels": [
+								"{@dice d6}",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"{@b By Any Means}. I complete jobs. Collateral damage isn't my problem. (Chaotic)"
+								],
+								[
+									"2",
+									"{@b Ambition}. I will climb to the top of the ladder. Everything I do is a stepping-stone to a Spireling's position. (Neutral)"
+								],
+								[
+									"3",
+									"{@b Decisiveness}. It's important to make up your mind so you can act swiftly and without delay. (Neutral)"
+								],
+								[
+									"4",
+									"{@b Honor}. There's room in the {@book Clasp|TDCSR|2|The Clasp} for both good and evil. Every day, I awake and choose to do what's right. (Good)"
+								],
+								[
+									"5",
+									"{@b Family}. The {@book Clasp|TDCSR|2|The Clasp} is family. Anything that's good for the family is good for me. (Lawful)"
+								],
+								[
+									"6",
+									"{@b Self-Interest}. There are too many bleeding hearts in the {@book Clasp|TDCSR|2|The Clasp} these days. Doing the right thing means doing the thing that makes my life better. (Evil)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Clasp Member Bonds",
+							"colLabels": [
+								"{@dice d6}",
+								"Bond"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I'd do anything—anything—to protect my comrades."
+								],
+								[
+									"2",
+									"I'll always be grateful to the Spireling who took me in when I was an orphaned kid."
+								],
+								[
+									"3",
+									"I was inspired to join the {@book Clasp|TDCSR|2|The Clasp} by the stories my parents told of being saved from the {@book Chroma Conclave's|TDCSR|1|The Chroma Conclave} attack on {@book Emon|TDCSR|3|Emon, the City of Fellowship}. I can look past the organization's flaws."
+								],
+								[
+									"4",
+									"I was nearly killed by the {@book Myriad|TDCSR|2|The Myriad}. If the {@book Clasp|TDCSR|2|The Clasp} is the enemy of those villains, then the {@book Clasp|TDCSR|2|The Clasp} is my friend."
+								],
+								[
+									"5",
+									"I've got family back in the old town who are counting on me for money. They don't know how I get it, but they don't need to know."
+								],
+								[
+									"6",
+									"I joined the {@book Clasp|TDCSR|2|The Clasp} to become rich, powerful, and beloved. That's all there is to it."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Clasp Member Flaws",
+							"colLabels": [
+								"{@dice d6}",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I'm hopeless at organizing my belongings, and I'm always losing things."
+								],
+								[
+									"2",
+									"I get bored whenever a plan is going too smoothly. A win is always more fun when it's by the skin of my teeth!"
+								],
+								[
+									"3",
+									"I've seen Spirelings walk out among cheering crowds of thousands. Gods, I wish that were me. I need that to be me."
+								],
+								[
+									"4",
+									"I'm rubbish with money, and never seem to leave town with a full purse. Keeps me coming back to the life, I suppose."
+								],
+								[
+									"5",
+									"I can't work with shoddy, makeshift {@item thieves' tools|PHB}. I need everything involving my work to be perfect."
+								],
+								[
+									"6",
+									"Any slight against me, no matter how small, is cause for revenge."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Lyceum Scholar",
+			"source": "TDCSR",
+			"page": 183,
+			"skillProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"arcana",
+							"history",
+							"persuasion"
+						],
+						"count": 2
+					}
+				}
+			],
+			"languageProficiencies": [
+				{
+					"any": 2
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"item": "fine clothes|phb",
+							"displayName": "A set of fine clothes"
+						},
+						{
+							"special": "student uniform"
+						},
+						{
+							"item": "writing kit|TDCSR"
+						},
+						{
+							"item": "pouch|phb",
+							"containsValue": 1000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "Your choice of two of the following: {@skill Arcana}, {@skill History}, or {@skill Persuasion}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "Two of your choice"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A set of {@item fine clothes|phb}, a student uniform, a {@item writing kit|TDCSR} ({@item pouch|PHB|small pouch} with a quill, {@item Ink (1-ounce bottle)|PHB|ink}, {@item Parchment (one sheet)|PHB|folded parchment} and a penknife), and a belt {@item pouch|PHB} containing 10 gp"
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Feature: Academic Requisition",
+					"page": 184,
+					"entries": [
+						"You've cleared enough lessons—and have gained an ally or two among the staff—to enable access to certain private areas within the {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} and other allied universities. Whenever you're on {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} grounds or at another major academic institution, you can requisition any set of {@filter tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} found in the fifth edition rules. Each set of {@filter tools|items|source=phb|miscellaneous=mundane|type=artisan's tools} is magically marked to sound an alarm if they are removed from the university's grounds.",
+						"When you seek services such as spellcasting from an NPC at the {@book Alabaster Lyceum|TDCSR|3|5. Alabaster Lyceum} or a related institution, you can use those services at a 25 percent discount, at the GM's discretion."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"name": "Suggested Characteristics",
+					"page": 184,
+					"entries": [
+						"The {@book Alabaster Lyceum|TDCSR|3|5. Alabaster Lyceum} accepts students of all major trades, the fine arts, and the magical arts. Pupils talented and privileged enough to be accepted travel to {@book Emon|TDCSR|3|Emon, the City of Fellowship} from all over Tal'Dorei, seeking to study among some of the greatest minds and most talented arcanists in the land. If you came from a smaller city, a rural area, or Tal'Dorei's relatively uncharted wilderness, studying at the {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} might have left you with a sense of culture shock, for good or for ill.",
+						"Your bond is likely associated with your goals as a student or graduate. Your ideal probably involves your hopes in using the knowledge you've gained at the {@book Lyceum|TDCSR|3|5. Alabaster Lyceum}, and your travels as an adventurer, to tailor the world to your liking.",
+						{
+							"type": "table",
+							"caption": "Lyceum Scholar Personality Traits",
+							"colLabels": [
+								"{@dice d8}",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I can't believe I'm here! At the {@book Alabaster Lyceum|TDCSR|3|5. Alabaster Lyceum}. Oh, gods, I've dreamed of this my whole life, and now I'm here!"
+								],
+								[
+									"2",
+									"I can't believe I squandered all the opportunities I had at school. I was supposed to be learning good stuff, but I wasted it all daydreaming about fighting monsters."
+								],
+								[
+									"3",
+									"Every night at school, I'd knock back a couple of meads and read with my pals! Just a bunch of nerds having fun, and I loved it."
+								],
+								[
+									"4",
+									"Everyone at school was such a stick in the mud. Dressing the same, listening to the same bards...ugh, it's sad. Just be yourself."
+								],
+								[
+									"5",
+									"I'm happiest when I've got my little party with me. At school, it was like we were a squad of heroes, slaying projects like monsters."
+								],
+								[
+									"6",
+									"I'd really rather you didn't bother me. Can't you see I'm studying here?"
+								],
+								[
+									"7",
+									"I don't care. I just don't care about it all. The dates I had to memorize, the formulae I learned...I just want to run away and live!"
+								],
+								[
+									"8",
+									"I'm just...tired. All the time. Oh, adventuring, sure, that's fine, as long as I can find time to...nap...goodnight."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Lyceum Scholar Ideals",
+							"colLabels": [
+								"{@dice d6}",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"{@b Preparedness}. I can't go out into the world unless I know what I'm up against. Study first, act later. (Neutral)"
+								],
+								[
+									"2",
+									"{@b Stardom}. Having a team is good and all, but you can't win a game of ball without the star charger, and you know that's me. (Evil)"
+								],
+								[
+									"3",
+									"{@b Individuality}. The world keeps us down by trying to put us all into little boxes. I'm tired of living in my box, and I don't care what you think about it. (Chaotic)"
+								],
+								[
+									"4",
+									"{@b Purpose}. I study because there are things I need to know. I'll find my place in the world, and I'll make the world better. (Good)"
+								],
+								[
+									"5",
+									"{@b Code of Conduct}. The student code is there to benefit all students, you know. It's the same for laws! (Lawful)"
+								],
+								[
+									"6",
+									"{@b Recreation}. All this studying crap wasn't worth anything if you weren't partying when you were done. Meet me down at the tavern, okay? (Chaotic)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Lyceum Scholar Bonds",
+							"colLabels": [
+								"{@dice d6}",
+								"Bond"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I came to the {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} with no one, but I fell in love with the city of {@book Emon|TDCSR|3|Emon, the City of Fellowship}. I've finally found a place that feels like home!"
+								],
+								[
+									"2",
+									"Most of my professors drove me to frustration, but there's one who was kind and wise. I know they'll always have my back."
+								],
+								[
+									"3",
+									"My family saved every copper piece to give me the opportunities I have now. I can't let them down."
+								],
+								[
+									"4",
+									"I came to the {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} with a childhood friend, but we've long been drifting apart."
+								],
+								[
+									"5",
+									"Discovery is the only thing that matters to me. The topic doesn't matter. Books keep me company on my loneliest days."
+								],
+								[
+									"6",
+									"The {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} is my life. I'd give up anything—everything—to protect it from harm."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Lyceum Scholar Flaws",
+							"colLabels": [
+								"{@dice d6}",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"The {@book Lyceum|TDCSR|3|5. Alabaster Lyceum} taught me to never want to leave my room. The campus was so huge, and the crowds were so horrible."
+								],
+								[
+									"2",
+									"You think you're so great just because you've got muscles, and endurance, and...shut up! Read a book sometime!"
+								],
+								[
+									"3",
+									"Huh? What? Sorry, I was thinking about a test I need to retake when I get back to school...."
+								],
+								[
+									"4",
+									"I spent too much time studying. Now I don't have any friends."
+								],
+								[
+									"5",
+									"If you don't match my aesthetic, I'm not interested in you. We can work together, but we won't be friends. Got it?"
+								],
+								[
+									"6",
+									"I'm always striving for perfection. I got top of my class, sure, but only with a 98 average. And that's. Not. Perfect."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Reformed Cultist",
+			"source": "TDCSR",
+			"page": 185,
+			"skillProficiencies": [
+				{
+					"deception": true,
+					"religion": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"any": 1
+				}
+			],
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"special": "vestments"
+						},
+						{
+							"item": "holy symbol|phb",
+							"displayName": "a holy symbol of your previous cult"
+						},
+						"common clothes|phb",
+						{
+							"item": "pouch|phb",
+							"containsValue": 1500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Deception} and {@skill Religion}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "One of your choice"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Vestments and a {@item holy symbol|phb} of your previous cult, a set of {@item common clothes|phb}, a belt {@item pouch|PHB} containing 15 gp"
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Feature: Fell Teachings",
+					"page": 186,
+					"entries": [
+						"You were inundated with knowledge about one of the {@book Betrayer Gods|TDCSR|2|Betrayer Gods}, and know by heart everything from their basic commandments to some of their most esoteric secrets. Choose one of the {@book Betrayer Gods|TDCSR|2|Betrayer Gods}. You have {@quickref Advantage and Disadvantage|PHB|2|0|advantage} on Intelligence ({@skill Religion}) checks to know information about their faith, including obscure secrets unknown to most worshipers.",
+						"Additionally, you can work with your GM to create a secret that you learned during your time in the cult. This secret might be the seed of a conspiracy, a myth of a legendary hero whose true meaning has mutated over the years, or even the location of a fabled artifact of the gods."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"name": "Suggested Characteristics",
+					"page": 186,
+					"entries": [
+						"The life of every former cultist is defined to some degree by the process of fleeing the past, and of trying to make a future away from the beliefs that once claimed them. Your bond is likely associated with those who gave you the insight and strength to flee your old ways. Your ideal might involve your desire to take down and destroy those who promote the evil you escaped, and perhaps finding new faith in a forgiving god.",
+						{
+							"type": "table",
+							"caption": "Reformed Cultist Personality Traits",
+							"colLabels": [
+								"{@dice d8}",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I need a {@item dagger|phb} close at hand at all times. Just in case they find me."
+								],
+								[
+									"2",
+									"I can't believe I'm out here fighting monsters. After everything I've been through, why can't I find a normal life?"
+								],
+								[
+									"3",
+									"I need a stiff drink before I do anything stressful these days. I know it's a problem. Just...let me have this."
+								],
+								[
+									"4",
+									"Murder is okay when it's for a good cause! I didn't tear my past out by the roots so I could let evil people cause more harm."
+								],
+								[
+									"5",
+									"My past is filled with stories like you wouldn't believe. Ones that'll really make your skin crawl. Do you want to hear...?"
+								],
+								[
+									"6",
+									"Yeah, I'm crying. I do that. Get over yourself."
+								],
+								[
+									"7",
+									"I know you've told me your name twice already, but that's not good enough. How can I be sure you are who you say you are?"
+								],
+								[
+									"8",
+									"My mind is always racing. I can't...I just need to...you have to give me a second—or else I can't...organize my thoughts."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Reformed Cultist Ideals",
+							"colLabels": [
+								"{@dice d6}",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"{@b Life}. I've spent too long shackled to an evil master. No matter what happened before, I deserve my freedom now. (Chaotic)"
+								],
+								[
+									"2",
+									"{@b Redemption}. People can change, but redemption must be something they choose for themselves. If they do, it is my duty to help them along that path. (Good)"
+								],
+								[
+									"3",
+									"{@b Power}. When I abandoned the cult, it wasn't out of some misguided sense of righteousness. That pathetic organization was merely a shackle on my potential. (Evil)"
+								],
+								[
+									"4",
+									"{@b Vengeance}. The cult has poisoned my life. I will see all its followers suffer. (Any)"
+								],
+								[
+									"5",
+									"{@b Hierarchy}. The cult was vile, but its strength was in stability and organization. As long as good folk lack unity, evil will always triumph. (Lawful)"
+								],
+								[
+									"6",
+									"{@b Reparations}. As a cultist, I harmed people whose names I'll never know. I feel obligated to repay my debt by aiding others. (Good)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Reformed Cultist Bonds",
+							"colLabels": [
+								"{@dice d6}",
+								"Bond"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"My cousin escaped the cult with me. I lost track of them when we fled, but I know they're alive. I can feel it."
+								],
+								[
+									"2",
+									"I was saved from the cult by a priest of one of the {@book Prime Deities|TDCSR|2|Prime Deities}. If not for that sign of faith, I would surely be lost."
+								],
+								[
+									"3",
+									"I was told by the person who saved me that a sage once said: \"Life needs things to live.\" I don't know what that means, but I've dedicated my existence to finding out."
+								],
+								[
+									"4",
+									"One of my cultist parents had a change of heart when I was a teenager, and we fled together in the dark of night. I didn't want to leave, but I understand now that their courage saved my life."
+								],
+								[
+									"5",
+									"I was bested by a warrior when I fumbled a cult-ordered assassination. I don't know why that person took pity on me, but they gave me purpose when I was lost."
+								],
+								[
+									"6",
+									"Now that I've saved myself, the only person important to me is my former cult leader—because I've sworn that they'll die by my hand."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Reformed Cultist Flaws",
+							"colLabels": [
+								"{@dice d6}",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I'm haunted by what I saw in those ritual chambers. Every time I see blood, I...oh, gods, I can't bear to even think about it."
+								],
+								[
+									"2",
+									"I ran from the cult long ago. But deep down, there's a part of me that still thinks they were right about certain things."
+								],
+								[
+									"3",
+									"I can't help but feel a rush whenever I see a life snuffed out before me. Just one more kill... just one more."
+								],
+								[
+									"4",
+									"Organized religion terrifies me. {@book Betrayer Gods|TDCSR|2|Betrayer Gods} or {@book Prime Deities|TDCSR|2|Prime Deities}...it doesn't matter. The sight of the faithful freezes my blood cold."
+								],
+								[
+									"5",
+									"Oh, I always tell the truth. Always. I've never had to keep a secret from anyone, so of course I'll be open with you."
+								],
+								[
+									"6",
+									"I don't trust easily. If you grew up being lied to about every little thing? The fundamental nature of the world? You wouldn't, either."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Variant Clasp Member (Myriad Operative)",
+			"source": "TDCSR",
+			"page": 182,
+			"_copy": {
+				"name": "Clasp Member",
+				"source": "TDCSR",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "insertArr",
+							"index": 1,
+							"items": {
+								"type": "entries",
+								"name": "Variant: Myriad Operative",
+								"page": 182,
+								"entries": [
+									"Your skill set might be similar to that of many members of the {@book Clasp|TDCSR|2|The Clasp}, but you work for a criminal organization that is far more sophisticated—and even less scrupulous. As a {@book Myriad|TDCSR|2|The Myriad} operative in Tal'Dorei, you might have been given a specific task that furthers that syndicate's hunger to expand beyond Wildemount, or which gives them an edge in their rivalry with the {@book Clasp|TDCSR|2|The Clasp}. Moreover, you understand the wisdom of keeping your activities secret from fellow criminals as well as law enforcement, since the agents of the {@book Clasp|TDCSR|2|The Clasp} will show you no mercy if your true identity is ever revealed."
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Variant Whitestone Rifle Corps (Grey Hunter)",
+			"source": "TDCSR",
+			"page": 182,
+			"_copy": {
+				"name": "Whitestone Rifle Corps",
+				"source": "TDCSR",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "insertArr",
+							"index": 1,
+							"items": {
+								"type": "entries",
+								"name": "Variant: Grey Hunter",
+								"page": 189,
+								"entries": [
+									"As elite as they are, the members of the {@book Whitestone Rifle Corps|TDCSR|3|Whitestone Rifle Corps} do not represent the apex of firearms skill in {@book Whitestone|TDCSR|3|Whitestone}. A clandestine group of elite soldiers and survivalists is drawn secretly from the Rifle Corps ranks. Called the {@book Grey Hunters|TDCSR|3|Grey Hunters}, these soldiers are special operatives of the de Rolo family, and loyally serve as spies, bodyguards, and even assassins when the job requires it. Though few officially know of them, rumors of the {@book Grey Hunters'|TDCSR|3|Grey Hunters} existence swirl constantly throughout the city-state, often in response to their activities after having been loaned out to protect {@book Whitestone's|TDCSR|3|Whitestone} allies.",
+									"You are one of these {@book Grey Hunters|TDCSR|3|Grey Hunters}, even if just a trainee (if you're starting your campaign at low levels). You have the ear of the lord and lady of {@book Whitestone|TDCSR|3|Whitestone}, though you must exercise this privilege graciously lest you lose it."
+								],
+								"data": {
+									"isFeature": true
+								}
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Whitestone Rifle Corps",
+			"source": "TDCSR",
+			"page": 187,
+			"skillProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"athletics",
+							"perception",
+							"survival"
+						],
+						"count": 2
+					}
+				}
+			],
+			"languageProficiencies": [
+				{
+					"any": 1
+				}
+			],
+			"weaponProficiencies": [
+				{
+					"firearms": true
+				}
+			],
+			"startingEquipment": [
+				{
+					"a": [
+						"musket|dmg"
+					],
+					"b": [
+						"pistol|dmg"
+					]
+				},
+				{
+					"_": [
+						"common clothes|phb",
+						{
+							"item": "pouch|phb",
+							"containsValue": 1000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "Your choice of two of the following: {@skill Athletics}, {@skill Perception}, or {@skill Survival}"
+						},
+						{
+							"type": "item",
+							"name": "Weapon Proficiencies:",
+							"entry": "{@filter Firearms|items|source=null|type=firearm}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "One of your choice"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "Your choice of a {@item musket} or a {@item pistol}, a set of {@item common clothes|phb}, and a {@item pouch|PHB} containing 10 gp"
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Feature: Legacy of Secrecy",
+					"page": 187,
+					"entries": [
+						"You have been entrusted with the use and care of a weapon both powerful and terrifying. The rifle you wield might transform the face of warfare and life in Tal'Dorei. It is a weapon that haunts the mind of its creator, {@creature Percival de Rolo|TDCSR}, manifesting as a pain that lives always behind his kind eyes.",
+						"You were granted a {@item musket} or a {@item pistol} by your commander in the {@book Whitestone Rifle Corps|TDCSR|3|Whitestone Rifle Corps}. This weapon is a symbol of your status, and when you display it, other folk around you—particularly adventurers, mercenaries, guards, engineers, and weapons enthusiasts—treat you differently. You might be seen as a noble defender of the people, a selfish hoarder of power, or anything in between, at the GM's discretion."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"name": "Feature: Rifle Corps Relationship",
+					"page": 187,
+					"entries": [
+						"You are—or were—a member of an elite and trusted band of {@book Whitestone's|TDCSR|3|Whitestone} staunchest defenders. Work with your GM to determine your current relationship with the Rifle Corps. If your campaign starts in {@book Whitestone|TDCSR|3|Whitestone}, you might be an active member of that unit. Otherwise, you can use the Rifle Corps Relationships table for suggestions.",
+						{
+							"type": "table",
+							"caption": "Rifle Corps Relationships",
+							"colLabels": [
+								"{@dice d6}",
+								"Current Relationship"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I retired honorably from the Rifle Corps—and now it's time for me to pursue my own adventures."
+								],
+								[
+									"2",
+									"I'm on an important mission to protect {@book Whitestone|TDCSR|3|Whitestone} or guard one of our allies."
+								],
+								[
+									"3",
+									"{@book Whitestone|TDCSR|3|Whitestone} is in trouble, and I was sent away to seek help."
+								],
+								[
+									"4",
+									"I don't think firearms technology should be kept secret, so I escaped from the Rifle Corps with my weapon and am on the run."
+								],
+								[
+									"5",
+									"I was on a mission with my company when I got separated from them. Now I need to find my way back home."
+								],
+								[
+									"6",
+									"My weapon was stolen. I built a new one, but I can't return home until I've tracked down the thief and recovered the original. ({@book Whitestone Hunter|TDCSR|3|Grey Hunters} variant only)"
+								]
+							]
+						}
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"type": "entries",
+					"name": "Suggested Characteristics",
+					"page": 188,
+					"entries": [
+						"Those who join the {@book Whitestone Rifle Corps|TDCSR|3|Whitestone Rifle Corps} become members of an elite and trusted band known as the city-state's staunchest defenders. But this means working with your GM to determine why you're not at home protecting {@book Whitestone|TDCSR|3|Whitestone}. Perhaps you took on a mission to guard someone on behalf of the de Rolo family, or you might have been separated from your company while on an assignment. Either way, you find yourself embroiled now in a series of new adventures as you try to make your way back home.",
+						"Your bond is likely associated with your comrades-in-arms or with {@book Whitestone|TDCSR|3|Whitestone} itself. Your ideal could be tied to justice or protection, but could also be a secretive, selfish perversion of those virtues.",
+						{
+							"type": "table",
+							"caption": "Rifle Corps Personality Traits",
+							"colLabels": [
+								"{@dice d8}",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I want to make a good impression at all times. That means keeping my clothes and gear clean and in top condition."
+								],
+								[
+									"2",
+									"I don't like being the center of attention. I'd rather let someone else do the talking while I watch their back."
+								],
+								[
+									"3",
+									"I feel safe only if I'm carrying my trusty rifle. And my dagger. And my concealed pistol. Oh, and of course my...."
+								],
+								[
+									"4",
+									"I don't trust people with my secrets easily, so it feels like a big deal when someone else shares a secret with me."
+								],
+								[
+									"5",
+									"I like coming up with solutions to problems using my esoteric knowledge of natural philosophy."
+								],
+								[
+									"6",
+									"Everyone around me takes things so seriously. Sometimes I just want to let loose and have fun!"
+								],
+								[
+									"7",
+									"Knowing things that other people don't know makes me feel special and important."
+								],
+								[
+									"8",
+									"I'm most at home in woods and mountains, where everything feels at once familiar, always growing and changing."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Rifle Corps Ideals",
+							"colLabels": [
+								"{@dice d6}",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"{@b Responsibility}. I have a duty to protect the people of {@book Whitestone|TDCSR|3|Whitestone} and to uphold the trust placed in me by the de Rolos. (Lawful)"
+								],
+								[
+									"2",
+									"{@b Militarization}. Everyone should have access to the most powerful weapons available, so they can defend themselves effectively. (Evil)"
+								],
+								[
+									"3",
+									"{@b Cooperation}. Any problem can be solved as long as people are willing to work together. (Good)"
+								],
+								[
+									"4",
+									"{@b Camaraderie}. It's important to have people you can trust to help out in a fight—and to uncork a bottle together afterward. (Any)"
+								],
+								[
+									"5",
+									"{@b Context}. There are no universal rights or wrongs. Every choice depends on the details of the situation. (Chaotic)"
+								],
+								[
+									"6",
+									"{@b Secrecy}. Information is valuable, but it can also be dangerous. I'll keep my mouth shut and gather as much intel as I can. (Neutral)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Rifle Corps Bons",
+							"colLabels": [
+								"{@dice d6}",
+								"Bond"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"I never knew what to do with myself until I joined the Rifle Corps. Now I have a purpose and comrades to give me direction."
+								],
+								[
+									"2",
+									"One of my fellow Rifle Corps soldiers saved my life—and then I saved theirs. That kind of bond lasts forever."
+								],
+								[
+									"3",
+									"{@book Whitestone|TDCSR|3|Whitestone} is the best city in all of Tal'Dorei. Nowhere else has been blessed by the {@deity The Dawnfather|Exandria|TDCSR|Dawnfather} and has a clock that tracks the movement of the stars!"
+								],
+								[
+									"4",
+									"My quick thinking saved a noble from assassination, and she showed me great kindness in return. I daren't say it, but I'm more loyal to her than I am to the de Rolos."
+								],
+								[
+									"5",
+									"My weapon is my life. I clean it, repair it, and care for it—and it serves me loyally in return."
+								],
+								[
+									"6",
+									"The people of {@book Whitestone|TDCSR|3|Whitestone} cared for my family when we had nothing. I promise to repay their compassion with my service."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"caption": "Rifle Corps Flaws",
+							"colLabels": [
+								"{@dice d6}",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"Who cares about keeping this gun safe? \"Don't let it fall into the wrong hands!\" Ha! It's only a matter of time before someone slips up and these weapons are everywhere."
+								],
+								[
+									"2",
+									"I think being part of the Rifle Corps is so cool. I love telling people about my position so I can impress them."
+								],
+								[
+									"3",
+									"My weapon was stolen. I built a new one, but I can't return home until I've tracked down the thief and recovered the original."
+								],
+								[
+									"4",
+									"I'm tired of protecting spoiled people who don't know how to protect themselves."
+								],
+								[
+									"5",
+									"I shoot first and ask questions later."
+								],
+								[
+									"6",
+									"The first and only time I killed someone, it changed my life. I still dream about it, and I'll never be the carefree person I was before."
+								]
+							]
 						}
 					]
 				}

--- a/json/bestiary/bestiary-aatm.json
+++ b/json/bestiary/bestiary-aatm.json
@@ -289,7 +289,7 @@
 				{
 					"name": "Fog of Death (1/Day)",
 					"entries": [
-						"Skall exudes a killing fog in a 30-foot-radius sphere centered on himself. The sphere spreads around corners, and its area is heavily obscured. The fog lasts until the start of Skall's next turn, and it can't be dispersed by wind. It does not move with him.",
+						"Skall exudes a killing fog in a 30-foot-radius sphere centered on himself. The sphere spreads around corners, and its area is {@quickref Vision and Light||2||heavily obscured}. The fog lasts until the start of Skall's next turn, and it can't be dispersed by wind. It does not move with him.",
 						"Each creature that enters the fog for the first time on a turn or starts its turn there must make a {@dc 19} Constitution saving throw, taking 28 ({@damage 8d6}) necrotic damage and 28 ({@damage 8d6}) poison damage on a failed save, or half as much damage on a successful one. A Medium or smaller Humanoid killed by this damage becomes a zombie under Skall's control. The zombie acts on Skall's initiative but immediately after his turn. Absent any other command, the zombie tries to kill any non-Undead creature it encounters."
 					]
 				}

--- a/json/bestiary/bestiary-abh.json
+++ b/json/bestiary/bestiary-abh.json
@@ -1,0 +1,905 @@
+{
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"XMM": "ABH"
+			}
+		}
+	},
+	"monster": [
+		{
+			"name": "Fiendish Icon",
+			"source": "ABH",
+			"page": 14,
+			"size": [
+				"S"
+			],
+			"type": "construct",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 22,
+				"formula": "5d6 + 5"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 15,
+			"dex": 12,
+			"con": 13,
+			"int": 6,
+			"wis": 11,
+			"cha": 6,
+			"skill": {
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 60"
+			],
+			"passive": 10,
+			"immune": [
+				"fire",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"deafened",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common and Infernal but can't speak"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The icon has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The icon makes two Slam attacks and uses Fiery Eruption."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}4 ({@damage 1d4 + 2}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Fiery Eruption",
+					"entries": [
+						"{@actSave dex} {@dc 11}, each creature in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the icon. {@actSaveFail} 7 ({@damage 2d6}) Fire damage."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"I"
+			],
+			"damageTags": [
+				"B",
+				"F"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Harvester Devil",
+			"source": "ABH",
+			"page": 15,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "fiend",
+				"tags": [
+					"devil"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 65,
+				"formula": "10d8 + 20"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 12,
+			"dex": 17,
+			"con": 14,
+			"int": 14,
+			"wis": 13,
+			"cha": 19,
+			"save": {
+				"con": "+4",
+				"wis": "+3"
+			},
+			"skill": {
+				"perception": "+3",
+				"persuasion": "+8",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+			],
+			"passive": 13,
+			"resist": [
+				"cold"
+			],
+			"immune": [
+				"fire",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Infernal; telepathy 120 ft."
+			],
+			"cr": "3",
+			"trait": [
+				{
+					"name": "Diabolic Ward",
+					"entries": [
+						"Attack rolls against the devil have {@variantrule Disadvantage|XPHB}. If the devil makes an attack roll, this trait is suppressed until the start of its next turn."
+					]
+				},
+				{
+					"name": "Diabolical Restoration",
+					"entries": [
+						"If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its {@variantrule Hit Points|XPHB} somewhere in the Nine Hells."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The devil has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The devil makes two attacks, using Infernal Blade or Confounding Ray in any combination."
+					]
+				},
+				{
+					"name": "Infernal Blade",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}6 ({@damage 1d6 + 3}) Slashing damage and 7 ({@damage 2d6}) Fire damage."
+					]
+				},
+				{
+					"name": "Confounding Ray",
+					"entries": [
+						"{@atkr r} {@hit 5}, range 120 ft. {@h}13 ({@damage 2d12}) Psychic damage. If the target is a creature, it can't make {@action Opportunity Attack|XPHB|Opportunity Attacks} until the start of the devil's next turn."
+					]
+				},
+				{
+					"name": "Compelling Contract (1/Day)",
+					"entries": [
+						"{@actSave cha} {@dc 14}, one creature within 30 feet of the devil. {@actSaveFail} The target has the {@condition Charmed|XPHB} condition. While it is {@condition Charmed|XPHB}, it has the {@condition Stunned|XPHB} condition, except the target can speak. If the target agrees to the devil's contract, the effect ends. Otherwise, the target repeats the save whenever it takes damage and at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+					]
+				}
+			],
+			"environment": [
+				"planar, nine hells"
+			],
+			"traitTags": [
+				"Devil's Sight",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"I",
+				"TP"
+			],
+			"damageTags": [
+				"F",
+				"S",
+				"Y"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"charmed",
+				"stunned"
+			],
+			"savingThrowForced": [
+				"charisma"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Speaker Devil",
+			"source": "ABH",
+			"page": 17,
+			"size": [
+				"L"
+			],
+			"type": {
+				"type": "fiend",
+				"tags": [
+					"devil"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 189,
+				"formula": "18d10 + 90"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": 30
+			},
+			"str": 21,
+			"dex": 19,
+			"con": 20,
+			"int": 22,
+			"wis": 18,
+			"cha": 17,
+			"save": {
+				"con": "+9",
+				"int": "+10",
+				"wis": "+8",
+				"cha": "+7"
+			},
+			"skill": {
+				"arcana": "+10",
+				"history": "+10",
+				"perception": "+8"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 18,
+			"resist": [
+				"cold"
+			],
+			"immune": [
+				"fire",
+				"poison"
+			],
+			"conditionImmune": [
+				"poisoned"
+			],
+			"languages": [
+				"Infernal; telepathy 120 ft."
+			],
+			"cr": "12",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The devil casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save {@dc 18}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Dimension Door|XPHB}",
+							"{@spell Modify Memory|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Diabolical Restoration",
+					"entries": [
+						"If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its {@variantrule Hit Points|XPHB} somewhere in the Nine Hells."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The devil has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The devil makes two Thundering Halberd attacks."
+					]
+				},
+				{
+					"name": "Thundering Halberd",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 10 ft. {@h}16 ({@damage 2d10 + 5}) Slashing damage plus 14 ({@damage 4d6}) Thunder damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Utterance of Pain",
+					"entries": [
+						"{@actSave wis} {@dc 18}, each creature in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the devil. {@actSaveFail} The target has the {@condition Stunned|XPHB} condition until the end of the devil's next turn."
+					]
+				},
+				{
+					"name": "Utterance of Unmaking",
+					"entries": [
+						"{@actSave con} {@dc 18}, each creature in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the devil. {@actSaveFail} 22 ({@damage 4d10}) Force damage. {@actSaveSuccess} Half damage."
+					]
+				}
+			],
+			"environment": [
+				"planar, nine hells"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"I",
+				"TP"
+			],
+			"damageTags": [
+				"O",
+				"S",
+				"T"
+			],
+			"damageTagsSpell": [
+				"O"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RCH"
+			],
+			"conditionInflict": [
+				"stunned"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"incapacitated"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Vampire Infernalist",
+			"source": "ABH",
+			"page": 18,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": {
+				"type": "undead",
+				"tags": [
+					"wizard"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 172,
+				"formula": "23d8 + 69"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 40
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 19,
+			"dex": 16,
+			"con": 17,
+			"int": 20,
+			"wis": 16,
+			"cha": 18,
+			"save": {
+				"con": "+8",
+				"int": "+10"
+			},
+			"skill": {
+				"arcana": "+10",
+				"perception": "+8",
+				"religion": "+10",
+				"stealth": "+8"
+			},
+			"senses": [
+				"Darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+			],
+			"passive": 18,
+			"resist": [
+				"fire",
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Infernal"
+			],
+			"cr": {
+				"cr": "14",
+				"xpLair": 13000
+			},
+			"gear": [
+				"orb|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The vampire casts one of the following spells, using Intelligence as the spellcasting ability (spell save {@dc 18}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Dispel Magic|XPHB}",
+						"{@spell Fireball|XPHB} (level 4 version)",
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Prestidigitation|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Wall of Fire|XPHB}"
+						],
+						"2": [
+							"{@spell Scrying|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+					"entries": [
+						"If the vampire fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Misty Escape",
+					"entries": [
+						"If the vampire drops to 0 {@variantrule Hit Points|XPHB} outside its resting place, the vampire uses Shape-Shift to become mist (no action required). If it can't use Shape-Shift, it is destroyed.",
+						"While it has 0 {@variantrule Hit Points|XPHB} in mist form, it can't return to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it returns to its vampire form and has the {@condition Paralyzed|XPHB} condition until it regains any {@variantrule Hit Points|XPHB}, and it regains 1 {@variantrule Hit Points|XPHB|Hit Point} after spending 1 hour there."
+					]
+				},
+				{
+					"name": "Vampire Weakness",
+					"entries": [
+						"The vampire has these weaknesses:",
+						{
+							"type": "list",
+							"style": "list-hang-subtrait",
+							"items": [
+								{
+									"type": "itemSub",
+									"name": "Forbiddance",
+									"entries": [
+										"The vampire can't enter a residence without an invitation from an occupant."
+									]
+								},
+								{
+									"type": "itemSub",
+									"name": "Running Water",
+									"entries": [
+										"The vampire takes 20 Acid damage if it ends its turn in running water."
+									]
+								},
+								{
+									"type": "itemSub",
+									"name": "Stake to the Heart",
+									"entries": [
+										"If a weapon that deals Piercing damage is driven into the vampire's heart while the vampire has the {@condition Incapacitated|XPHB} condition in its resting place, the vampire has the {@condition Paralyzed|XPHB} condition until the weapon is removed."
+									]
+								},
+								{
+									"type": "itemSub",
+									"name": "Sunlight",
+									"entries": [
+										"The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has {@variantrule Disadvantage|XPHB} on attack rolls and ability checks."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack (Vampire Form Only)",
+					"entries": [
+						"The vampire makes two Hellfire Claw attacks and uses Bite."
+					]
+				},
+				{
+					"name": "Hellfire Claw (Vampire Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 5 ft. {@h}13 ({@damage 2d8 + 4}) Slashing damage plus 10 ({@damage 3d6}) Fire damage. If the target is a Medium or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 17}) from one of two claws."
+					]
+				},
+				{
+					"name": "Bite (Imp or Vampire Form Only)",
+					"entries": [
+						"{@actSave con} {@dc 18}, one creature within 5 feet that is willing or that has the {@condition Grappled|XPHB}, {@condition Incapacitated|XPHB}, or {@condition Restrained|XPHB} condition. {@actSaveFail} 6 ({@damage 1d4 + 4}) Piercing damage plus 16 ({@damage 3d10}) Necrotic damage and the creature loses its highest-level available spell slot (if any). The target's {@variantrule Hit Points|XPHB|Hit Point} maximum decreases by an amount equal to the Necrotic damage taken, and the vampire regains {@variantrule Hit Points|XPHB} equal to that amount. A Humanoid reduced to 0 {@variantrule Hit Points|XPHB} by this damage and then buried rises the following sunset as a Vampire Spawn under the vampire's control."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"If the vampire isn't in sunlight or running water, it shape-shifts into a Tiny imp ({@variantrule Speed|XPHB} 20 ft., {@variantrule Fly Speed|XPHB} 40 ft.), or a Medium cloud of mist ({@variantrule Speed|XPHB} 5 ft., {@variantrule Fly Speed|XPHB} 20 ft. [hover]), or it returns to its vampire form. Anything it is wearing transforms with it.",
+						"While in imp form, the vampire's game statistics, other than its size and {@variantrule Speed|XPHB}, are unchanged.",
+						"While in mist form, the vampire can't take any actions, speak, or manipulate objects. It is weightless and can enter an enemy's space and stop there. If air can pass through a space, the mist can do so, but it can't pass through liquid. It has {@variantrule Resistance|XPHB} to all damage, except the damage it takes from sunlight."
+					]
+				}
+			],
+			"legendaryActionsLair": 4,
+			"legendary": [
+				{
+					"name": "Hellfire Strike",
+					"entries": [
+						"The vampire moves up to half its {@variantrule Speed|XPHB}, and it makes one Hellfire Claw attack."
+					]
+				},
+				{
+					"name": "Infernal Majesty",
+					"entries": [
+						"{@actSave cha} {@dc 17}, each creature in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the vampire. {@actSaveFail} 9 ({@damage 2d8}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the start of its next turn. {@actSaveSuccess} Half damage only. {@actSaveSuccessOrFail} The vampire can't take this action again until the start of its next turn."
+					]
+				},
+				{
+					"name": "Teleport",
+					"entries": [
+						"The vampire teleports up to 30 feet to an unoccupied space it can see."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Vampire Infernalist",
+				"source": "ABH"
+			},
+			"environment": [
+				"planar, nine hells",
+				"underdark",
+				"urban"
+			],
+			"traitTags": [
+				"Devil's Sight",
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"I"
+			],
+			"damageTags": [
+				"A",
+				"F",
+				"N",
+				"P",
+				"S",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"F"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"HPR",
+				"MA"
+			],
+			"conditionInflict": [
+				"frightened",
+				"grappled"
+			],
+			"savingThrowForced": [
+				"charisma",
+				"constitution"
+			],
+			"savingThrowForcedSpell": [
+				"dexterity",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Vampire Warden",
+			"source": "ABH",
+			"page": 20,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 190,
+				"formula": "21d8 + 96"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 21,
+			"dex": 15,
+			"con": 18,
+			"int": 10,
+			"wis": 14,
+			"cha": 17,
+			"save": {
+				"con": "+8",
+				"wis": "+6"
+			},
+			"skill": {
+				"athletics": "+9",
+				"perception": "+10"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 20,
+			"resist": [
+				"necrotic"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"frightened"
+			],
+			"languages": [
+				"Common"
+			],
+			"cr": "10",
+			"spellcasting": [
+				{
+					"name": "Guardian's Command",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The vampire casts {@spell Compulsion|XPHB}, requiring no spell components and using Charisma as the spellcasting ability (spell save {@dc 15})."
+					],
+					"will": [
+						"{@spell Compulsion|XPHB}"
+					],
+					"ability": "cha",
+					"displayAs": "action",
+					"hidden": [
+						"will"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The vampire has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Vampire Weakness",
+					"entries": [
+						"The vampire has these weaknesses:",
+						{
+							"type": "list",
+							"style": "list-hang-subtrait",
+							"items": [
+								{
+									"type": "itemSub",
+									"name": "Forbiddance",
+									"entries": [
+										"The vampire can't enter a residence without an invitation from an occupant."
+									]
+								},
+								{
+									"type": "itemSub",
+									"name": "Running Water",
+									"entries": [
+										"The vampire takes 20 Acid damage if it ends its turn in running water."
+									]
+								},
+								{
+									"type": "itemSub",
+									"name": "Stake to the Heart",
+									"entries": [
+										"If a weapon that deals Piercing damage is driven into the vampire's heart while the vampire has the {@condition Incapacitated|XPHB} condition, the vampire has the {@condition Paralyzed|XPHB} condition until the weapon is removed."
+									]
+								},
+								{
+									"type": "itemSub",
+									"name": "Sunlight",
+									"entries": [
+										"The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has {@variantrule Disadvantage|XPHB} on attack rolls and ability checks."
+									]
+								},
+								{
+									"type": "itemSub",
+									"name": "Immobile Restoration",
+									"entries": [
+										"If the vampire drops to 0 {@variantrule Hit Points|XPHB} while it doesn't have the {@condition Petrified|XPHB} condition, it turns to stone, regains 50 {@variantrule Hit Points|XPHB}, and has the {@condition Petrified|XPHB} condition for 1 hour."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The vampire makes two Claw attacks and uses Bite or Guardian's Command."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 5 ft. {@h}14 ({@damage 2d8 + 5}) Slashing damage plus 7 ({@damage 2d6}) Necrotic damage. If the target is a Large or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 16}) from one of two claws."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@actSave con} {@dc 16}, one creature within 5 feet that is willing or that has the {@condition Grappled|XPHB}, {@condition Incapacitated|XPHB}, or {@condition Restrained|XPHB} condition. {@actSaveFail} 7 ({@damage 1d4 + 5}) Piercing damage plus 7 ({@damage 2d6}) Necrotic damage. The target's {@variantrule Hit Points|XPHB|Hit Point} maximum decreases by an amount equal to the Necrotic damage taken, and the vampire regains {@variantrule Hit Points|XPHB} equal to that amount."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Resilient Flesh",
+					"entries": [
+						"{@actTrigger} The vampire is hit by a melee attack roll from an attacker the vampire can see. {@actResponse} The vampire reduces the damage it takes from the attack by 11 ({@dice 2d6 + 4})."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"tokenCredit": "ThePrisoner",
+			"tokenCustom": true,
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"A",
+				"N",
+				"P",
+				"S"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"HPR",
+				"MA"
+			],
+			"conditionInflict": [
+				"grappled"
+			],
+			"conditionInflictSpell": [
+				"charmed"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true
+		}
+	]
+}

--- a/json/bestiary/bestiary-ai.json
+++ b/json/bestiary/bestiary-ai.json
@@ -4,6 +4,9 @@
 			"name": "Ancient Deep Crow",
 			"source": "AI",
 			"page": 211,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"H"
 			],
@@ -71,7 +74,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the ancient deep crow can take the Hide action as a bonus action."
+						"While in dim light or darkness, the ancient deep crow can take the {@action Hide} action as a bonus action."
 					]
 				}
 			],
@@ -145,6 +148,7 @@
 				"Y"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -433,6 +437,9 @@
 			"name": "Chaos Quadrapod",
 			"source": "AI",
 			"page": 209,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"L"
 			],
@@ -534,6 +541,9 @@
 			"name": "Clockwork Dragon",
 			"source": "AI",
 			"page": 209,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"M"
 			],
@@ -701,7 +711,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the deep crow can take the Hide action as a bonus action."
+						"While in dim light or darkness, the deep crow can take the {@action Hide} action as a bonus action."
 					]
 				},
 				{
@@ -937,6 +947,9 @@
 			"isNamedCreature": true,
 			"source": "AI",
 			"page": 200,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"M"
 			],
@@ -1095,6 +1108,9 @@
 			"isNamedCreature": true,
 			"source": "AI",
 			"page": 197,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"M"
 			],
@@ -1274,7 +1290,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -1464,6 +1484,9 @@
 			"name": "Keg Robot",
 			"source": "AI",
 			"page": 212,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"M"
 			],
@@ -1598,6 +1621,9 @@
 			"isNamedCreature": true,
 			"source": "AI",
 			"page": 199,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"M"
 			],
@@ -1909,6 +1935,9 @@
 			"isNamedCreature": true,
 			"source": "AI",
 			"page": 196,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"M"
 			],
@@ -2530,6 +2559,9 @@
 			"name": "Prophetess Dran",
 			"source": "AI",
 			"page": 208,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"M"
 			],
@@ -2850,6 +2882,9 @@
 			"name": "Splugoth the Returned",
 			"source": "AI",
 			"page": 213,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"S"
 			],
@@ -2912,7 +2947,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Splugoth can take the Disengage or Hide action as a bonus action on each of his turns."
+						"Splugoth can take the {@action Disengage} or {@action Hide} action as a bonus action on each of his turns."
 					]
 				},
 				{
@@ -2988,6 +3023,9 @@
 			"isNamedCreature": true,
 			"source": "AI",
 			"page": 198,
+			"referenceSources": [
+				"OoW"
+			],
 			"size": [
 				"M"
 			],

--- a/json/bestiary/bestiary-aitfr-dn.json
+++ b/json/bestiary/bestiary-aitfr-dn.json
@@ -82,6 +82,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Undead Fortitude"
 			],
@@ -95,8 +96,7 @@
 			"damageTags": [
 				"B",
 				"I",
-				"P",
-				"R"
+				"P"
 			],
 			"miscTags": [
 				"MW",
@@ -187,6 +187,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"actionTags": [
 				"Multiattack",
 				"Parry"
@@ -364,6 +365,7 @@
 				"name": "Kyrilla, Accursed Gorgon",
 				"source": "AitFR-DN"
 			},
+			"tokenCustom": true,
 			"attachedItems": [
 				"longbow|phb"
 			],
@@ -482,6 +484,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],

--- a/json/bestiary/bestiary-aitfr-fcd.json
+++ b/json/bestiary/bestiary-aitfr-fcd.json
@@ -1,4 +1,11 @@
 {
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"MM": "AitFR-FCD"
+			}
+		}
+	},
 	"monster": [
 		{
 			"name": "Mercenary Envoy",
@@ -77,6 +84,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"heavy crossbow|phb",
 				"longsword|phb"
@@ -309,6 +317,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],

--- a/json/bestiary/bestiary-aitfr-isf.json
+++ b/json/bestiary/bestiary-aitfr-isf.json
@@ -1,4 +1,11 @@
 {
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"MM": "AitFR-ISF"
+			}
+		}
+	},
 	"monster": [
 		{
 			"name": "Exul",
@@ -106,6 +113,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"handaxe|phb"
 			],
@@ -264,10 +272,11 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"{@atk mw,rw} {@hit 5} to hit, reach 5 ft. or range 20/60 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage"
+						"{@atk mw,rw} {@hit 5} to hit, reach 5 ft. or range 20/60 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage."
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],

--- a/json/bestiary/bestiary-aitfr-thp.json
+++ b/json/bestiary/bestiary-aitfr-thp.json
@@ -59,7 +59,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the horror can take the Hide action as a bonus action."
+						"While in dim light or darkness, the horror can take the {@action Hide} action as a bonus action."
 					]
 				},
 				{
@@ -121,6 +121,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Incorporeal Movement",
 				"Legendary Resistances",
@@ -277,6 +278,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"quarterstaff|phb"
 			],
@@ -435,6 +437,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Shapechanger"
 			],

--- a/json/bestiary/bestiary-awm.json
+++ b/json/bestiary/bestiary-awm.json
@@ -29,7 +29,6 @@
 			"int": 11,
 			"wis": 10,
 			"cha": 10,
-			"passive": 0,
 			"cr": "3",
 			"trait": [
 				{
@@ -49,10 +48,11 @@
 				{
 					"name": "Constrict",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, one target. {@h}13 ({@damage 3d6+3}) bludgeoning damage. If the target is Medium or smaller, it is {@condition grappled} (escape {@dc 13}) and pulled 5 feet toward the big water slurpent. Until this grapple ends, the target is {@condition restrained}, the big water slurpent tries to drown it, and the big water slurpent can't constrict another target."
+						"{@atk mw} {@hit 5} to hit, one target. {@h}13 ({@damage 3d6+3}) bludgeoning damage. If the target is Medium or smaller, it is {@condition grappled} (escape {@dc 13}) and pulled 5 feet toward the big water slurpent. Until this {@action grapple} ends, the target is {@condition restrained}, the big water slurpent tries to drown it, and the big water slurpent can't constrict another target."
 					]
 				}
 			],
+			"tokenCustom": true,
 			"damageTags": [
 				"B"
 			],
@@ -61,7 +61,6 @@
 			],
 			"conditionInflict": [
 				"grappled",
-				"invisible",
 				"restrained"
 			],
 			"hasToken": true,
@@ -97,7 +96,6 @@
 			"int": 4,
 			"wis": 12,
 			"cha": 6,
-			"passive": 0,
 			"cr": "1/4",
 			"trait": [
 				{
@@ -171,7 +169,6 @@
 			"int": 5,
 			"wis": 12,
 			"cha": 6,
-			"passive": 0,
 			"cr": "0",
 			"trait": [
 				{
@@ -190,8 +187,12 @@
 				}
 			],
 			"familiar": true,
+			"tokenCustom": true,
 			"traitTags": [
 				"Pack Tactics"
+			],
+			"damageTags": [
+				"P"
 			],
 			"miscTags": [
 				"MW"
@@ -231,7 +232,6 @@
 			"int": 11,
 			"wis": 11,
 			"cha": 12,
-			"passive": 0,
 			"cr": "1/8",
 			"trait": [
 				{
@@ -255,6 +255,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Amphibious"
 			],
@@ -263,6 +264,9 @@
 			],
 			"miscTags": [
 				"MW"
+			],
+			"conditionInflict": [
+				"charmed"
 			],
 			"savingThrowForced": [
 				"wisdom"
@@ -297,20 +301,18 @@
 			"int": 13,
 			"wis": 14,
 			"cha": 14,
-			"passive": 0,
 			"cr": "3",
 			"spellcasting": [
 				{
 					"name": "Innate Spellcasting",
 					"type": "spellcasting",
+					"headerEntries": [
+						"The hag's spellcasting ability is Charisma (spell save {@dc 12}). It can innately cast the following spells:"
+					],
 					"will": [
 						"{@spell dancing lights}",
 						"{@spell minor illusion}",
 						"{@spell vicious mockery}"
-					],
-					"footerEntries": [
-						"The hag's spellcasting ability is Charisma",
-						"(spell save {@dc 12}). It can innately cast the following spells:"
 					]
 				}
 			],
@@ -348,6 +350,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Amphibious",
 				"Mimicry"
@@ -363,9 +366,6 @@
 			],
 			"miscTags": [
 				"MW"
-			],
-			"conditionInflict": [
-				"invisible"
 			],
 			"savingThrowForcedSpell": [
 				"wisdom"
@@ -405,7 +405,6 @@
 			"int": 10,
 			"wis": 8,
 			"cha": 8,
-			"passive": 0,
 			"cr": "1/4",
 			"trait": [
 				{
@@ -463,7 +462,7 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"Dwarf"
+					"dwarf"
 				]
 			},
 			"alignment": [
@@ -485,7 +484,9 @@
 			"int": 10,
 			"wis": 11,
 			"cha": 10,
-			"passive": 0,
+			"resist": [
+				"poison"
+			],
 			"cr": "1/4",
 			"trait": [
 				{
@@ -519,6 +520,7 @@
 		},
 		{
 			"name": "Great Kroom, Purple Worm",
+			"shortName": "Great Kroom",
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "AWM",
@@ -551,7 +553,6 @@
 			"int": 11,
 			"wis": 11,
 			"cha": 12,
-			"passive": 0,
 			"cr": "15",
 			"trait": [
 				{
@@ -581,10 +582,6 @@
 					]
 				}
 			],
-			"environment": [
-				"desert",
-				"underdark"
-			],
 			"traitTags": [
 				"Tunneler"
 			],
@@ -593,6 +590,7 @@
 				"Swallow"
 			],
 			"damageTags": [
+				"I",
 				"P"
 			],
 			"miscTags": [
@@ -628,7 +626,6 @@
 			"int": 6,
 			"wis": 13,
 			"cha": 6,
-			"passive": 0,
 			"cr": "5",
 			"trait": [
 				{
@@ -648,17 +645,17 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d8 + 3}) piercing damage. Target must make a {@dc 15} Constitution save, or take d ({@damage 1d10}) poison damage until cured."
+						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d8 + 3}) piercing damage. Target must make a {@dc 15} Constitution save, or take 6 ({@damage 1d10}) poison damage until cured."
 					]
 				},
 				{
 					"name": "Tentacle",
 					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 10 ft., one target. {@h}7 ({@damage 1d8 + 3}) bludgeoning damage ,Target must make a {@dc 19} Constitution save, or take 42 ({@damage 12d6}) poison damage"
+						"{@atk mw} {@hit 6} to hit, reach 10 ft., one target. {@h}7 ({@damage 1d8 + 3}) bludgeoning damage. Target must make a {@dc 19} Constitution save, or take 42 ({@damage 12d6}) poison damage."
 					]
 				},
 				{
-					"name": "Slam",
+					"name": "Slam!",
 					"entries": [
 						"Target must make a {@dc 14} Constitution save, or be {@condition grappled}."
 					]
@@ -667,23 +664,29 @@
 			"environment": [
 				"underdark"
 			],
+			"tokenCustom": true,
 			"actionTags": [
 				"Multiattack",
 				"Tentacles"
 			],
 			"damageTags": [
 				"B",
+				"I",
 				"P"
 			],
 			"miscTags": [
 				"MW",
 				"RCH"
 			],
+			"conditionInflict": [
+				"grappled"
+			],
 			"hasToken": true,
 			"hasFluff": true
 		},
 		{
 			"name": "Hill Giant, Blorbo",
+			"shortName": "Blorbo",
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "AWM",
@@ -711,7 +714,6 @@
 			"int": 5,
 			"wis": 9,
 			"cha": 6,
-			"passive": 0,
 			"cr": "4",
 			"action": [
 				{
@@ -753,6 +755,7 @@
 		},
 		{
 			"name": "Saleeth the Couatl",
+			"shortName": "Saleeth",
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "AWM",
@@ -786,7 +789,6 @@
 			"int": 18,
 			"wis": 20,
 			"cha": 18,
-			"passive": 0,
 			"cr": "4",
 			"spellcasting": [
 				{
@@ -829,7 +831,7 @@
 				{
 					"name": "Shielded Mind",
 					"entries": [
-						"The couatl is immune to scrying and to any effect that would sense its emotions, read its thoughts, or detect its location."
+						"The couatl is immune to {@spell scrying} and to any effect that would sense its emotions, read its thoughts, or detect its location."
 					]
 				}
 			],
@@ -837,23 +839,24 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 5 ft., one creature. {@h}8 ({@damage 1d6 + 5}) piercing damage, Target must make a {@dc 13} Constitution save, or fall {@condition unconscious}. Another creature can use an action to shake the target awake."
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one creature. {@h}8 ({@damage 1d6 + 5}) piercing damage. Target must make a {@dc 13} Constitution save, or fall {@condition unconscious}. Another creature can use an action to shake the target awake."
 					]
 				},
 				{
 					"name": "Constrict",
 					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 10 ft., one Medium or smaller creature. {@h}10 ({@damage 2d6 + 3}) bludgeoning damage, Target is {@condition grappled} (escape {@dc 15}). The couatl can constrain only one target at a time."
+						"{@atk mw} {@hit 6} to hit, reach 10 ft., one Medium or smaller creature. {@h}10 ({@damage 2d6 + 3}) bludgeoning damage. Target is {@condition grappled} (escape {@dc 15}). The couatl can constrain only one target at a time."
 					]
 				},
 				{
 					"name": "Change Shape",
 					"entries": [
-						"The couatl magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the couatl's choice).",
+						"The couatl magically polymorphs into {@filter a humanoid or beast that has a challenge rating equal to or less than its own|bestiary|Challenge Rating=[&0;&4]|type=beast;humanoid}, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the couatl's choice).",
 						"In a new form, the couatl retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and other actions are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks. If the new form has a bite attack, the couatl can use its bite in that form."
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Magic Weapons"
 			],
@@ -875,7 +878,8 @@
 				"RCH"
 			],
 			"conditionInflict": [
-				"grappled"
+				"grappled",
+				"unconscious"
 			],
 			"savingThrowForcedSpell": [
 				"wisdom"

--- a/json/bestiary/bestiary-bam.json
+++ b/json/bestiary/bestiary-bam.json
@@ -4,10 +4,8 @@
 			"name": "Aartuk Elder",
 			"source": "BAM",
 			"page": 8,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"L"
@@ -139,10 +137,8 @@
 			"name": "Aartuk Starhorror",
 			"source": "BAM",
 			"page": 9,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -279,10 +275,8 @@
 			"name": "Aartuk Weedling",
 			"source": "BAM",
 			"page": 9,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -390,13 +384,9 @@
 			"name": "Adult Lunar Dragon",
 			"source": "BAM",
 			"page": 34,
-			"otherSources": [
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"LoX",
+				"VEoR"
 			],
 			"size": [
 				"H"
@@ -700,6 +690,7 @@
 				"source": "BAM"
 			},
 			"dragonAge": "adult",
+			"tokenCustom": true,
 			"traitTags": [
 				"Flyby",
 				"Legendary Resistances",
@@ -1094,10 +1085,8 @@
 			"name": "Astral Elf Aristocrat",
 			"source": "BAM",
 			"page": 11,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -1272,10 +1261,8 @@
 			"name": "Astral Elf Commander",
 			"source": "BAM",
 			"page": 12,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -1418,10 +1405,8 @@
 			"name": "Astral Elf Honor Guard",
 			"source": "BAM",
 			"page": 12,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -1538,10 +1523,8 @@
 			"name": "Astral Elf Star Priest",
 			"source": "BAM",
 			"page": 13,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -1705,10 +1688,8 @@
 			"name": "Astral Elf Warrior",
 			"source": "BAM",
 			"page": 13,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -1828,10 +1809,8 @@
 			"name": "Autognome",
 			"source": "BAM",
 			"page": 13,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"S"
@@ -1986,10 +1965,8 @@
 			"name": "B'rohg",
 			"source": "BAM",
 			"page": 16,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"H"
@@ -2076,10 +2053,8 @@
 			"name": "Braxat",
 			"source": "BAM",
 			"page": 15,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"H"
@@ -2225,10 +2200,8 @@
 			"name": "Brown Scavver",
 			"source": "BAM",
 			"page": 49,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"L"
@@ -2412,10 +2385,8 @@
 			"name": "Cosmic Horror",
 			"source": "BAM",
 			"page": 18,
-			"otherSources": [
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"VEoR"
 			],
 			"size": [
 				"G"
@@ -2572,10 +2543,8 @@
 			"name": "Dohwar",
 			"source": "BAM",
 			"page": 19,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"S"
@@ -2673,10 +2642,8 @@
 			"name": "Esthetic",
 			"source": "BAM",
 			"page": 20,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"G"
@@ -2804,10 +2771,8 @@
 			"name": "Eye Monger",
 			"source": "BAM",
 			"page": 21,
-			"otherSources": [
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"VEoR"
 			],
 			"size": [
 				"L"
@@ -2918,10 +2883,8 @@
 			"name": "Feyr",
 			"source": "BAM",
 			"page": 22,
-			"otherSources": [
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"L"
@@ -3048,10 +3011,8 @@
 			"name": "Gaj",
 			"source": "BAM",
 			"page": 23,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"L"
@@ -3202,13 +3163,9 @@
 			"name": "Giff Shipmate",
 			"source": "BAM",
 			"page": 24,
-			"otherSources": [
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "SJA"
-				}
+			"referenceSources": [
+				"LoX",
+				"SjA"
 			],
 			"size": [
 				"M"
@@ -3310,10 +3267,8 @@
 			"name": "Giff Shock Trooper",
 			"source": "BAM",
 			"page": 25,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -3572,10 +3527,8 @@
 			"name": "Githyanki Buccaneer",
 			"source": "BAM",
 			"page": 27,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -3848,10 +3801,8 @@
 			"name": "Githyanki Xenomancer",
 			"source": "BAM",
 			"page": 27,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -3990,10 +3941,8 @@
 			"name": "Gray Scavver",
 			"source": "BAM",
 			"page": 49,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -4065,10 +4014,8 @@
 			"name": "Hadozee Explorer",
 			"source": "BAM",
 			"page": 28,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -4147,7 +4094,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The hadozee takes the Disengage or Hide action."
+						"The hadozee takes the {@action Disengage} or {@action Hide} action."
 					]
 				}
 			],
@@ -4185,10 +4132,8 @@
 			"name": "Hadozee Shipmate",
 			"source": "BAM",
 			"page": 29,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -4275,6 +4220,9 @@
 			"name": "Hadozee Warrior",
 			"source": "BAM",
 			"page": 29,
+			"referenceSources": [
+				"LoX"
+			],
 			"size": [
 				"M"
 			],
@@ -4494,10 +4442,8 @@
 			"name": "Kindori",
 			"source": "BAM",
 			"page": 31,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"G"
@@ -4708,10 +4654,8 @@
 			"name": "Megapede",
 			"source": "BAM",
 			"page": 36,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"G"
@@ -4813,10 +4757,8 @@
 			"name": "Mercane",
 			"source": "BAM",
 			"page": 37,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"L"
@@ -5089,10 +5031,8 @@
 			"name": "Neh-thalggu",
 			"source": "BAM",
 			"page": 39,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"L"
@@ -5354,10 +5294,8 @@
 			"name": "Neogi Pirate",
 			"source": "BAM",
 			"page": 41,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"S"
@@ -5650,10 +5588,8 @@
 			"name": "Night Scavver",
 			"source": "BAM",
 			"page": 49,
-			"otherSources": [
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"VEoR"
 			],
 			"size": [
 				"H"
@@ -5838,6 +5774,9 @@
 			"name": "Plasmoid Explorer",
 			"source": "BAM",
 			"page": 43,
+			"referenceSources": [
+				"LoX"
+			],
 			"size": [
 				"M"
 			],
@@ -6065,10 +6004,8 @@
 			"name": "Psurlon",
 			"source": "BAM",
 			"page": 44,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -6366,10 +6303,8 @@
 			"name": "Psurlon Ringer",
 			"source": "BAM",
 			"page": 45,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -6454,6 +6389,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],
@@ -6487,10 +6423,8 @@
 			"name": "Reigar",
 			"source": "BAM",
 			"page": 47,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -6794,10 +6728,8 @@
 			"name": "Space Clown",
 			"source": "BAM",
 			"page": 54,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -7016,10 +6948,8 @@
 			"name": "Space Guppy",
 			"source": "BAM",
 			"page": 55,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"S"
@@ -7146,7 +7076,7 @@
 				{
 					"name": "Escape",
 					"entries": [
-						"The hamster takes the Dash or Disengage action."
+						"The hamster takes the {@action Dash} or {@action Disengage} action."
 					]
 				}
 			],
@@ -7294,10 +7224,8 @@
 			"name": "Ssurran Defiler",
 			"source": "BAM",
 			"page": 58,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -7439,10 +7367,8 @@
 			"name": "Ssurran Poisoner",
 			"source": "BAM",
 			"page": 58,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -7558,10 +7484,8 @@
 			"name": "Starlight Apparition",
 			"source": "BAM",
 			"page": 59,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -7706,10 +7630,8 @@
 			"name": "Thri-kreen Gladiator",
 			"source": "BAM",
 			"page": 60,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -7823,10 +7745,8 @@
 			"name": "Thri-kreen Hunter",
 			"source": "BAM",
 			"page": 61,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -7938,10 +7858,8 @@
 			"name": "Thri-kreen Mystic",
 			"source": "BAM",
 			"page": 61,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -8078,10 +7996,8 @@
 			"name": "Vampirate",
 			"source": "BAM",
 			"page": 62,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -8200,10 +8116,8 @@
 			"name": "Vampirate Captain",
 			"source": "BAM",
 			"page": 63,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -8340,10 +8254,8 @@
 			"name": "Vampirate Mage",
 			"source": "BAM",
 			"page": 63,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"
@@ -8463,6 +8375,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Spider Climb",
 				"Unusual Nature"
@@ -8503,10 +8416,8 @@
 			"name": "Void Scavver",
 			"source": "BAM",
 			"page": 49,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"H"
@@ -8741,10 +8652,8 @@
 			"name": "Young Solar Dragon",
 			"source": "BAM",
 			"page": 53,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"L"
@@ -8845,6 +8754,7 @@
 				}
 			],
 			"dragonAge": "young",
+			"tokenCustom": true,
 			"traitTags": [
 				"Flyby",
 				"Unusual Nature"
@@ -8880,10 +8790,8 @@
 			"name": "Zodar",
 			"source": "BAM",
 			"page": 64,
-			"otherSources": [
-				{
-					"source": "LoX"
-				}
+			"referenceSources": [
+				"LoX"
 			],
 			"size": [
 				"M"

--- a/json/bestiary/bestiary-bgdia.json
+++ b/json/bestiary/bestiary-bgdia.json
@@ -211,7 +211,7 @@
 				{
 					"name": "Smoke Bomb (1/Day)",
 					"entries": [
-						"Amrik hurls a smoke bomb up to 20 feet away. The bomb explodes on impact, creating a cloud of black smoke that fills a 10-foot-radius sphere. The area within the cloud is heavily obscured. A strong wind disperses the cloud, which otherwise remains until the end of Amrik's next turn."
+						"Amrik hurls a smoke bomb up to 20 feet away. The bomb explodes on impact, creating a cloud of black smoke that fills a 10-foot-radius sphere. The area within the cloud is {@quickref Vision and Light||2||heavily obscured}. A strong wind disperses the cloud, which otherwise remains until the end of Amrik's next turn."
 					]
 				}
 			],
@@ -1001,6 +1001,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"hasToken": true,
@@ -2622,6 +2623,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW",
 				"RCH"
@@ -3615,7 +3617,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of her turns in combat, Nine-Fingers can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of her turns in combat, Nine-Fingers can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -3923,7 +3925,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of her turns in combat, Rilsa can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of her turns in combat, Rilsa can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -4348,8 +4350,7 @@
 				"P"
 			],
 			"spellcastingTags": [
-				"CW",
-				"I"
+				"CW"
 			],
 			"hasToken": true
 		},
@@ -4606,7 +4607,7 @@
 				{
 					"name": "Goring Rush",
 					"entries": [
-						"Immediately after using the Dash action, Torogar can make one melee attack with his horns."
+						"Immediately after using the {@action Dash} action, Torogar can make one melee attack with his horns."
 					]
 				},
 				{
@@ -4736,6 +4737,10 @@
 			"name": "Tressym",
 			"source": "BGDIA",
 			"page": 241,
+			"referenceSources": [
+				"IMR",
+				"SKT"
+			],
 			"_copy": {
 				"name": "Tressym",
 				"source": "SKT"

--- a/json/bestiary/bestiary-bgg.json
+++ b/json/bestiary/bestiary-bgg.json
@@ -609,10 +609,8 @@
 			"name": "Cinder Hulk",
 			"source": "BGG",
 			"page": 123,
-			"otherSources": [
-				{
-					"source": "GotSF"
-				}
+			"referenceSources": [
+				"GotSF"
 			],
 			"size": [
 				"L"
@@ -670,7 +668,7 @@
 				{
 					"name": "Death Burst",
 					"entries": [
-						"When the cinder hulk dies, it leaves behind a cloud of cinders and smoke that fills a 10-foot-radius sphere centered on its space. The sphere is heavily obscured. Any creature that moves into the area for the first time on a turn or starts its turn there must succeed on a {@dc 16} Constitution saving throw or take 10 ({@damage 3d6}) fire damage. The cloud lasts for 1 minute or until it is dispersed by strong wind."
+						"When the cinder hulk dies, it leaves behind a cloud of cinders and smoke that fills a 10-foot-radius sphere centered on its space. The sphere is {@quickref Vision and Light||2||heavily obscured}. Any creature that moves into the area for the first time on a turn or starts its turn there must succeed on a {@dc 16} Constitution saving throw or take 10 ({@damage 3d6}) fire damage. The cloud lasts for 1 minute or until it is dispersed by strong wind."
 					]
 				}
 			],
@@ -838,7 +836,7 @@
 					"name": "Thunderous Clap (Requires Cloud Rune)",
 					"entries": [
 						"The giant magically summons a thundercloud that fills a 30-foot-radius sphere centered on a point the giant can see within 60 feet of itself. The cloud spreads around corners. Each creature in that area must make a {@dc 20} Constitution saving throw as the cloud emits a thunderous boom. On a failed save, a creature takes 52 ({@damage 8d12}) thunder damage and has the {@condition prone} condition. On a successful save, a creature takes half as much damage only. The thunderclap is audible within 300 feet of the cloud's center point.",
-						"The cloud's area is heavily obscured. The cloud lingers until the start of the giant's next turn or until a strong wind disperses it."
+						"The cloud's area is {@quickref Vision and Light||2||heavily obscured}. The cloud lingers until the start of the giant's next turn or until a strong wind disperses it."
 					]
 				}
 			],
@@ -1849,7 +1847,7 @@
 				{
 					"name": "Shattering Roar {@recharge 5}",
 					"entries": [
-						"The cradle lets out a painfully load roar. Each creature within 60 feet of the cradle must make a {@dc 23} Constitution saving throw. On a failed save, a creature takes 33 ({@damage 6d10}) thunder damage and has the {@condition incapacitated} condition until the end of its next turn."
+						"The cradle lets out a painfully loud roar. Each creature within 60 feet of the cradle must make a {@dc 23} Constitution saving throw. On a failed save, a creature takes 33 ({@damage 6d10}) thunder damage and has the {@condition incapacitated} condition until the end of its next turn."
 					]
 				}
 			],
@@ -3176,10 +3174,8 @@
 			"name": "Firbolg Wanderer",
 			"source": "BGG",
 			"page": 137,
-			"otherSources": [
-				{
-					"source": "GotSF"
-				}
+			"referenceSources": [
+				"GotSF"
 			],
 			"size": [
 				"M"
@@ -3324,10 +3320,8 @@
 			"name": "Fire Giant Forgecaller",
 			"source": "BGG",
 			"page": 138,
-			"otherSources": [
-				{
-					"source": "GotSF"
-				}
+			"referenceSources": [
+				"GotSF"
 			],
 			"size": [
 				"H"
@@ -3470,13 +3464,9 @@
 			"name": "Fire Giant of Evil Fire",
 			"source": "BGG",
 			"page": 139,
-			"otherSources": [
-				{
-					"source": "GotSF"
-				},
-				{
-					"source": "HFStCM"
-				}
+			"referenceSources": [
+				"GotSF",
+				"HFStCM"
 			],
 			"size": [
 				"H"
@@ -5133,6 +5123,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"club|phb"
 			],
@@ -6883,10 +6874,8 @@
 			"name": "Scion of Grolantor",
 			"source": "BGG",
 			"page": 165,
-			"otherSources": [
-				{
-					"source": "HFStCM"
-				}
+			"referenceSources": [
+				"HFStCM"
 			],
 			"size": [
 				"G"
@@ -7586,7 +7575,7 @@
 				{
 					"name": "Vengeful Storm {@recharge}",
 					"entries": [
-						"The scion conjures a churning storm cloud in a 30-foot-radius, 10-foot-tall cylinder centered on a point within 120 feet of itself. The cloud's area is heavily obscured. The cloud lasts for 1 minute, until the scion dies, or when the scion uses this bonus action again.",
+						"The scion conjures a churning storm cloud in a 30-foot-radius, 10-foot-tall cylinder centered on a point within 120 feet of itself. The cloud's area is {@quickref Vision and Light||2||heavily obscured}. The cloud lasts for 1 minute, until the scion dies, or when the scion uses this bonus action again.",
 						"When the cloud appears, and as a bonus action on later turns, the scion can move the cloud up to 30 feet and cause one of the following effects in a 30-foot-radius, 120-foot-high cylinder directly below it; the scion can't choose the same effect two rounds in a row:"
 					]
 				},

--- a/json/bestiary/bestiary-bmt.json
+++ b/json/bestiary/bestiary-bmt.json
@@ -63,6 +63,7 @@
 				"canHover": true
 			},
 			"tokenCredit": "MOAI",
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -253,6 +254,7 @@
 				"canHover": true
 			},
 			"tokenCredit": "Smite, Hirez",
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -832,7 +834,7 @@
 				{
 					"name": "Bite (Wolf or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}26 ({@damage 5d8 + 4}) piercing damage. If the target is a Humanoid, it must succeed on a {@dc 15} Constitution saving throw or be cursed with lycanthropy. While cursed in this way, the target retains its alignment, languages, and equipment but otherwise uses the werewolf stat block, excluding actions that require equipment the target doesn't have. During any night when there's a full moon in the sky, the target becomes an NPC under the DM's control and remains so until the night ends. A {@spell Remove Curse} spell or similar magic ends this curse."
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}26 ({@damage 5d8 + 4}) piercing damage. If the target is a Humanoid, it must succeed on a {@dc 15} Constitution saving throw or be cursed with {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}. While cursed in this way, the target retains its alignment, languages, and equipment but otherwise uses the werewolf stat block, excluding actions that require equipment the target doesn't have. During any night when there's a full moon in the sky, the target becomes an NPC under the DM's control and remains so until the night ends. A {@spell Remove Curse} spell or similar magic ends this curse."
 					]
 				},
 				{
@@ -858,7 +860,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"Augustus takes the Dash, Disengage, or Hide action."
+						"Augustus takes the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				}
 			],
@@ -971,7 +973,7 @@
 				{
 					"name": "Bite (Rat or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}26 ({@damage 5d8 + 4}) piercing damage. If the target is a Humanoid, it must succeed on a {@dc 14} Constitution saving throw or be cursed with lycanthropy. While cursed in this way, the target retains its alignment, languages, and equipment but otherwise uses the wererat stat block, excluding actions that require equipment the target doesn't have. During any night when there's a full moon in the sky, the target becomes an NPC under the DM's control and remains so until the night ends. A {@spell Remove Curse} spell or similar magic ends this curse."
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}26 ({@damage 5d8 + 4}) piercing damage. If the target is a Humanoid, it must succeed on a {@dc 14} Constitution saving throw or be cursed with {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}. While cursed in this way, the target retains its alignment, languages, and equipment but otherwise uses the wererat stat block, excluding actions that require equipment the target doesn't have. During any night when there's a full moon in the sky, the target becomes an NPC under the DM's control and remains so until the night ends. A {@spell Remove Curse} spell or similar magic ends this curse."
 					]
 				},
 				{
@@ -997,7 +999,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"Delour takes the Dash, Disengage, or Hide action."
+						"Delour takes the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				}
 			],
@@ -1332,6 +1334,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -1467,7 +1470,7 @@
 				{
 					"name": "Swift Step (Acrobat Form Only)",
 					"entries": [
-						"The deck defender takes the Dash or Disengage action."
+						"The deck defender takes the {@action Dash} or {@action Disengage} action."
 					]
 				}
 			],
@@ -2217,7 +2220,9 @@
 				}
 			],
 			"tokenCredit": "Nidoart",
+			"tokenCustom": true,
 			"traitTags": [
+				"Ethereal Sight",
 				"Incorporeal Movement",
 				"Legendary Resistances"
 			],
@@ -3018,6 +3023,7 @@
 				"canHover": true
 			},
 			"tokenCredit": "Databuffer",
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -4329,6 +4335,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -4456,7 +4463,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Oddlewin takes the Disengage or Hide action."
+						"Oddlewin takes the {@action Disengage} or {@action Hide} action."
 					]
 				}
 			],
@@ -5031,6 +5038,7 @@
 				}
 			],
 			"tokenCredit": "Chris Cold",
+			"tokenCustom": true,
 			"traitTags": [
 				"Incorporeal Movement"
 			],

--- a/json/bestiary/bestiary-cm.json
+++ b/json/bestiary/bestiary-cm.json
@@ -7,6 +7,9 @@
 				"MOT"
 			]
 		},
+		"internalCopies": [
+			"monster"
+		],
 		"otherSources": {
 			"monster": {
 				"MM": "CM",
@@ -473,7 +476,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Bak Mei takes the Disengage or Hide action."
+						"Bak Mei takes the {@action Disengage} or {@action Hide} action."
 					]
 				}
 			],
@@ -646,6 +649,9 @@
 			"name": "Chwinga",
 			"source": "CM",
 			"page": 212,
+			"referenceSources": [
+				"ToA"
+			],
 			"_copy": {
 				"name": "Chwinga",
 				"source": "ToA"
@@ -791,6 +797,7 @@
 				}
 			],
 			"traitTags": [
+				"Ethereal Sight",
 				"Incorporeal Movement",
 				"Regeneration"
 			],
@@ -1009,6 +1016,11 @@
 				"name": "Dragon Turtle",
 				"source": "MM",
 				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "turtle",
+						"with": "tortoise"
+					},
 					"trait": {
 						"mode": "removeArr",
 						"names": "Amphibious"
@@ -1036,8 +1048,7 @@
 				"DR",
 				"T"
 			],
-			"hasToken": true,
-			"hasFluff": true
+			"hasToken": true
 		},
 		{
 			"name": "Faerl",
@@ -1368,6 +1379,7 @@
 			"miscTags": [
 				"AOE",
 				"CUR",
+				"HPR",
 				"MW"
 			],
 			"conditionInflict": [
@@ -1606,6 +1618,7 @@
 		},
 		{
 			"name": "Hag of the Fetid Gaze",
+			"isNpc": true,
 			"source": "CM",
 			"page": 76,
 			"_copy": {
@@ -1884,7 +1897,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Jade Tigress takes the Disengage or Hide action."
+						"Jade Tigress takes the {@action Disengage} or {@action Hide} action."
 					]
 				}
 			],
@@ -2106,6 +2119,7 @@
 				"Dwarvish"
 			],
 			"tokenCredit": "Obsidian Entertainment",
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -2524,6 +2538,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Damage Absorption",
 				"Immutable Form",
@@ -2596,7 +2611,7 @@
 					"name": "Spellcasting",
 					"type": "spellcasting",
 					"headerEntries": [
-						"The sage casts one of the following spells, using Intelligence as the spellcasting ability (save {@dc 14}, {@hit 6} to hit with spell attacks):"
+						"The sage casts one of the following spells, using Intelligence as the spellcasting ability (save {@dc 16}, {@hit 8} to hit with spell attacks):"
 					],
 					"will": [
 						"{@spell light}",
@@ -2604,7 +2619,7 @@
 						"{@spell mending}",
 						"{@spell prestidigitation}",
 						{
-							"entry": "{@spell shocking grasp}",
+							"entry": "{@spell Shocking Grasp}",
 							"hidden": true
 						}
 					],
@@ -2613,15 +2628,11 @@
 							"{@spell comprehend languages}",
 							"{@spell detect magic}",
 							"{@spell dispel magic}",
-							{
-								"entry": "{@spell fireball}",
-								"hidden": true
-							},
 							"{@spell identify}",
 							"{@spell levitate}",
 							"{@spell locate object}",
 							{
-								"entry": "{@spell shield}",
+								"entry": "{@spell Shield}",
 								"hidden": true
 							},
 							"{@spell Tenser's Floating Disk}",
@@ -2653,9 +2664,9 @@
 					]
 				},
 				{
-					"name": "Fireball (3rd-Level Spell; 3/Day)",
+					"name": "Lightning Eruption (3/Day)",
 					"entries": [
-						"The sage creates a fiery explosion centered on a point it can see within 150 feet of it. Each creature in a 20-foot-radius sphere centered on that point must make a {@dc 14} Dexterity saving throw, taking 28 ({@damage 8d6}) fire damage on a failed save, or half as much damage on a successful one. The fire spreads around corners and ignites flammable objects in the area that aren't being worn or carried."
+						"The sage creates an eruption of magical lightning centered on a point it can see within 150 feet of it. Each creature in a 20-foot-radius sphere centered on that point must make a {@dc 16} Dexterity saving throw, taking 28 ({@damage 8d6}) lightning damage on a failed save, or half as much damage on a successful one."
 					]
 				}
 			],
@@ -2672,11 +2683,9 @@
 				"X"
 			],
 			"damageTags": [
-				"F",
 				"L"
 			],
 			"damageTagsSpell": [
-				"F",
 				"L",
 				"Y"
 			],
@@ -2684,7 +2693,8 @@
 				"O"
 			],
 			"miscTags": [
-				"AOE"
+				"AOE",
+				"MA"
 			],
 			"conditionInflictSpell": [
 				"incapacitated"
@@ -2695,7 +2705,6 @@
 			"savingThrowForcedSpell": [
 				"charisma",
 				"constitution",
-				"dexterity",
 				"intelligence",
 				"wisdom"
 			],
@@ -3242,6 +3251,27 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Ogruhl",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "CM",
+			"page": 205,
+			"_copy": {
+				"name": "Dragon Tortoise",
+				"source": "CM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the dragon tortoise",
+						"with": "Ogruhl",
+						"flags": "i"
+					}
+				}
+			},
+			"hasToken": true,
+			"hasFluff": true
+		},
+		{
 			"name": "Parasite-infested Behir",
 			"source": "CM",
 			"page": 220,
@@ -3324,6 +3354,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -4235,6 +4266,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"greatsword|phb"
 			],
@@ -4593,6 +4625,7 @@
 			"miscTags": [
 				"AOE",
 				"CUR",
+				"HPR",
 				"MW"
 			],
 			"conditionInflict": [
@@ -4709,6 +4742,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Fey Ancestry"
 			],
@@ -4751,6 +4785,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"traitTags": [
 				"Fey Ancestry"
 			],

--- a/json/bestiary/bestiary-coa.json
+++ b/json/bestiary/bestiary-coa.json
@@ -152,6 +152,7 @@
 				}
 			],
 			"tokenCredit": "Mate Lukacs",
+			"tokenCustom": true,
 			"attachedItems": [
 				"warhammer|phb"
 			],
@@ -270,7 +271,7 @@
 				{
 					"name": "Cunning",
 					"entries": [
-						"Aeshma takes the Dash, Disengage, or Hide action."
+						"Aeshma takes the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				}
 			],
@@ -557,6 +558,7 @@
 				}
 			],
 			"tokenCredit": "jameszapata",
+			"tokenCustom": true,
 			"senseTags": [
 				"SD",
 				"U"
@@ -758,6 +760,7 @@
 				}
 			],
 			"tokenCredit": "Jeferson Cordeiro",
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1306,6 +1309,7 @@
 				}
 			],
 			"tokenCredit": "sμ (smew)",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Spider Climb"
@@ -2056,6 +2060,7 @@
 				"name": "Bel",
 				"source": "CoA"
 			},
+			"tokenCustom": true,
 			"attachedItems": [
 				"greatsword|phb"
 			],
@@ -3161,6 +3166,7 @@
 				"slashing"
 			],
 			"tokenCredit": "Unknown",
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -3288,6 +3294,7 @@
 				}
 			],
 			"tokenCredit": "Rahzy",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances"
 			],
@@ -3809,6 +3816,7 @@
 				}
 			],
 			"tokenCredit": "Donggeon Son",
+			"tokenCustom": true,
 			"traitTags": [
 				"Regeneration"
 			],
@@ -4114,6 +4122,7 @@
 				}
 			],
 			"tokenCredit": "Paizo",
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -4323,6 +4332,9 @@
 			"damageTags": [
 				"F"
 			],
+			"miscTags": [
+				"AOE"
+			],
 			"savingThrowForced": [
 				"dexterity",
 				"wisdom"
@@ -4529,6 +4541,7 @@
 				}
 			],
 			"tokenCredit": "Artguyonthefly",
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -4953,6 +4966,7 @@
 			},
 			"spellcasting": null,
 			"tokenCredit": "Irene Meniconi",
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -5218,6 +5232,7 @@
 				"cold"
 			],
 			"tokenCredit": "Caverns of the Snow Witch",
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -5545,6 +5560,7 @@
 				}
 			},
 			"tokenCredit": "CrazyMind351",
+			"tokenCustom": true,
 			"damageTags": [
 				"B",
 				"L",
@@ -7199,6 +7215,7 @@
 			"wis": 16,
 			"cha": 16,
 			"tokenCredit": "Konstantin Vavilov",
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -7408,6 +7425,7 @@
 				}
 			],
 			"tokenCredit": "Bufflewump, Kekai Kotaki",
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -7855,6 +7873,7 @@
 				}
 			],
 			"tokenCredit": "V-OneShot",
+			"tokenCustom": true,
 			"traitTags": [
 				"Devil's Sight",
 				"Magic Resistance"
@@ -8667,6 +8686,7 @@
 				}
 			],
 			"tokenCredit": "RussFairchild",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Magic Resistance"
@@ -9197,6 +9217,7 @@
 				"name": "Zariel",
 				"source": "CoA"
 			},
+			"tokenCustom": true,
 			"attachedItems": [
 				"flail|phb",
 				"longsword|phb"

--- a/json/bestiary/bestiary-cos.json
+++ b/json/bestiary/bestiary-cos.json
@@ -924,6 +924,38 @@
 			"hasFluff": true
 		},
 		{
+			"name": "Cat Skeleton",
+			"source": "CoS",
+			"page": 109,
+			"_copy": {
+				"name": "Cat",
+				"source": "MM",
+				"_templates": [
+					{
+						"name": "Skeleton",
+						"source": "DMG"
+					}
+				],
+				"_mod": {
+					"_": [
+						{
+							"mode": "setProp",
+							"prop": "vulnerable",
+							"value": null
+						},
+						{
+							"mode": "setProp",
+							"prop": "languages",
+							"value": null
+						}
+					]
+				}
+			},
+			"tokenCredit": "BoneTea",
+			"tokenCustom": true,
+			"hasToken": true
+		},
+		{
 			"name": "Clovin Belview",
 			"isNpc": true,
 			"isNamedCreature": true,
@@ -1624,6 +1656,40 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Hungry Ghast",
+			"source": "CoS",
+			"page": 192,
+			"_copy": {
+				"name": "Ghast",
+				"source": "MM",
+				"_mod": {
+					"trait": {
+						"mode": "appendArr",
+						"items": {
+							"name": "Spider Climb",
+							"entries": [
+								"The ghast can climb difficult surfaces, including upside down on ceilings, without having to make an ability check."
+							]
+						}
+					}
+				}
+			},
+			"size": [
+				"S"
+			],
+			"alignment": [
+				"L",
+				"G"
+			],
+			"hp": {
+				"average": 7,
+				"formula": "2d6"
+			},
+			"tokenCredit": "Will O'Brien",
+			"tokenCustom": true,
+			"hasToken": true
+		},
+		{
 			"name": "Ireena Kolyana",
 			"isNpc": true,
 			"isNamedCreature": true,
@@ -1812,7 +1878,7 @@
 							{
 								"name": "Fey Ancestry",
 								"entries": [
-									"Kasimir has advantage on saving throws against being {@condition charmed}, and magic can't put the him to sleep."
+									"Kasimir has advantage on saving throws against being {@condition charmed}, and magic can't put him to sleep."
 								]
 							},
 							{
@@ -1830,7 +1896,8 @@
 				"tags": [
 					{
 						"tag": "elf",
-						"prefix": "Dusk"
+						"prefix": "Dusk",
+						"prefixHidden": true
 					}
 				]
 			},
@@ -1985,6 +2052,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"damageTags": [
 				"B",
 				"S"
@@ -2069,7 +2137,8 @@
 				"dexterity",
 				"wisdom"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Lady Lydia Petrovna",
@@ -2113,7 +2182,8 @@
 				"C",
 				"E"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ludmilla Vilisevic",
@@ -2144,6 +2214,12 @@
 			"_copy": {
 				"name": "Bandit Captain",
 				"source": "MM",
+				"_templates": [
+					{
+						"name": "Vistana",
+						"source": "CoS"
+					}
+				],
 				"_mod": {
 					"*": {
 						"mode": "replaceTxt",
@@ -2195,6 +2271,9 @@
 			"isNamedCreature": true,
 			"source": "CoS",
 			"page": 233,
+			"reprintedAs": [
+				"Madam Eva|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -2711,6 +2790,10 @@
 					}
 				}
 			},
+			"alignment": [
+				"L",
+				"E"
+			],
 			"hasToken": true,
 			"hasFluffImages": true
 		},
@@ -2776,7 +2859,8 @@
 				"tags": [
 					{
 						"tag": "elf",
-						"prefix": "Dusk"
+						"prefix": "Dusk",
+						"prefixHidden": true
 					}
 				]
 			},
@@ -2894,6 +2978,7 @@
 				}
 			],
 			"traitTags": [
+				"Ethereal Sight",
 				"Incorporeal Movement"
 			],
 			"senseTags": [
@@ -3508,10 +3593,7 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					{
-						"tag": "elf",
-						"prefix": "Dusk"
-					}
+					"elf"
 				]
 			},
 			"alignment": [
@@ -3754,6 +3836,9 @@
 			"isNamedCreature": true,
 			"source": "CoS",
 			"page": 240,
+			"reprintedAs": [
+				"Strahd von Zarovich|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -3907,7 +3992,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"Strahd regains 20 hit points at the start of his turn if he has at least 1 hit point and isn't in running water or sunlight. If he takes radiant damage or damage from holy water, this trait doesn't function at the start of his next turn."
+						"Strahd regains 20 hit points at the start of his turn if he has at least 1 hit point and isn't in running water or sunlight. If he takes radiant damage or damage from {@item Holy Water (Flask)|PHB|holy water}, this trait doesn't function at the start of his next turn."
 					]
 				},
 				{
@@ -4541,10 +4626,8 @@
 			"name": "Tree Blight",
 			"source": "CoS",
 			"page": 230,
-			"otherSources": [
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Tree Blight|XMM"
@@ -5136,6 +5219,7 @@
 				"average": 7,
 				"formula": "2d6"
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -5187,6 +5271,10 @@
 					}
 				}
 			},
+			"alignment": [
+				"L",
+				"E"
+			],
 			"senses": [
 				"darkvision 60 ft."
 			],

--- a/json/bestiary/bestiary-crcotn.json
+++ b/json/bestiary/bestiary-crcotn.json
@@ -1321,6 +1321,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Keen Senses",
 				"Pack Tactics"
@@ -2101,6 +2102,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -2712,6 +2714,7 @@
 				"Common",
 				"Orc"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -3991,9 +3994,6 @@
 			"damageTagsSpell": [
 				"F"
 			],
-			"spellcastingTags": [
-				"I"
-			],
 			"hasToken": true,
 			"hasFluffImages": true
 		},
@@ -4115,6 +4115,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],
@@ -4952,7 +4953,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"The infiltrator takes the Dash or Disengage action."
+						"The infiltrator takes the {@action Dash} or {@action Disengage} action."
 					]
 				}
 			],
@@ -5129,6 +5130,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -5604,6 +5606,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"longbow|phb",
 				"shortsword|phb"
@@ -5697,7 +5700,6 @@
 				"F"
 			],
 			"spellcastingTags": [
-				"I",
 				"O"
 			],
 			"hasToken": true,
@@ -6309,6 +6311,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"club|phb"
 			],
@@ -6375,6 +6378,7 @@
 				"paralyzed",
 				"poisoned"
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Death Burst",
 				"Unusual Nature"
@@ -6952,6 +6956,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Amphibious"
 			],

--- a/json/bestiary/bestiary-dc.json
+++ b/json/bestiary/bestiary-dc.json
@@ -130,6 +130,7 @@
 				}
 			],
 			"traitTags": [
+				"Ethereal Sight",
 				"Incorporeal Movement",
 				"Legendary Resistances"
 			],

--- a/json/bestiary/bestiary-dip.json
+++ b/json/bestiary/bestiary-dip.json
@@ -18,13 +18,9 @@
 			"name": "Anchorite of Talos",
 			"source": "DIP",
 			"page": 51,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"DC",
+				"SDW"
 			],
 			"size": [
 				"M"

--- a/json/bestiary/bestiary-ditlcot.json
+++ b/json/bestiary/bestiary-ditlcot.json
@@ -1,4 +1,11 @@
 {
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"MM": "DitLCoT"
+			}
+		}
+	},
 	"monster": [
 		{
 			"name": "Pech",

--- a/json/bestiary/bestiary-dmg.json
+++ b/json/bestiary/bestiary-dmg.json
@@ -5,13 +5,12 @@
 			"source": "DMG",
 			"page": 164,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"TCE"
+			],
+			"reprintedAs": [
+				"Avatar of Death|XDMG"
 			],
 			"size": [
 				"M"
@@ -106,6 +105,9 @@
 			"name": "Giant Fly",
 			"source": "DMG",
 			"page": 169,
+			"reprintedAs": [
+				"Giant Fly|XDMG"
+			],
 			"size": [
 				"L"
 			],
@@ -144,19 +146,11 @@
 			"name": "Larva",
 			"source": "DMG",
 			"page": 63,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"SatO",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Larva|XMM"

--- a/json/bestiary/bestiary-dod.json
+++ b/json/bestiary/bestiary-dod.json
@@ -5,6 +5,9 @@
 			"isNamedCreature": true,
 			"source": "DoD",
 			"page": 22,
+			"referenceSources": [
+				"WBtW"
+			],
 			"size": [
 				"H"
 			],

--- a/json/bestiary/bestiary-dosi.json
+++ b/json/bestiary/bestiary-dosi.json
@@ -88,6 +88,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Death Burst",
 				"Unusual Nature"
@@ -192,6 +193,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],
@@ -431,6 +433,7 @@
 					]
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -582,10 +585,11 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"Tarak takes the Dash, Disengage, or Hide action."
+						"Tarak takes the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],
@@ -669,6 +673,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"shortsword|phb"
 			],
@@ -692,13 +697,9 @@
 			"name": "Violet Fungus",
 			"source": "DoSI",
 			"page": 48,
-			"otherSources": [
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"PaBTSO"
 			],
 			"_copy": {
 				"name": "Violet Fungus",

--- a/json/bestiary/bestiary-dsotdq.json
+++ b/json/bestiary/bestiary-dsotdq.json
@@ -2750,6 +2750,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"damageTags": [
 				"A",
 				"I",
@@ -2947,6 +2948,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"heavy crossbow|phb",
 				"lance|phb"
@@ -4232,6 +4234,7 @@
 				}
 			},
 			"type": "undead",
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -4274,6 +4277,7 @@
 				}
 			},
 			"spellcasting": null,
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -5344,6 +5348,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"longsword|phb"
 			],
@@ -5744,7 +5749,7 @@
 				{
 					"name": "Elusive",
 					"entries": [
-						"The kender takes the Disengage or Hide action."
+						"The kender takes the {@action Disengage} or {@action Hide} action."
 					]
 				}
 			],
@@ -5892,6 +5897,7 @@
 				}
 			],
 			"traitTags": [
+				"Ethereal Sight",
 				"Incorporeal Movement"
 			],
 			"senseTags": [
@@ -6898,7 +6904,7 @@
 				{
 					"name": "Miasma {@recharge 4}",
 					"entries": [
-						"Lohezet magically conjures a billowing cloud of purple fog in a 20-foot-radius sphere centered on a point within 120 feet of himself. The area within the sphere is heavily obscured, and when a creature starts its turn in the sphere or enters the sphere for the first time on a turn, it must make a {@dc 17} Constitution saving throw. On a failed save, the creature takes 39 ({@damage 6d12}) poison damage and is {@condition poisoned} until the start of its next turn. On a successful save, the creature takes half as much damage and isn't {@condition poisoned}. The cloud lasts for 1 minute, until Lohezet ends it early (no action required), or until Lohezet uses this action again. A strong wind disperses the cloud."
+						"Lohezet magically conjures a billowing cloud of purple fog in a 20-foot-radius sphere centered on a point within 120 feet of himself. The area within the sphere is {@quickref Vision and Light||2||heavily obscured}, and when a creature starts its turn in the sphere or enters the sphere for the first time on a turn, it must make a {@dc 17} Constitution saving throw. On a failed save, the creature takes 39 ({@damage 6d12}) poison damage and is {@condition poisoned} until the start of its next turn. On a successful save, the creature takes half as much damage and isn't {@condition poisoned}. The cloud lasts for 1 minute, until Lohezet ends it early (no action required), or until Lohezet uses this action again. A strong wind disperses the cloud."
 					]
 				}
 			],
@@ -6955,10 +6961,8 @@
 			"isNamedCreature": true,
 			"source": "DSotDQ",
 			"page": 206,
-			"otherSources": [
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"VEoR"
 			],
 			"size": [
 				"M"
@@ -7879,7 +7883,7 @@
 				{
 					"name": "Elusive",
 					"entries": [
-						"Tem takes the Disengage or Hide action."
+						"Tem takes the {@action Disengage} or {@action Hide} action."
 					]
 				}
 			],
@@ -8681,6 +8685,7 @@
 				}
 			],
 			"trait": null,
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -8711,6 +8716,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"traitTags": [
 				"Death Burst",
 				"Magic Resistance",
@@ -8793,6 +8799,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Flyby"
 			],

--- a/json/bestiary/bestiary-efa.json
+++ b/json/bestiary/bestiary-efa.json
@@ -1,0 +1,3322 @@
+{
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"XMM": "EFA",
+				"ERLW": "EFA"
+			}
+		}
+	},
+	"monster": [
+		{
+			"name": "Boromar Smuggler",
+			"source": "EFA",
+			"page": 57,
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"halfling"
+				]
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 27,
+				"formula": "6d6 + 6"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 11,
+			"dex": 15,
+			"con": 12,
+			"int": 11,
+			"wis": 10,
+			"cha": 14,
+			"save": {
+				"dex": "+4",
+				"wis": "+2"
+			},
+			"skill": {
+				"perception": "+2",
+				"sleight of hand": "+6",
+				"stealth": "+6"
+			},
+			"passive": 12,
+			"languages": [
+				"Common",
+				"Halfling",
+				"Thieves' cant"
+			],
+			"cr": "1/2",
+			"gear": [
+				"leather armor|xphb",
+				"pistol|xphb",
+				"shortsword|xphb"
+			],
+			"trait": [
+				{
+					"name": "Hustle",
+					"entries": [
+						"The smuggler can move through the space of any creature that is of a larger size, but it can't stop there."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Shortsword",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 1d6 + 2}) Piercing damage plus 2 ({@damage 1d4}) Poison damage."
+					]
+				},
+				{
+					"name": "Pistol",
+					"entries": [
+						"{@atkr r} {@hit 4}, range 30/90 ft. {@h}7 ({@damage 1d10 + 2}) Piercing damage."
+					]
+				}
+			],
+			"languageTags": [
+				"C",
+				"H",
+				"TC"
+			],
+			"damageTags": [
+				"I",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"RNG"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Boromar Underboss",
+			"source": "EFA",
+			"page": 57,
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"halfling"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 104,
+				"formula": "19d6 + 38"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 10,
+			"dex": 18,
+			"con": 15,
+			"int": 12,
+			"wis": 14,
+			"cha": 17,
+			"save": {
+				"dex": "+7",
+				"con": "+5",
+				"wis": "+5"
+			},
+			"skill": {
+				"insight": "+5",
+				"perception": "+8",
+				"sleight of hand": "+10"
+			},
+			"passive": 18,
+			"resist": [
+				"poison"
+			],
+			"languages": [
+				"Common",
+				"Halfling",
+				"Thieves' cant"
+			],
+			"cr": "8",
+			"gear": [
+				"studded leather armor|xphb"
+			],
+			"trait": [
+				{
+					"name": "Hustle",
+					"entries": [
+						"The underboss can move through the space of any creature that is of a larger size, but it can't stop there."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The underboss makes three attacks, using Poisoned Blade or Arcane Firearm in any combination."
+					]
+				},
+				{
+					"name": "Poisoned Blade",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}13 ({@damage 2d8 + 4}) Slashing damage plus 7 ({@damage 2d6}) Poison damage, and the target has the {@condition Poisoned|XPHB} condition until the start of the underboss's next turn. If the target is already {@condition Poisoned|XPHB}, it instead takes an extra 7 ({@damage 2d6}) Poison damage."
+					]
+				},
+				{
+					"name": "Arcane Firearm",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 30/90 ft. {@h}26 ({@damage 4d10 + 4}) Force damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Uncanny Dodge",
+					"entries": [
+						"{@actTrigger} The underboss is hit by an attack roll. {@actResponse} The underboss halves the damage (round down) it takes from that attack."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"H",
+				"TC"
+			],
+			"damageTags": [
+				"I",
+				"O",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Cannith Artificer",
+			"source": "EFA",
+			"page": 80,
+			"referenceSources": [
+				"FFotR"
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 71,
+				"formula": "11d8 + 22"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 13,
+			"dex": 13,
+			"con": 14,
+			"int": 18,
+			"wis": 14,
+			"cha": 11,
+			"save": {
+				"con": "+4",
+				"int": "+6"
+			},
+			"skill": {
+				"arcana": "+6",
+				"perception": "+4",
+				"sleight of hand": "+3"
+			},
+			"passive": 14,
+			"languages": [
+				"Common plus two other languages"
+			],
+			"cr": "4",
+			"gear": [
+				"chain mail|xphb",
+				"mace|xphb",
+				"tinker's tools|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The artificer casts one of the following spells, using its Tinker's Tools as an Arcane Focus and using Intelligence as the spellcasting ability (spell save {@dc 14}):"
+					],
+					"will": [
+						"{@spell Burning Hands|XPHB} (level 3 version)",
+						"{@spell Mending|XPHB}",
+						"{@spell Thunderwave|XPHB} (level 3 version)"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Cure Wounds|XPHB}",
+							"{@spell Invisibility|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The artificer makes two attacks, using Battering Mace or Artillery Strike in any combination."
+					]
+				},
+				{
+					"name": "Battering Mace",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}14 ({@damage 3d6 + 4}) Bludgeoning damage, and if the target is a Large or smaller creature, it has the {@condition Prone|XPHB} condition."
+					]
+				},
+				{
+					"name": "Artillery Strike",
+					"entries": [
+						"{@atkr r} {@hit 6}, range 120 ft. {@h}22 ({@damage 4d8 + 4}) Force damage."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"B",
+				"O"
+			],
+			"damageTagsSpell": [
+				"F",
+				"T"
+			],
+			"spellcastingTags": [
+				"CA"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"conditionInflictSpell": [
+				"invisible"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Daask Bruiser",
+			"source": "EFA",
+			"page": 58,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"gnoll"
+				]
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 150,
+				"formula": "20d8 + 60"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 20,
+			"dex": 13,
+			"con": 16,
+			"int": 10,
+			"wis": 12,
+			"cha": 14,
+			"save": {
+				"str": "+9",
+				"con": "+7",
+				"wis": "+5"
+			},
+			"skill": {
+				"athletics": "+9",
+				"intimidation": "+6",
+				"perception": "+5"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 15,
+			"languages": [
+				"Common",
+				"Gnoll"
+			],
+			"cr": "9",
+			"trait": [
+				{
+					"name": "Blood Frenzy",
+					"entries": [
+						"The bruiser has {@variantrule Advantage|XPHB} on attack rolls against any creature that doesn't have all its {@variantrule Hit Points|XPHB}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The bruiser makes three Pummel attacks and uses Glare."
+					]
+				},
+				{
+					"name": "Pummel",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 5 ft. {@h}12 ({@damage 2d6 + 5}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Glare",
+					"entries": [
+						"{@actSave wis} {@dc 14}, one creature the bruiser can see within 30 feet. {@actSaveFail} The target has the {@condition Frightened|XPHB} condition until the start of the bruiser's next turn."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Smackback",
+					"entries": [
+						"{@actTrigger} The bruiser takes damage from a creature within 5 feet. {@actResponse} The bruiser makes one Pummel attack, targeting the triggering creature."
+					]
+				}
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"OTH"
+			],
+			"damageTags": [
+				"B"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Daask Raider",
+			"source": "EFA",
+			"page": 58,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"gnoll"
+				]
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 33,
+				"formula": "6d8 + 6"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 16,
+			"dex": 12,
+			"con": 13,
+			"int": 10,
+			"wis": 11,
+			"cha": 8,
+			"save": {
+				"str": "+5"
+			},
+			"skill": {
+				"athletics": "+5",
+				"perception": "+2"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 12,
+			"languages": [
+				"Common",
+				"Gnoll"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Pack Tactics",
+					"entries": [
+						"The raider has {@variantrule Advantage|XPHB} on an attack roll against a creature if at least one of the raider's allies is within 5 feet of the creature and the ally doesn't have the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Pummel",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}5 ({@damage 1d4 + 3}) Bludgeoning damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Smackback",
+					"entries": [
+						"{@actTrigger} The raider takes damage from a creature within 5 feet. {@actResponse} The raider makes one Pummel attack, targeting the triggering creature."
+					]
+				}
+			],
+			"traitTags": [
+				"Pack Tactics"
+			],
+			"senseTags": [
+				"D"
+			],
+			"languageTags": [
+				"C",
+				"OTH"
+			],
+			"damageTags": [
+				"B"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Dreaming Dark Infiltrator",
+			"source": "EFA",
+			"page": 59,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 104,
+				"formula": "16d8 + 32"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 14,
+			"dex": 17,
+			"con": 15,
+			"int": 18,
+			"wis": 16,
+			"cha": 17,
+			"save": {
+				"int": "+7",
+				"wis": "+6",
+				"cha": "+6"
+			},
+			"skill": {
+				"deception": "+6",
+				"insight": "+6",
+				"stealth": "+6"
+			},
+			"senses": [
+				"Truesight 30 ft."
+			],
+			"passive": 13,
+			"resist": [
+				"psychic"
+			],
+			"languages": [
+				"Common",
+				"Quori; telepathy 120 ft."
+			],
+			"cr": "7",
+			"gear": [
+				"chain shirt|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The infiltrator casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save {@dc 15}):"
+					],
+					"daily": {
+						"1": [
+							"{@spell Synaptic Static|XPHB}"
+						],
+						"3": [
+							"{@spell Detect Thoughts|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The infiltrator makes three Mind Blade attacks."
+					]
+				},
+				{
+					"name": "Mind Blade",
+					"entries": [
+						"{@atkr m,r} {@hit 7}, reach 5 ft. or range 30 ft. {@h}14 ({@damage 3d6 + 4}) Psychic damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Mind Curse",
+					"entries": [
+						"{@actSave wis} {@dc 15}, one creature hit by the infiltrator's Mind Blade attack this turn. {@actSaveFail} The target takes 14 ({@damage 4d6}) Psychic damage and is cursed. While cursed in this way, it has {@variantrule Disadvantage|XPHB} on attack rolls against the infiltrator, and the infiltrator always knows its location while it and the infiltrator are on the same plane of existence. A cursed creature repeats the save whenever it finishes a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}, ending the effect on itself on a success. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"TP"
+			],
+			"damageTags": [
+				"Y"
+			],
+			"damageTagsSpell": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"CUR",
+				"MA",
+				"RA"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"intelligence",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Dreaming Dark Mindkiller",
+			"source": "EFA",
+			"page": 60,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				19
+			],
+			"hp": {
+				"average": 180,
+				"formula": "24d8 + 72"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 15,
+			"dex": 19,
+			"con": 16,
+			"int": 21,
+			"wis": 18,
+			"cha": 17,
+			"save": {
+				"dex": "+8",
+				"int": "+9",
+				"wis": "+8",
+				"cha": "+7"
+			},
+			"skill": {
+				"deception": "+7",
+				"insight": "+8",
+				"perception": "+8",
+				"stealth": "+8"
+			},
+			"senses": [
+				"Truesight 30 ft."
+			],
+			"passive": 18,
+			"resist": [
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Common",
+				"Quori; telepathy 120 ft."
+			],
+			"cr": "11",
+			"spellcasting": [
+				{
+					"name": "Slayer's Puppet (1/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The mindkiller casts {@spell Dominate Person|XPHB}, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 17})."
+					],
+					"daily": {
+						"1": [
+							"{@spell Dominate Person|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The mindkiller makes two Nightmare Whisper attacks."
+					]
+				},
+				{
+					"name": "Nightmare Whisper",
+					"entries": [
+						"{@atkr m,r} {@hit 9}, reach 5 ft. or range 30 ft. {@h}27 ({@damage 5d8 + 5}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the start of the mindkiller's next turn. If the target is already {@condition Frightened|XPHB}, it instead takes an extra 10 ({@damage 3d6}) Psychic damage."
+					]
+				},
+				{
+					"name": "Primal Fear (1/Day)",
+					"entries": [
+						"{@actSave wis} {@dc 17}, each creature in a 30-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point the mindkiller can see within 120 feet. {@actSaveFail} 35 ({@damage 10d6}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the start of the mindkiller's next turn. While {@condition Frightened|XPHB} in this way, the target can do only one of the following on each of its turns: move, take an action, or take a {@variantrule Bonus Action|XPHB}. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"TP"
+			],
+			"damageTags": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"conditionInflictSpell": [
+				"charmed"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Emerald Claw Commander",
+			"source": "EFA",
+			"page": 90,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				20
+			],
+			"hp": {
+				"average": 78,
+				"formula": "12d8 + 24"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 18,
+			"dex": 11,
+			"con": 15,
+			"int": 15,
+			"wis": 12,
+			"cha": 14,
+			"save": {
+				"con": "+4",
+				"wis": "+3"
+			},
+			"skill": {
+				"athletics": "+6",
+				"intimidation": "+4",
+				"perception": "+3"
+			},
+			"passive": 13,
+			"languages": [
+				"Common",
+				"Dwarvish"
+			],
+			"cr": "4",
+			"gear": [
+				"flail|xphb",
+				{
+					"item": "javelin|xphb",
+					"quantity": 5
+				},
+				"plate armor|xphb",
+				"shield|xphb"
+			],
+			"trait": [
+				{
+					"name": "Aura of Authority",
+					"entries": [
+						"While in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the commander, the commander and its allies have {@variantrule Advantage|XPHB} on attack rolls and saving throws, provided the commander doesn't have the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The commander makes two attacks, using Flail or Javelin in any combination."
+					]
+				},
+				{
+					"name": "Flail",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Bludgeoning damage\u2014plus 7 ({@damage 2d6}) Necrotic damage if the commander is Bloodied\u2014and the target has {@variantrule Disadvantage|XPHB} on its next attack roll before the start of the commander's next turn."
+					]
+				},
+				{
+					"name": "Javelin",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 30/120 ft. {@h}7 ({@damage 1d6 + 4}) Piercing damage\u2014plus 7 ({@damage 2d6}) Necrotic damage if the commander is {@status Bloodied|XPHB}."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"D"
+			],
+			"damageTags": [
+				"B",
+				"N",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Emerald Claw Knight",
+			"source": "EFA",
+			"page": 90,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 52,
+				"formula": "8d8 + 16"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 17,
+			"dex": 11,
+			"con": 14,
+			"int": 13,
+			"wis": 10,
+			"cha": 13,
+			"save": {
+				"wis": "+2"
+			},
+			"skill": {
+				"athletics": "+5",
+				"perception": "+2"
+			},
+			"passive": 12,
+			"languages": [
+				"Common",
+				"Dwarvish"
+			],
+			"cr": "2",
+			"gear": [
+				"chain mail|xphb",
+				"flail|xphb",
+				{
+					"item": "javelin|xphb",
+					"quantity": 5
+				},
+				"shield|xphb"
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The knight makes two attacks, using Flail or Javelin in any combination."
+					]
+				},
+				{
+					"name": "Flail",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}7 ({@damage 1d8 + 3}) Bludgeoning damage\u2014plus 4 ({@damage 1d8}) Necrotic damage if the knight is Bloodied\u2014and the target has {@variantrule Disadvantage|XPHB} on its next attack roll before the start of the knight's next turn."
+					]
+				},
+				{
+					"name": "Javelin",
+					"entries": [
+						"{@atkr m,r} {@hit 5}, reach 5 ft. or range 30/120 ft. {@h}6 ({@damage 1d6 + 3}) Piercing damage\u2014plus 4 ({@damage 1d8}) Necrotic damage if the knight is {@status Bloodied|XPHB}."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"D"
+			],
+			"damageTags": [
+				"B",
+				"N",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Ghallanda Troubleshooter",
+			"source": "EFA",
+			"page": 80,
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"halfling"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 78,
+				"formula": "12d6 + 36"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 10,
+			"dex": 16,
+			"con": 17,
+			"int": 13,
+			"wis": 14,
+			"cha": 17,
+			"save": {
+				"dex": "+5",
+				"con": "+5",
+				"wis": "+4",
+				"cha": "+5"
+			},
+			"skill": {
+				"insight": "+4",
+				"perception": "+4",
+				"stealth": "+5"
+			},
+			"passive": 14,
+			"conditionImmune": [
+				"frightened"
+			],
+			"languages": [
+				"Common",
+				"Halfling"
+			],
+			"cr": "3",
+			"gear": [
+				{
+					"item": "dagger|xphb",
+					"quantity": 6
+				},
+				"leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The troubleshooter casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 13}):"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Sleep|XPHB}",
+							"{@spell Unseen Servant|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Hustle",
+					"entries": [
+						"The troubleshooter can move through the space of any creature that is of a larger size, but it can't stop there."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The troubleshooter makes two Poisoned Dagger attacks."
+					]
+				},
+				{
+					"name": "Poisoned Dagger",
+					"entries": [
+						"{@atkr m,r} {@hit 5}, reach 5 ft. or range 20/60 ft. {@h}5 ({@damage 1d4 + 3}) Piercing damage, and the target has the {@condition Poisoned|XPHB} condition until the start of the troubleshooter's next turn."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Nimble Escape",
+					"entries": [
+						"The troubleshooter takes the {@action Disengage|XPHB} or {@action Hide|XPHB} action."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"H"
+			],
+			"damageTags": [
+				"P"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"conditionInflictSpell": [
+				"incapacitated",
+				"unconscious"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Homunculus Servant",
+			"source": "EFA",
+			"page": 21,
+			"summonedBySpell": "Homunculus Servant|EFA",
+			"summonedBySpellLevel": 2,
+			"size": [
+				"T"
+			],
+			"type": "construct",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"special": "5 + 5 per spell level (the homunculus has a number of Hit Dice [d4s] equal to the spell's level)"
+			},
+			"speed": {
+				"walk": 20,
+				"fly": 30
+			},
+			"initiative": 0,
+			"str": 4,
+			"dex": 15,
+			"con": 12,
+			"int": 10,
+			"wis": 10,
+			"cha": 7,
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 10,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"poisoned"
+			],
+			"languages": [
+				"telepathy 1 mile (works only with you)"
+			],
+			"pbNote": "equals your Proficiency Bonus",
+			"trait": [
+				{
+					"name": "Evasion",
+					"entries": [
+						"If the homunculus is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the homunculus instead takes no damage if it succeeds on the save and only half damage if it fails. It can't use this trait if it has the {@condition Incapacitated|XPHB} condition."
+					]
+				},
+				{
+					"name": "Magic Bond",
+					"entries": [
+						"Add the spell's level to any ability check or saving throw the homunculus makes."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Force Strike",
+					"entries": [
+						"{@atkr m,r} {@hitYourSpellAttack Bonus equals your spell attack modifier}, reach 5 ft. or range 30 ft. {@h}{@dice 1d6 + summonSpellLevel} Force damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Channel Magic",
+					"entries": [
+						"{@actTrigger} You cast a spell that has a range of touch while the homunculus is within 120 feet of you. {@actResponse} The homunculus delivers the spell through its touch."
+					]
+				}
+			],
+			"senseTags": [
+				"D"
+			],
+			"languageTags": [
+				"TP"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"hasToken": true
+		},
+		{
+			"name": "Jorasco Medic",
+			"source": "EFA",
+			"page": 81,
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"halfling"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 58,
+				"formula": "9d6 + 27"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 12,
+			"dex": 15,
+			"con": 16,
+			"int": 14,
+			"wis": 17,
+			"cha": 14,
+			"save": {
+				"con": "+5",
+				"wis": "+5"
+			},
+			"skill": {
+				"insight": "+5",
+				"medicine": "+5",
+				"perception": "+5",
+				"stealth": "+4"
+			},
+			"passive": 15,
+			"languages": [
+				"Common",
+				"Halfling"
+			],
+			"cr": "4",
+			"gear": [
+				"breastplate|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Mark of Healing (2/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The medic casts {@spell Cure Wounds|XPHB} or {@spell Lesser Restoration|XPHB}, using Wisdom as the spellcasting ability."
+					],
+					"daily": {
+						"2": [
+							"{@spell Cure Wounds|XPHB}",
+							"{@spell Lesser Restoration|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Lucky",
+					"entries": [
+						"When the medic rolls a 1 on the {@dice d20} of a {@variantrule D20 Test|XPHB}, it can reroll the die, and it must use the new roll."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The medic makes two Radiant Burst attacks."
+					]
+				},
+				{
+					"name": "Radiant Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 5}, reach 5 ft. or range 30 ft. {@h}7 ({@damage 2d6}) Radiant damage, and the creature has the {@condition Blinded|XPHB} condition until the start of the medic's next turn."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"H"
+			],
+			"damageTags": [
+				"R"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"blinded"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Kundarak Warden",
+			"source": "EFA",
+			"page": 81,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"dwarf"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 82,
+				"formula": "11d8 + 33"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 15,
+			"dex": 12,
+			"con": 16,
+			"int": 17,
+			"wis": 13,
+			"cha": 10,
+			"save": {
+				"str": "+5",
+				"dex": "+4",
+				"con": "+6",
+				"int": "+6",
+				"wis": "+4"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 11,
+			"languages": [
+				"Common",
+				"Dwarvish"
+			],
+			"cr": "5",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The warden casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save {@dc 14}):"
+					],
+					"will": [
+						"{@spell Alarm|XPHB}",
+						"{@spell Arcane Lock|XPHB}",
+						"{@spell Mage Armor|XPHB} (included in AC)"
+					],
+					"daily": {
+						"1": [
+							"{@spell Dispel Magic|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				},
+				{
+					"name": "Protective Magic (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The warden casts {@spell Counterspell|XPHB} or {@spell Shield|XPHB} in response to the spell's trigger, using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"3": [
+							"{@spell Counterspell|XPHB}",
+							"{@spell Shield|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "reaction",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The warden has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The warden makes two Arcane Whip attacks. It can replace one attack with a use of Shackling Glyph if available."
+					]
+				},
+				{
+					"name": "Arcane Whip",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 10 ft. {@h}13 ({@damage 3d6 + 3}) Force damage, and if the target is a Medium or smaller creature, it has the {@condition Prone|XPHB} condition. If the target already has the {@condition Prone|XPHB} condition, the attack deals an extra 7 ({@damage 2d6}) Force damage."
+					]
+				},
+				{
+					"name": "Shackling Glyph {@recharge}",
+					"entries": [
+						"{@actSave str} {@dc 14}, one creature the warden can see within 60 feet. {@actSaveFail} The creature has the {@condition Grappled|XPHB} condition (escape {@dc 14}). While {@condition Grappled|XPHB}, the creature has the {@condition Restrained|XPHB} condition."
+					]
+				}
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"D"
+			],
+			"damageTags": [
+				"O"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RCH"
+			],
+			"conditionInflict": [
+				"grappled",
+				"prone",
+				"restrained"
+			],
+			"savingThrowForced": [
+				"strength"
+			],
+			"savingThrowForcedSpell": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Lyrandar Scion",
+			"source": "EFA",
+			"page": 82,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"khoravar"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 60,
+				"formula": "11d8 + 11"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 12,
+			"dex": 16,
+			"con": 13,
+			"int": 12,
+			"wis": 15,
+			"cha": 18,
+			"save": {
+				"str": "+3",
+				"dex": "+5"
+			},
+			"skill": {
+				"acrobatics": "+5",
+				"perception": "+4"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 14,
+			"resist": [
+				"lightning",
+				"thunder"
+			],
+			"languages": [
+				"Common",
+				"Elvish"
+			],
+			"cr": "4",
+			"gear": [
+				"wand|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The scion casts one of the following spells, using Charisma as the spellcasting ability (spell save {@dc 14}):"
+					],
+					"will": [
+						"{@spell Elementalism|XPHB}",
+						"{@spell Gust of Wind|XPHB}",
+						"{@spell Thunderwave|XPHB}"
+					],
+					"ability": "cha",
+					"displayAs": "action"
+				},
+				{
+					"name": "Jump (2/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The scion casts {@spell Jump|XPHB}, requiring no spell components and using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"2": [
+							"{@spell Jump|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				},
+				{
+					"name": "Feather Fall (2/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The scion casts {@spell Feather Fall|XPHB} in response to that spell's trigger, using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"2": [
+							"{@spell Feather Fall|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "reaction",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The scion makes two Thunderbolt attacks and uses Spellcasting."
+					]
+				},
+				{
+					"name": "Thunderbolt",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 30 ft. {@h}11 ({@damage 2d6 + 4}) Lightning damage plus 9 ({@damage 2d8}) Thunder damage. Critical {@h}The creature also has the {@condition Deafened|XPHB} condition for 1 minute."
+					]
+				}
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"E"
+			],
+			"damageTags": [
+				"L",
+				"T"
+			],
+			"damageTagsSpell": [
+				"T"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"deafened"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Medani Inquisitive",
+			"source": "EFA",
+			"page": 82,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"khoravar"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 45,
+				"formula": "7d8 + 14"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 14,
+			"dex": 10,
+			"con": 14,
+			"int": 15,
+			"wis": 16,
+			"cha": 14,
+			"save": {
+				"con": "+4",
+				"wis": "+5"
+			},
+			"skill": {
+				"insight": "+5",
+				"investigation": "+4"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 13,
+			"languages": [
+				"Common",
+				"Elvish"
+			],
+			"cr": "3",
+			"gear": [
+				"breastplate|xphb",
+				"quarterstaff|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The inquisitive casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save {@dc 13}):"
+					],
+					"will": [
+						"{@spell Guidance|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Detect Thoughts|XPHB}",
+							"{@spell See Invisibility|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The inquisitive makes three Crooked Staff attacks. It can replace one attack with a use of Inquisitive Eye."
+					]
+				},
+				{
+					"name": "Crooked Staff",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}6 ({@damage 1d8 + 2}) Bludgeoning damage. If the target is a Medium or smaller creature, it has the {@condition Prone|XPHB} condition. If the target already has the {@condition Prone|XPHB} condition, the attack deals an extra 7 ({@damage 2d6}) Radiant damage."
+					]
+				},
+				{
+					"name": "Inquisitive Eye",
+					"entries": [
+						"{@actSave wis} {@dc 13}, one creature the inquisitive can see within 60 feet. {@actSaveFail} 10 ({@damage 3d6}) Psychic damage, and the target is marked. The inquisitive has {@variantrule Advantage|XPHB} on attack rolls against a target it has marked. While marked, the target can't become hidden from the inquisitive, and if it has the {@condition Invisible|XPHB} condition, it gains no benefit from that condition against the inquisitive. The mark disappears after 1 minute or when the inquisitive uses this action again. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Spontaneous Barrier {@recharge 4}",
+					"entries": [
+						"{@actTrigger} The inquisitive or an ally it can see is hit with an attack roll. {@actResponse} The inquisitive adds 2 to its or the ally's AC against that attack, possibly causing it to miss."
+					]
+				}
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"E"
+			],
+			"damageTags": [
+				"B",
+				"R",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"invisible",
+				"prone"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Orien Enforcer",
+			"source": "EFA",
+			"page": 83,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 55,
+				"formula": "10d8 + 10"
+			},
+			"speed": {
+				"walk": 35
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 12,
+			"dex": 18,
+			"con": 13,
+			"int": 16,
+			"wis": 14,
+			"cha": 11,
+			"save": {
+				"dex": "+6",
+				"wis": "+4"
+			},
+			"skill": {
+				"acrobatics": "+6",
+				"perception": "+4"
+			},
+			"passive": 14,
+			"languages": [
+				"Common plus two other languages"
+			],
+			"cr": "4",
+			"gear": [
+				{
+					"item": "dagger|xphb",
+					"quantity": 6
+				},
+				"studded leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Misty Step (2/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The enforcer casts {@spell Misty Step|XPHB}, using Intelligence as the spellcasting ability."
+					],
+					"daily": {
+						"2": [
+							"{@spell Misty Step|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The enforcer makes three Dagger attacks. It can replace one attack with a use of Lightning Cage if available."
+					]
+				},
+				{
+					"name": "Dagger",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 20/60 ft. {@h}9 ({@damage 2d4 + 4}) Piercing damage plus 7 ({@damage 2d6}) Poison damage."
+					]
+				},
+				{
+					"name": "Lightning Cage {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 13}, each creature in a 20-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point the enforcer can see within 60 feet. {@actSaveFail} 13 ({@damage 3d8}) Lightning damage, and the creature can't take Reactions until the end of the enforcer's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Temporal Disruption (1/Day)",
+					"entries": [
+						"{@actTrigger} The enforcer takes damage from a melee attack. {@actResponse} The enforcer teleports up to 30 feet to an unoccupied space it can see. Each creature within 10 feet of the space the enforcer left must succeed on a {@dc 13} Constitution saving throw, or its {@variantrule Speed|XPHB} is halved until the start of the enforcer's next turn."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"I",
+				"L",
+				"P"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Sentinel Marshal",
+			"source": "EFA",
+			"page": 83,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"L",
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 110,
+				"formula": "20d8 + 20"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 18,
+			"dex": 19,
+			"con": 12,
+			"int": 11,
+			"wis": 15,
+			"cha": 10,
+			"save": {
+				"dex": "+7",
+				"con": "+4"
+			},
+			"skill": {
+				"athletics": "+7",
+				"insight": "+5",
+				"perception": "+8"
+			},
+			"passive": 18,
+			"languages": [
+				"Common plus two other languages"
+			],
+			"cr": "6",
+			"gear": [
+				"longsword|xphb",
+				"pistol|xphb",
+				"studded leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Shield (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The marshal casts {@spell Shield|XPHB} in response to the spell's trigger, using Wisdom as the spellcasting ability."
+					],
+					"daily": {
+						"3": [
+							"{@spell Shield|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "reaction",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The marshal makes three attacks, using Longsword or Pistol in any combination."
+					]
+				},
+				{
+					"name": "Longsword",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}13 ({@damage 2d8 + 4}) Slashing damage, and the target has {@variantrule Disadvantage|XPHB} on the next attack roll it makes before the start of the marshal's next turn."
+					]
+				},
+				{
+					"name": "Pistol",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 30/90 ft. {@h}15 ({@damage 2d10 + 4}) Piercing damage."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"RNG"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Shadow-Marked Agent",
+			"source": "EFA",
+			"page": 84,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"elf"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 132,
+				"formula": "24d8 + 24"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 12,
+			"dex": 20,
+			"con": 12,
+			"int": 11,
+			"wis": 16,
+			"cha": 17,
+			"save": {
+				"dex": "+8",
+				"wis": "+6"
+			},
+			"skill": {
+				"perception": "+6",
+				"performance": "+6",
+				"sleight of hand": "+8",
+				"stealth": "+11"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 16,
+			"languages": [
+				"Common",
+				"Elvish",
+				"Thieves' cant"
+			],
+			"cr": "7",
+			"gear": [
+				"studded leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The agent casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability ({@dc 14}):"
+					],
+					"will": [
+						"{@spell Disguise Self|XPHB}",
+						"{@spell Minor Illusion|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Pass without Trace|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The agent makes two Shadow Knife attacks."
+					]
+				},
+				{
+					"name": "Shadow Knife",
+					"entries": [
+						"{@atkr m,r} {@hit 8}, reach 5 ft. or range 20/60 ft. {@h}10 ({@damage 2d4 + 5}) Piercing damage plus 14 ({@damage 4d6}) Necrotic damage, and the target's {@variantrule Speed|XPHB} is reduced by 10 feet until the end of its next turn."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shadow Cloak",
+					"entries": [
+						"The agent has the {@condition Invisible|XPHB} condition until the start of its next turn. This invisibility ends early immediately after the agent makes an attack roll."
+					]
+				}
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"E",
+				"TC"
+			],
+			"damageTags": [
+				"N",
+				"P"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"invisible"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Sivis Scribe",
+			"source": "EFA",
+			"page": 84,
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"gnome"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 56,
+				"formula": "16d6"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 11,
+			"dex": 15,
+			"con": 10,
+			"int": 16,
+			"wis": 12,
+			"cha": 11,
+			"save": {
+				"wis": "+3"
+			},
+			"skill": {
+				"arcana": "+5",
+				"sleight of hand": "+4"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 11,
+			"languages": [
+				"Common",
+				"Gnomish plus three other languages"
+			],
+			"cr": "3",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The scribe casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability ({@dc 13}):"
+					],
+					"will": [
+						"{@spell Comprehend Languages|XPHB}",
+						"{@spell Mage Armor|XPHB} (included in AC)",
+						"{@spell Message|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Sending|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Words of Reason",
+					"entries": [
+						"Allies in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the scribe have {@variantrule Advantage|XPHB} on saving throws to avoid or end the {@condition Charmed|XPHB} or {@condition Frightened|XPHB} condition. This trait doesn't function if the scribe has the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The scribe makes two Bursting Sigil attacks."
+					]
+				},
+				{
+					"name": "Bursting Sigil",
+					"entries": [
+						"{@atkr m,r} {@hit 5}, reach 5 ft. or range 60 ft. {@h}13 ({@damage 3d6 + 3}) Radiant damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Word of Stasis {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 13}, each creature in a 20-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point the scribe can see within 60 feet. {@actSaveFail} The target has the {@condition Incapacitated|XPHB} condition until the start of the scribe's next turn. While the target is {@condition Incapacitated|XPHB}, its {@variantrule Speed|XPHB} is 0 and can't increase."
+					]
+				}
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"G"
+			],
+			"damageTags": [
+				"R"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"incapacitated"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Steel Defender",
+			"source": "EFA",
+			"page": 19,
+			"summonedByClass": "Artificer|EFA",
+			"size": [
+				"M"
+			],
+			"type": "construct",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				{
+					"special": "12 + your Intelligence modifier"
+				}
+			],
+			"hp": {
+				"special": "5 + five times your Artificer level (the defender has a number of Hit Dice [d8s] equal to your Artificer level)"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 14,
+			"dex": 12,
+			"con": 14,
+			"int": 4,
+			"wis": 10,
+			"cha": 6,
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 10,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"poisoned"
+			],
+			"languages": [
+				"understands the languages you know"
+			],
+			"pbNote": "equals your Proficiency Bonus",
+			"trait": [
+				{
+					"name": "Steel Bond",
+					"entries": [
+						"Add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to any ability check or saving throw the defender makes."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Force-Empowered Rend",
+					"entries": [
+						"{@atkr m} {@hitYourSpellAttack Bonus equals your spell attack modifier}, reach 5 ft. {@h}{@dice 1d8 + 2} plus your Intelligence modifier Force damage."
+					]
+				},
+				{
+					"name": "Repair (3/Day)",
+					"entries": [
+						"The defender, or one Construct or object it can see within 5 feet of itself, regains a number of {@variantrule Hit Points|XPHB} equal to {@dice 2d8} plus your Intelligence modifier."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Deflect Attack",
+					"entries": [
+						"{@actTrigger} A creature the defender can see within 5 feet of itself makes an attack roll against a creature other than the defender. {@actResponse} The triggering creature makes the attack roll with {@variantrule Disadvantage|XPHB}."
+					]
+				}
+			],
+			"senseTags": [
+				"D"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"hasToken": true
+		},
+		{
+			"name": "Tarkanan Marauder",
+			"source": "EFA",
+			"page": 73,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 247,
+				"formula": "26d8 + 130"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 15,
+			"dex": 17,
+			"con": 20,
+			"int": 16,
+			"wis": 15,
+			"cha": 13,
+			"save": {
+				"dex": "+7",
+				"con": "+9",
+				"wis": "+6"
+			},
+			"skill": {
+				"deception": "+5",
+				"perception": "+6",
+				"stealth": "+7"
+			},
+			"passive": 16,
+			"languages": [
+				"Common",
+				"Thieves' cant"
+			],
+			"cr": "11",
+			"gear": [
+				"breastplate|xphb",
+				"shortsword|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The marauder casts one of the following spells, requiring no Material components and using Constitution as the spellcasting ability (spell save {@dc 17}):"
+					],
+					"will": [
+						"{@spell Message|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Disintegrate|XPHB}"
+						]
+					},
+					"ability": "con",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Evasion",
+					"entries": [
+						"If the marauder is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the marauder instead takes no damage if it succeeds on the save and only half as much damage if it fails. It can't use this trait if it has the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The marauder makes three Aberrant Strike attacks."
+					]
+				},
+				{
+					"name": "Aberrant Strike",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}13 ({@damage 3d6 + 3}) Piercing damage, plus 21 ({@damage 6d6}) Force damage if the marauder had {@variantrule Advantage|XPHB} on the attack roll."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Tear Through Space",
+					"entries": [
+						"The marauder teleports to a space it can see within 30 feet, appearing in a dazzling flash. {@actSave con} {@dc 17}, each creature in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the marauder when it appears. {@actSaveFail} The target has the {@condition Blinded|XPHB} condition until the end of the marauder's next turn."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"TC"
+			],
+			"damageTags": [
+				"O",
+				"P"
+			],
+			"damageTagsSpell": [
+				"O"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"blinded"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"savingThrowForcedSpell": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Tarkanan Ruffian",
+			"source": "EFA",
+			"page": 73,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 32,
+				"formula": "5d8 + 10"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 14,
+			"dex": 13,
+			"con": 15,
+			"int": 11,
+			"wis": 10,
+			"cha": 13,
+			"save": {
+				"dex": "+3",
+				"con": "+4"
+			},
+			"skill": {
+				"intimidation": "+3",
+				"perception": "+2"
+			},
+			"passive": 12,
+			"languages": [
+				"Common",
+				"Thieves' cant"
+			],
+			"cr": "1",
+			"gear": [
+				"spear|xphb",
+				"studded leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The ruffian casts one of the following spells, requiring no Material components and using Constitution as the spellcasting ability (spell save {@dc 12}, {@hit 4} to hit with spell attacks):"
+					],
+					"will": [
+						"{@spell Thaumaturgy|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Witch Bolt|XPHB}"
+						]
+					},
+					"ability": "con",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Aberrant Surge",
+					"entries": [
+						"When the ruffian casts {@spell Witch Bolt|XPHB}, roll {@dice 1d8}. On an even number, the ruffian gains a number of {@variantrule Temporary Hit Points|XPHB} equal to the number rolled. On an odd number, one creature of the ruffian's choice within 30 feet of it takes Force damage equal to the number rolled; if no other creatures are in range, it takes the damage."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Spear",
+					"entries": [
+						"{@atkr m,r} {@hit 4}, reach 5 ft. or range 20/60 ft. {@h}6 ({@damage 1d8 + 2}) Piercing damage."
+					]
+				}
+			],
+			"languageTags": [
+				"C",
+				"TC"
+			],
+			"damageTags": [
+				"P"
+			],
+			"damageTagsSpell": [
+				"L"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Tharashk Hunter",
+			"source": "EFA",
+			"page": 85,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human",
+					"orc"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 97,
+				"formula": "15d8 + 30"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 12,
+			"dex": 19,
+			"con": 15,
+			"int": 11,
+			"wis": 16,
+			"cha": 10,
+			"save": {
+				"dex": "+7",
+				"con": "+5"
+			},
+			"skill": {
+				"perception": "+6",
+				"stealth": "+7",
+				"survival": "+6"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 16,
+			"languages": [
+				"Common",
+				"Orc plus one other language"
+			],
+			"cr": "6",
+			"gear": [
+				"longbow|xphb",
+				"shortsword|xphb",
+				"studded leather armor|xphb"
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The hunter makes three attacks, using Shortsword or Longbow in any combination."
+					]
+				},
+				{
+					"name": "Shortsword",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}11 ({@damage 2d6 + 4}) Piercing damage, and the target has {@variantrule Disadvantage|XPHB} on attack rolls and ability checks until the end of its next turn."
+					]
+				},
+				{
+					"name": "Longbow",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 150/600 ft. {@h}17 ({@damage 3d8 + 4}) Piercing damage, and the target's {@variantrule Speed|XPHB} is reduced by 10 feet until the end of its next turn."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Mark of Tharashk",
+					"entries": [
+						"The hunter magically marks one creature it can see within 150 feet. The mark lasts for 1 hour, until the target dies, or until the hunter uses this {@variantrule Bonus Action|XPHB} again. While the target is marked in this way, the hunter has {@variantrule Advantage|XPHB} on attack rolls against the target, and the target gains no benefit from the {@condition Invisible|XPHB} condition against the hunter."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Uncanny Dodge",
+					"entries": [
+						"{@actTrigger} The hunter is hit by an attack roll. {@actResponse} The hunter halves the damage (round down) it takes from that attack."
+					]
+				}
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"O",
+				"X"
+			],
+			"damageTags": [
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"RNG"
+			],
+			"conditionInflict": [
+				"invisible"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Umbragen Shadow Walker",
+			"source": "EFA",
+			"page": 99,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"elf"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 162,
+				"formula": "25d8 + 50"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 12,
+			"dex": 19,
+			"con": 14,
+			"int": 13,
+			"wis": 15,
+			"cha": 20,
+			"save": {
+				"dex": "+8",
+				"wis": "+6"
+			},
+			"skill": {
+				"arcana": "+5",
+				"perception": "+6",
+				"stealth": "+8"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 16,
+			"vulnerable": [
+				"radiant"
+			],
+			"languages": [
+				"Common",
+				"Elvish",
+				"Undercommon"
+			],
+			"cr": "9",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The shadow walker casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 17}):"
+					],
+					"will": [
+						"{@spell Dancing Lights|XPHB}",
+						"{@spell Darkness|XPHB}",
+						"{@spell Minor Illusion|XPHB}"
+					],
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Fey Ancestry",
+					"entries": [
+						"Magic can't put the shadow walker to sleep."
+					]
+				},
+				{
+					"name": "Sunlight Sensitivity",
+					"entries": [
+						"While in sunlight, the shadow walker has {@variantrule Disadvantage|XPHB} on ability checks and attack rolls."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The shadow walker makes three Gloom Burst attacks and uses Shadow Cowl."
+					]
+				},
+				{
+					"name": "Gloom Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 9}, reach 5 ft. or range 120 ft. {@h}14 ({@damage 2d8 + 5}) Psychic damage."
+					]
+				},
+				{
+					"name": "Shadow Cowl",
+					"entries": [
+						"{@actSave wis} {@dc 17}, one creature the shadow walker can see within 120 feet. {@actSaveFail} 14 ({@damage 4d6}) Necrotic damage, and the target has the {@condition Blinded|XPHB} condition until the start of the shadow walker's next turn."
+					]
+				}
+			],
+			"traitTags": [
+				"Fey Ancestry",
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"E",
+				"U"
+			],
+			"damageTags": [
+				"N",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Vadalis Heir",
+			"source": "EFA",
+			"page": 85,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 52,
+				"formula": "8d8 + 16"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 12,
+			"dex": 16,
+			"con": 15,
+			"int": 10,
+			"wis": 17,
+			"cha": 13,
+			"save": {
+				"dex": "+5",
+				"con": "+4",
+				"wis": "+5"
+			},
+			"skill": {
+				"animal handling": "+7",
+				"nature": "+4",
+				"stealth": "+5"
+			},
+			"passive": 13,
+			"languages": [
+				"Common",
+				"Sylvan"
+			],
+			"cr": "4",
+			"gear": [
+				"leather armor|xphb",
+				"scimitar|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The heir casts one of the following spells, using Wisdom as the spellcasting ability (spell save {@dc 13}):"
+					],
+					"will": [
+						"{@spell Druidcraft|XPHB}",
+						"{@spell Light|XPHB}",
+						"{@spell Speak with Animals|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Ice Storm|XPHB}"
+						],
+						"3e": [
+							"{@spell Animal Friendship|XPHB}",
+							"{@spell Animal Messenger|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Pack Tactics",
+					"entries": [
+						"The heir has {@variantrule Advantage|XPHB} on an attack roll against a creature if at least one of the heir's allies is within 5 feet of the creature and the ally doesn't have the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The heir makes four attacks, using Scimitar or Lunar Wisp in any combination."
+					]
+				},
+				{
+					"name": "Scimitar",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}6 ({@damage 1d6 + 3}) Slashing damage plus 3 ({@damage 1d6}) Poison damage."
+					]
+				},
+				{
+					"name": "Lunar Wisp",
+					"entries": [
+						"{@atkr r} {@hit 5}, range 60 ft. {@h}9 ({@damage 2d8}) Radiant damage, and the target emits {@variantrule Dim Light|XPHB} in a 10-foot radius and can't benefit from the {@condition Invisible|XPHB} condition until the end of the heir's next turn."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Spur Beast",
+					"entries": [
+						"The heir targets a Beast it can see within 30 feet. The target can take a {@variantrule Reaction|XPHB} to move up to half its {@variantrule Speed|XPHB} and make one melee attack."
+					]
+				}
+			],
+			"traitTags": [
+				"Pack Tactics"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"S"
+			],
+			"damageTags": [
+				"I",
+				"R",
+				"S"
+			],
+			"damageTagsSpell": [
+				"B",
+				"C"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"MLW",
+				"RA"
+			],
+			"conditionInflictSpell": [
+				"charmed"
+			],
+			"savingThrowForcedSpell": [
+				"charisma",
+				"dexterity",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Vulkoori Stingblade",
+			"source": "EFA",
+			"page": 98,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"elf"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 27,
+				"formula": "6d8"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 11,
+			"dex": 15,
+			"con": 10,
+			"int": 11,
+			"wis": 12,
+			"cha": 12,
+			"save": {
+				"dex": "+4"
+			},
+			"skill": {
+				"perception": "+3",
+				"stealth": "+4"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 13,
+			"resist": [
+				"poison"
+			],
+			"languages": [
+				"Common",
+				"Elvish",
+				"Giant"
+			],
+			"cr": "1/2",
+			"gear": [
+				"shortsword|xphb",
+				"studded leather armor|xphb"
+			],
+			"trait": [
+				{
+					"name": "Fey Ancestry",
+					"entries": [
+						"Magic can't put the stingblade to sleep."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Stingblade",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 1d6 + 2}) Piercing damage plus 2 ({@damage 1d4}) Poison damage."
+					]
+				},
+				{
+					"name": "Boomerang",
+					"entries": [
+						"{@atkr r} {@hit 4}, reach 30/120 ft. {@h}7 ({@damage 2d4 + 2}) Bludgeoning damage."
+					]
+				}
+			],
+			"traitTags": [
+				"Fey Ancestry"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"languageTags": [
+				"C",
+				"E",
+				"GI"
+			],
+			"damageTags": [
+				"B",
+				"I",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Vulkoori Venom Priest",
+			"source": "EFA",
+			"page": 98,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"elf"
+				]
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 44,
+				"formula": "8d8 + 8"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 15,
+			"dex": 16,
+			"con": 12,
+			"int": 10,
+			"wis": 16,
+			"cha": 13,
+			"save": {
+				"con": "+3",
+				"wis": "+5"
+			},
+			"skill": {
+				"perception": "+5",
+				"religion": "+2",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 15,
+			"resist": [
+				"poison"
+			],
+			"languages": [
+				"Common",
+				"Elvish",
+				"Giant"
+			],
+			"cr": "2",
+			"gear": [
+				"holy symbol|xphb",
+				"quarterstaff|xphb",
+				"studded leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The priest casts one of the following spells, using Wisdom as the spellcasting ability (spell save {@dc 13}, {@hit 5} to hit with spell attacks):"
+					],
+					"will": [
+						"{@spell Dancing Lights|XPHB}",
+						"{@spell Ray of Sickness|XPHB}",
+						"{@spell Thaumaturgy|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Cure Wounds|XPHB}",
+							"{@spell Hold Person|XPHB}",
+							"{@spell Protection from Poison|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Fey Ancestry",
+					"entries": [
+						"Magic can't put the priest to sleep."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Venom Staff",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}9 ({@damage 2d6 + 2}) Bludgeoning damage, and the target has the {@condition Poisoned|XPHB} condition until the end of the priest's next turn."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Intensify Poison",
+					"entries": [
+						"Each creature with the {@condition Poisoned|XPHB} condition within a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the priest takes 3 ({@damage 1d6}) Poison damage."
+					]
+				}
+			],
+			"traitTags": [
+				"Fey Ancestry"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"languageTags": [
+				"C",
+				"E",
+				"GI"
+			],
+			"damageTags": [
+				"B",
+				"I"
+			],
+			"damageTagsSpell": [
+				"I"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"conditionInflictSpell": [
+				"paralyzed",
+				"poisoned"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		}
+	]
+}

--- a/json/bestiary/bestiary-egw.json
+++ b/json/bestiary/bestiary-egw.json
@@ -493,6 +493,9 @@
 			"name": "Animated Knife",
 			"source": "EGW",
 			"page": 248,
+			"referenceSources": [
+				"FS"
+			],
 			"_copy": {
 				"name": "Flying Sword",
 				"source": "MM",
@@ -531,10 +534,8 @@
 			"name": "Animated Tree",
 			"source": "EGW",
 			"page": 130,
-			"otherSources": [
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"MOT"
 			],
 			"_copy": {
 				"name": "Treant",
@@ -720,6 +721,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 261,
+			"referenceSources": [
+				"US"
+			],
 			"size": [
 				"S"
 			],
@@ -807,7 +811,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Bol'bara can take the Disengage or Hide action as a bonus action on each of her turns."
+						"Bol'bara can take the {@action Disengage} or {@action Hide} action as a bonus action on each of her turns."
 					]
 				}
 			],
@@ -846,6 +850,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],
@@ -891,6 +896,9 @@
 					"source": "CRCotN",
 					"page": 295
 				}
+			],
+			"referenceSources": [
+				"CRCotN"
 			],
 			"size": [
 				"L"
@@ -1498,6 +1506,9 @@
 			"name": "Damaged Flesh Golem",
 			"source": "EGW",
 			"page": 248,
+			"referenceSources": [
+				"FS"
+			],
 			"_copy": {
 				"name": "Flesh Golem",
 				"source": "MM",
@@ -1522,6 +1533,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 249,
+			"referenceSources": [
+				"FS"
+			],
 			"_copy": {
 				"name": "Wight",
 				"source": "MM",
@@ -1773,6 +1787,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -1942,6 +1957,9 @@
 					"source": "CRCotN",
 					"page": 291
 				}
+			],
+			"referenceSources": [
+				"CRCotN"
 			],
 			"size": [
 				"L"
@@ -2149,6 +2167,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Keen Senses",
 				"Pack Tactics"
@@ -2183,6 +2202,10 @@
 					"source": "CRCotN",
 					"page": 292
 				}
+			],
+			"referenceSources": [
+				"CRCotN",
+				"US"
 			],
 			"size": [
 				"G"
@@ -2294,6 +2317,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 240,
+			"referenceSources": [
+				"FS"
+			],
 			"_copy": {
 				"name": "Cult Fanatic",
 				"source": "MM",
@@ -2319,6 +2345,7 @@
 			"speed": {
 				"walk": 15
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2448,6 +2475,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 231,
+			"referenceSources": [
+				"DD"
+			],
 			"_copy": {
 				"name": "Drow",
 				"source": "MM",
@@ -2465,6 +2495,7 @@
 				"formula": "3d8"
 			},
 			"cr": "1/2",
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -2484,6 +2515,7 @@
 					}
 				]
 			},
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Sunlight Sensitivity"
@@ -2501,6 +2533,9 @@
 			"name": "Kobold Underling",
 			"source": "EGW",
 			"page": 221,
+			"referenceSources": [
+				"DD"
+			],
 			"size": [
 				"S"
 			],
@@ -2593,6 +2628,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW",
 				"RNG",
@@ -2759,6 +2795,9 @@
 					"page": 295
 				}
 			],
+			"referenceSources": [
+				"CRCotN"
+			],
 			"size": [
 				"L"
 			],
@@ -2827,6 +2866,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 256,
+			"referenceSources": [
+				"US"
+			],
 			"_copy": {
 				"name": "Horizonback Tortoise",
 				"source": "EGW",
@@ -2961,7 +3003,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the nergaliid can take the Hide action as a bonus action."
+						"While in dim light or darkness, the nergaliid can take the {@action Hide} action as a bonus action."
 					]
 				},
 				{
@@ -3024,6 +3066,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 251,
+			"referenceSources": [
+				"US"
+			],
 			"_copy": {
 				"name": "Ogre",
 				"source": "MM",
@@ -3041,6 +3086,7 @@
 				"E"
 			],
 			"int": 10,
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -3050,6 +3096,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 240,
+			"referenceSources": [
+				"FS"
+			],
 			"_copy": {
 				"name": "Giant Toad",
 				"source": "MM",
@@ -3095,6 +3144,7 @@
 				"C",
 				"E"
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Magic Resistance"
@@ -3108,6 +3158,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 261,
+			"referenceSources": [
+				"US"
+			],
 			"_copy": {
 				"name": "Priest",
 				"source": "MM",
@@ -3161,6 +3214,7 @@
 					"ability": "wis"
 				}
 			],
+			"tokenCustom": true,
 			"damageTagsSpell": [
 				"O",
 				"R"
@@ -3178,6 +3232,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 240,
+			"referenceSources": [
+				"FS"
+			],
 			"_copy": {
 				"name": "Cultist",
 				"source": "MM",
@@ -3196,6 +3253,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"traitTags": [
 				"Fey Ancestry"
 			],
@@ -3205,6 +3263,9 @@
 			"name": "Sahuagin Warlock of Uk'otoa",
 			"source": "EGW",
 			"page": 297,
+			"referenceSources": [
+				"ToR"
+			],
 			"size": [
 				"M"
 			],
@@ -3683,7 +3744,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the shadowghast can take the Hide action as a bonus action."
+						"While in dim light or darkness, the shadowghast can take the {@action Hide} action as a bonus action."
 					]
 				}
 			],
@@ -3735,6 +3796,9 @@
 			"name": "Sharkbody Abomination",
 			"source": "EGW",
 			"page": 215,
+			"referenceSources": [
+				"ToR"
+			],
 			"_copy": {
 				"name": "Hunter Shark",
 				"source": "MM",
@@ -3769,6 +3833,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 221,
+			"referenceSources": [
+				"DD"
+			],
 			"size": [
 				"M"
 			],
@@ -3864,6 +3931,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 254,
+			"referenceSources": [
+				"US"
+			],
 			"_copy": {
 				"name": "Lizardfolk Shaman",
 				"source": "MM",
@@ -3926,6 +3996,9 @@
 			"name": "Swarm of Undead Snakes",
 			"source": "EGW",
 			"page": 247,
+			"referenceSources": [
+				"FS"
+			],
 			"_copy": {
 				"name": "Swarm of Poisonous Snakes",
 				"source": "MM",
@@ -4059,6 +4132,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 211,
+			"referenceSources": [
+				"ToR"
+			],
 			"_copy": {
 				"name": "Bandit Captain",
 				"source": "MM",
@@ -4080,6 +4156,7 @@
 				"N",
 				"E"
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -4225,6 +4302,9 @@
 			"name": "Vox Seeker",
 			"source": "EGW",
 			"page": 270,
+			"referenceSources": [
+				"DD"
+			],
 			"size": [
 				"T"
 			],
@@ -4295,6 +4375,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Spider Climb"
 			],
@@ -4316,6 +4397,9 @@
 			"isNamedCreature": true,
 			"source": "EGW",
 			"page": 223,
+			"referenceSources": [
+				"DD"
+			],
 			"size": [
 				"M"
 			],
@@ -4392,6 +4476,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"longbow|phb",
 				"shortsword|phb"

--- a/json/bestiary/bestiary-erlw.json
+++ b/json/bestiary/bestiary-erlw.json
@@ -146,27 +146,23 @@
 							"style": "list-hang-notitle",
 							"items": [
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "1. Psyche-Reconstruction Ray",
-									"style": "italic",
 									"entry": "The target must make a {@dc 22} Wisdom saving throw, taking 49 ({@damage 9d10}) psychic damage on a failed save, or half as much damage on a successful one. If this damage reduces a creature to 0 hit points, it dies and transforms into a spectator under Belashyrra's control and acts immediately after Belashyrra in the initiative order. The target can't be returned to its original form by any means short of a {@spell wish} spell."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "2. Domination Ray",
-									"style": "italic",
 									"entry": "The target must succeed on a {@dc 22} Wisdom saving throw or be {@condition charmed} by Belashyrra for 1 minute or until the target takes damage. Belashyrra can issue telepathic commands to the {@condition charmed} creature (no action required), which it does its best to obey."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "3. Mind-Weakening Ray",
-									"style": "italic",
 									"entry": "The target must succeed on a {@dc 22} Intelligence saving throw or take 36 ({@damage 8d8}) psychic damage and be unable to cast spells or activate magic items for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "4. Blinding Ray",
-									"style": "italic",
 									"entry": "The target and each creature within 10 feet of it must succeed on a {@dc 22} Constitution saving throw or take 19 ({@damage 3d12}) radiant damage and be {@condition blinded} for 1 minute. Until this blindness ends, Belashyrra can see through the {@condition blinded} creature's eyes. The {@condition blinded} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								}
 							]
@@ -220,6 +216,7 @@
 				"Y"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -247,6 +244,9 @@
 			"name": "Bone Knight",
 			"source": "ERLW",
 			"page": 316,
+			"referenceSources": [
+				"EFA"
+			],
 			"size": [
 				"M"
 			],
@@ -411,6 +411,9 @@
 			"name": "Changeling",
 			"source": "ERLW",
 			"page": 317,
+			"referenceSources": [
+				"EFR"
+			],
 			"size": [
 				"M"
 			],
@@ -506,6 +509,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW",
 				"RW",
@@ -626,6 +630,9 @@
 			"isNamedCreature": true,
 			"source": "ERLW",
 			"page": 271,
+			"referenceSources": [
+				"EFR"
+			],
 			"_copy": {
 				"name": "Spy",
 				"source": "MM",
@@ -652,6 +659,7 @@
 				"average": 21,
 				"formula": "6d6"
 			},
+			"tokenCustom": true,
 			"languageTags": [
 				"H",
 				"X"
@@ -1027,6 +1035,7 @@
 			],
 			"miscTags": [
 				"CUR",
+				"HPR",
 				"MW"
 			],
 			"conditionInflictSpell": [
@@ -1319,6 +1328,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Flyby"
 			],
@@ -1370,7 +1380,7 @@
 				{
 					"name": "Quickness {@recharge 5}",
 					"entries": [
-						"The fastieth can take the Dodge action as a bonus action."
+						"The fastieth can take the {@action Dodge} action as a bonus action."
 					]
 				}
 			],
@@ -1398,6 +1408,9 @@
 			"isNamedCreature": true,
 			"source": "ERLW",
 			"page": 272,
+			"referenceSources": [
+				"EFR"
+			],
 			"_copy": {
 				"name": "Half-Ogre (Ogrillon)",
 				"source": "MM"
@@ -1407,6 +1420,7 @@
 				"E"
 			],
 			"int": 14,
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2149,6 +2163,9 @@
 			"name": "Kalashtar",
 			"source": "ERLW",
 			"page": 317,
+			"referenceSources": [
+				"EFR"
+			],
 			"size": [
 				"M"
 			],
@@ -2241,6 +2258,9 @@
 			"name": "Karrnathi Undead Soldier",
 			"source": "ERLW",
 			"page": 295,
+			"referenceSources": [
+				"EFA"
+			],
 			"size": [
 				"M"
 			],
@@ -2370,6 +2390,9 @@
 			"isNamedCreature": true,
 			"source": "ERLW",
 			"page": 296,
+			"referenceSources": [
+				"EFA"
+			],
 			"size": [
 				"M"
 			],
@@ -3027,6 +3050,9 @@
 			"name": "Magewright",
 			"source": "ERLW",
 			"page": 318,
+			"referenceSources": [
+				"EFR"
+			],
 			"size": [
 				"M"
 			],
@@ -3487,6 +3513,9 @@
 			"isNamedCreature": true,
 			"source": "ERLW",
 			"page": 303,
+			"referenceSources": [
+				"EFA"
+			],
 			"size": [
 				"H"
 			],
@@ -3691,6 +3720,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH",
 				"RW"
@@ -3714,12 +3744,16 @@
 				"name": "Guard",
 				"source": "MM"
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
 			"name": "Shifter",
 			"source": "ERLW",
 			"page": 319,
+			"referenceSources": [
+				"EFR"
+			],
 			"size": [
 				"M"
 			],
@@ -3815,6 +3849,9 @@
 			"isNamedCreature": true,
 			"source": "ERLW",
 			"page": 304,
+			"referenceSources": [
+				"EFA"
+			],
 			"size": [
 				"L"
 			],
@@ -4057,6 +4094,9 @@
 			"name": "Tarkanan Assassin",
 			"source": "ERLW",
 			"page": 320,
+			"referenceSources": [
+				"EFA"
+			],
 			"size": [
 				"M"
 			],
@@ -4193,6 +4233,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW"
 			],
@@ -4807,6 +4848,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Magic Resistance"
 			],
@@ -5046,6 +5088,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Keen Senses"
 			],
@@ -5398,6 +5441,9 @@
 			"name": "Warforged Soldier",
 			"source": "ERLW",
 			"page": 320,
+			"referenceSources": [
+				"EFR"
+			],
 			"size": [
 				"M"
 			],
@@ -5511,6 +5557,9 @@
 			"name": "Warforged Titan",
 			"source": "ERLW",
 			"page": 315,
+			"referenceSources": [
+				"EFA"
+			],
 			"size": [
 				"H"
 			],
@@ -5617,6 +5666,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],

--- a/json/bestiary/bestiary-esk.json
+++ b/json/bestiary/bestiary-esk.json
@@ -4,6 +4,10 @@
 			"name": "Expert",
 			"source": "ESK",
 			"page": 63,
+			"referenceSources": [
+				"DC",
+				"SDW"
+			],
 			"level": 1,
 			"size": [
 				"M"
@@ -107,6 +111,10 @@
 			"name": "Spellcaster",
 			"source": "ESK",
 			"page": 63,
+			"referenceSources": [
+				"DC",
+				"SDW"
+			],
 			"level": 1,
 			"size": [
 				"M"
@@ -248,6 +256,10 @@
 			"name": "Warrior",
 			"source": "ESK",
 			"page": 63,
+			"referenceSources": [
+				"DC",
+				"SDW"
+			],
 			"level": 1,
 			"size": [
 				"M"

--- a/json/bestiary/bestiary-fraif.json
+++ b/json/bestiary/bestiary-fraif.json
@@ -1,0 +1,6366 @@
+{
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"XMM": "FRAiF",
+				"MM": "FRAiF",
+				"MPMM": "FRAiF",
+				"FTD": "FRAiF"
+			}
+		}
+	},
+	"monster": [
+		{
+			"name": "Adult Deep Dragon",
+			"source": "FRAiF",
+			"page": 258,
+			"size": [
+				"H"
+			],
+			"type": "dragon",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 161,
+				"formula": "17d12 + 51"
+			},
+			"speed": {
+				"walk": 40,
+				"burrow": 30,
+				"fly": 80,
+				"swim": 40
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 20,
+			"dex": 14,
+			"con": 17,
+			"int": 16,
+			"wis": 16,
+			"cha": 18,
+			"save": {
+				"dex": "+6",
+				"wis": "+7"
+			},
+			"skill": {
+				"perception": "+11",
+				"stealth": "+10"
+			},
+			"senses": [
+				"Blindsight 60 ft.",
+				"Darkvision 150 ft."
+			],
+			"passive": 21,
+			"resist": [
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Draconic",
+				"Undercommon"
+			],
+			"cr": {
+				"cr": "11",
+				"xpLair": 8400
+			},
+			"trait": [
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+					"entries": [
+						"If the dragon fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The dragon makes three Rend attacks."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 10 ft. {@h}14 ({@damage 2d8 + 5}) Slashing damage plus 5 ({@damage 1d10}) Poison damage."
+					]
+				},
+				{
+					"name": "Nightmare Breath {@recharge 5}",
+					"entries": [
+						"{@actSave wis} {@dc 15}, each creature in a 30-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 38 ({@damage 7d10}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the end of the dragon's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The dragon shape-shifts into a Small or Medium Humanoid or a Small or Medium Beast, or it returns to its true form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"legendaryActionsLair": 4,
+			"legendary": [
+				{
+					"name": "Pounce",
+					"entries": [
+						"The dragon moves up to half its {@variantrule Speed|XPHB}, and it makes one Rend attack."
+					]
+				},
+				{
+					"name": "Spore Salvo",
+					"entries": [
+						"{@actSave con} {@dc 15}, one creature within 30 feet of the dragon that it can see. {@actSaveFail} 13 ({@damage 3d8}) Poison damage, and the target has the {@condition Poisoned|XPHB} condition. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically. {@actSaveSuccessOrFail} The dragon can't take this action again until the start of its next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Deep Dragon",
+				"source": "FRAiF"
+			},
+			"environment": [
+				"underdark"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"dragonCastingColor": "deep",
+			"dragonAge": "adult",
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"U"
+			],
+			"damageTags": [
+				"I",
+				"S",
+				"Y"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"frightened",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Adult Spirit Dragon",
+			"source": "FRAiF",
+			"page": 278,
+			"size": [
+				"H"
+			],
+			"type": "dragon",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 207,
+				"formula": "18d12 + 90"
+			},
+			"speed": {
+				"walk": 40,
+				"burrow": 30,
+				"fly": 80
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 22,
+			"dex": 15,
+			"con": 21,
+			"int": 20,
+			"wis": 15,
+			"cha": 19,
+			"save": {
+				"dex": "+7",
+				"con": "+10"
+			},
+			"skill": {
+				"history": "+10",
+				"insight": "+7",
+				"perception": "+7",
+				"stealth": "+7"
+			},
+			"senses": [
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
+			],
+			"passive": 17,
+			"resist": [
+				"necrotic"
+			],
+			"languages": [
+				"Common",
+				"Draconic; telepathy 120 ft."
+			],
+			"cr": {
+				"cr": "15",
+				"xpLair": 15000
+			},
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The dragon casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 18}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)",
+						"{@spell Thunderwave|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Legend Lore|XPHB} (as an action)"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+					"entries": [
+						"If the dragon fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The dragon makes three Rend attacks. It can replace one attack with a use of (A) Time-Warping Breath or (B) Spellcasting to cast {@spell Thunderwave|XPHB}."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hit 11}, reach 10 ft. {@h}15 ({@damage 2d8 + 6}) Slashing damage plus 7 ({@damage 2d6}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Ruinous Breath {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 18}, each creature in a 60-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 63 ({@damage 14d8}) Necrotic damage. {@actSaveSuccess} Half damage."
+					]
+				},
+				{
+					"name": "Time-Warping Breath",
+					"entries": [
+						"{@actSave wis} {@dc 18}, each creature that isn't currently affected by this breath in a 60-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} The target's {@variantrule Speed|XPHB} is halved, it can't take Reactions, and it can take either an action or a {@variantrule Bonus Action|XPHB} on its turn, not both. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+					]
+				}
+			],
+			"legendaryActionsLair": 4,
+			"legendary": [
+				{
+					"name": "Pounce",
+					"entries": [
+						"The dragon moves up to half its {@variantrule Speed|XPHB}, and it makes one Rend attack."
+					]
+				},
+				{
+					"name": "Shattering Wave",
+					"entries": [
+						"The dragon uses Spellcasting to cast {@spell Thunderwave|XPHB}."
+					]
+				},
+				{
+					"name": "Unearth Ruins",
+					"entries": [
+						"The dragon magically raises broken, ancient ruins in a 20-foot-radius, 60-foot-high {@variantrule Cylinder [Area of Effect]|XPHB|Cylinder} centered on a point it can see within 120 feet. Ground in the {@variantrule Cylinder [Area of Effect]|XPHB|Cylinder} becomes {@variantrule Difficult Terrain|XPHB}. Each creature in the {@variantrule Cylinder [Area of Effect]|XPHB|Cylinder} when it appears is subjected to the following effect. {@actSave str} {@dc 18}. {@actSaveFail} 5 ({@damage 2d4}) Bludgeoning damage, and the target has the {@condition Prone|XPHB} condition. {@actSaveSuccessOrFail} The dragon can't take this action again until the start of its next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Spirit Dragon",
+				"source": "FRAiF"
+			},
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"any"
+			],
+			"dragonCastingColor": "spirit",
+			"dragonAge": "adult",
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"TP"
+			],
+			"damageTags": [
+				"B",
+				"N",
+				"S"
+			],
+			"damageTagsSpell": [
+				"T"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"strength",
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Ancient Deep Dragon",
+			"source": "FRAiF",
+			"page": 259,
+			"size": [
+				"G"
+			],
+			"type": "dragon",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				20
+			],
+			"hp": {
+				"average": 247,
+				"formula": "15d20 + 90"
+			},
+			"speed": {
+				"walk": 40,
+				"burrow": 40,
+				"fly": 80,
+				"swim": 40
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 23,
+			"dex": 16,
+			"con": 22,
+			"int": 19,
+			"wis": 18,
+			"cha": 21,
+			"save": {
+				"dex": "+9",
+				"wis": "+10"
+			},
+			"skill": {
+				"perception": "+16",
+				"stealth": "+15"
+			},
+			"senses": [
+				"Blindsight 60 ft.",
+				"Darkvision 300 ft."
+			],
+			"passive": 26,
+			"resist": [
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Draconic",
+				"Undercommon"
+			],
+			"cr": {
+				"cr": "18",
+				"xpLair": 22000
+			},
+			"trait": [
+				{
+					"name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+					"entries": [
+						"If the dragon fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The dragon makes three Rend attacks."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hit 12}, reach 15 ft. {@h}17 ({@damage 2d10 + 6}) Slashing damage plus 5 ({@damage 1d10}) Poison damage."
+					]
+				},
+				{
+					"name": "Nightmare Breath {@recharge 5}",
+					"entries": [
+						"{@actSave wis} {@dc 20}, each creature in a 90-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 44 ({@damage 8d10}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the end of the dragon's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The dragon shape-shifts into a Small or Medium Humanoid or a Small or Medium Beast, or it returns to its true form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"legendaryActionsLair": 4,
+			"legendary": [
+				{
+					"name": "Pounce",
+					"entries": [
+						"The dragon moves up to half its {@variantrule Speed|XPHB}, and it makes one Rend attack."
+					]
+				},
+				{
+					"name": "Spore Salvo",
+					"entries": [
+						"{@actSave con} {@dc 20}, one creature within 30 feet of the dragon that it can see. {@actSaveFail} 16 ({@damage 3d10}) Poison damage, and the target has the {@condition Poisoned|XPHB} condition. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically. {@actSaveSuccessOrFail} The dragon can't take this action again until the start of its next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Deep Dragon",
+				"source": "FRAiF"
+			},
+			"environment": [
+				"underdark"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"dragonCastingColor": "deep",
+			"dragonAge": "ancient",
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"U"
+			],
+			"damageTags": [
+				"I",
+				"S",
+				"Y"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"frightened",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Ancient Spirit Dragon",
+			"source": "FRAiF",
+			"page": 279,
+			"size": [
+				"G"
+			],
+			"type": "dragon",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				21
+			],
+			"hp": {
+				"average": 420,
+				"formula": "24d20 + 168"
+			},
+			"speed": {
+				"walk": 40,
+				"burrow": 30,
+				"fly": 80
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 26,
+			"dex": 14,
+			"con": 25,
+			"int": 24,
+			"wis": 18,
+			"cha": 23,
+			"save": {
+				"dex": "+9",
+				"con": "+14"
+			},
+			"skill": {
+				"history": "+14",
+				"insight": "+11",
+				"perception": "+11",
+				"stealth": "+9"
+			},
+			"senses": [
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
+			],
+			"passive": 21,
+			"resist": [
+				"necrotic"
+			],
+			"languages": [
+				"Common",
+				"Draconic; telepathy 120 ft."
+			],
+			"cr": "22",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The dragon casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 22}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)",
+						"{@spell Thunderwave|XPHB} (level 2 version)"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Legend Lore|XPHB} (as an action)",
+							"{@spell Sequester|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+					"entries": [
+						"If the dragon fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The dragon makes three Rend attacks. It can replace one attack with a use of (A) Time-Warping Breath or (B) Spellcasting to cast {@spell Thunderwave|XPHB} (level 2 version)."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hit 15}, reach 15 ft. {@h}19 ({@damage 2d10 + 8}) Slashing damage plus 9 ({@damage 2d8}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Ruinous Breath {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 22}, each creature in a 90-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 72 ({@damage 16d8}) Necrotic damage. {@actSaveSuccess} Half damage."
+					]
+				},
+				{
+					"name": "Time-Warping Breath",
+					"entries": [
+						"{@actSave wis} {@dc 22}, each creature that isn't currently affected by this breath in a 90-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} The target's {@variantrule Speed|XPHB} is halved, it can't take Reactions, and it can take either an action or a {@variantrule Bonus Action|XPHB} on its turn, not both. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+					]
+				}
+			],
+			"legendaryActionsLair": 4,
+			"legendary": [
+				{
+					"name": "Pounce",
+					"entries": [
+						"The dragon moves up to half its {@variantrule Speed|XPHB}, and it makes one Rend attack."
+					]
+				},
+				{
+					"name": "Shattering Wave",
+					"entries": [
+						"The dragon uses Spellcasting to cast {@spell Thunderwave|XPHB} (level 2 version)."
+					]
+				},
+				{
+					"name": "Unearth Ruins",
+					"entries": [
+						"The dragon magically raises broken, ancient ruins in a 20-foot-radius, 60-foot-high {@variantrule Cylinder [Area of Effect]|XPHB|Cylinder} centered on a point it can see within 120 feet. Ground in the {@variantrule Cylinder [Area of Effect]|XPHB|Cylinder} becomes {@variantrule Difficult Terrain|XPHB}. Each creature in the {@variantrule Cylinder [Area of Effect]|XPHB|Cylinder} when it appears is subjected to the following effect. {@actSave str} {@dc 22}. {@actSaveFail} 13 ({@damage 3d8}) Bludgeoning damage, and the target has the {@condition Prone|XPHB} condition. {@actSaveSuccessOrFail} The dragon can't take this action again until the start of its next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Spirit Dragon",
+				"source": "FRAiF"
+			},
+			"environment": [
+				"any"
+			],
+			"dragonCastingColor": "spirit",
+			"dragonAge": "ancient",
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"TP"
+			],
+			"damageTags": [
+				"B",
+				"N",
+				"S"
+			],
+			"damageTagsSpell": [
+				"T"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"conditionInflictSpell": [
+				"invisible",
+				"unconscious"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"strength",
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Aranea",
+			"source": "FRAiF",
+			"page": 250,
+			"size": [
+				"M"
+			],
+			"type": "monstrosity",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 66,
+				"formula": "12d8 + 12"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": {
+					"number": 30,
+					"condition": "(spider or hybrid form only)"
+				}
+			},
+			"str": 10,
+			"dex": 17,
+			"con": 12,
+			"int": 12,
+			"wis": 10,
+			"cha": 15,
+			"skill": {
+				"perception": "+2",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 12,
+			"languages": [
+				"Common"
+			],
+			"cr": "2",
+			"gear": [
+				"sling|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The aranea casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 12}):"
+					],
+					"will": [
+						"{@spell Friends|XPHB}",
+						"{@spell Silent Image|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Hold Person|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Spider Climb (Hybrid or Spider Form Only)",
+					"entries": [
+						"The aranea can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+					]
+				},
+				{
+					"name": "Web Walker",
+					"entries": [
+						"The aranea ignores movement restrictions caused by webs, and it knows the location of any other creature in contact with the same web."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The aranea makes two attacks, using Bite, Slam, or Sling in any combination."
+					]
+				},
+				{
+					"name": "Bite (Hybrid or Spider Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}6 ({@damage 1d6 + 3}) Piercing damage plus 2 ({@damage 1d4}) Poison damage."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}7 ({@damage 1d8 + 3}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Sling (Humanoid or Hybrid Form Only)",
+					"entries": [
+						"{@atkr r} {@hit 5}, range 30/120 ft. {@h}8 ({@damage 2d4 + 3}) Bludgeoning damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The aranea shape-shifts into a humanoid form, into a humanoid-spider hybrid form, or back into its true spider form. Its game statistics are the same in each form, except where noted. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"swamp"
+			],
+			"treasure": [
+				"individual"
+			],
+			"traitTags": [
+				"Spider Climb",
+				"Web Walker"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"B",
+				"I",
+				"P"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RNG"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"paralyzed"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Beast of Malar",
+			"source": "FRAiF",
+			"page": 251,
+			"size": [
+				"M"
+			],
+			"type": "monstrosity",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 168,
+				"formula": "16d8 + 96"
+			},
+			"speed": {
+				"walk": 50,
+				"burrow": {
+					"number": 40,
+					"condition": "(land form only)"
+				},
+				"fly": {
+					"number": 60,
+					"condition": "(sky form only)"
+				},
+				"swim": {
+					"number": 40,
+					"condition": "(sea form only)"
+				}
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 21,
+			"dex": 16,
+			"con": 23,
+			"int": 10,
+			"wis": 14,
+			"cha": 12,
+			"save": {
+				"str": "+9"
+			},
+			"skill": {
+				"perception": "+10",
+				"stealth": "+7"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 20,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"understands Common but can't speak"
+			],
+			"cr": "11",
+			"trait": [
+				{
+					"name": "Amphibious (Sea Form Only)",
+					"entries": [
+						"The beast breathes air and water."
+					]
+				},
+				{
+					"name": "Divine Immortality",
+					"entries": [
+						"If the beast dies, its body dissolves into black goo, and it gains a new body after {@dice 1d10} days, reviving with all its {@variantrule Hit Points|XPHB} in a place of Malar's choosing."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the beast fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The beast has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Regeneration",
+					"entries": [
+						"The beast regains 20 {@variantrule Hit Points|XPHB} at the start of its turn. If the beast takes Radiant damage or damage from a {@variantrule Critical Hit|XPHB}, this trait doesn't function at the start of the beast's next turn. The beast dies only if it starts its turn with 0 {@variantrule Hit Points|XPHB} and doesn't regenerate."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The beast makes three attacks, using Bite or Claws in any combination."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 5 ft. {@h}23 ({@damage 4d8 + 5}) Piercing damage."
+					]
+				},
+				{
+					"name": "Claws (Land or Sky Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 5 ft. {@h}18 ({@damage 3d8 + 5}) Slashing damage. If the target is Large or smaller, it has the {@condition Prone|XPHB} condition."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Recuperative Shape-Shift",
+					"entries": [
+						"The beast shape-shifts into its land form, sea form, or sky form and regains 9 ({@dice 2d8}) {@variantrule Hit Points|XPHB}. Its game statistics are the same in each form, except where noted. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"environment": [
+				"coastal",
+				"forest",
+				"hill"
+			],
+			"traitTags": [
+				"Amphibious",
+				"Legendary Resistances",
+				"Magic Resistance",
+				"Regeneration"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Biha Babir",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "FRAiF",
+			"page": 253,
+			"size": [
+				"L"
+			],
+			"type": {
+				"type": "elemental",
+				"tags": [
+					"genie"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 229,
+				"formula": "17d10 + 136"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": 60,
+				"swim": 90
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 22,
+			"dex": 12,
+			"con": 26,
+			"int": 18,
+			"wis": 17,
+			"cha": 20,
+			"save": {
+				"dex": "+5",
+				"wis": "+7",
+				"cha": "+9"
+			},
+			"skill": {
+				"deception": "+9",
+				"insight": "+7",
+				"perception": "+7",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
+			],
+			"passive": 17,
+			"resist": [
+				"acid",
+				"cold",
+				"lightning"
+			],
+			"languages": [
+				"Common",
+				"Primordial (Aquan)"
+			],
+			"cr": "12",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Biha Babir casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 17}):"
+					],
+					"will": [
+						"{@spell Create or Destroy Water|XPHB}",
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Major Image|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Control Water|XPHB} (Flood, Part Water, or Redirect Flow only)",
+							"{@spell Dispel Magic|XPHB}",
+							"{@spell Invisibility|XPHB}"
+						],
+						"1e": [
+							"{@spell Control Weather|XPHB}",
+							"{@spell Plane Shift|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"Biha Babir can breathe air and water."
+					]
+				},
+				{
+					"name": "Elemental Restoration",
+					"entries": [
+						"If Biha Babir dies outside the Elemental Plane of Water, her body dissolves into brine, and she gains a new body in {@dice 1d4} days, reviving with all her {@variantrule Hit Points|XPHB} somewhere on the Plane of Water."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If Biha Babir fails a saving throw, she can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Wishes",
+					"entries": [
+						"Biha Babir knows the {@spell Wish|XPHB} spell but can cast it only on behalf of a non-genie creature who communicates a wish in a way Biha Babir can understand. If Biha Babir casts the spell for a creature, she suffers none of the spell's stress. Once Biha Babir has cast it three times, she can't do so again for 365 days."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Biha Babir makes two Marine Burst attacks. She can replace one of these attacks with a Tail attack."
+					]
+				},
+				{
+					"name": "Marine Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 10}, reach 5 ft. or range 60 ft. {@h}17 ({@damage 2d10 + 6}) Cold damage."
+					]
+				},
+				{
+					"name": "Tail (Marid Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 15 ft. {@h}13 ({@damage 2d6 + 6}) Bludgeoning damage, and if the target is Huge or smaller, it has the {@condition Prone|XPHB} condition."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Fluid Form",
+					"entries": [
+						"Biha Babir shape-shifts into a form resembling a Beast or Humanoid that is Medium or smaller, while retaining her game statistics (other than her size), or returns to her true marid form."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Misty Burst",
+					"entries": [
+						"Biha Babir teleports to an unoccupied space she can see within 30 feet of herself and makes one Marine Burst attack."
+					]
+				},
+				{
+					"name": "Whirlpool",
+					"entries": [
+						"{@actSave str} {@dc 18}, each creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Biha Babir. {@actSaveFail} 10 ({@damage 3d6}) Force damage, and the target is pulled 15 feet straight toward Biha Babir. {@actSaveSuccess} Half damage only. {@actSaveSuccessOrFail} Biha Babir can't use this action again until the start of her next turn."
+					]
+				}
+			],
+			"traitTags": [
+				"Amphibious",
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AQ",
+				"C",
+				"P"
+			],
+			"damageTags": [
+				"B",
+				"C",
+				"O"
+			],
+			"damageTagsSpell": [
+				"B"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"conditionInflictSpell": [
+				"invisible"
+			],
+			"savingThrowForced": [
+				"strength"
+			],
+			"savingThrowForcedSpell": [
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Cultist of Bane",
+			"source": "FRAiF",
+			"page": 254,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 142,
+				"formula": "19d8 + 57"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 18,
+			"dex": 14,
+			"con": 16,
+			"int": 13,
+			"wis": 19,
+			"cha": 15,
+			"save": {
+				"con": "+7",
+				"wis": "+8",
+				"cha": "+6"
+			},
+			"skill": {
+				"intimidation": "+6",
+				"perception": "+8"
+			},
+			"passive": 18,
+			"languages": [
+				"Common"
+			],
+			"cr": "9",
+			"gear": [
+				"breastplate|xphb",
+				"holy symbol|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The cultist casts one of the following spells, using Wisdom as the spellcasting ability (spell save {@dc 16}):"
+					],
+					"daily": {
+						"1": [
+							"{@spell Dominate Person|XPHB}"
+						],
+						"2e": [
+							"{@spell Calm Emotions|XPHB}",
+							"{@spell Detect Thoughts|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Determined Survivor",
+					"entries": [
+						"The cultist regains 10 {@variantrule Hit Points|XPHB} at the start of each of its turns if it is {@status Bloodied|XPHB} and has at least 1 {@variantrule Hit Points|XPHB|Hit Point}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The cultist makes three attacks, using Gauntlet or Oppressive Burst in any combination. It can replace one attack with a use of Spellcasting to cast {@spell Dominate Person|XPHB}, if available."
+					]
+				},
+				{
+					"name": "Gauntlet",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}17 ({@damage 3d8 + 4}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Oppressive Burst",
+					"entries": [
+						"{@atkr r} {@hit 8}, range 120 ft. {@h}16 ({@damage 2d10 + 5}) Psychic damage, and the target can't take Reactions until the start of the cultist's next turn."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Counterattack",
+					"entries": [
+						"{@actTrigger} The cultist is hit by an attack roll. {@actResponse} The cultist makes one Gauntlet or Oppressive Burst attack against the triggering creature."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"treasure": [
+				"individual",
+				"relics"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"B",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflictSpell": [
+				"charmed"
+			],
+			"savingThrowForcedSpell": [
+				"charisma",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Cultist of Bhaal",
+			"source": "FRAiF",
+			"page": 255,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 144,
+				"formula": "17d8 + 68"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 13,
+			"dex": 19,
+			"con": 18,
+			"int": 15,
+			"wis": 17,
+			"cha": 14,
+			"save": {
+				"dex": "+7",
+				"int": "+5"
+			},
+			"skill": {
+				"perception": "+6",
+				"stealth": "+7"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 16,
+			"languages": [
+				"Common"
+			],
+			"cr": "7",
+			"gear": [
+				"holy symbol|xphb",
+				"studded leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The cultist casts one of the following spells, using Wisdom as the spellcasting ability (spell save {@dc 14}):"
+					],
+					"daily": {
+						"2": [
+							"{@spell Mind Spike|XPHB}"
+						],
+						"1e": [
+							"{@spell Dimension Door|XPHB}",
+							"{@spell Mislead|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Blood-Soaked Resolve",
+					"entries": [
+						"While {@status Bloodied|XPHB}, the cultist has {@variantrule Advantage|XPHB} on saving throws."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The cultist makes three Cursed Blade attacks. It can replace one of these attacks with a use of Spellcasting."
+					]
+				},
+				{
+					"name": "Cursed Blade",
+					"entries": [
+						"{@atkr m,r} {@hit 7} (with {@variantrule Advantage|XPHB} if the target doesn't have all its {@variantrule Hit Points|XPHB}), reach 5 ft. or range 20/80 ft. {@h}14 ({@damage 3d6 + 4}) Slashing damage. {@hom}The blade magically returns to the cultist's hand immediately after a ranged attack."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"treasure": [
+				"individual",
+				"relics"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"S"
+			],
+			"damageTagsSpell": [
+				"O",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflictSpell": [
+				"invisible"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Cultist of Myrkul",
+			"source": "FRAiF",
+			"page": 255,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 204,
+				"formula": "24d8 + 96"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 13,
+			"dex": 14,
+			"con": 18,
+			"int": 20,
+			"wis": 18,
+			"cha": 15,
+			"save": {
+				"con": "+8",
+				"int": "+9",
+				"wis": "+8",
+				"cha": "+6"
+			},
+			"skill": {
+				"arcana": "+9",
+				"insight": "+8",
+				"religion": "+9"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 14,
+			"resist": [
+				"necrotic"
+			],
+			"languages": [
+				"Common"
+			],
+			"cr": "11",
+			"gear": [
+				"breastplate|xphb",
+				"holy symbol|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The cultist casts one of the following spells, using Intelligence as the spellcasting ability (spell save {@dc 17}):"
+					],
+					"will": [
+						"{@spell Speak with Dead|XPHB}",
+						"{@spell Thaumaturgy|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Animate Dead|XPHB}",
+							"{@spell Circle of Death|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Nearer to the Dead",
+					"entries": [
+						"While {@status Bloodied|XPHB}, the cultist has {@variantrule Immunity|XPHB} to the {@condition Frightened|XPHB} and {@condition Poisoned|XPHB} conditions."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The cultist makes three Necrotic Burst attacks."
+					]
+				},
+				{
+					"name": "Necrotic Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 9}, reach 5 ft. or range 120 ft. {@h}27 ({@damage 5d10}) Necrotic damage and the target can't regain {@variantrule Hit Points|XPHB} until the end of the cultist's next turn."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"treasure": [
+				"individual",
+				"relics"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"N"
+			],
+			"damageTagsSpell": [
+				"N"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"savingThrowForcedSpell": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Dead Three Scion",
+			"source": "FRAiF",
+			"page": 256,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 221,
+				"formula": "26d8 + 104"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 20,
+			"dex": 14,
+			"con": 19,
+			"int": 18,
+			"wis": 21,
+			"cha": 24,
+			"save": {
+				"con": "+9",
+				"wis": "+10"
+			},
+			"skill": {
+				"arcana": "+9",
+				"intimidation": "+12",
+				"stealth": "+7"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 15,
+			"immune": [
+				"necrotic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Common"
+			],
+			"cr": "16",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The scion casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 20}):"
+					],
+					"will": [
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Dispel Magic|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Dimension Door|XPHB}",
+							"{@spell Invisibility|XPHB}",
+							"{@spell Scrying|XPHB}"
+						],
+						"1e": [
+							"{@spell Circle of Death|XPHB}",
+							"{@spell Create Undead|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				},
+				{
+					"name": "Command",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The scion casts {@spell Command|XPHB} (level 2 version), using the same spellcasting ability as Spellcasting. The scion can't take this action again until the start of its next turn."
+					],
+					"legendary": {
+						"1": [
+							"{@spell Command|XPHB} (level 2 version)"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "legendary",
+					"hidden": [
+						"legendary"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Culling Aura",
+					"entries": [
+						"{@actSave con} {@dc 20}, each {@status Bloodied|XPHB} creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the scion at the end of the scion's turn. {@actSaveFail} The target can't regain {@variantrule Hit Points|XPHB} until the start of the scion's next turn."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the scion fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The scion has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The scion makes two attacks, using Death Touch or Mindwrack Bolt in any combination."
+					]
+				},
+				{
+					"name": "Death Touch",
+					"entries": [
+						"{@atkr m} {@hit 12}, reach 5 ft. {@h}25 ({@damage 4d8 + 7}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Mindwrack Bolt",
+					"entries": [
+						"{@atkr r} {@hit 12}, range 120 ft. {@h}21 ({@damage 6d6}) Psychic damage and the target has the {@condition Poisoned|XPHB} condition until the start of the scion's next turn."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The scion makes a Death Touch or Mindwrack Bolt attack."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"relics"
+			],
+			"traitTags": [
+				"Legendary Resistances",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"N",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"N",
+				"O"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"conditionInflictSpell": [
+				"invisible",
+				"prone"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Deep Dragon Wyrmling",
+			"source": "FRAiF",
+			"page": 257,
+			"size": [
+				"M"
+			],
+			"type": "dragon",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 27,
+				"formula": "5d8 + 5"
+			},
+			"speed": {
+				"walk": 30,
+				"burrow": 15,
+				"fly": 60,
+				"swim": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 14,
+			"dex": 11,
+			"con": 12,
+			"int": 11,
+			"wis": 12,
+			"cha": 13,
+			"save": {
+				"dex": "+2",
+				"wis": "+3"
+			},
+			"skill": {
+				"perception": "+5",
+				"stealth": "+4"
+			},
+			"senses": [
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
+			],
+			"passive": 15,
+			"resist": [
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"Draconic"
+			],
+			"cr": "1",
+			"action": [
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}6 ({@damage 1d8 + 2}) Slashing damage."
+					]
+				},
+				{
+					"name": "Nightmare Breath {@recharge 5}",
+					"entries": [
+						"{@actSave wis} {@dc 11}, each creature in a 15-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 7 ({@damage 2d6}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the end of the dragon's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"environment": [
+				"underdark"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"dragonCastingColor": "deep",
+			"dragonAge": "wyrmling",
+			"senseTags": [
+				"B",
+				"D"
+			],
+			"actionTags": [
+				"Breath Weapon"
+			],
+			"languageTags": [
+				"DR"
+			],
+			"damageTags": [
+				"S",
+				"Y"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Domestic Wonder",
+			"source": "FRAiF",
+			"page": 245,
+			"otherSources": [
+				{
+					"source": "FRHoF",
+					"page": 132
+				}
+			],
+			"size": [
+				"M"
+			],
+			"type": "construct",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				9
+			],
+			"hp": {
+				"average": 5,
+				"formula": "1d8 + 1"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 13,
+			"dex": 8,
+			"con": 13,
+			"int": 3,
+			"wis": 8,
+			"cha": 1,
+			"passive": 9,
+			"cr": "0",
+			"trait": [
+				{
+					"name": "Mechanical Determination",
+					"entries": [
+						"If damage reduces the wonder to 0 {@variantrule Hit Points|XPHB}, it makes a Constitution saving throw with a DC of 5 plus the damage taken unless the damage is Lightning or from a {@variantrule Critical Hit|XPHB}. On a successful save, the wonder drops to 1 {@variantrule Hit Points|XPHB|Hit Point} instead."
+					]
+				},
+				{
+					"name": "Wind-Up Operation",
+					"entries": [
+						"The wonder has the {@condition Unconscious|XPHB} condition until another creature winds it with the wonder's unique key for 1 minute. Once wound, the wonder operates for 10 days or until a creature touches the wonder with its key as a {@action Utilize|XPHB} action to deactivate it, after which the wonder has the {@condition Unconscious|XPHB} condition until it is wound again."
+					]
+				}
+			],
+			"conditionInflict": [
+				"unconscious"
+			],
+			"hasToken": true
+		},
+		{
+			"name": "Drow Elite Warrior of Lolth",
+			"source": "FRAiF",
+			"page": 260,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 71,
+				"formula": "11d8 + 22"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 13,
+			"dex": 18,
+			"con": 14,
+			"int": 11,
+			"wis": 13,
+			"cha": 12,
+			"save": {
+				"dex": "+7",
+				"con": "+5",
+				"wis": "+4"
+			},
+			"skill": {
+				"perception": "+4",
+				"stealth": "+10"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 14,
+			"languages": [
+				"Common",
+				"Elvish",
+				"Undercommon"
+			],
+			"cr": "5",
+			"gear": [
+				"shield|xphb",
+				"shortsword|xphb",
+				"studded leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Underdark Magic (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The drow casts {@spell Darkness|XPHB}, {@spell Faerie Fire|XPHB}, or {@spell Levitate|XPHB} (self only), requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 12})."
+					],
+					"daily": {
+						"3": [
+							"{@spell Darkness|XPHB}",
+							"{@spell Faerie Fire|XPHB}",
+							"{@spell Levitate|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Fey Ancestry",
+					"entries": [
+						"The drow has {@variantrule Advantage|XPHB} on saving throws it makes to avoid or end the {@condition Charmed|XPHB} condition, and magic can't put the drow to sleep."
+					]
+				},
+				{
+					"name": "Sunlight Sensitivity",
+					"entries": [
+						"While in sunlight, the drow has {@variantrule Disadvantage|XPHB} on attack rolls."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The drow makes two attacks using Shortsword or Drow Hand Crossbow in any combination"
+					]
+				},
+				{
+					"name": "Shortsword",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}11 ({@damage 2d6 + 4}) Piercing damage plus 10 ({@damage 3d6}) Poison damage."
+					]
+				},
+				{
+					"name": "Drow Hand Crossbow",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 30/120 ft. {@h}7 ({@damage 1d6 + 4}) Piercing damage, and the target makes a saving throw. {@actSave con} {@dc 15}. {@actSaveFail} The target has the {@condition Poisoned|XPHB} condition for 1 hour. While {@condition Poisoned|XPHB} in this way, the target also has the {@condition Unconscious|XPHB} condition. The target wakes up if it takes damage or if a creature within 5 feet of it takes an action to wake it."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"any"
+			],
+			"traitTags": [
+				"Fey Ancestry",
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"E",
+				"U"
+			],
+			"damageTags": [
+				"I",
+				"P"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"RNG"
+			],
+			"conditionInflict": [
+				"poisoned",
+				"unconscious"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Drow Mage of Lolth",
+			"source": "FRAiF",
+			"page": 261,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 81,
+				"formula": "18d8"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": {
+					"number": 15,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 9,
+			"dex": 14,
+			"con": 10,
+			"int": 17,
+			"wis": 13,
+			"cha": 12,
+			"save": {
+				"dex": "+5",
+				"wis": "+4"
+			},
+			"skill": {
+				"arcana": "+6",
+				"perception": "+4",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 14,
+			"languages": [
+				"Abyssal",
+				"Common",
+				"Elvish",
+				"Undercommon"
+			],
+			"cr": "7",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The drow casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save {@dc 14}, {@hit 6} to hit with spell attacks):"
+					],
+					"will": [
+						"{@spell Dancing Lights|XPHB}",
+						"{@spell Mage Armor|XPHB} (included in AC)",
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Minor Illusion|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Summon Fiend|XPHB} (demon only)"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				},
+				{
+					"name": "Underdark Magic (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The drow casts {@spell Faerie Fire|XPHB} or {@spell Misty Step|XPHB}, requiring no Material components and using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"3": [
+							"{@spell Faerie Fire|XPHB}",
+							"{@spell Misty Step|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Fey Ancestry",
+					"entries": [
+						"The drow has {@variantrule Advantage|XPHB} on saving throws it makes to avoid or end the {@condition Charmed|XPHB} condition, and magic can't put the drow to sleep."
+					]
+				},
+				{
+					"name": "Sunlight Sensitivity",
+					"entries": [
+						"While in sunlight, the drow has {@variantrule Disadvantage|XPHB} on attack rolls."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The drow makes three Abyssal Burst attacks."
+					]
+				},
+				{
+					"name": "Abyssal Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 120 ft. {@h}21 ({@damage 4d8 + 3}) Poison damage."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"any"
+			],
+			"traitTags": [
+				"Fey Ancestry",
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AB",
+				"C",
+				"E",
+				"U"
+			],
+			"damageTags": [
+				"I"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"savingThrowForcedSpell": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Drow of Lolth",
+			"source": "FRAiF",
+			"page": 260,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 13,
+				"formula": "3d8"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 10,
+			"dex": 14,
+			"con": 10,
+			"int": 11,
+			"wis": 11,
+			"cha": 12,
+			"skill": {
+				"perception": "+2",
+				"stealth": "+4"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 12,
+			"languages": [
+				"Common",
+				"Elvish",
+				"Undercommon"
+			],
+			"cr": "1/4",
+			"gear": [
+				"chain shirt|xphb",
+				"rapier|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The drow casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 11}):"
+					],
+					"will": [
+						"{@spell Dancing Lights|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Faerie Fire|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Fey Ancestry",
+					"entries": [
+						"The drow has {@variantrule Advantage|XPHB} on saving throws it makes to avoid or end the {@condition Charmed|XPHB} condition, and magic can't put the drow to sleep."
+					]
+				},
+				{
+					"name": "Sunlight Sensitivity",
+					"entries": [
+						"While in sunlight, the drow has {@variantrule Disadvantage|XPHB} on attack rolls."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Rapier",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}6 ({@damage 1d8 + 2}) Piercing damage."
+					]
+				},
+				{
+					"name": "Drow Hand Crossbow",
+					"entries": [
+						"{@atkr r} {@hit 4}, range 30/120 ft. {@h}4 ({@damage 1d4 + 2}) Piercing damage, and the target makes a saving throw. {@actSave con} {@dc 12}. {@actSaveFail} The target has the {@condition Poisoned|XPHB} condition for 1 hour. If the target fails the save by 5 or more, it also has the {@condition Unconscious|XPHB} condition while {@condition Poisoned|XPHB} in this way. The target wakes up if it takes damage or if a creature within 5 feet of it takes an action to wake it."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"any"
+			],
+			"traitTags": [
+				"Fey Ancestry",
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"languageTags": [
+				"C",
+				"E",
+				"U"
+			],
+			"damageTags": [
+				"P"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"RNG"
+			],
+			"conditionInflict": [
+				"poisoned",
+				"unconscious"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"savingThrowForcedSpell": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Drow Priestess of Lolth",
+			"source": "FRAiF",
+			"page": 261,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 99,
+				"formula": "18d8 + 18"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": {
+					"number": 15,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 10,
+			"dex": 14,
+			"con": 12,
+			"int": 13,
+			"wis": 18,
+			"cha": 17,
+			"save": {
+				"con": "+4",
+				"wis": "+7",
+				"cha": "+6"
+			},
+			"skill": {
+				"insight": "+7",
+				"perception": "+7",
+				"religion": "+4",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 17,
+			"languages": [
+				"Abyssal",
+				"Common",
+				"Elvish",
+				"Undercommon"
+			],
+			"cr": "8",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The drow casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability:"
+					],
+					"will": [
+						"{@spell Dancing Lights|XPHB}",
+						"{@spell Guidance|XPHB}",
+						"{@spell Thaumaturgy|XPHB}"
+					],
+					"ability": "wis",
+					"displayAs": "action"
+				},
+				{
+					"name": "Lolth's Blessing (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The drow casts {@spell Cure Wounds|XPHB}, {@spell Darkness|XPHB}, {@spell Dispel Magic|XPHB}, or {@spell Lesser Restoration|XPHB}, using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"3": [
+							"{@spell Cure Wounds|XPHB}",
+							"{@spell Darkness|XPHB}",
+							"{@spell Dispel Magic|XPHB}",
+							"{@spell Lesser Restoration|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Fey Ancestry",
+					"entries": [
+						"The drow has {@variantrule Advantage|XPHB} on saving throws it makes to avoid or end the {@condition Charmed|XPHB} condition, and magic can't put the drow to sleep."
+					]
+				},
+				{
+					"name": "Sunlight Sensitivity",
+					"entries": [
+						"While in sunlight, the drow has {@variantrule Disadvantage|XPHB} on attack rolls."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The drow makes three Scourge attacks."
+					]
+				},
+				{
+					"name": "Scourge",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 10 ft. {@h}6 ({@damage 1d6 + 3}) Piercing damage plus 17 ({@damage 5d6}) Poison damage."
+					]
+				},
+				{
+					"name": "Spider Vortex {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 15}, each enemy in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the drow. {@actSaveFail} 33 ({@damage 6d10}) Piercing damage, and the target has the {@condition Restrained|XPHB} condition until the start of the drow's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"any"
+			],
+			"traitTags": [
+				"Fey Ancestry",
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AB",
+				"C",
+				"E",
+				"U"
+			],
+			"damageTags": [
+				"I",
+				"P"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"restrained"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Flying Wonder",
+			"source": "FRAiF",
+			"page": 246,
+			"size": [
+				"T"
+			],
+			"type": "construct",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 2,
+				"formula": "1d4"
+			},
+			"speed": {
+				"walk": 5,
+				"fly": 30
+			},
+			"str": 2,
+			"dex": 15,
+			"con": 10,
+			"int": 3,
+			"wis": 10,
+			"cha": 1,
+			"senses": [
+				"Blindsight 60 ft."
+			],
+			"passive": 10,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common but can't speak"
+			],
+			"cr": "0",
+			"trait": [
+				{
+					"name": "Increased Carrying Capacity",
+					"entries": [
+						"The wonder can carry up to 100 pounds."
+					]
+				},
+				{
+					"name": "Wind-Up Operation",
+					"entries": [
+						"The wonder has the {@condition Unconscious|XPHB} condition until another creature winds it with the wonder's unique key for 1 minute. Once wound, the wonder operates for 24 hours or until a creature touches the wonder with its key as a {@action Utilize|XPHB} action to deactivate it, after which the wonder has the {@condition Unconscious|XPHB} condition until it is wound again."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Chime",
+					"entries": [
+						"The wonder chirps a merry, metronomic tune. The wonder chooses one ally that it can see within 60 feet. Until the start of the wonder's next turn, the target has {@variantrule Advantage|XPHB} on the next ability check it makes with a Musical Instrument or Tinker's Tools."
+					]
+				},
+				{
+					"name": "Sprint",
+					"entries": [
+						"The wonder takes the {@action Dash|XPHB} action."
+					]
+				}
+			],
+			"senseTags": [
+				"B"
+			],
+			"languageTags": [
+				"C",
+				"CS"
+			],
+			"conditionInflict": [
+				"unconscious"
+			],
+			"hasToken": true
+		},
+		{
+			"name": "Karas Chembryl",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "FRAiF",
+			"page": 263,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 104,
+				"formula": "19d8 + 19"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": 30
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 11,
+			"dex": 20,
+			"con": 12,
+			"int": 18,
+			"wis": 15,
+			"cha": 17,
+			"save": {
+				"dex": "+8",
+				"con": "+4",
+				"int": "+7",
+				"wis": "+5"
+			},
+			"skill": {
+				"acrobatics": "+8",
+				"perception": "+8",
+				"stealth": "+11"
+			},
+			"senses": [
+				"Blindsight 10 ft."
+			],
+			"passive": 18,
+			"resist": [
+				"poison",
+				"psychic"
+			],
+			"languages": [
+				"Common",
+				"Elvish",
+				"Infernal",
+				"Thieves' cant"
+			],
+			"cr": {
+				"cr": "8",
+				"xpLair": 5000
+			},
+			"gear": [
+				"studded leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Karas casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save {@dc 15}, {@hit 7} to hit with spell attacks):"
+					],
+					"will": [
+						"{@spell Friends|XPHB}",
+						"{@spell Silence|XPHB}",
+						"{@spell Thaumaturgy|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Blight|XPHB}",
+							"{@spell Mislead|XPHB}"
+						],
+						"2": [
+							"{@spell Ray of Sickness|XPHB} (level 5 version)"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Evasion",
+					"entries": [
+						"If Karas is subjected to an effect that allows her to make a Dexterity saving throw to take only half damage, Karas instead takes no damage if she succeeds on the save and only half damage if she fails. She can't use this trait if she has the {@condition Incapacitated|XPHB} condition."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day or 4/Day in Lair)",
+					"entries": [
+						"If Karas fails a saving throw, she can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Karas makes two attacks using Dread Dagger or Tyrant's Blade in any combination."
+					]
+				},
+				{
+					"name": "Dread Dagger",
+					"entries": [
+						"{@atkr m,r} {@hit 8}, reach 5 ft. or range 20/60 ft. {@h}10 ({@damage 2d4 + 5}) Piercing damage plus 4 ({@damage 1d8}) Necrotic damage. {@hom}The dagger magically returns to Karas's hand immediately after a ranged attack."
+					]
+				},
+				{
+					"name": "Tyrant's Blade",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}8 ({@damage 1d6 + 5}) Slashing damage, and the target has the {@condition Frightened|XPHB} condition until the start of Karas's next turn. If the target is already {@condition Frightened|XPHB}, it instead takes 10 ({@damage 3d6}) Psychic damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Withdraw",
+					"entries": [
+						"Karas moves up to half her {@variantrule Speed|XPHB} without provoking {@action Opportunity Attack|XPHB} action and takes the {@action Hide|XPHB} action."
+					]
+				}
+			],
+			"legendaryActionsLair": 4,
+			"legendary": [
+				{
+					"name": "Harrow",
+					"entries": [
+						"{@actSave wis} {@dc 15}, one creature Karas can see within 90 feet of herself. {@actSaveFail} 10 ({@damage 3d6}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition for 1 minute. While {@condition Frightened|XPHB}, the target's {@variantrule Speed|XPHB} is 0 feet, and it repeats the save at the end of each of its turns, ending the effect on a success. {@actSaveSuccessOrFail} Karas can't take this action again until the start of her next turn."
+					]
+				},
+				{
+					"name": "Stealth Attack",
+					"entries": [
+						"Karas makes one Dread Dagger attack and uses Withdraw."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Karas Chembryl",
+				"source": "FRAiF"
+			},
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"E",
+				"I",
+				"TC"
+			],
+			"damageTags": [
+				"N",
+				"P",
+				"S",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"I",
+				"N"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"deafened",
+				"invisible",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Manshoon",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "FRAiF",
+			"page": 265,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human",
+					"wizard"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 214,
+				"formula": "33d8 + 66"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 10,
+			"dex": 14,
+			"con": 14,
+			"int": 23,
+			"wis": 15,
+			"cha": 16,
+			"save": {
+				"int": "+11",
+				"wis": "+7"
+			},
+			"skill": {
+				"arcana": "+11",
+				"history": "+11",
+				"insight": "+7"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 12,
+			"immune": [
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed"
+			],
+			"languages": [
+				"Common",
+				"Draconic",
+				"Infernal",
+				"Undercommon"
+			],
+			"cr": "13",
+			"gear": [
+				"component pouch|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Manshoon casts one of the following spells, using Intelligence as the spellcasting ability (spell save {@dc 19}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Light|XPHB}",
+						"{@spell Lightning Bolt|XPHB} (level 4 version)",
+						"{@spell Mage Armor|XPHB} (included in AC)",
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Prestidigitation|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Scrying|XPHB}",
+							"{@spell Sending|XPHB}",
+							"{@spell Wall of Force|XPHB}"
+						],
+						"1e": [
+							"{@spell Befuddlement|XPHB}",
+							"{@spell Clone|XPHB}",
+							"{@spell Finger of Death|XPHB}",
+							"{@spell Mind Blank|XPHB} (cast before combat)",
+							"{@spell Simulacrum|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				},
+				{
+					"name": "Misty Step",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Manshoon casts {@spell Misty Step|XPHB}, using the same spellcasting ability as Spellcasting."
+					],
+					"will": [
+						"{@spell Misty Step|XPHB}"
+					],
+					"ability": "int",
+					"displayAs": "bonus",
+					"hidden": [
+						"will"
+					]
+				},
+				{
+					"name": "Protective Magic",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Manshoon casts {@spell Counterspell|XPHB} or {@spell Shield|XPHB} in response to the spell's trigger, using the same spellcasting ability as Spellcasting."
+					],
+					"will": [
+						"{@spell Counterspell|XPHB}",
+						"{@spell Shield|XPHB}"
+					],
+					"ability": "int",
+					"displayAs": "reaction",
+					"hidden": [
+						"will"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Manshoon has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Manshoon makes three Arcane Burst attacks. He can replace two attacks with a use of Spellcasting."
+					]
+				},
+				{
+					"name": "Arcane Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 11}, reach 5 ft., or range 120 ft. {@h}32 ({@damage 4d12 + 6}) Force damage."
+					]
+				}
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"I",
+				"U"
+			],
+			"damageTags": [
+				"O"
+			],
+			"damageTagsSpell": [
+				"L",
+				"N",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"dexterity",
+				"intelligence",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Nimblewright Guard",
+			"source": "FRAiF",
+			"page": 266,
+			"size": [
+				"M"
+			],
+			"type": "construct",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 67,
+				"formula": "9d8 + 27"
+			},
+			"speed": {
+				"walk": 60
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 12,
+			"dex": 18,
+			"con": 16,
+			"int": 8,
+			"wis": 12,
+			"cha": 6,
+			"save": {
+				"dex": "+6"
+			},
+			"skill": {
+				"acrobatics": "+6",
+				"perception": "+3"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 13,
+			"immune": [
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"paralyzed",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common plus one other language but can't speak"
+			],
+			"cr": "3",
+			"trait": [
+				{
+					"name": "Evasion",
+					"entries": [
+						"If the nimblewright is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the save and only half damage if it fails, provided it doesn't have the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The nimblewright makes three attacks, using Scimitar or Clockwork Crossbow in any combination."
+					]
+				},
+				{
+					"name": "Scimitar",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}7 ({@damage 1d6 + 4}) Slashing damage."
+					]
+				},
+				{
+					"name": "Clockwork Crossbow",
+					"entries": [
+						"{@atkr r} {@hit 6}, range 80/320 ft. {@h}8 ({@damage 1d8 + 4}) Piercing damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Parry",
+					"entries": [
+						"{@actTrigger} The nimblewright is hit by a melee attack roll while holding a weapon. {@actResponse} The nimblewright adds 2 to its AC against that attack, potentially causing it to miss."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"attachedItems": [
+				"scimitar|phb"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack",
+				"Parry"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"X"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Nimblewright Hulk",
+			"source": "FRAiF",
+			"page": 267,
+			"size": [
+				"L"
+			],
+			"type": "construct",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 104,
+				"formula": "11d10 + 44"
+			},
+			"speed": {
+				"walk": 50
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 19,
+			"dex": 18,
+			"con": 19,
+			"int": 10,
+			"wis": 12,
+			"cha": 6,
+			"save": {
+				"str": "+7",
+				"dex": "+7"
+			},
+			"skill": {
+				"acrobatics": "+7",
+				"perception": "+7"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 17,
+			"immune": [
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"paralyzed",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common plus one other language but can't speak"
+			],
+			"cr": "7",
+			"trait": [
+				{
+					"name": "Evasion",
+					"entries": [
+						"If the nimblewright is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the save and only half damage if it fails, provided it doesn't have the {@condition Incapacitated|XPHB} condition."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The nimblewright has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The nimblewright makes four attacks, using Halting Slam or Radiant Ray in any combination."
+					]
+				},
+				{
+					"name": "Halting Slam",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 10 ft. {@h}15 ({@damage 2d10 + 4}) Bludgeoning damage, and the target's {@variantrule Speed|XPHB} is reduced to 0 until the end of its next turn."
+					]
+				},
+				{
+					"name": "Radiant Ray",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 60 ft. {@h}14 ({@damage 4d6}) Radiant damage."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"X"
+			],
+			"damageTags": [
+				"B",
+				"R"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RCH"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Nimblewright Steed",
+			"source": "FRAiF",
+			"page": 267,
+			"size": [
+				"L"
+			],
+			"type": "construct",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 47,
+				"formula": "5d10 + 20"
+			},
+			"speed": {
+				"walk": 60
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 17,
+			"dex": 18,
+			"con": 18,
+			"int": 6,
+			"wis": 10,
+			"cha": 6,
+			"save": {
+				"dex": "+6"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 10,
+			"immune": [
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"paralyzed",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common plus one other language but can't speak"
+			],
+			"cr": "2",
+			"trait": [
+				{
+					"name": "Evasion",
+					"entries": [
+						"If the nimblewright is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the save and only half damage if it fails, provided it doesn't have the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Hooves",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}7 ({@damage 1d8 + 3}) Bludgeoning damage. If the nimblewright moved at least 20 feet straight toward the target immediately before the hit, the target takes an extra 4 ({@damage 1d8}) Bludgeoning damage and, if it is Huge or smaller, has the {@condition Prone|XPHB} condition."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Nimble Movement",
+					"entries": [
+						"The nimblewright takes the {@action Disengage|XPHB} action."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"senseTags": [
+				"D"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"X"
+			],
+			"damageTags": [
+				"B"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Phaerimm Agent",
+			"source": "FRAiF",
+			"page": 269,
+			"referenceSources": [
+				"NF"
+			],
+			"size": [
+				"L"
+			],
+			"type": "aberration",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 123,
+				"formula": "19d10 + 19"
+			},
+			"speed": {
+				"walk": 10,
+				"fly": {
+					"number": 40,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 12,
+			"dex": 18,
+			"con": 12,
+			"int": 17,
+			"wis": 16,
+			"cha": 18,
+			"save": {
+				"con": "+4",
+				"int": "+6",
+				"wis": "+6",
+				"cha": "+7"
+			},
+			"skill": {
+				"arcana": "+9",
+				"insight": "+6",
+				"perception": "+6"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 16,
+			"conditionImmune": [
+				"charmed"
+			],
+			"languages": [
+				"telepathy 120 ft. understands Common and Deep Speech but can't speak"
+			],
+			"cr": "8",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The phaerimm casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save {@dc 15}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Mage Hand|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Clairvoyance|XPHB}",
+							"{@spell Major Image|XPHB}",
+							"{@spell Synaptic Static|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				},
+				{
+					"name": "Protective Magic (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The phaerimm casts {@spell Counterspell|XPHB} or {@spell Shield|XPHB} in response to the spell's trigger, using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"3": [
+							"{@spell Counterspell|XPHB}",
+							"{@spell Shield|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "reaction",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The phaerimm has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The phaerimm makes three attacks, using Dread Stinger or Mindwarp Ray in any combination."
+					]
+				},
+				{
+					"name": "Dread Stinger",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}7 ({@damage 1d6 + 4}) Piercing damage plus 13 ({@damage 2d12}) Poison damage."
+					]
+				},
+				{
+					"name": "Mindwarp Ray",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 120 ft. {@h}13 ({@damage 2d8 + 4}) Psychic damage, and the target has the {@condition Charmed|XPHB} condition until the start of the phaerimm's next turn."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Teleport",
+					"entries": [
+						"The phaerimm teleports up to 30 feet to an unoccupied space it can see."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"arcana",
+				"implements"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack",
+				"Teleport"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"DS",
+				"TP"
+			],
+			"damageTags": [
+				"I",
+				"P",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"charmed"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"intelligence",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Phaerimm Hatchling",
+			"source": "FRAiF",
+			"page": 268,
+			"referenceSources": [
+				"NF"
+			],
+			"size": [
+				"S"
+			],
+			"type": "aberration",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 13,
+				"formula": "3d6 + 3"
+			},
+			"speed": {
+				"walk": 10,
+				"fly": {
+					"number": 30,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 11,
+			"dex": 12,
+			"con": 12,
+			"int": 14,
+			"wis": 16,
+			"cha": 14,
+			"skill": {
+				"perception": "+5"
+			},
+			"senses": [
+				"Truesight 60 ft."
+			],
+			"passive": 15,
+			"conditionImmune": [
+				"charmed"
+			],
+			"languages": [
+				"telepathy 30 ft. understands Common and Deep Speech but can't speak"
+			],
+			"cr": "1/4",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The phaerimm casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save {@dc 12}):"
+					],
+					"will": [
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Mage Hand|XPHB}"
+					],
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The phaerimm has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The phaerimm makes two Stinger attacks."
+					]
+				},
+				{
+					"name": "Stinger",
+					"entries": [
+						"{@atkr m} {@hit 3}, reach 5 ft. {@h}3 ({@damage 1d4 + 1}) Piercing damage."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"arcana",
+				"implements"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"DS",
+				"TP"
+			],
+			"damageTags": [
+				"P"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Polar Serpent",
+			"source": "FRAiF",
+			"page": 269,
+			"size": [
+				"L"
+			],
+			"type": "elemental",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 58,
+				"formula": "9d10 + 9"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 40
+			},
+			"str": 18,
+			"dex": 19,
+			"con": 12,
+			"int": 4,
+			"wis": 12,
+			"cha": 6,
+			"skill": {
+				"perception": "+3",
+				"stealth": "+6"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 13,
+			"immune": [
+				"cold"
+			],
+			"vulnerable": [
+				"fire"
+			],
+			"languages": [
+				"understands Primordial but can't speak"
+			],
+			"cr": "3",
+			"trait": [
+				{
+					"name": "Misty Slithering",
+					"entries": [
+						"The serpent can move through a space as narrow as 1 inch without expending extra movement to do so."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The serpent makes one Bite attack and uses Constrict."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Piercing damage plus 3 ({@damage 1d6}) Cold damage."
+					]
+				},
+				{
+					"name": "Constrict",
+					"entries": [
+						"{@actSave str} {@dc 14}, one Medium or smaller creature the snake can see within 10 feet. {@actSaveFail} 3 ({@damage 1d6}) Bludgeoning damage plus 7 ({@damage 2d6}) Cold damage. The target has the {@condition Grappled|XPHB} condition (escape {@dc 14}), and it has the {@condition Restrained|XPHB} condition until the grapple ends."
+					]
+				}
+			],
+			"environment": [
+				"arctic",
+				"underdark"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"CS",
+				"P"
+			],
+			"damageTags": [
+				"B",
+				"C",
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"grappled",
+				"restrained"
+			],
+			"savingThrowForced": [
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Queen Forfallen",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "FRAiF",
+			"page": 271,
+			"size": [
+				"M"
+			],
+			"type": "construct",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 153,
+				"formula": "18d8 + 72"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 20,
+			"dex": 14,
+			"con": 19,
+			"int": 15,
+			"wis": 17,
+			"cha": 18,
+			"save": {
+				"wis": "+7"
+			},
+			"skill": {
+				"athletics": "+9",
+				"insight": "+7",
+				"perception": "+7"
+			},
+			"passive": 17,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"Common"
+			],
+			"cr": "10",
+			"gear": [
+				"breastplate|xphb",
+				"greataxe|xphb",
+				{
+					"item": "handaxe|xphb",
+					"quantity": 6
+				}
+			],
+			"trait": [
+				{
+					"name": "Inspiring Presence",
+					"entries": [
+						"Creatures of Forfallen's choice (excluding herself) in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from her have {@variantrule Advantage|XPHB} on attack rolls. She can't use this trait if she has the {@condition Incapacitated|XPHB} condition."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Forfallen has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Forfallen makes three attacks, using Greataxe or Handaxe in any combination."
+					]
+				},
+				{
+					"name": "Greataxe",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 5 ft. {@h}18 ({@damage 2d12 + 5}) Slashing damage, and the target has the {@condition Poisoned|XPHB} condition until the end of its next turn."
+					]
+				},
+				{
+					"name": "Handaxe",
+					"entries": [
+						"{@atkr m,r} {@hit 9}, reach 5 ft. or range 20/60 ft. {@h}22 ({@damage 5d6 + 5}) Slashing damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Rust's Grip",
+					"entries": [
+						"{@actSave con} {@dc 16}, one creature Forfallen can see within 20 feet. The target has {@variantrule Disadvantage|XPHB} on this save if it has the {@condition Poisoned|XPHB} condition. {@actSaveFail 1} The target has the {@condition Restrained|XPHB} condition and repeats the save at the end of its next turn if it's still {@condition Restrained|XPHB}, ending the effect on itself on a success. {@actSaveFail 2} The target has the {@condition Petrified|XPHB} condition instead of the {@condition Restrained|XPHB} condition, becoming a statue of rusted iron."
+					]
+				}
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"conditionInflict": [
+				"petrified",
+				"poisoned",
+				"restrained"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Rusted Behemoth",
+			"source": "FRAiF",
+			"page": 272,
+			"size": [
+				"H"
+			],
+			"type": "construct",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 157,
+				"formula": "15d12 + 60"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 22,
+			"dex": 10,
+			"con": 19,
+			"int": 6,
+			"wis": 12,
+			"cha": 6,
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 11,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Giant"
+			],
+			"cr": "9",
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The Rusted makes three attacks, using Slam or Rusted Shot Put in any combination."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 10 ft. {@h}20 ({@damage 4d6 + 6}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Rusted Shot Put",
+					"entries": [
+						"{@atkr r} {@hit 10}, range 60/240 ft. {@h}15 ({@damage 2d8 + 6}) Bludgeoning damage, and the target has the {@condition Poisoned|XPHB} condition until the end of its next turn."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Rust-Riddled Hide",
+					"entries": [
+						"{@actTrigger} The Rusted is hit by an attack roll that deals Bludgeoning, Piercing, or Slashing damage. {@actResponse d}{@actSave con} {@dc 16}, each creature of the Rusted's choice in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the Rusted. {@actSaveFail} the target has the {@condition Poisoned|XPHB} condition until the end of the target's next turn."
+					]
+				}
+			],
+			"environment": [
+				"coastal",
+				"forest"
+			],
+			"treasure": [
+				"individual"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"GI"
+			],
+			"damageTags": [
+				"B"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Rusted Berserker",
+			"source": "FRAiF",
+			"page": 273,
+			"size": [
+				"M"
+			],
+			"type": "construct",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 82,
+				"formula": "11d8 + 33"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 18,
+			"dex": 14,
+			"con": 17,
+			"int": 6,
+			"wis": 10,
+			"cha": 6,
+			"passive": 10,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"Common"
+			],
+			"cr": "4",
+			"gear": [
+				"greatsword|xphb",
+				{
+					"item": "javelin|xphb",
+					"quantity": 6
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The Rusted makes two attacks, using Greatsword or Javelin in any combination."
+					]
+				},
+				{
+					"name": "Greatsword",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}11 ({@damage 2d6 + 4}) Slashing damage, and the target has the {@condition Poisoned|XPHB} condition until the end of its next turn."
+					]
+				},
+				{
+					"name": "Javelin",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 30/120 ft. {@h}11 ({@damage 2d6 + 4}) Piercing damage, and the target has the {@condition Poisoned|XPHB} condition until the end of its next turn."
+					]
+				}
+			],
+			"environment": [
+				"coastal",
+				"forest"
+			],
+			"treasure": [
+				"individual"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Rusted Wyrm",
+			"source": "FRAiF",
+			"page": 273,
+			"size": [
+				"G"
+			],
+			"type": "construct",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				20
+			],
+			"hp": {
+				"average": 231,
+				"formula": "14d20 + 84"
+			},
+			"speed": {
+				"walk": 40,
+				"swim": 60
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 25,
+			"dex": 13,
+			"con": 22,
+			"int": 8,
+			"wis": 14,
+			"cha": 6,
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 12,
+			"immune": [
+				"fire",
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"frightened",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Draconic"
+			],
+			"cr": "14",
+			"trait": [
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the Rusted fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The Rusted makes two Bite attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 12}, reach 20 ft. {@h}29 ({@damage 4d10 + 7}) Piercing damage."
+					]
+				},
+				{
+					"name": "Steam Breath {@recharge 5}",
+					"entries": [
+						"{@actSave dex} {@dc 19}, each creature and flammable object that isn't being worn or carried in a 60-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 45 ({@damage 7d12}) Fire damage, and the target starts {@hazard burning|XPHB}. {@actSaveSuccess} Half damage only. {@actSaveSuccessOrFail} Being underwater doesn't grant {@variantrule Resistance|XPHB} to this Fire damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Encasing Rust",
+					"entries": [
+						"{@actSave con} {@dc 19}, one creature within 20 feet of the Rusted. {@actSaveFail} 14 ({@damage 4d6}) Poison damage, and the target has the {@condition Poisoned|XPHB} condition until the end of its next turn. While {@condition Poisoned|XPHB}, the target has the {@condition Paralyzed|XPHB} condition."
+					]
+				}
+			],
+			"environment": [
+				"coastal",
+				"forest"
+			],
+			"treasure": [
+				"individual"
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR"
+			],
+			"damageTags": [
+				"F",
+				"I",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"paralyzed",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Sammaster (Dracolich Form)",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "FRAiF",
+			"page": 275,
+			"size": [
+				"H"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				20
+			],
+			"hp": {
+				"average": 276,
+				"formula": "24d12 + 120"
+			},
+			"speed": {
+				"walk": 40,
+				"burrow": 30,
+				"fly": 80
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 25,
+			"dex": 10,
+			"con": 21,
+			"int": 23,
+			"wis": 15,
+			"cha": 21,
+			"save": {
+				"dex": "+7",
+				"con": "+12",
+				"int": "+13",
+				"wis": "+9"
+			},
+			"skill": {
+				"arcana": "+20",
+				"history": "+13",
+				"perception": "+16"
+			},
+			"senses": [
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
+			],
+			"passive": 26,
+			"immune": [
+				"acid",
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Draconic",
+				"Infernal"
+			],
+			"cr": "22",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Sammaster casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save {@dc 21}, {@hit 13} to hit with spell attacks):"
+					],
+					"will": [
+						"{@spell Blight|XPHB}",
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Dispel Magic|XPHB}",
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Prestidigitation|XPHB}",
+						"{@spell Ray of Sickness|XPHB} (level 6 version)"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Dimension Door|XPHB}",
+							"{@spell Speak with Dead|XPHB}"
+						],
+						"1e": [
+							"{@spell Create Undead|XPHB} (level 8 version)",
+							"{@spell Power Word Kill|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If Sammaster fails a saving throw, he can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Life Suppression",
+					"entries": [
+						"Creatures within 60 feet of Sammaster can't regain {@variantrule Hit Points|XPHB}."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Sammaster has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Soul Gem",
+					"entries": [
+						"Sammaster has a magical soul gem as his dracolich heart. The gem can't be damaged or removed until he is reduced to 0 {@variantrule Hit Points|XPHB}. If Sammaster is reduced to 0 {@variantrule Hit Points|XPHB}, his dracolich form dissolves to dust. After {@dice 1d10} days, he appears in an unoccupied space within 5 feet of his soul gem (so long as the gem still exists), using the Sammaster (Lich Form) stat block. The gem is a Tiny object that has AC 20; HP 50; and {@variantrule Immunity|XPHB} to Acid, Necrotic, Poison, and Psychic damage. The gem regains all its {@variantrule Hit Points|XPHB} at the end of every turn, but it turns to dust if reduced to 0 {@variantrule Hit Points|XPHB}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Sammaster makes three Rend attacks. He can replace one attack with a use of Spellcasting to cast {@spell Blight|XPHB} or {@spell Ray of Sickness|XPHB} (level 6 version)."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hit 14}, reach 10 ft. {@h}18 ({@damage 2d10 + 7}) Slashing damage plus 18 ({@damage 4d8}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Corroding Breath {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 20}, each creature in a 90-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 52 ({@damage 8d12}) Acid or Necrotic damage (Sammaster's choice). {@actSaveSuccess} Half damage."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Pounce",
+					"entries": [
+						"Sammaster moves up to half his {@variantrule Speed|XPHB}, and he makes one Rend attack."
+					]
+				},
+				{
+					"name": "Sickening Ray",
+					"entries": [
+						"Sammaster uses Spellcasting to cast {@spell Ray of Sickness|XPHB} (level 6 version)."
+					]
+				},
+				{
+					"name": "Terrifying Presence",
+					"entries": [
+						"{@actSave wis} {@dc 21}, each creature in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Sammaster. {@actSaveFail} 13 ({@damage 2d12}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the end of its next turn. {@actSaveSuccessOrFail} Sammaster can't take this action again until the start of his next turn."
+					]
+				}
+			],
+			"traitTags": [
+				"Legendary Resistances",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"I"
+			],
+			"damageTags": [
+				"A",
+				"N",
+				"S",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"I",
+				"N",
+				"O",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"conditionInflictSpell": [
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Sammaster (Lich Form)",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "FRAiF",
+			"page": 276,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "undead",
+				"tags": [
+					"wizard"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 322,
+				"formula": "43d8 + 129"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 12,
+			"dex": 14,
+			"con": 16,
+			"int": 23,
+			"wis": 15,
+			"cha": 21,
+			"save": {
+				"dex": "+9",
+				"con": "+10",
+				"int": "+13",
+				"wis": "+9"
+			},
+			"skill": {
+				"arcana": "+20",
+				"history": "+13",
+				"perception": "+9"
+			},
+			"senses": [
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
+			],
+			"passive": 19,
+			"resist": [
+				"acid",
+				"cold",
+				"lightning"
+			],
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Draconic",
+				"Infernal"
+			],
+			"cr": "22",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Sammaster casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save {@dc 21}):"
+					],
+					"will": [
+						"{@spell Cone of Cold|XPHB}",
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Dispel Magic|XPHB}",
+						"{@spell Invisibility|XPHB}",
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Prestidigitation|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Speak with Dead|XPHB}",
+							"{@spell Wall of Force|XPHB}"
+						],
+						"1e": [
+							"{@spell Create Undead|XPHB} (level 8 version)",
+							"{@spell Disintegrate|XPHB}",
+							"{@spell Power Word Kill|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				},
+				{
+					"name": "Protective Magic",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Sammaster casts {@spell Counterspell|XPHB} or {@spell Shield|XPHB} in response to the spell's trigger, using the same spellcasting ability as Spellcasting."
+					],
+					"will": [
+						"{@spell Counterspell|XPHB}",
+						"{@spell Shield|XPHB}"
+					],
+					"ability": "int",
+					"displayAs": "reaction",
+					"hidden": [
+						"will"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If Sammaster fails a saving throw, he can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Life Suppression",
+					"entries": [
+						"Creatures within 60 feet of Sammaster can't regain {@variantrule Hit Points|XPHB}."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Sammaster has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Soul Gem",
+					"entries": [
+						"If Sammaster is reduced to 0 {@variantrule Hit Points|XPHB} while his magical soul gem exists, his lich form dissolves to dust. After {@dice 1d10} days, he appears in the space of his soul gem, using the Sammaster (Dracolich Form) stat block. The gem is a Tiny object that has AC 20; HP 50; and {@variantrule Immunity|XPHB} to Acid, Necrotic, Poison, and Psychic damage. The gem regains all its {@variantrule Hit Points|XPHB} at the end of every turn, but it turns to dust if reduced to 0 {@variantrule Hit Points|XPHB}. If the gem is destroyed, Sammaster can create a new one by completing an 8-hour ritual using a gem worth 1,000+ GP, which the ritual consumes, and by expending 5,000 GP."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Sammaster makes three attacks, using Corrosive Burst or Paralyzing Touch in any combination. He can replace two attacks with a use of Spellcasting."
+					]
+				},
+				{
+					"name": "Corrosive Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 13}, reach 5 ft. or range 120 ft. {@h}38 ({@damage 5d12 + 6}) Acid or Necrotic damage (Sammaster's choice)."
+					]
+				},
+				{
+					"name": "Paralyzing Touch",
+					"entries": [
+						"{@atkr m} {@hit 13}, reach 5 ft. {@h}16 ({@damage 3d6 + 6}) Cold damage, and the target has the {@condition Paralyzed|XPHB} condition until the start of Sammaster's next turn."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Deathly Teleport",
+					"entries": [
+						"Sammaster teleports up to 60 feet to an unoccupied space he can see, and each creature within 10 feet of the space he left takes 19 ({@damage 3d12}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Dissolve",
+					"entries": [
+						"Sammaster makes one Corrosive Burst attack."
+					]
+				},
+				{
+					"name": "Terrifying Presence",
+					"entries": [
+						"{@actSave wis} {@dc 21}, each creature in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Sammaster. {@actSaveFail} 13 ({@damage 2d12}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the end of its next turn. {@actSaveSuccessOrFail} Sammaster can't take this action again until the start of his next turn."
+					]
+				}
+			],
+			"traitTags": [
+				"Legendary Resistances",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"I"
+			],
+			"damageTags": [
+				"A",
+				"C",
+				"N",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"C",
+				"O",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"frightened",
+				"paralyzed"
+			],
+			"conditionInflictSpell": [
+				"invisible"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Spirit Dragon Wyrmling",
+			"source": "FRAiF",
+			"page": 277,
+			"size": [
+				"M"
+			],
+			"type": "dragon",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 52,
+				"formula": "8d8 + 16"
+			},
+			"speed": {
+				"walk": 30,
+				"burrow": 20,
+				"fly": 60
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 15,
+			"dex": 12,
+			"con": 15,
+			"int": 14,
+			"wis": 11,
+			"cha": 14,
+			"save": {
+				"dex": "+3",
+				"con": "+4"
+			},
+			"skill": {
+				"perception": "+2",
+				"stealth": "+3"
+			},
+			"senses": [
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
+			],
+			"passive": 12,
+			"resist": [
+				"necrotic"
+			],
+			"languages": [
+				"Common",
+				"Draconic; telepathy 120 ft."
+			],
+			"cr": "2",
+			"action": [
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}9 ({@damage 2d6 + 2}) Slashing damage plus 3 ({@damage 1d6}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Ruinous Breath {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 12}, each creature in a 15-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 13 ({@damage 3d8}) Necrotic damage. {@actSaveSuccess} Half damage."
+					]
+				},
+				{
+					"name": "Time-Warping Breath",
+					"entries": [
+						"{@actSave wis} {@dc 12}, each creature that isn't currently affected by this breath in a 15-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} The target's {@variantrule Speed|XPHB} is halved, it can't take Reactions, and it can take either an action or a {@variantrule Bonus Action|XPHB} on its turn, not both. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Spirit Dragon",
+				"source": "FRAiF"
+			},
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"any"
+			],
+			"dragonCastingColor": "spirit",
+			"dragonAge": "wyrmling",
+			"tokenCredit": "Sandara",
+			"tokenCustom": true,
+			"senseTags": [
+				"B",
+				"D"
+			],
+			"actionTags": [
+				"Breath Weapon"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"TP"
+			],
+			"damageTags": [
+				"N",
+				"S"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Spore of Moander",
+			"source": "FRAiF",
+			"page": 280,
+			"size": [
+				"H"
+			],
+			"type": "plant",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				19
+			],
+			"hp": {
+				"average": 230,
+				"formula": "20d12 + 100"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 22,
+			"dex": 9,
+			"con": 20,
+			"int": 4,
+			"wis": 10,
+			"cha": 6,
+			"save": {
+				"str": "+10",
+				"con": "+9"
+			},
+			"senses": [
+				"Blindsight 120 ft."
+			],
+			"passive": 10,
+			"resist": [
+				"acid",
+				"cold",
+				"lightning"
+			],
+			"immune": [
+				"fire",
+				"poison"
+			],
+			"conditionImmune": [
+				"blinded",
+				"deafened",
+				"exhaustion",
+				"paralyzed",
+				"poisoned",
+				"prone"
+			],
+			"languages": [
+				"understands Abyssal but can't speak"
+			],
+			"cr": "12",
+			"trait": [
+				{
+					"name": "Explosive Core",
+					"entries": [
+						"When the spore is subjected to Fire damage, each creature in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the spore takes 7 ({@damage 2d6}) Fire damage."
+					]
+				},
+				{
+					"name": "Rolling Mass",
+					"entries": [
+						"The spore doesn't need to expend extra movement to move through {@variantrule Difficult Terrain|XPHB}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The spore makes four Tendril attacks. Alternatively, it makes two Tendril attacks and uses Consume once."
+					]
+				},
+				{
+					"name": "Tendril",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 20 ft. {@h}11 ({@damage 1d10 + 6}) Piercing damage plus 10 ({@damage 3d6}) Acid damage. If the target is Large or smaller, the spore pulls the target 5 feet straight toward itself."
+					]
+				},
+				{
+					"name": "Consume",
+					"entries": [
+						"{@actSave str} {@dc 18}, one Large or smaller creature within 5 feet. {@actSaveFail} The target is pulled into the spore's space and has the {@condition Grappled|XPHB} condition (escape {@dc 16}). Until the grapple ends, the target has the {@condition Blinded|XPHB} and {@condition Restrained|XPHB} conditions, and it takes 17 ({@damage 5d6}) Acid damage at the start of each of the spore's turns. When the spore moves, the {@condition Grappled|XPHB} target moves with it, costing it no extra movement. The spore can have one Large creature or up to nine Medium or smaller creatures {@condition Grappled|XPHB} at a time."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"swamp"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AB",
+				"CS"
+			],
+			"damageTags": [
+				"A",
+				"F",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"grappled"
+			],
+			"savingThrowForced": [
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Swanmay",
+			"source": "FRAiF",
+			"page": 281,
+			"size": [
+				"M"
+			],
+			"type": "fey",
+			"alignment": [
+				"N",
+				"G"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 71,
+				"formula": "11d8 + 22"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": {
+					"number": 40,
+					"condition": "(swan form only)"
+				}
+			},
+			"str": 10,
+			"dex": 18,
+			"con": 14,
+			"int": 10,
+			"wis": 16,
+			"cha": 15,
+			"save": {
+				"con": "+4",
+				"wis": "+5"
+			},
+			"skill": {
+				"nature": "+4",
+				"perception": "+5"
+			},
+			"passive": 15,
+			"languages": [
+				"Common",
+				"Sylvan"
+			],
+			"cr": "3",
+			"gear": [
+				"longbow|xphb",
+				"scimitar|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The swanmay casts one of the following spells, requiring no Somatic or Material components and using Wisdom as the spellcasting ability (spell save {@dc 13}):"
+					],
+					"will": [
+						"{@spell Druidcraft|XPHB}",
+						"{@spell Speak with Animals|XPHB} (swan form only)"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Animal Friendship|XPHB}",
+							"{@spell Beast Sense|XPHB}",
+							"{@spell Spike Growth|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Flyby (Swan Form Only)",
+					"entries": [
+						"The swanmay doesn't provoke an {@action Opportunity Attack|XPHB} action when it flies out of an enemy's reach."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The swanmay makes two attacks, using Beak, Longbow, or Scimitar in any combination."
+					]
+				},
+				{
+					"name": "Beak (Swan Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}7 ({@damage 1d6 + 4}) Piercing damage. If the target is a Large or smaller creature, it has the {@condition Prone|XPHB} condition."
+					]
+				},
+				{
+					"name": "Scimitar (Humanoid Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}11 ({@damage 2d6 + 4}) Slashing damage."
+					]
+				},
+				{
+					"name": "Longbow (Humanoid Form Only)",
+					"entries": [
+						"{@atkr r} {@hit 6}, range 150/600 ft. {@h}13 ({@damage 2d8 + 4}) Piercing damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The swanmay shape-shifts into a Small swan, or it returns to its true humanoid form. Its game statistics are the same in each form, except where noted. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"environment": [
+				"forest"
+			],
+			"treasure": [
+				"individual"
+			],
+			"traitTags": [
+				"Flyby"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"S"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"damageTagsSpell": [
+				"P"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"RNG"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"conditionInflictSpell": [
+				"charmed"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Valindra Shadowmantle",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "FRAiF",
+			"page": 283,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "undead",
+				"tags": [
+					"wizard"
+				]
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				20
+			],
+			"hp": {
+				"average": 315,
+				"formula": "42d8 + 126"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 11,
+			"dex": 16,
+			"con": 16,
+			"int": 21,
+			"wis": 14,
+			"cha": 16,
+			"save": {
+				"dex": "+10",
+				"con": "+10",
+				"int": "+12",
+				"wis": "+9"
+			},
+			"skill": {
+				"arcana": "+19",
+				"history": "+12",
+				"insight": "+9",
+				"perception": "+9"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 19,
+			"resist": [
+				"cold",
+				"lightning"
+			],
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"languages": [
+				"all"
+			],
+			"cr": {
+				"cr": "21",
+				"xpLair": 41000
+			},
+			"gear": [
+				"component pouch|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Valindra casts one of the following spells, using Intelligence as the spellcasting ability (spell save {@dc 20}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Dispel Magic|XPHB}",
+						"{@spell Fly|XPHB}",
+						"{@spell Invisibility|XPHB}",
+						"{@spell Lightning Bolt|XPHB} (level 5 version)",
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Prestidigitation|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Animate Dead|XPHB}",
+							"{@spell Plane Shift|XPHB}"
+						],
+						"1e": [
+							"{@spell Cone of Cold|XPHB} (level 8 version)",
+							"{@spell Finger of Death|XPHB}",
+							"{@spell Power Word Kill|XPHB}",
+							"{@spell Scrying|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				},
+				{
+					"name": "Illusory Disguise",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Valindra casts {@spell Disguise Self|XPHB}, using the same spellcasting ability as Spellcasting. The spell lasts until Valindra drops to 30 {@variantrule Hit Points|XPHB} or fewer or uses her Life-Rending Gaze Legendary Action. Intelligence ({@skill Investigation|XPHB}) checks made to discern her true appearance are made with {@variantrule Disadvantage|XPHB}."
+					],
+					"will": [
+						"{@spell Disguise Self|XPHB}"
+					],
+					"ability": "int",
+					"displayAs": "bonus",
+					"hidden": [
+						"will"
+					]
+				},
+				{
+					"name": "Protective Magic",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Valindra casts {@spell Counterspell|XPHB} or {@spell Shield|XPHB} in response to the spell's trigger, using the same spellcasting ability as Spellcasting."
+					],
+					"will": [
+						"{@spell Counterspell|XPHB}",
+						"{@spell Shield|XPHB}"
+					],
+					"ability": "int",
+					"displayAs": "reaction",
+					"hidden": [
+						"will"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Legendary Resistance (4/Day or 5/Day in Lair)",
+					"entries": [
+						"If Valindra fails a saving throw, she can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Spirit Gem",
+					"entries": [
+						"If destroyed, Valindra re-forms in {@dice 1d10} days if her spirit gem is intact, reviving with all her {@variantrule Hit Points|XPHB}. The new body appears in an unoccupied space within her lair."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Valindra makes three attacks, using Eldritch Burst or Paralyzing Touch in any combination. She can replace two attacks with a use of Spellcasting to cast {@spell Lightning Bolt|XPHB} (level 5 version)."
+					]
+				},
+				{
+					"name": "Eldritch Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 12}, reach 5 ft. or range 120 ft. {@h}31 ({@damage 4d12 + 5}) Force damage."
+					]
+				},
+				{
+					"name": "Paralyzing Touch",
+					"entries": [
+						"{@atkr m} {@hit 12}, reach 5 ft. {@h}14 ({@damage 2d8 + 5}) Cold damage, and the target has the {@condition Paralyzed|XPHB} condition until the start of Valindra's next turn."
+					]
+				},
+				{
+					"name": "Deathly Grasp {@recharge 5}",
+					"entries": [
+						"{@actSave dex} {@dc 20}, each creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Valindra. {@actSaveFail 1} 39 ({@damage 6d12}) Force damage and the target has the {@condition Restrained|XPHB} condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically. Subsequent Failures: 39 ({@damage 6d12}) Necrotic damage, and Valindra gains 20 {@variantrule Temporary Hit Points|XPHB}."
+					]
+				}
+			],
+			"legendaryActionsLair": 4,
+			"legendary": [
+				{
+					"name": "Disrupt Life",
+					"entries": [
+						"{@actSave con} {@dc 20}, each creature that isn't Undead in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Valindra. {@actSaveFail} 21 ({@damage 6d6}) Necrotic damage. {@actSaveSuccess} Half damage. {@actSaveSuccessOrFail} Valindra can't take this action again until the start of her next turn."
+					]
+				},
+				{
+					"name": "Eldritch Jaunt",
+					"entries": [
+						"Valindra makes one Eldritch Burst attack. Before or after the attack, Valindra can teleport up to 20 feet to an unoccupied space she can see."
+					]
+				},
+				{
+					"name": "Life-Rending Gaze",
+					"entries": [
+						"{@actSave wis} {@dc 20}, one creature Valindra can see within 30 feet. {@actSaveFail} 22 ({@damage 4d10}) Necrotic damage, and the target has the {@condition Frightened|XPHB} condition until the end of its next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"XX"
+			],
+			"damageTags": [
+				"C",
+				"N",
+				"O"
+			],
+			"damageTagsSpell": [
+				"C",
+				"L",
+				"N",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"frightened",
+				"paralyzed",
+				"restrained"
+			],
+			"conditionInflictSpell": [
+				"invisible"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"dexterity",
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"dexterity",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Werewyvern",
+			"source": "FRAiF",
+			"page": 284,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "dragon",
+				"tags": [
+					"lycanthrope"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 152,
+				"formula": "16d8 + 80"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": {
+					"number": 40,
+					"condition": "(wyvern or hybrid form only)"
+				}
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 19,
+			"dex": 15,
+			"con": 20,
+			"int": 10,
+			"wis": 12,
+			"cha": 12,
+			"save": {
+				"dex": "+5",
+				"wis": "+4"
+			},
+			"skill": {
+				"perception": "+4",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 14,
+			"languages": [
+				"Common",
+				"Draconic (can't speak in wyvern form)"
+			],
+			"cr": "8",
+			"gear": [
+				{
+					"item": "javelin|xphb",
+					"quantity": 6
+				}
+			],
+			"trait": [
+				{
+					"name": "Flyby (Wyvern or Hybrid Form Only)",
+					"entries": [
+						"The werewyvern doesn't provoke an {@action Opportunity Attack|XPHB} action when it flies out of an enemy's reach."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The werewyvern makes three attacks, using Javelin or Rend in any combination. It can replace one of these attacks with one Stinger attack."
+					]
+				},
+				{
+					"name": "Javelin (Humanoid or Hybrid Form Only)",
+					"entries": [
+						"{@atkr m,r} {@hit 7}, reach 5 ft. or range 30/120 ft. {@h}18 ({@damage 4d6 + 4}) Piercing damage."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}18 ({@damage 4d6 + 4}) Slashing damage."
+					]
+				},
+				{
+					"name": "Stinger (Wyvern or Hybrid Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}7 ({@damage 1d6 + 4}) Piercing damage plus 16 ({@damage 3d10}) Poison damage, and the target has the {@condition Poisoned|XPHB} condition until the start of the werewyvern's next turn. If the target is a Humanoid, it is subjected to the following effect. {@actSave con} {@dc 16}. {@actSaveFail} The target is cursed. If the cursed target drops to 0 {@variantrule Hit Points|XPHB}, it instead becomes a Werewyvern under the DM's control and has 20 {@variantrule Hit Points|XPHB}. {@actSaveSuccess} The target is immune to this werewyvern's curse for 24 hours."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The werewyvern shape-shifts into a Medium wyvern-humanoid hybrid or a Large wyvern, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"environment": [
+				"hill",
+				"mountain"
+			],
+			"treasure": [
+				"individual"
+			],
+			"traitTags": [
+				"Flyby"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"DR"
+			],
+			"damageTags": [
+				"I",
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Young Deep Dragon",
+			"source": "FRAiF",
+			"page": 257,
+			"size": [
+				"L"
+			],
+			"type": "dragon",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 93,
+				"formula": "11d10 + 33"
+			},
+			"speed": {
+				"walk": 40,
+				"burrow": 20,
+				"fly": 80,
+				"swim": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 18,
+			"dex": 13,
+			"con": 16,
+			"int": 12,
+			"wis": 14,
+			"cha": 16,
+			"save": {
+				"dex": "+4",
+				"wis": "+5"
+			},
+			"skill": {
+				"perception": "+8",
+				"stealth": "+7"
+			},
+			"senses": [
+				"Blindsight 30 ft.",
+				"Darkvision 150 ft."
+			],
+			"passive": 18,
+			"resist": [
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Draconic",
+				"Undercommon"
+			],
+			"cr": "5",
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The dragon makes three Rend attacks."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 10 ft. {@h}11 ({@damage 2d6 + 4}) Slashing damage plus 3 ({@damage 1d6}) Poison damage."
+					]
+				},
+				{
+					"name": "Nightmare Breath {@recharge 5}",
+					"entries": [
+						"{@actSave wis} {@dc 14}, each creature in a 30-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 22 ({@damage 4d10}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the end of the dragon's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"environment": [
+				"underdark"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"dragonCastingColor": "deep",
+			"dragonAge": "young",
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"U"
+			],
+			"damageTags": [
+				"I",
+				"S",
+				"Y"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Young Spirit Dragon",
+			"source": "FRAiF",
+			"page": 277,
+			"size": [
+				"L"
+			],
+			"type": "dragon",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 152,
+				"formula": "16d10 + 64"
+			},
+			"speed": {
+				"walk": 40,
+				"burrow": 30,
+				"fly": 80
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 19,
+			"dex": 13,
+			"con": 19,
+			"int": 17,
+			"wis": 14,
+			"cha": 16,
+			"save": {
+				"dex": "+4",
+				"con": "+7"
+			},
+			"skill": {
+				"insight": "+5",
+				"perception": "+5",
+				"stealth": "+4"
+			},
+			"senses": [
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
+			],
+			"passive": 15,
+			"resist": [
+				"necrotic"
+			],
+			"languages": [
+				"Common",
+				"Draconic; telepathy 120 ft."
+			],
+			"cr": "8",
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The dragon makes three Rend attacks. It can replace one attack with a use of Time-Warping Breath."
+					]
+				},
+				{
+					"name": "Rend",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 10 ft. {@h}14 ({@damage 3d6 + 4}) Slashing damage plus 7 ({@damage 2d6}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Ruinous Breath {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 15}, each creature in a 30-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 36 ({@damage 8d8}) Necrotic damage. {@actSaveSuccess} Half damage."
+					]
+				},
+				{
+					"name": "Time-Warping Breath",
+					"entries": [
+						"{@actSave wis} {@dc 15}, each creature that isn't currently affected by this breath in a 30-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} The target's {@variantrule Speed|XPHB} is halved, it can't take Reactions, and it can take either an action or a {@variantrule Bonus Action|XPHB} on its turn, not both. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Spirit Dragon",
+				"source": "FRAiF"
+			},
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"any"
+			],
+			"dragonCastingColor": "spirit",
+			"dragonAge": "young",
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"TP"
+			],
+			"damageTags": [
+				"N",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Zhentilar Paladin of Bane",
+			"source": "FRAiF",
+			"page": 285,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 58,
+				"formula": "9d8 + 18"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 16,
+			"dex": 11,
+			"con": 14,
+			"int": 12,
+			"wis": 13,
+			"cha": 17,
+			"save": {
+				"str": "+5",
+				"cha": "+5"
+			},
+			"skill": {
+				"athletics": "+5",
+				"intimidation": "+5",
+				"religion": "+3"
+			},
+			"passive": 11,
+			"languages": [
+				"Common"
+			],
+			"cr": "4",
+			"gear": [
+				"plate armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The Zhentilar casts one of the following spells, using Charisma as the spellcasting ability (spell save {@dc 13}):"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Command|XPHB}",
+							"{@spell Fear|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Aura of Dread",
+					"entries": [
+						"Creatures in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the Zhentilar have their Speeds halved while in the {@variantrule Emanation [Area of Effect]|XPHB|Emanation}. The Zhentilar can designate creatures to be unaffected by the aura."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The Zhentilar makes three attacks, using Dooming Blade or Oppressive Ray in any combination. It can replace one attack with a use of Spellcasting."
+					]
+				},
+				{
+					"name": "Dooming Blade",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}7 ({@damage 1d8 + 3}) Bludgeoning damage plus 7 ({@damage 2d6}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Oppressive Ray",
+					"entries": [
+						"{@atkr r} {@hit 5}, range 90 ft. {@h}16 ({@damage 3d10}) Psychic damage."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"armaments"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"B",
+				"N",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflictSpell": [
+				"frightened",
+				"prone"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Zhentilar Soldier",
+			"source": "FRAiF",
+			"page": 285,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 22,
+				"formula": "4d8 + 4"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 14,
+			"dex": 14,
+			"con": 13,
+			"int": 10,
+			"wis": 11,
+			"cha": 11,
+			"save": {
+				"dex": "+4",
+				"con": "+3"
+			},
+			"skill": {
+				"acrobatics": "+4",
+				"athletics": "+4"
+			},
+			"passive": 10,
+			"languages": [
+				"Common"
+			],
+			"cr": "1",
+			"gear": [
+				"leather armor|xphb",
+				"pistol|xphb",
+				"shortsword|xphb"
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The Zhentilar makes two attacks, using Shortsword or Pistol in any combination. It can replace one attack with a use of Knock Down."
+					]
+				},
+				{
+					"name": "Shortsword",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 1d6 + 2}) Piercing damage plus 2 ({@damage 1d4}) Poison damage."
+					]
+				},
+				{
+					"name": "Pistol",
+					"entries": [
+						"{@atkr r} {@hit 4}, range 80/320 ft. {@h}7 ({@damage 1d10 + 2}) Piercing damage."
+					]
+				},
+				{
+					"name": "Knock Down",
+					"entries": [
+						"{@actSave str} {@dc 12}, one creature within 5 feet that the Zhentilar can see. {@actSaveFail} 4 ({@damage 1d4 + 2}) Bludgeoning damage. If the target is a Medium or smaller creature, it has the {@condition Prone|XPHB} condition."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"armaments"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"B",
+				"I",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"RNG"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Zlan",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "FRAiF",
+			"page": 287,
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "undead",
+				"tags": [
+					"wizard"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 199,
+				"formula": "19d12 + 76"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 20,
+			"dex": 12,
+			"con": 19,
+			"int": 21,
+			"wis": 18,
+			"cha": 14,
+			"save": {
+				"dex": "+7",
+				"con": "+10",
+				"int": "+11",
+				"wis": "+10"
+			},
+			"skill": {
+				"arcana": "+17",
+				"history": "+11",
+				"perception": "+10"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 20,
+			"resist": [
+				"lightning",
+				"necrotic"
+			],
+			"immune": [
+				"cold",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"languages": [
+				"all"
+			],
+			"cr": "18",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Zlan casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save {@dc 19}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Dispel Magic|XPHB}",
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Message|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Dimension Door|XPHB}",
+							"{@spell Fly|XPHB}",
+							"{@spell Scrying|XPHB}"
+						],
+						"1e": [
+							"{@spell Befuddlement|XPHB}",
+							"{@spell Disintegrate|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				},
+				{
+					"name": "Counterspell",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Zlan casts {@spell Counterspell|XPHB} in response to the spell's trigger, using the same spellcasting ability as Spellcasting."
+					],
+					"will": [
+						"{@spell Counterspell|XPHB}"
+					],
+					"ability": "int",
+					"displayAs": "reaction",
+					"hidden": [
+						"will"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Chardalyn Sense",
+					"entries": [
+						"Zlan senses the emotions of anyone touching a piece of chardalyn within 100 miles of itself."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If Zlan fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Zlan has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Next of the Seven (6/Year)",
+					"entries": [
+						"If Zlan dies within 100 miles of a piece of chardalyn at least 4 inches long, it re-forms from that piece of chardalyn in {@dice 1d10} days, regaining all its {@variantrule Hit Points|XPHB}. The new body appears in the unoccupied space nearest to the piece of chardalyn, and another lich's mind in the body seizes psychic control of the body."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Zlan makes three attacks, using Slam or Bewildering Bolt in any combination. It can replace two attacks with a use of Spellcasting."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atkr m} {@hit 11}, reach 10 ft. {@h}12 ({@damage 3d4 + 5}) Bludgeoning damage plus 22 ({@damage 4d10}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Bewildering Bolt",
+					"entries": [
+						"{@atkr r} {@hit 11}, range 120 ft. {@h}27 ({@damage 4d10 + 5}) Psychic damage, and the target has the {@condition Charmed|XPHB} condition until the end of its next turn."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Retaliation",
+					"entries": [
+						"Zlan makes one Slam or Bewildering Bolt attack."
+					]
+				},
+				{
+					"name": "Stoke Paranoia",
+					"entries": [
+						"{@actSave wis} {@dc 19}, one creature Zlan can see within 30 feet (with {@variantrule Disadvantage|XPHB} if the target is holding or wearing chardalyn). {@actSaveFail} 27 ({@damage 6d8}) Psychic damage and the target has the {@condition Charmed|XPHB} condition for 1 minute or until Zlan dies. While {@condition Charmed|XPHB}, the target doesn't act as an ally to any creature. {@actSaveSuccess} Half damage only. {@actSaveSuccessOrFail} Zlan can't take this action again until the start of its next turn."
+					]
+				}
+			],
+			"traitTags": [
+				"Legendary Resistances",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"XX"
+			],
+			"damageTags": [
+				"B",
+				"N",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"O",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"charmed"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"dexterity",
+				"intelligence",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		}
+	]
+}

--- a/json/bestiary/bestiary-ftd.json
+++ b/json/bestiary/bestiary-ftd.json
@@ -171,7 +171,7 @@
 				{
 					"name": "Explosive Crystal (Costs 3 Actions)",
 					"entries": [
-						"The dragon spits an amethyst that that explodes at a point it can see within 60 feet of it. Each creature within a 20-foot-radius sphere centered on that point must succeed on a {@dc 20} Dexterity saving throw or take 13 ({@damage 3d8}) force damage and be knocked {@condition prone}."
+						"The dragon spits an amethyst that explodes at a point it can see within 60 feet of it. Each creature within a 20-foot-radius sphere centered on that point must succeed on a {@dc 20} Dexterity saving throw or take 13 ({@damage 3d8}) force damage and be knocked {@condition prone}."
 					]
 				}
 			],
@@ -625,6 +625,9 @@
 			"name": "Adult Deep Dragon",
 			"source": "FTD",
 			"page": 174,
+			"reprintedAs": [
+				"Adult Deep Dragon|FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -2660,6 +2663,7 @@
 				}
 			],
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -2881,7 +2885,7 @@
 				{
 					"name": "Explosive Crystal (Costs 3 Actions)",
 					"entries": [
-						"The dragon spits an amethyst that that explodes at a point it can see within 60 feet of it. Each creature within a 20-foot-radius sphere centered on that point must succeed on a {@dc 23} Dexterity saving throw or take 18 ({@damage 4d8}) force damage and be knocked {@condition prone}."
+						"The dragon spits an amethyst that explodes at a point it can see within 60 feet of it. Each creature within a 20-foot-radius sphere centered on that point must succeed on a {@dc 23} Dexterity saving throw or take 18 ({@damage 4d8}) force damage and be knocked {@condition prone}."
 					]
 				}
 			],
@@ -3338,6 +3342,9 @@
 			"name": "Ancient Deep Dragon",
 			"source": "FTD",
 			"page": 173,
+			"reprintedAs": [
+				"Ancient Deep Dragon|FRAiF"
+			],
 			"size": [
 				"G"
 			],
@@ -4858,6 +4865,9 @@
 			"name": "Ancient Sea Serpent",
 			"source": "FTD",
 			"page": 219,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"G"
 			],
@@ -6141,6 +6151,7 @@
 			],
 			"dragonCastingColor": "black",
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -6745,6 +6756,7 @@
 			],
 			"dragonCastingColor": "brass",
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -7066,6 +7078,7 @@
 			],
 			"dragonCastingColor": "bronze",
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -7387,6 +7400,7 @@
 			],
 			"dragonCastingColor": "copper",
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -7916,6 +7930,7 @@
 				}
 			],
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -7967,6 +7982,9 @@
 			"name": "Deep Dragon Wyrmling",
 			"source": "FTD",
 			"page": 175,
+			"reprintedAs": [
+				"Deep Dragon Wyrmling|FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -9105,7 +9123,7 @@
 				{
 					"name": "Commanding Thought (Costs 2 Actions)",
 					"entries": [
-						"The shard targets a creature it can see within 30 feet of it. The target must succeed on a {@dc 20} Wisdom saving throw or be {@condition charmed} until the end of its next turn. While {@condition charmed} in this way, the target becomes the shard's puppet, acting and moving in accordance with its telepathic commands. While under the shard's control, the target can take only the Attack (shard chooses the target) or Dash action on its turn."
+						"The shard targets a creature it can see within 30 feet of it. The target must succeed on a {@dc 20} Wisdom saving throw or be {@condition charmed} until the end of its next turn. While {@condition charmed} in this way, the target becomes the shard's puppet, acting and moving in accordance with its telepathic commands. While under the shard's control, the target can take only the Attack (shard chooses the target) or {@action Dash} action on its turn."
 					]
 				}
 			],
@@ -9263,6 +9281,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"B",
 				"D"
@@ -10472,7 +10491,7 @@
 				{
 					"name": "Necrotic Breath {@recharge}",
 					"entries": [
-						"The dragonborn exhales shadowy fire in a 30-foot cone. Each creature in that area must make a {@dc 15} Wisdom saving throw. On a failed save, the creature takes 36 ({@damage 8d8}) necrotic damage and is {@condition frightened} of the dragonborn for 1 minute. On a successful save, the creature takes half as much damage and isn't {@condition frightened}. A {@condition frightened} creature can repeat the saving throw at end of each of its turns, ending the effect on itself on a success."
+						"The dragonborn exhales shadowy fire in a 30-foot cone. Each creature in that area must make a {@dc 15} Wisdom saving throw. On a failed save, the creature takes 36 ({@damage 8d8}) necrotic damage and is {@condition frightened} of the dragonborn for 1 minute. On a successful save, the creature takes half as much damage and isn't {@condition frightened}. A {@condition frightened} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				}
 			],
@@ -10886,7 +10905,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"{@atk mw} +3 plus PB to hit, reach 5 ft., one target. {@h}{@damage 1d6} plus PB piercing damage."
+						"{@atk mw} {@hit 3} plus PB to hit, reach 5 ft., one target. {@h}{@damage 1d6} plus PB piercing damage."
 					]
 				}
 			],
@@ -11105,7 +11124,7 @@
 				{
 					"name": "Rapid Movement",
 					"entries": [
-						"The egg hunter takes the Dash or Disengage action."
+						"The egg hunter takes the {@action Dash} or {@action Disengage} action."
 					]
 				}
 			],
@@ -11797,6 +11816,7 @@
 				}
 			],
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -12378,6 +12398,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"damageTags": [
 				"P"
 			],
@@ -12671,6 +12692,7 @@
 			],
 			"dragonCastingColor": "gold",
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -12962,6 +12984,7 @@
 			],
 			"dragonCastingColor": "green",
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -13461,7 +13484,7 @@
 				{
 					"name": "Blood-Chilling Roar {@recharge 4}",
 					"entries": [
-						"The liondrake lets out a terrifying roar audible out to 300 feet. Any creature within 30 feet of the liondrake that can hear its roar must succeed on a {@dc 14} Wisdom saving throw or be {@condition frightened} of the liondrake for 1 minute. A creature that fails the save by 5 or more is also {@condition paralyzed} for the same duration. A creature can repeat the saving throw at the end of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this liondrake's Blood-Chilling Roar for the next 24 hours."
+						"The liondrake lets out a terrifying roar audible out to 300 feet. Any creature within 30 feet of the liondrake that can hear its roar must succeed on a {@dc 14} Wisdom saving throw or be {@condition frightened} of the liondrake for 1 minute. A creature that fails the save by 5 or more is also {@condition paralyzed} for the same duration. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this liondrake's Blood-Chilling Roar for the next 24 hours."
 					]
 				}
 			],
@@ -15701,6 +15724,7 @@
 				}
 			],
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -15995,6 +16019,7 @@
 			],
 			"dragonCastingColor": "white",
 			"dragonAge": "greatwyrm",
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -16529,6 +16554,9 @@
 			"name": "Young Deep Dragon",
 			"source": "FTD",
 			"page": 175,
+			"reprintedAs": [
+				"Young Deep Dragon|FRAiF"
+			],
 			"size": [
 				"L"
 			],

--- a/json/bestiary/bestiary-ggr.json
+++ b/json/bestiary/bestiary-ggr.json
@@ -11,6 +11,9 @@
 			"name": "Anarch",
 			"source": "GGR",
 			"page": 239,
+			"referenceSources": [
+				"AZfyT"
+			],
 			"size": [
 				"M"
 			],
@@ -1730,6 +1733,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -2838,6 +2842,9 @@
 			"spellcastingTags": [
 				"CW"
 			],
+			"miscTags": [
+				"AOE"
+			],
 			"conditionInflict": [
 				"poisoned"
 			],
@@ -3615,6 +3622,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW"
 			],
@@ -3755,6 +3763,9 @@
 			"name": "Flying Horror",
 			"source": "GGR",
 			"page": 203,
+			"referenceSources": [
+				"AZfyT"
+			],
 			"size": [
 				"M"
 			],
@@ -3839,6 +3850,7 @@
 				"Y"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -4189,6 +4201,7 @@
 				"L"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"savingThrowForced": [
@@ -4621,6 +4634,9 @@
 			"name": "Horncaller",
 			"source": "GGR",
 			"page": 253,
+			"referenceSources": [
+				"AZfyT"
+			],
 			"size": [
 				"M"
 			],
@@ -4740,7 +4756,7 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"Simic hybrid"
+					"simic hybrid"
 				]
 			},
 			"alignment": [
@@ -4824,7 +4840,7 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"Simic hybrid"
+					"simic hybrid"
 				]
 			},
 			"alignment": [
@@ -4910,7 +4926,7 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"Simic hybrid"
+					"simic hybrid"
 				]
 			},
 			"alignment": [
@@ -5011,7 +5027,7 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"Simic hybrid"
+					"simic hybrid"
 				]
 			},
 			"alignment": [
@@ -5112,7 +5128,7 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"Simic hybrid"
+					"simic hybrid"
 				]
 			},
 			"alignment": [
@@ -5511,7 +5527,7 @@
 				{
 					"name": "Supreme Legal Authority",
 					"entries": [
-						"Isperia chooses up to three creatures she can see within 90 feet of her. Each target must succeed on a {@dc 23} Intelligence saving throw or Isperia chooses an action for that target: Attack, Cast a Spell, Dash, Disengage, Dodge, Help, Hide, Ready, Search, or Use an Object. The affected target can't take that action for 1 minute. At the end of each of the target's turns, it can end the effect on itself with a successful {@dc 23} Intelligence saving throw. A target that succeeds on the saving throw becomes immune to Isperia's Supreme Legal Authority for 24 hours."
+						"Isperia chooses up to three creatures she can see within 90 feet of her. Each target must succeed on a {@dc 23} Intelligence saving throw or Isperia chooses an action for that target: {@action Attack}, {@action Cast a Spell}, {@action Dash}, {@action Disengage}, {@action Dodge}, {@action Help}, {@action Hide}, {@action Ready}, {@action Search}, or {@action Use an Object}. The affected target can't take that action for 1 minute. At the end of each of the target's turns, it can end the effect on itself with a successful {@dc 23} Intelligence saving throw. A target that succeeds on the saving throw becomes immune to Isperia's Supreme Legal Authority for 24 hours."
 					]
 				}
 			],
@@ -5841,6 +5857,7 @@
 				"CW"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -6031,6 +6048,10 @@
 			"name": "Kraul Warrior",
 			"source": "GGR",
 			"page": 213,
+			"referenceSources": [
+				"AZfyT",
+				"KKW"
+			],
 			"size": [
 				"M"
 			],
@@ -6475,6 +6496,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW"
 			],
@@ -6656,6 +6678,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW",
 				"RW",
@@ -6761,7 +6784,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the vampire can take the Hide action as a bonus action."
+						"While in dim light or darkness, the vampire can take the {@action Hide} action as a bonus action."
 					]
 				},
 				{
@@ -7711,6 +7734,7 @@
 				}
 			],
 			"traitTags": [
+				"Ethereal Sight",
 				"Incorporeal Movement",
 				"Legendary Resistances"
 			],
@@ -7732,6 +7756,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"HPR",
 				"MW"
 			],
@@ -8173,6 +8198,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -8364,7 +8390,7 @@
 				{
 					"name": "Nimble",
 					"entries": [
-						"The performer can take the Disengage action as a bonus action on each of its turns."
+						"The performer can take the {@action Disengage} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -8456,7 +8482,7 @@
 				{
 					"name": "Nimble",
 					"entries": [
-						"The performer can take the Disengage action as a bonus action on each of its turns."
+						"The performer can take the {@action Disengage} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -8554,7 +8580,7 @@
 				{
 					"name": "Nimble",
 					"entries": [
-						"The performer can take the Disengage action as a bonus action on each of its turns."
+						"The performer can take the {@action Disengage} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -8740,6 +8766,9 @@
 			"name": "Rubblebelt Stalker",
 			"source": "GGR",
 			"page": 239,
+			"referenceSources": [
+				"AZfyT"
+			],
 			"size": [
 				"M"
 			],
@@ -8795,7 +8824,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The stalker can take the Disengage or Hide action as a bonus action on each of its turns."
+						"The stalker can take the {@action Disengage} or {@action Hide} action as a bonus action on each of its turns."
 					]
 				},
 				{
@@ -8852,6 +8881,9 @@
 			"name": "Scorchbringer Guard",
 			"source": "GGR",
 			"page": 243,
+			"referenceSources": [
+				"KKW"
+			],
 			"size": [
 				"M"
 			],
@@ -9065,7 +9097,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the horror can take the Hide action as a bonus action."
+						"While in dim light or darkness, the horror can take the {@action Hide} action as a bonus action."
 					]
 				},
 				{
@@ -9124,6 +9156,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -9632,10 +9665,9 @@
 			"name": "Soldier",
 			"source": "GGR",
 			"page": 226,
-			"otherSources": [
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"KKW",
+				"MOT"
 			],
 			"size": [
 				"M"
@@ -9923,6 +9955,9 @@
 			"name": "Thought Spy",
 			"source": "GGR",
 			"page": 233,
+			"referenceSources": [
+				"AZfyT"
+			],
 			"size": [
 				"M"
 			],
@@ -9999,7 +10034,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of its turns, the thought spy can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of its turns, the thought spy can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				}
 			],
@@ -10232,7 +10267,7 @@
 				{
 					"name": "Awaken Grove Guardians (Costs 3 Actions)",
 					"entries": [
-						"Trostani animates one or two trees she can see within 120 feet of her, causing them to uproot themselves and become awakened trees (see the Monster Manual for their stat blocks) for 1 minute or until Trostani uses a bonus action to end the effect. These trees understand Druidic and obey Trostani's spoken commands, but can't speak. If she issues no commands to them, the trees do nothing but follow her and take the Dodge action."
+						"Trostani animates one or two trees she can see within 120 feet of her, causing them to uproot themselves and become awakened trees (see the Monster Manual for their stat blocks) for 1 minute or until Trostani uses a bonus action to end the effect. These trees understand Druidic and obey Trostani's spoken commands, but can't speak. If she issues no commands to them, the trees do nothing but follow her and take the {@action Dodge} action."
 					]
 				}
 			],

--- a/json/bestiary/bestiary-gos.json
+++ b/json/bestiary/bestiary-gos.json
@@ -11,7 +11,8 @@
 				"TftYP": "GoS",
 				"PotA": "GoS",
 				"ToA": "GoS",
-				"MTF": "GoS"
+				"MTF": "GoS",
+				"MM": "GoS"
 			}
 		}
 	},
@@ -20,10 +21,9 @@
 			"name": "Amphisbaena",
 			"source": "GoS",
 			"page": 230,
-			"otherSources": [
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"MOT",
+				"TftYP-THSoT"
 			],
 			"size": [
 				"M"
@@ -270,10 +270,8 @@
 			"name": "Bullywug Royal",
 			"source": "GoS",
 			"page": 232,
-			"otherSources": [
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"WBtW"
 			],
 			"size": [
 				"M"
@@ -462,8 +460,7 @@
 				"R"
 			],
 			"spellcastingTags": [
-				"CC",
-				"I"
+				"CC"
 			],
 			"hasToken": true,
 			"hasFluffImages": true
@@ -472,10 +469,8 @@
 			"name": "Drowned Ascetic",
 			"source": "GoS",
 			"page": 233,
-			"otherSources": [
-				{
-					"source": "LR"
-				}
+			"referenceSources": [
+				"LR"
 			],
 			"size": [
 				"M"
@@ -590,10 +585,8 @@
 			"name": "Drowned Assassin",
 			"source": "GoS",
 			"page": 234,
-			"otherSources": [
-				{
-					"source": "LR"
-				}
+			"referenceSources": [
+				"LR"
 			],
 			"size": [
 				"M"
@@ -670,7 +663,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The drowned assassin makes two hand crossbow attacks or two dagger attacks. It can then take the Dash, Disengage, or Hide action."
+						"The drowned assassin makes two hand crossbow attacks or two dagger attacks. It can then take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -734,10 +727,8 @@
 			"name": "Drowned Blade",
 			"source": "GoS",
 			"page": 235,
-			"otherSources": [
-				{
-					"source": "LR"
-				}
+			"referenceSources": [
+				"LR"
 			],
 			"size": [
 				"M"
@@ -847,10 +838,8 @@
 			"name": "Drowned Master",
 			"source": "GoS",
 			"page": 235,
-			"otherSources": [
-				{
-					"source": "LR"
-				}
+			"referenceSources": [
+				"LR"
 			],
 			"size": [
 				"M"
@@ -1457,7 +1446,7 @@
 				{
 					"name": "Ink Cloud (Costs 3 Actions)",
 					"entries": [
-						"While underwater, the kraken expels an ink cloud in a 40-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than the kraken. Each creature other than the kraken that ends its turn there must succeed on a {@dc 18} Constitution saving throw, taking 11 ({@damage 2d10}) poison damage on a failed save or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn."
+						"While underwater, the kraken expels an ink cloud in a 40-foot radius. The cloud spreads around corners, and that area is {@quickref Vision and Light||2||heavily obscured} to creatures other than the kraken. Each creature other than the kraken that ends its turn there must succeed on a {@dc 18} Constitution saving throw, taking 11 ({@damage 2d10}) poison damage on a failed save or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn."
 					]
 				}
 			],
@@ -2131,13 +2120,9 @@
 			"name": "Lizardfolk Render",
 			"source": "GoS",
 			"page": 241,
-			"otherSources": [
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR",
+				"SLW"
 			],
 			"size": [
 				"L"
@@ -2367,10 +2352,8 @@
 			"name": "Lizardfolk Subchief",
 			"source": "GoS",
 			"page": 242,
-			"otherSources": [
-				{
-					"source": "SLW"
-				}
+			"referenceSources": [
+				"SLW"
 			],
 			"size": [
 				"M"
@@ -2526,10 +2509,8 @@
 			"name": "Locathah",
 			"source": "GoS",
 			"page": 243,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"size": [
 				"M"
@@ -3570,6 +3551,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"light crossbow|phb",
 				"trident|phb"
@@ -3624,6 +3606,7 @@
 				"Abyssal",
 				"Draconic"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"AB",
 				"C",
@@ -4160,6 +4143,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"quarterstaff|phb"
 			],
@@ -4194,13 +4178,9 @@
 			"name": "Sahuagin Blademaster",
 			"source": "GoS",
 			"page": 249,
-			"otherSources": [
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "LR"
-				}
+			"referenceSources": [
+				"LR",
+				"SDW"
 			],
 			"size": [
 				"M"
@@ -4573,10 +4553,8 @@
 			"name": "Sahuagin Deep Diver",
 			"source": "GoS",
 			"page": 250,
-			"otherSources": [
-				{
-					"source": "LR"
-				}
+			"referenceSources": [
+				"LR"
 			],
 			"size": [
 				"M"
@@ -4728,10 +4706,8 @@
 			"name": "Sahuagin Hatchling Swarm",
 			"source": "GoS",
 			"page": 250,
-			"otherSources": [
-				{
-					"source": "LR"
-				}
+			"referenceSources": [
+				"LR"
 			],
 			"size": [
 				"L"
@@ -4835,10 +4811,8 @@
 			"name": "Sahuagin High Priestess",
 			"source": "GoS",
 			"page": 251,
-			"otherSources": [
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"SDW"
 			],
 			"size": [
 				"M"
@@ -5251,6 +5225,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],
@@ -5415,6 +5390,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Magic Resistance",
 				"Water Breathing"
@@ -5540,10 +5516,8 @@
 			"name": "Skeletal Juggernaut",
 			"source": "GoS",
 			"page": 253,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"size": [
 				"L"
@@ -5634,6 +5608,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -5647,13 +5622,9 @@
 			"name": "Skeletal Swarm",
 			"source": "GoS",
 			"page": 254,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"DC",
+				"IMR"
 			],
 			"size": [
 				"L"
@@ -6108,6 +6079,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Immutable Form",
 				"Legendary Resistances"
@@ -6159,6 +6131,7 @@
 				}
 			},
 			"type": "undead",
+			"tokenCustom": true,
 			"traitTags": [
 				"Sunlight Sensitivity"
 			],

--- a/json/bestiary/bestiary-gotsf.json
+++ b/json/bestiary/bestiary-gotsf.json
@@ -42,6 +42,7 @@
 				"acid",
 				"poison"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		}
 	]

--- a/json/bestiary/bestiary-hat-tg.json
+++ b/json/bestiary/bestiary-hat-tg.json
@@ -413,7 +413,7 @@
 				{
 					"name": "Cunning",
 					"entries": [
-						"Forge takes the Dash, Disengage, or Hide action, or he gives himself advantage on the next attack roll he makes before the end of this turn."
+						"Forge takes the {@action Dash}, {@action Disengage}, or {@action Hide} action, or he gives himself advantage on the next attack roll he makes before the end of this turn."
 					]
 				}
 			],

--- a/json/bestiary/bestiary-hftt.json
+++ b/json/bestiary/bestiary-hftt.json
@@ -2,7 +2,7 @@
 	"_meta": {
 		"otherSources": {
 			"monster": {
-				"MM": "HtfT"
+				"MM": "HftT"
 			}
 		}
 	},
@@ -199,6 +199,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"quarterstaff|phb"
 			],
@@ -232,10 +233,8 @@
 			"name": "Thessalhydra",
 			"source": "HftT",
 			"page": 41,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"size": [
 				"H"
@@ -344,6 +343,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],

--- a/json/bestiary/bestiary-hol.json
+++ b/json/bestiary/bestiary-hol.json
@@ -1,4 +1,11 @@
 {
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"MM": "HoL"
+			}
+		}
+	},
 	"monster": [
 		{
 			"name": "Apprentice",
@@ -85,6 +92,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"quarterstaff|phb"
 			],
@@ -196,6 +204,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"mace|phb"
 			],
@@ -278,10 +287,11 @@
 				{
 					"name": "Disengage",
 					"entries": [
-						"You take the Disengage action."
+						"You take the {@action Disengage} action."
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],
@@ -356,6 +366,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"longsword|phb"
 			],

--- a/json/bestiary/bestiary-hotb.json
+++ b/json/bestiary/bestiary-hotb.json
@@ -1,0 +1,1067 @@
+{
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"XMM": "HotB"
+			}
+		}
+	},
+	"monster": [
+		{
+			"name": "Curate",
+			"source": "HotB",
+			"page": 15,
+			"size": [
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"L",
+				"G"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 97,
+				"formula": "15d8 + 30"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 8,
+			"dex": 14,
+			"con": 14,
+			"int": 14,
+			"wis": 18,
+			"cha": 14,
+			"save": {
+				"int": "+5",
+				"wis": "+7",
+				"cha": "+5"
+			},
+			"skill": {
+				"persuasion": "+5",
+				"religion": "+5"
+			},
+			"passive": 14,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Celestial",
+				"Common"
+			],
+			"cr": "6",
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The curate has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Raise the Dead (1/Day)",
+					"entries": [
+						"In a ritual that takes 8 hours, the curate touches a creature that has died within the past 7 days. That creature returns to life with 1 {@variantrule Hit Points|XPHB|Hit Point}. The curate can't revive a creature that died of old age."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The curate makes three Celestial Radiance attacks."
+					]
+				},
+				{
+					"name": "Celestial Radiance",
+					"entries": [
+						"{@atkr m,r} {@hit 7}, reach 5 ft. or range 60 ft. {@h}18 ({@damage 4d8}) Radiant damage."
+					]
+				},
+				{
+					"name": "Healer's Touch (2/Day)",
+					"entries": [
+						"The curate touches another creature. That creature regains 13 ({@dice 2d8 + 4}) {@variantrule Hit Points|XPHB}."
+					]
+				}
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CE"
+			],
+			"damageTags": [
+				"R"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Gray Ooze Glob",
+			"source": "HotB",
+			"page": 18,
+			"size": [
+				"S"
+			],
+			"type": "ooze",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				9
+			],
+			"hp": {
+				"average": 19,
+				"formula": "3d6 + 9"
+			},
+			"speed": {
+				"walk": 10,
+				"climb": 10
+			},
+			"str": 12,
+			"dex": 6,
+			"con": 16,
+			"int": 1,
+			"wis": 6,
+			"cha": 2,
+			"skill": {
+				"stealth": "+2"
+			},
+			"senses": [
+				"Blindsight 60 ft."
+			],
+			"passive": 8,
+			"resist": [
+				"acid",
+				"cold",
+				"fire"
+			],
+			"conditionImmune": [
+				"blinded",
+				"charmed",
+				"deafened",
+				"exhaustion",
+				"frightened",
+				"grappled",
+				"prone",
+				"restrained"
+			],
+			"cr": "1/2",
+			"trait": [
+				{
+					"name": "Amorphous",
+					"entries": [
+						"The ooze can move through a space as narrow as 1 inch without expending extra movement to do so."
+					]
+				},
+				{
+					"name": "Corrosive Form",
+					"entries": [
+						"Whenever a creature hits the ooze with a melee attack, that creature takes 2 Acid damage."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Pseudopod",
+					"entries": [
+						"{@atkr m} {@hit 3}, reach 5 ft. {@h}10 ({@damage 2d8 + 1}) Acid damage."
+					]
+				}
+			],
+			"traitTags": [
+				"Amorphous"
+			],
+			"senseTags": [
+				"B"
+			],
+			"damageTags": [
+				"A"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Ivlis",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "HotB",
+			"page": 26,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 49,
+				"formula": "10d8 + 10"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 11,
+			"dex": 14,
+			"con": 12,
+			"int": 10,
+			"wis": 14,
+			"cha": 14,
+			"skill": {
+				"deception": "+4",
+				"persuasion": "+4"
+			},
+			"passive": 12,
+			"languages": [
+				"Common"
+			],
+			"cr": "2",
+			"gear": [
+				"leather armor|xphb"
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Ivlis makes three Chaos Blast attacks. She can replace one attack with a use of Sinister Command if available."
+					]
+				},
+				{
+					"name": "Chaos Blast",
+					"entries": [
+						"{@atkr m,r} {@hit 4}, reach 5 ft. or range 60 ft. {@h}7 ({@damage 2d6}) damage. Roll {@dice 1d4} to determine the damage type: 1, Acid; 2, Cold; 3, Fire; 4, Lightning."
+					]
+				},
+				{
+					"name": "Sinister Command {@recharge 5}",
+					"entries": [
+						"{@actSave wis} {@dc 12}, one creature Ivlis can see within 60 feet. {@actSaveFail} The target has the {@condition Charmed|XPHB} condition until the end of its next turn. While {@condition Charmed|XPHB}, the target has the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"charmed",
+				"incapacitated"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Jacko",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "HotB",
+			"page": 11,
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"halfling"
+				]
+			},
+			"alignment": [
+				"C",
+				"N"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 22,
+				"formula": "5d8"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 10,
+			"dex": 16,
+			"con": 10,
+			"int": 12,
+			"wis": 14,
+			"cha": 16,
+			"skill": {
+				"perception": "+6",
+				"stealth": "+5"
+			},
+			"passive": 16,
+			"languages": [
+				"Common",
+				"Halfling"
+			],
+			"cr": "1",
+			"gear": [
+				{
+					"item": "dagger|xphb",
+					"quantity": 6
+				},
+				"disguise kit|xphb"
+			],
+			"trait": [
+				{
+					"name": "Quick Disguise",
+					"entries": [
+						"Jacko spends 1 minute to disguise himself as a different Humanoid of approximately his height and weight. While Jacko is disguised, a creature that takes the {@action Study|XPHB} action to inspect Jacko's appearance can make a {@dc 13} Intelligence ({@skill Investigation|XPHB}) check, discerning his disguise on a successful check."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Jacko makes two Poison Dagger attacks."
+					]
+				},
+				{
+					"name": "Poison Dagger",
+					"entries": [
+						"{@atkr m,r} {@hit 5}, reach 5 ft. or range 20/60 ft. {@h}5 ({@damage 1d4 + 3}) Piercing damage plus 3 ({@damage 1d6}) Poison damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Cunning Action",
+					"entries": [
+						"Jacko takes the {@action Dash|XPHB}, {@action Disengage|XPHB}, or {@action Hide|XPHB} action."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"H"
+			],
+			"damageTags": [
+				"I",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Kuo-toa Marauder",
+			"source": "HotB",
+			"page": 8,
+			"size": [
+				"M"
+			],
+			"type": "aberration",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 22,
+				"formula": "4d8 + 4"
+			},
+			"speed": {
+				"walk": 30,
+				"swim": 30
+			},
+			"str": 14,
+			"dex": 10,
+			"con": 12,
+			"int": 10,
+			"wis": 11,
+			"cha": 10,
+			"skill": {
+				"perception": "+4"
+			},
+			"senses": [
+				"Darkvision 120 ft.",
+				"Truesight 30 ft."
+			],
+			"passive": 14,
+			"languages": [
+				"Common",
+				"Undercommon"
+			],
+			"cr": "1/2",
+			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"The kuo-toa can breathe air and water."
+					]
+				},
+				{
+					"name": "Sunlight Sensitivity",
+					"entries": [
+						"While in sunlight, the kuo-toa has {@variantrule Disadvantage|XPHB} on ability checks and attack rolls."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Brine Slicer",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}9 ({@damage 2d6 + 2}) Slashing damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Slippery",
+					"entries": [
+						"The kuo-toa takes the {@action Disengage|XPHB} action."
+					]
+				}
+			],
+			"traitTags": [
+				"Amphibious",
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"SD",
+				"U"
+			],
+			"languageTags": [
+				"C",
+				"U"
+			],
+			"damageTags": [
+				"S"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Lizardfolk Warden",
+			"source": "HotB",
+			"page": 10,
+			"size": [
+				"M"
+			],
+			"type": "elemental",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 32,
+				"formula": "5d8 + 10"
+			},
+			"speed": {
+				"walk": 30,
+				"swim": 30
+			},
+			"str": 15,
+			"dex": 12,
+			"con": 14,
+			"int": 10,
+			"wis": 12,
+			"cha": 8,
+			"skill": {
+				"stealth": "+5",
+				"survival": "+5"
+			},
+			"passive": 11,
+			"languages": [
+				"Common",
+				"Draconic"
+			],
+			"cr": "1",
+			"gear": [
+				"shield|xphb"
+			],
+			"trait": [
+				{
+					"name": "Hold Breath",
+					"entries": [
+						"The lizardfolk can hold its breath for 15 minutes."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The lizardfolk makes one Bite attack and one Bone Pike attack."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 1d6 + 2}) Piercing damage plus 3 ({@damage 1d6}) Poison damage."
+					]
+				},
+				{
+					"name": "Bone Pike",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 10 ft. {@h}7 ({@damage 1d10 + 2}) Piercing damage."
+					]
+				},
+				{
+					"name": "Poison Spit",
+					"entries": [
+						"{@atkr r} {@hit 4}, range 60 ft. {@h}12 ({@damage 3d6 + 2}) Poison damage."
+					]
+				}
+			],
+			"traitTags": [
+				"Hold Breath"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR"
+			],
+			"damageTags": [
+				"I",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"RCH"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Narthus",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "HotB",
+			"page": 26,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 22,
+				"formula": "4d8 + 4"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 14,
+			"dex": 11,
+			"con": 12,
+			"int": 10,
+			"wis": 14,
+			"cha": 10,
+			"skill": {
+				"medicine": "+4",
+				"religion": "+2"
+			},
+			"passive": 12,
+			"languages": [
+				"Common"
+			],
+			"cr": "1",
+			"gear": [
+				"chain shirt|xphb",
+				"mace|xphb"
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Narthus makes two attacks using Vile Mace or Fateful Bolt in any combination."
+					]
+				},
+				{
+					"name": "Vile Mace",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 1d6 + 2}) Bludgeoning damage plus 3 ({@damage 1d6}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Fateful Bolt",
+					"entries": [
+						"{@atkr r} {@hit 4}, range 120 ft. {@h}8 ({@damage 1d12 + 2}) Necrotic damage, and the next attack roll made against the target before the end of Narthus's next turn has {@variantrule Advantage|XPHB}."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"B",
+				"N"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Pral",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "HotB",
+			"page": 6,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 52,
+				"formula": "8d8 + 16"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 15,
+			"dex": 16,
+			"con": 14,
+			"int": 14,
+			"wis": 11,
+			"cha": 14,
+			"save": {
+				"dex": "+5"
+			},
+			"skill": {
+				"athletics": "+4",
+				"deception": "+4"
+			},
+			"passive": 10,
+			"languages": [
+				"Common"
+			],
+			"cr": "1",
+			"gear": [
+				"leather armor|xphb",
+				"light crossbow|xphb",
+				"rapier|xphb"
+			],
+			"action": [
+				{
+					"name": "Rapier",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}7 ({@damage 1d8 + 3}) Piercing damage."
+					]
+				},
+				{
+					"name": "Light Crossbow",
+					"entries": [
+						"{@atkr r} {@hit 5}, range 80/320 ft. {@h}7 ({@damage 1d8 + 3}) Piercing damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Parry",
+					"entries": [
+						"{@actTrigger} Pral is hit with a melee attack roll while holding a weapon. {@actResponse} Pral adds 2 to his AC against that attack, potentially causing the attack to miss."
+					]
+				}
+			],
+			"actionTags": [
+				"Parry"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"RNG"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Sprite Skirmisher",
+			"source": "HotB",
+			"page": 9,
+			"size": [
+				"T"
+			],
+			"type": "fey",
+			"alignment": [
+				"N",
+				"G"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 10,
+				"formula": "4d4"
+			},
+			"speed": {
+				"walk": 10,
+				"fly": 40
+			},
+			"str": 3,
+			"dex": 18,
+			"con": 10,
+			"int": 14,
+			"wis": 13,
+			"cha": 11,
+			"skill": {
+				"perception": "+3",
+				"stealth": "+8"
+			},
+			"passive": 13,
+			"languages": [
+				"Common",
+				"Elvish",
+				"Sylvan"
+			],
+			"cr": "1/4",
+			"action": [
+				{
+					"name": "Needle Sword",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}6 ({@damage 1d4 + 4}) Piercing damage."
+					]
+				},
+				{
+					"name": "Enchanting Bow",
+					"entries": [
+						"{@atkr r} {@hit 6}, range 40/160 ft. {@h}1 Piercing damage, and the target has the {@condition Charmed|XPHB} condition until the start of the sprite's next turn."
+					]
+				},
+				{
+					"name": "Heart Sight",
+					"entries": [
+						"{@actSave cha} {@dc 10}, one creature within 5 feet the sprite can see (Celestials, Fiends, Undead automatically fail the save). {@actSaveFail} The sprite knows the target's emotions."
+					]
+				},
+				{
+					"name": "Invisibility",
+					"entries": [
+						"The sprite has the {@condition Invisible|XPHB} condition for 1 minute. This effect ends early immediately after the sprite makes an attack roll or deals damage, or if the sprite has the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"languageTags": [
+				"C",
+				"E",
+				"S"
+			],
+			"damageTags": [
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"charmed",
+				"incapacitated",
+				"invisible"
+			],
+			"savingThrowForced": [
+				"charisma"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Vinx",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "HotB",
+			"page": 12,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"dwarf"
+				]
+			},
+			"alignment": [
+				"C",
+				"G"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 11,
+				"formula": "2d8 + 2"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 11,
+			"dex": 14,
+			"con": 12,
+			"int": 11,
+			"wis": 13,
+			"cha": 11,
+			"skill": {
+				"perception": "+5",
+				"stealth": "+6",
+				"survival": "+5"
+			},
+			"passive": 15,
+			"languages": [
+				"Common",
+				"Dwarvish"
+			],
+			"cr": "1/4",
+			"gear": [
+				"leather armor|xphb",
+				"shortsword|xphb",
+				"sling|xphb"
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Vinx makes two attacks, using Shortsword and Sling in any combination."
+					]
+				},
+				{
+					"name": "Shortsword",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 1d6 + 2}) Piercing damage."
+					]
+				},
+				{
+					"name": "Sling",
+					"entries": [
+						"{@atkr r} {@hit 4}, range 30/120 ft. {@h}4 ({@damage 1d4 + 2}) Bludgeoning damage."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"D"
+			],
+			"damageTags": [
+				"B",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"RNG"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Wight Lifedrinker",
+			"source": "HotB",
+			"page": 19,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 82,
+				"formula": "11d8 + 33"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 15,
+			"dex": 14,
+			"con": 16,
+			"int": 10,
+			"wis": 13,
+			"cha": 15,
+			"skill": {
+				"perception": "+3",
+				"stealth": "+4"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 13,
+			"resist": [
+				"necrotic"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"poisoned"
+			],
+			"languages": [
+				"Common plus one other language"
+			],
+			"cr": "3",
+			"gear": [
+				"studded leather armor|xphb"
+			],
+			"trait": [
+				{
+					"name": "Sunlight Sensitivity",
+					"entries": [
+						"While in sunlight, the wight has {@variantrule Disadvantage|XPHB} on ability checks and attack rolls."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The wight makes two attacks, using Necrotic Sword or Necrotic Bow in any combination. It can replace one attack with a use of Drink Life."
+					]
+				},
+				{
+					"name": "Necrotic Sword",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}6 ({@damage 1d8 + 2}) Slashing damage plus 4 ({@damage 1d8}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Necrotic Bow",
+					"entries": [
+						"{@atkr r} {@hit 4}, range 150/600 ft. {@h}6 ({@damage 1d8 + 2}) Piercing damage plus 4 ({@damage 1d8}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Drink Life {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 13}, one creature within 5 feet. {@actSaveFail} 6 ({@damage 1d8 + 2}) Necrotic damage, and the wight regains a number of {@variantrule Hit Points|XPHB} equal to the Necrotic damage taken."
+					]
+				}
+			],
+			"traitTags": [
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"N",
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		}
+	]
+}

--- a/json/bestiary/bestiary-hotdq.json
+++ b/json/bestiary/bestiary-hotdq.json
@@ -23,6 +23,9 @@
 					"page": 180
 				}
 			],
+			"referenceSources": [
+				"RoT"
+			],
 			"size": [
 				"M"
 			],
@@ -292,6 +295,9 @@
 					"source": "ToD",
 					"page": 181
 				}
+			],
+			"referenceSources": [
+				"RoT"
 			],
 			"size": [
 				"H"
@@ -599,6 +605,9 @@
 					"page": 182
 				}
 			],
+			"referenceSources": [
+				"RoT"
+			],
 			"size": [
 				"M"
 			],
@@ -716,6 +725,9 @@
 					"source": "ToD",
 					"page": 183
 				}
+			],
+			"referenceSources": [
+				"RoT"
 			],
 			"size": [
 				"M"
@@ -1248,6 +1260,9 @@
 					"page": 185
 				}
 			],
+			"referenceSources": [
+				"RoT"
+			],
 			"reprintedAs": [
 				"Guard Drake|MPMM"
 			],
@@ -1315,7 +1330,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guard-drake.mp3"
+				"path": "bestiary/guard-drake.opus"
 			},
 			"senseTags": [
 				"D"
@@ -1437,7 +1452,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"Jamna can take a bonus action to take the Dash, Disengage, or Hide action."
+						"Jamna can take a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -1664,6 +1679,15 @@
 					}
 				}
 			},
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"half-elf"
+				]
+			},
+			"languages": [
+				"Common"
+			],
 			"hasToken": true,
 			"hasFluffImages": true
 		},
@@ -1701,6 +1725,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"spear|phb"
 			],
@@ -1748,7 +1773,15 @@
 					"human"
 				]
 			},
+			"alignment": [
+				"L",
+				"G"
+			],
+			"languages": [
+				"Common"
+			],
 			"hasToken": true,
+			"hasFluff": true,
 			"hasFluffImages": true
 		},
 		{
@@ -1762,6 +1795,9 @@
 					"source": "ToD",
 					"page": 187
 				}
+			],
+			"referenceSources": [
+				"RoT"
 			],
 			"size": [
 				"M"
@@ -1969,6 +2005,7 @@
 			"ac": [
 				11
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1986,6 +2023,9 @@
 					"source": "ToD",
 					"page": 188
 				}
+			],
+			"referenceSources": [
+				"RoT"
 			],
 			"size": [
 				"M"
@@ -2176,12 +2216,12 @@
 			"page": 93,
 			"otherSources": [
 				{
-					"source": "RoT"
-				},
-				{
 					"source": "ToD",
 					"page": 180
 				}
+			],
+			"referenceSources": [
+				"RoT"
 			],
 			"size": [
 				"M"
@@ -2323,7 +2363,7 @@
 				{
 					"name": "Hide",
 					"entries": [
-						"Rezmir takes the Hide action."
+						"Rezmir takes the {@action Hide} action."
 					]
 				}
 			],

--- a/json/bestiary/bestiary-idrotf.json
+++ b/json/bestiary/bestiary-idrotf.json
@@ -46,8 +46,39 @@
 					]
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
+		},
+		{
+			"name": "Arveiaturace",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "IDRotF",
+			"page": 105,
+			"_copy": {
+				"name": "Ancient White Dragon",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the dragon",
+						"with": "Arveiaturace",
+						"flags": "i"
+					}
+				}
+			},
+			"senses": [
+				"blindsight 60 ft. (blind beyond this radius)",
+				"darkvision 60 ft."
+			],
+			"senseTags": [
+				"B",
+				"D"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Auril (First Form)",
@@ -587,7 +618,7 @@
 				{
 					"name": "Blizzard Veil",
 					"entries": [
-						"Auril creates a magical blizzard in a 30-foot-radius sphere centered on herself. The area within the sphere is heavily obscured, and the sphere moves with Auril. The effect lasts until Auril drops to 0 hit points in this form, until she chooses to end the effect (no action required), or until her {@status concentration} is broken (as if {@status concentration||concentrating} on a spell)."
+						"Auril creates a magical blizzard in a 30-foot-radius sphere centered on herself. The area within the sphere is {@quickref Vision and Light||2||heavily obscured}, and the sphere moves with Auril. The effect lasts until Auril drops to 0 hit points in this form, until she chooses to end the effect (no action required), or until her {@status concentration} is broken (as if {@status concentration||concentrating} on a spell)."
 					]
 				}
 			],
@@ -910,7 +941,8 @@
 				}
 			],
 			"traitTags": [
-				"Charge"
+				"Charge",
+				"Sure-Footed"
 			],
 			"actionTags": [
 				"Multiattack"
@@ -982,6 +1014,7 @@
 				"L",
 				"G"
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -1396,6 +1429,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1410,6 +1444,7 @@
 				"blindsight 60 ft.",
 				"tremorsense 60 ft."
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"B",
 				"T"
@@ -1436,6 +1471,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1452,6 +1488,7 @@
 				"burrow": 5,
 				"fly": 30
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1474,6 +1511,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1505,6 +1543,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"miscTags": [
 				"AOE",
 				"MW"
@@ -1515,6 +1554,9 @@
 			"name": "Chwinga",
 			"source": "IDRotF",
 			"page": 282,
+			"referenceSources": [
+				"CM"
+			],
 			"_copy": {
 				"name": "Chwinga",
 				"source": "ToA"
@@ -2030,6 +2072,7 @@
 			"cr": "0",
 			"spellcasting": null,
 			"action": null,
+			"tokenCustom": true,
 			"actionTags": [],
 			"spellcastingTags": [],
 			"miscTags": [],
@@ -2694,7 +2737,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+						"The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from {@item Holy Water (Flask)|PHB|holy water}, this trait doesn't function at the start of the vampire's next turn."
 					]
 				},
 				{
@@ -3326,7 +3369,7 @@
 				{
 					"name": "Bite (Bear or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 5 ft., one creature. {@h}16 ({@damage 2d10 + 5}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 15} Constitution saving throw or be cursed with werebear lycanthropy, as described in the Monster Manual."
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one creature. {@h}16 ({@damage 2d10 + 5}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 15} Constitution saving throw or be cursed with werebear {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}, as described in the Monster Manual."
 					]
 				},
 				{
@@ -3602,6 +3645,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"battleaxe|phb",
 				"javelin|phb"
@@ -3669,7 +3713,7 @@
 				{
 					"name": "Escape",
 					"entries": [
-						"The hare can take the Dash, Disengage, or Hide action as a bonus action on each of its turns."
+						"The hare can take the {@action Dash}, {@action Disengage}, or {@action Hide} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -3749,6 +3793,13 @@
 			"alignment": [
 				"N",
 				"G"
+			],
+			"languages": [
+				"Common"
+			],
+			"tokenCustom": true,
+			"languageTags": [
+				"C"
 			],
 			"hasToken": true,
 			"hasFluff": true
@@ -4178,6 +4229,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"javelin|phb"
 			],
@@ -4298,6 +4350,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"heavy crossbow|phb",
 				"sickle|phb"
@@ -4415,6 +4468,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"javelin|phb",
 				"warhammer|phb"
@@ -4485,8 +4539,7 @@
 				"R"
 			],
 			"spellcastingTags": [
-				"CC",
-				"I"
+				"CC"
 			],
 			"hasToken": true,
 			"hasFluff": true,
@@ -4585,10 +4638,15 @@
 					}
 				}
 			},
+			"alignment": [
+				"L",
+				"E"
+			],
 			"languages": [
 				"Common",
 				"Infernal"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"I"
@@ -4737,7 +4795,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of its next turn."
+						"The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from {@item Holy Water (Flask)|PHB|holy water}, this trait doesn't function at the start of its next turn."
 					]
 				},
 				{
@@ -5199,6 +5257,7 @@
 			"alignment": [
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -5255,7 +5314,8 @@
 				}
 			],
 			"traitTags": [
-				"Charge"
+				"Charge",
+				"Sure-Footed"
 			],
 			"damageTags": [
 				"B"
@@ -5424,6 +5484,7 @@
 				}
 			],
 			"traitTags": [
+				"Ethereal Sight",
 				"Incorporeal Movement"
 			],
 			"senseTags": [
@@ -5609,17 +5670,30 @@
 							"replace": "gladiator",
 							"with": "chieftain"
 						}
-					],
-					"_": [
-						{
-							"mode": "addSkills",
-							"skills": {
-								"survival": 1
-							}
-						}
 					]
 				}
 			},
+			"ac": [
+				{
+					"ac": 16,
+					"from": [
+						"{@item hide armor|PHB}",
+						"{@item shield|PHB}"
+					]
+				}
+			],
+			"skill": {
+				"athletics": "+10",
+				"intimidation": "+5",
+				"survival": "+5"
+			},
+			"languages": [
+				"Common"
+			],
+			"tokenCustom": true,
+			"languageTags": [
+				"C"
+			],
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -5637,17 +5711,30 @@
 							"replace": "gladiator",
 							"with": "great warrior"
 						}
-					],
-					"_": [
-						{
-							"mode": "addSkills",
-							"skills": {
-								"survival": 1
-							}
-						}
 					]
 				}
 			},
+			"ac": [
+				{
+					"ac": 16,
+					"from": [
+						"{@item hide armor|PHB}",
+						"{@item shield|PHB}"
+					]
+				}
+			],
+			"skill": {
+				"athletics": "+10",
+				"intimidation": "+5",
+				"survival": "+5"
+			},
+			"languages": [
+				"Common"
+			],
+			"tokenCustom": true,
+			"languageTags": [
+				"C"
+			],
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -5680,6 +5767,7 @@
 				"Common",
 				"Druidic"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"DU"
@@ -5742,6 +5830,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -6481,6 +6570,7 @@
 				"swim": 30,
 				"climb": 30
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -6664,6 +6754,7 @@
 			],
 			"languages": null,
 			"trait": null,
+			"tokenCustom": true,
 			"traitTags": [],
 			"senseTags": [
 				"B"
@@ -7113,6 +7204,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Hold Breath"
 			],

--- a/json/bestiary/bestiary-imr.json
+++ b/json/bestiary/bestiary-imr.json
@@ -214,7 +214,7 @@
 							"items": {
 								"name": "Shortsword",
 								"entries": [
-									"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage, and the target must succeed on a {@dc 11} Constitution saving throw or be cursed with wererat lycanthropy."
+									"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage, and the target must succeed on a {@dc 11} Constitution saving throw or be cursed with wererat {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 								]
 							}
 						},
@@ -224,7 +224,7 @@
 							"items": {
 								"name": "Light Crossbow",
 								"entries": [
-									"{@atk rw} {@hit 6} to hit, range 80/320 ft., one target. {@h}7 ({@damage 1d8 + 3}) piercing damage, and the target must succeed on a {@dc 11} Constitution saving throw or be cursed with wererat lycanthropy."
+									"{@atk rw} {@hit 6} to hit, range 80/320 ft., one target. {@h}7 ({@damage 1d8 + 3}) piercing damage, and the target must succeed on a {@dc 11} Constitution saving throw or be cursed with wererat {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 								]
 							}
 						}
@@ -245,6 +245,7 @@
 				"Common",
 				"Giant Owl"
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Keen Senses",
 				"Sneak Attack"
@@ -405,6 +406,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"light crossbow|phb"
 			],
@@ -481,6 +483,7 @@
 			"speed": {
 				"walk": 20
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -513,6 +516,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"D",
@@ -559,12 +563,13 @@
 				{
 					"name": "Petrifying Gaze",
 					"entries": [
-						"When a creature that can see the medusa's eyes starts its turn within 30 feet of the medusa, the medusa can force it to make a {@dc 14} Constitution saving throw if the medusa isn't {@condition incapacitated} and can see the creature. If the saving throw fails by 5 or more, the creature is instantly {@condition petrified}. Otherwise, a creature that fails the save begins to turn to metal, wood, or porcelain (the medusa's choice) and is {@condition restrained}. The {@condition restrained} creature must repeat the saving throw at the end of its next turn, becoming {@condition petrified} on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the  {@spell greater restoration} spell or other magic.",
+						"When a creature that can see the medusa's eyes starts its turn within 30 feet of the medusa, the medusa can force it to make a {@dc 14} Constitution saving throw if the medusa isn't {@condition incapacitated} and can see the creature. If the saving throw fails by 5 or more, the creature is instantly {@condition petrified}. Otherwise, a creature that fails the save begins to turn to metal, wood, or porcelain (the medusa's choice) and is {@condition restrained}. The {@condition restrained} creature must repeat the saving throw at the end of its next turn, becoming {@condition petrified} on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the {@spell greater restoration} spell or other magic.",
 						"Unless {@status surprised}, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save.",
 						"If the medusa sees itself reflected on a polished surface within 30 feet of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze."
 					]
 				}
 			],
+			"tokenCustom": true,
 			"spellcastingTags": [
 				"I"
 			],
@@ -607,6 +612,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -737,6 +743,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"shortsword|phb"
 			],
@@ -1155,6 +1162,7 @@
 				"Common",
 				"Primordial"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"P"
@@ -1274,6 +1282,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"spear|phb"
 			],
@@ -1327,6 +1336,7 @@
 				"exhaustion",
 				"poisoned"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1348,6 +1358,7 @@
 				"exhaustion",
 				"poisoned"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1369,6 +1380,7 @@
 				"exhaustion",
 				"poisoned"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1390,6 +1402,7 @@
 				"exhaustion",
 				"poisoned"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1426,6 +1439,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"damageTags": [
 				"S",
 				"Y"
@@ -1462,6 +1476,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"damageTags": [
 				"B",
 				"F",
@@ -1926,7 +1941,7 @@
 				{
 					"name": "Ink Cloud (Costs 3 Actions)",
 					"entries": [
-						"While underwater, the thessalkraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than the thessalkraken. Each creature other than the thessalkraken that ends its turn there must succeed on a {@dc 18} Constitution saving throw, taking 16 ({@damage 3d10}) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the thessalkraken's next turn."
+						"While underwater, the thessalkraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is {@quickref Vision and Light||2||heavily obscured} to creatures other than the thessalkraken. Each creature other than the thessalkraken that ends its turn there must succeed on a {@dc 18} Constitution saving throw, taking 16 ({@damage 3d10}) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the thessalkraken's next turn."
 					]
 				}
 			],
@@ -1934,6 +1949,7 @@
 				"name": "Thessalkraken",
 				"source": "IMR"
 			},
+			"tokenCustom": true,
 			"traitTags": [
 				"Amphibious"
 			],
@@ -2003,6 +2019,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"I",
@@ -2010,9 +2027,6 @@
 			],
 			"damageTagsSpell": [
 				"F"
-			],
-			"spellcastingTags": [
-				"I"
 			],
 			"hasToken": true
 		},
@@ -2089,6 +2103,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Hold Breath"
 			],

--- a/json/bestiary/bestiary-jttrc.json
+++ b/json/bestiary/bestiary-jttrc.json
@@ -242,10 +242,8 @@
 			"name": "Aurumvorax",
 			"source": "JttRC",
 			"page": 105,
-			"otherSources": [
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"QftIS"
 			],
 			"size": [
 				"S"
@@ -346,10 +344,8 @@
 			"name": "Aurumvorax Den Leader",
 			"source": "JttRC",
 			"page": 105,
-			"otherSources": [
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"QftIS"
 			],
 			"size": [
 				"M"
@@ -711,6 +707,7 @@
 				"exhaustion",
 				"poisoned"
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -845,6 +842,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -1633,6 +1631,7 @@
 			"senses": [
 				"darkvision 60 ft."
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Water Breathing"
 			],
@@ -1709,8 +1708,7 @@
 				"Tletlahtolli"
 			],
 			"spellcastingTags": [
-				"CC",
-				"I"
+				"CC"
 			],
 			"hasToken": true,
 			"hasFluffImages": true

--- a/json/bestiary/bestiary-kftgv.json
+++ b/json/bestiary/bestiary-kftgv.json
@@ -38,6 +38,7 @@
 				"paralyzed",
 				"poisoned"
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -68,6 +69,7 @@
 			"alignment": [
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -97,6 +99,7 @@
 			"alignment": [
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -126,6 +129,7 @@
 			"alignment": [
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -157,6 +161,7 @@
 				"poison",
 				"psychic"
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -189,6 +194,7 @@
 				"poison",
 				"psychic"
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -229,6 +235,7 @@
 			"immune": [
 				"fire"
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -263,6 +270,7 @@
 				"fire",
 				"lightning"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -292,6 +300,7 @@
 			"immune": [
 				"fire"
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -322,6 +331,7 @@
 			"immune": [
 				"fire"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -438,11 +448,8 @@
 					]
 				}
 			],
+			"reactionNote": "Charmayne can take up to three reactions per round but only one per turn.",
 			"reaction": [
-				{
-					"name": "Charmayne can take up to three reactions per round but only one per turn.",
-					"entries": []
-				},
 				{
 					"name": "Elemental Rebuke",
 					"entries": [
@@ -456,6 +463,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances"
 			],
@@ -565,6 +573,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Unusual Nature"
 			],
@@ -675,6 +684,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Flyby",
 				"Unusual Nature"
@@ -709,6 +719,7 @@
 				"performance": "+7"
 			},
 			"reaction": null,
+			"tokenCustom": true,
 			"actionTags": [],
 			"hasToken": true
 		},
@@ -755,6 +766,7 @@
 				}
 			],
 			"tokenCredit": "David Calabrese",
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -803,6 +815,7 @@
 					]
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -852,6 +865,7 @@
 					"displayAs": "action"
 				}
 			],
+			"tokenCustom": true,
 			"savingThrowForcedSpell": [
 				"constitution",
 				"dexterity",
@@ -887,6 +901,7 @@
 			"alignment": [
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -916,6 +931,7 @@
 			"alignment": [
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -945,6 +961,7 @@
 			"alignment": [
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1051,6 +1068,7 @@
 			"languages": [
 				"Common"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1081,6 +1099,7 @@
 				"L",
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1111,6 +1130,7 @@
 				"L",
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1141,6 +1161,7 @@
 				"L",
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1212,6 +1233,7 @@
 				"Common",
 				"Elvish"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1293,6 +1315,7 @@
 					"displayAs": "action"
 				}
 			],
+			"tokenCustom": true,
 			"savingThrowForcedSpell": [
 				"constitution"
 			],
@@ -1343,6 +1366,7 @@
 				"Terran",
 				"Undercommon"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1617,6 +1641,7 @@
 				"L",
 				"G"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1868,6 +1893,7 @@
 				"C",
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1898,6 +1924,7 @@
 				"C",
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1928,6 +1955,7 @@
 				"C",
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2153,6 +2181,7 @@
 				"acrobatics": "+4",
 				"performance": "+4"
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2336,6 +2365,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2366,6 +2396,7 @@
 				"C",
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2396,6 +2427,7 @@
 				"C",
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2426,6 +2458,7 @@
 				"C",
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2455,6 +2488,7 @@
 			"alignment": [
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2484,6 +2518,7 @@
 			"alignment": [
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2513,6 +2548,7 @@
 			"alignment": [
 				"N"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{

--- a/json/bestiary/bestiary-kkw.json
+++ b/json/bestiary/bestiary-kkw.json
@@ -1,4 +1,11 @@
 {
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"MM": "KKW"
+			}
+		}
+	},
 	"monster": [
 		{
 			"name": "Goblin Gang Member",
@@ -54,7 +61,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+						"The goblin can take the {@action Disengage} or {@action Hide} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -153,7 +160,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Krenko can take the Disengage or Hide action as a bonus action on each of his turns."
+						"Krenko can take the {@action Disengage} or {@action Hide} action as a bonus action on each of his turns."
 					]
 				}
 			],

--- a/json/bestiary/bestiary-lfl.json
+++ b/json/bestiary/bestiary-lfl.json
@@ -1,0 +1,931 @@
+{
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"XMM": "LFL"
+			}
+		}
+	},
+	"monster": [
+		{
+			"name": "Incarnation of Transience",
+			"group": [
+				"Incarnation of Nature"
+			],
+			"source": "LFL",
+			"size": [
+				"H"
+			],
+			"type": "fey",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 142,
+				"formula": "15d12 + 45"
+			},
+			"speed": {
+				"walk": 40,
+				"swim": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 21,
+			"dex": 20,
+			"con": 17,
+			"int": 10,
+			"wis": 14,
+			"cha": 16,
+			"save": {
+				"dex": "+8",
+				"con": "+6"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 12,
+			"conditionImmune": [
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"prone",
+				"restrained"
+			],
+			"languages": [
+				"Sylvan; telepathy 120 ft."
+			],
+			"cr": "7",
+			"trait": [
+				{
+					"name": "Ephemeral Movement",
+					"entries": [
+						"The incarnation can move through other creatures and objects as if they were {@variantrule Difficult Terrain|XPHB}, and its movement doesn't provoke {@action Opportunity Attack|XPHB|Opportunity Attacks}. It takes 5 ({@damage 1d10}) Force damage if it ends its turn inside an object."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The incarnation has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The incarnation makes three attacks, using Bite or Miasmic Globule in any combination."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}14 ({@damage 2d8 + 5}) Piercing damage."
+					]
+				},
+				{
+					"name": "Miasmic Globule",
+					"entries": [
+						"{@atkr r} {@hit 8}, range 60/120 ft. {@h}15 ({@damage 6d4}) Acid damage, and the target's {@variantrule Speed|XPHB} is reduced by 10 feet until the end of the incarnation's next turn."
+					]
+				},
+				{
+					"name": "Spectral Stampede",
+					"entries": [
+						"The incarnation moves up to 80 feet in a straight line. Each creature whose space the incarnation enters is targeted once by the following effect. {@actSave dex} {@dc 16}. {@actSaveFail} 18 ({@damage 4d8}) Force damage. If the target is the incarnation's size or smaller, it has the {@condition Prone|XPHB} condition. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The incarnation changes its size to Medium, Large, or Huge."
+					]
+				}
+			],
+			"environment": [
+				"planar, feywild"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"S",
+				"TP"
+			],
+			"damageTags": [
+				"A",
+				"O",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Incarnation of Vibrance",
+			"group": [
+				"Incarnation of Nature"
+			],
+			"source": "LFL",
+			"size": [
+				"H"
+			],
+			"type": "fey",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 230,
+				"formula": "20d12 + 100"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 20,
+			"dex": 17,
+			"con": 20,
+			"int": 10,
+			"wis": 16,
+			"cha": 21,
+			"save": {
+				"con": "+9",
+				"cha": "+9"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 13,
+			"resist": [
+				"radiant"
+			],
+			"conditionImmune": [
+				"blinded",
+				"charmed",
+				"deafened",
+				"frightened"
+			],
+			"languages": [
+				"Sylvan; telepathy 120 ft."
+			],
+			"cr": "10",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The incarnation casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability:"
+					],
+					"will": [
+						"{@spell Daylight|XPHB}",
+						"{@spell Druidcraft|XPHB}",
+						"{@spell Plant Growth|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Blindness/Deafness|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The incarnation has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The incarnation makes two Vine attacks and uses Radiant Blast. It can replace one vine attack with a use of Spellcasting to cast {@spell Blindness/Deafness|XPHB} if available."
+					]
+				},
+				{
+					"name": "Vine",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 20 ft. {@h}18 ({@damage 3d8 + 5}) Bludgeoning damage. If the target is the incarnation's size or smaller, it has the {@condition Grappled|XPHB} condition (escape {@dc 15}) from one of two vines."
+					]
+				},
+				{
+					"name": "Radiant Blast",
+					"entries": [
+						"{@actSave con} {@dc 17}, each creature of the incarnation's choice in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the incarnation. {@actSaveFail} The creature takes 14 ({@damage 2d8 + 5}) Radiant damage. {@actSaveSuccess} Half damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The incarnation changes its size to Medium, Large, or Huge."
+					]
+				},
+				{
+					"name": "Teleport",
+					"entries": [
+						"The incarnation teleports up to 60 feet to an unoccupied space it can see. The incarnation can't teleport while it has a creature {@condition Grappled|XPHB}."
+					]
+				}
+			],
+			"environment": [
+				"planar, feywild"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack",
+				"Teleport"
+			],
+			"languageTags": [
+				"S",
+				"TP"
+			],
+			"damageTags": [
+				"B",
+				"R"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"grappled"
+			],
+			"conditionInflictSpell": [
+				"blinded",
+				"deafened"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"savingThrowForcedSpell": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Lorwyn Giant",
+			"source": "LFL",
+			"size": [
+				"H"
+			],
+			"type": "giant",
+			"alignment": [
+				"C",
+				"N"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 115,
+				"formula": "11d12 + 44"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 21,
+			"dex": 13,
+			"con": 18,
+			"int": 9,
+			"wis": 16,
+			"cha": 8,
+			"save": {
+				"con": "+7",
+				"wis": "+6"
+			},
+			"passive": 13,
+			"languages": [
+				"Common",
+				"Giant"
+			],
+			"cr": "6",
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The giant makes two attacks, using Stone Sword or Boulder in any combination."
+					]
+				},
+				{
+					"name": "Stone Sword",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 15 ft. {@h}21 ({@damage 3d10 + 5}) Slashing damage."
+					]
+				},
+				{
+					"name": "Boulder",
+					"entries": [
+						"{@atkr r} {@hit 8}, range 60/240 ft. {@h}14 ({@damage 2d8 + 5}) Bludgeoning damage. If the target is a Large or smaller creature, it has the {@condition Prone|XPHB} condition."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Name Sleep {@recharge 5}",
+					"entries": [
+						"The giant falls into a deep, restorative slumber. The giant gains 20 {@variantrule Temporary Hit Points|XPHB} and has the {@condition Unconscious|XPHB} condition until it takes damage or the end of its next turn. The giant has {@variantrule Advantage|XPHB} on ability checks and saving throws for 1 minute."
+					]
+				}
+			],
+			"environment": [
+				"planar, feywild"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"GI"
+			],
+			"damageTags": [
+				"B",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"prone",
+				"unconscious"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Merrow Doublespeaker",
+			"source": "LFL",
+			"size": [
+				"M"
+			],
+			"type": "monstrosity",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 67,
+				"formula": "9d8 + 27"
+			},
+			"speed": {
+				"walk": 20,
+				"swim": 40
+			},
+			"str": 18,
+			"dex": 17,
+			"con": 16,
+			"int": 12,
+			"wis": 13,
+			"cha": 16,
+			"save": {
+				"dex": "+5",
+				"cha": "+5"
+			},
+			"skill": {
+				"deception": "+5",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 11,
+			"languages": [
+				"Common",
+				"Primordial (Aquan)"
+			],
+			"cr": "4",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The merrow casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 13}):"
+					],
+					"will": [
+						"{@spell Command|XPHB}",
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Minor Illusion|XPHB}"
+					],
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"The merrow can breathe air and water."
+					]
+				},
+				{
+					"name": "Mimicry",
+					"entries": [
+						"The merrow can mimic voices and animal sounds. A creature that hears the mimicries can tell they are imitations with a successful {@dc 15} Wisdom ({@skill Insight|XPHB}) check."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The merrow makes three Spined Tail attacks. It can replace one of these attacks with a use of Spellcasting to cast {@spell Command|XPHB}."
+					]
+				},
+				{
+					"name": "Spined Tail",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 20/60 ft. {@h}14 ({@damage 3d6 + 4}) Piercing damage."
+					]
+				}
+			],
+			"environment": [
+				"planar, feywild"
+			],
+			"treasure": [
+				"individual"
+			],
+			"traitTags": [
+				"Amphibious",
+				"Mimicry"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AQ",
+				"C",
+				"P"
+			],
+			"damageTags": [
+				"P"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflictSpell": [
+				"prone"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Merrow Haranguer",
+			"source": "LFL",
+			"size": [
+				"M"
+			],
+			"type": "monstrosity",
+			"alignment": [
+				"L",
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 90,
+				"formula": "12d8 + 36"
+			},
+			"speed": {
+				"walk": 5,
+				"swim": 40
+			},
+			"str": 18,
+			"dex": 18,
+			"con": 16,
+			"int": 14,
+			"wis": 15,
+			"cha": 19,
+			"save": {
+				"dex": "+7",
+				"cha": "+7"
+			},
+			"skill": {
+				"performance": "+7",
+				"persuasion": "+7"
+			},
+			"passive": 12,
+			"languages": [
+				"Common",
+				"Primordial (Aquan)"
+			],
+			"cr": "5",
+			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"The merrow can breathe air and water."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The merrow makes three attacks, using Coral Scepter and Poisoned Longbow in any combination."
+					]
+				},
+				{
+					"name": "Coral Scepter",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}14 ({@damage 2d10 + 4}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Poisoned Longbow",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 150/600 ft. {@h}8 ({@damage 1d8 + 4}) Piercing damage plus 7 ({@damage 2d6}) Poison damage."
+					]
+				},
+				{
+					"name": "Invective",
+					"entries": [
+						"{@actSave wis} {@dc 15}, up to three creatures the merrow can see within 60 feet. {@actSaveFail} 14 ({@damage 4d6}) Psychic damage, and the creature has {@variantrule Disadvantage|XPHB} on its next attack roll before the end of the merrow's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"environment": [
+				"planar, feywild"
+			],
+			"treasure": [
+				"individual"
+			],
+			"traitTags": [
+				"Amphibious"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AQ",
+				"C",
+				"P"
+			],
+			"damageTags": [
+				"B",
+				"I",
+				"P",
+				"Y"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RNG"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Noggle Ransacker",
+			"source": "LFL",
+			"size": [
+				"S"
+			],
+			"type": "fey",
+			"alignment": [
+				"C",
+				"N"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 13,
+				"formula": "3d6 + 3"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 14,
+			"dex": 15,
+			"con": 13,
+			"int": 8,
+			"wis": 10,
+			"cha": 12,
+			"skill": {
+				"stealth": "+4"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 10,
+			"languages": [
+				"Common",
+				"Sylvan"
+			],
+			"cr": "1/4",
+			"trait": [
+				{
+					"name": "Siege Monster",
+					"entries": [
+						"The noggle deals double damage to objects and structures."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Sabotaging Swipe",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}6 ({@damage 1d8 + 2}) Slashing damage. If the target is wearing armor, it is subjected to the following effect. {@actSave dex} {@dc 12}. {@actSaveFail} The armor takes a -1 penalty to the AC it offers. The target can take an action to remove the penalty from its armor."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Nimble Escape",
+					"entries": [
+						"The noggle takes the {@action Disengage|XPHB} or {@action Hide|XPHB} action."
+					]
+				}
+			],
+			"environment": [
+				"planar, feywild"
+			],
+			"treasure": [
+				"individual"
+			],
+			"traitTags": [
+				"Siege Monster"
+			],
+			"senseTags": [
+				"D"
+			],
+			"languageTags": [
+				"C",
+				"S"
+			],
+			"damageTags": [
+				"S"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Noggle Wild Mage",
+			"source": "LFL",
+			"size": [
+				"S"
+			],
+			"type": "fey",
+			"alignment": [
+				"C",
+				"N"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 22,
+				"formula": "4d6 + 8"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 11,
+			"dex": 16,
+			"con": 14,
+			"int": 10,
+			"wis": 12,
+			"cha": 17,
+			"save": {
+				"con": "+4",
+				"cha": "+5"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 11,
+			"languages": [
+				"Common",
+				"Sylvan"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Bloodied Wild Magic",
+					"entries": [
+						"While {@status Bloodied|XPHB}, the noggle has a {@variantrule Fly Speed|XPHB} of 30 feet and it can choose for any damage it deals to be Force damage."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The noggle makes two attacks, using Noggling Stick or Befuddling Ray in any combination."
+					]
+				},
+				{
+					"name": "Noggling Stick",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}5 ({@damage 1d4 + 3}) Bludgeoning damage plus 2 ({@damage 1d4}) Psychic damage."
+					]
+				},
+				{
+					"name": "Befuddling Ray",
+					"entries": [
+						"{@atkr r} {@hit 5}, range 60 ft. {@h}6 ({@damage 1d6 + 3}) Psychic damage, and the target subtracts {@dice 1d4} from the next saving throw it makes before the end of the noggle's next turn."
+					]
+				}
+			],
+			"environment": [
+				"planar, feywild"
+			],
+			"treasure": [
+				"individual"
+			],
+			"tokenCustom": true,
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"S"
+			],
+			"damageTags": [
+				"B",
+				"Y"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"hasToken": true,
+			"hasFluff": true
+		},
+		{
+			"name": "Shadowmoor Giant",
+			"source": "LFL",
+			"size": [
+				"H"
+			],
+			"type": "giant",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 172,
+				"formula": "15d12 + 75"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 22,
+			"dex": 14,
+			"con": 20,
+			"int": 7,
+			"wis": 19,
+			"cha": 8,
+			"save": {
+				"con": "+8",
+				"wis": "+7"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 14,
+			"languages": [
+				"Giant"
+			],
+			"cr": "8",
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The giant makes three attacks, using Tree Club or Boulder in any combination."
+					]
+				},
+				{
+					"name": "Tree Club",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 15 ft. {@h}17 ({@damage 2d10 + 6}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Boulder",
+					"entries": [
+						"{@atkr r} {@hit 9}, range 60/240 ft. {@h}13 ({@damage 2d6 + 6}) Bludgeoning damage. If the target is a Large or smaller creature, it has the {@condition Prone|XPHB} condition."
+					]
+				},
+				{
+					"name": "Wild Magic Cataclysm {@recharge 5}",
+					"entries": [
+						"{@actSave dex} {@dc 15}, each creature in a 20-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point within 120 feet. {@actSaveFail} 28 ({@damage 8d6}) damage (roll {@dice 1d4} to determine damage type: 1\u2014Acid; 2\u2014Fire; 3\u2014Lightning; 4\u2014Thunder). {@actSaveSuccess} Half damage."
+					]
+				}
+			],
+			"environment": [
+				"planar, feywild"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"tokenCustom": true,
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"GI"
+			],
+			"damageTags": [
+				"B"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"MLW",
+				"RA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true
+		}
+	]
+}

--- a/json/bestiary/bestiary-llk.json
+++ b/json/bestiary/bestiary-llk.json
@@ -5,6 +5,11 @@
 				"MM",
 				"VGM"
 			]
+		},
+		"otherSources": {
+			"monster": {
+				"MM": "LLK"
+			}
 		}
 	},
 	"monster": [
@@ -12,10 +17,8 @@
 			"name": "Brain in a Jar",
 			"source": "LLK",
 			"page": 38,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"size": [
 				"M"
@@ -242,6 +245,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Magic Resistance"
 			],
@@ -336,6 +340,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -363,6 +368,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -460,7 +466,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of his turns, Garret can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of his turns, Garret can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -582,6 +588,9 @@
 			"isNamedCreature": true,
 			"source": "LLK",
 			"page": 23,
+			"referenceSources": [
+				"IMR"
+			],
 			"_copy": {
 				"name": "Medusa",
 				"source": "MM",
@@ -607,7 +616,7 @@
 				{
 					"name": "Petrifying Gaze",
 					"entries": [
-						"When a creature that can see the medusa's eyes starts its turn within 30 feet of the medusa, the medusa can force it to make a {@dc 14} Constitution saving throw if the medusa isn't {@condition incapacitated} and can see the creature. If the saving throw fails by 5 or more, the creature is instantly {@condition petrified}. Otherwise, a creature that fails the save begins to turn to glass and is {@condition restrained}. The {@condition restrained} creature must repeat the saving throw at the end of its next turn, becoming {@condition petrified} on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the  {@spell greater restoration} spell or other magic.",
+						"When a creature that can see the medusa's eyes starts its turn within 30 feet of the medusa, the medusa can force it to make a {@dc 14} Constitution saving throw if the medusa isn't {@condition incapacitated} and can see the creature. If the saving throw fails by 5 or more, the creature is instantly {@condition petrified}. Otherwise, a creature that fails the save begins to turn to glass and is {@condition restrained}. The {@condition restrained} creature must repeat the saving throw at the end of its next turn, becoming {@condition petrified} on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the {@spell greater restoration} spell or other magic.",
 						"Unless {@status surprised}, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save.",
 						"If the medusa sees itself reflected on a polished surface within 30 feet of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze."
 					]
@@ -765,6 +774,7 @@
 				"CL"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW"
 			],
@@ -848,6 +858,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -929,6 +940,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"B"
 			],
@@ -981,6 +993,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		}
 	]

--- a/json/bestiary/bestiary-lmop.json
+++ b/json/bestiary/bestiary-lmop.json
@@ -108,10 +108,8 @@
 			"name": "Evil Mage",
 			"source": "LMoP",
 			"page": 57,
-			"otherSources": [
-				{
-					"source": "RMBRE"
-				}
+			"referenceSources": [
+				"RMBRE"
 			],
 			"size": [
 				"M"

--- a/json/bestiary/bestiary-lox.json
+++ b/json/bestiary/bestiary-lox.json
@@ -35,6 +35,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{

--- a/json/bestiary/bestiary-lr.json
+++ b/json/bestiary/bestiary-lr.json
@@ -196,6 +196,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"club|phb"
 			],
@@ -316,6 +317,7 @@
 				"Common",
 				"Aquan"
 			],
+			"tokenCustom": true,
 			"actionTags": [
 				"Multiattack"
 			],
@@ -744,6 +746,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],
@@ -815,7 +818,7 @@
 							{
 								"name": "Ink Cloud",
 								"entries": [
-									"While underwater, Whymsee can expel an ink cloud in a 20-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than kraken priests or a kraken. Each creature other than a kraken priest or a kraken that ends its turn there must succeed on a {@dc 14} Constitution saving throw, taking 9 ({@damage 2d8}) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of Whymsee's next turn."
+									"While underwater, Whymsee can expel an ink cloud in a 20-foot radius. The cloud spreads around corners, and that area is {@quickref Vision and Light||2||heavily obscured} to creatures other than kraken priests or a kraken. Each creature other than a kraken priest or a kraken that ends its turn there must succeed on a {@dc 14} Constitution saving throw, taking 9 ({@damage 2d8}) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of Whymsee's next turn."
 								]
 							},
 							{
@@ -850,6 +853,7 @@
 				"Common",
 				"Aquan"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"AQ",
 				"C"

--- a/json/bestiary/bestiary-lrdt.json
+++ b/json/bestiary/bestiary-lrdt.json
@@ -1,4 +1,11 @@
 {
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"MM": "LRDT"
+			}
+		}
+	},
 	"monster": [
 		{
 			"name": "Alax Jadescales",

--- a/json/bestiary/bestiary-mabjov.json
+++ b/json/bestiary/bestiary-mabjov.json
@@ -76,7 +76,7 @@
 				{
 					"name": "Spring Attack",
 					"entries": [
-						"The achaierai takes the Disengage action."
+						"The achaierai takes the {@action Disengage} action."
 					]
 				}
 			],
@@ -745,6 +745,7 @@
 		{
 			"name": "Bhaal, Ravager",
 			"shortName": "ravager",
+			"isNamedCreature": true,
 			"source": "MaBJoV",
 			"page": 95,
 			"size": [
@@ -958,6 +959,7 @@
 		{
 			"name": "Bhaal, Slayer",
 			"shortName": "slayer",
+			"isNamedCreature": true,
 			"source": "MaBJoV",
 			"page": 93,
 			"size": [
@@ -1346,8 +1348,7 @@
 			"damageTags": [
 				"B",
 				"N",
-				"P",
-				"R"
+				"P"
 			],
 			"miscTags": [
 				"HPR",
@@ -1480,7 +1481,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Borivik can take the Disengage or Hide action."
+						"Borivik can take the {@action Disengage} or {@action Hide} action."
 					]
 				}
 			],
@@ -2580,7 +2581,7 @@
 				13,
 				{
 					"ac": 18,
-					"condition": "with {@item staff of power} and  {@spell mage armor}",
+					"condition": "with {@item staff of power} and {@spell mage armor}",
 					"braces": true
 				}
 			],
@@ -3807,7 +3808,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"Imoen takes the Dash, Disengage, or Hide action."
+						"Imoen takes the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				}
 			],
@@ -4897,7 +4898,7 @@
 				{
 					"name": "Beak (Raven or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}1 piercing damage in raven form, or 6 ({@damage 1d4 + 4}) piercing damage in hybrid form. If the target is Humanoid, it must succeed on a {@dc 15} Constitution saving throw or be cursed with wereraven lycanthropy."
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}1 piercing damage in raven form, or 6 ({@damage 1d4 + 4}) piercing damage in hybrid form. If the target is Humanoid, it must succeed on a {@dc 15} Constitution saving throw or be cursed with wereraven {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				},
 				{
@@ -5314,7 +5315,7 @@
 				{
 					"name": "Greatsword",
 					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d6 + 5}) slashing damage"
+						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d6 + 5}) slashing damage."
 					]
 				}
 			],
@@ -8106,7 +8107,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The tasloi can take the Disengage or Hide action as a bonus action on each of its turns."
+						"The tasloi can take the {@action Disengage} or {@action Hide} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -8209,7 +8210,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The tasloi can take the Disengage or Hide action as a bonus action on each of its turns."
+						"The tasloi can take the {@action Disengage} or {@action Hide} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -8476,7 +8477,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, Valygar can take the Hide action as a bonus action."
+						"While in dim light or darkness, Valygar can take the {@action Hide} action as a bonus action."
 					]
 				}
 			],
@@ -8580,7 +8581,7 @@
 				{
 					"name": "Animal Companions",
 					"entries": [
-						"Vellin is accompanied by Akela ({@creature wolf} with 18 hit points). Vellin can mount or dismount Akela using 5 feet of movement. While mounted, Vellin can order Akela to Dash, Disengage, and Dodge. In addition, Vellin has an {@creature owl} companion with 3 hit points. On Vellin's turn, the owl can perform a flyby on a creature of Vellin's choice. The next attack that Vellin makes against that creature has advantage."
+						"Vellin is accompanied by Akela ({@creature wolf} with 18 hit points). Vellin can mount or dismount Akela using 5 feet of movement. While mounted, Vellin can order Akela to {@action Dash}, {@action Disengage}, and {@action Dodge}. In addition, Vellin has an {@creature owl} companion with 3 hit points. On Vellin's turn, the owl can perform a flyby on a creature of Vellin's choice. The next attack that Vellin makes against that creature has advantage."
 					]
 				},
 				{
@@ -8626,7 +8627,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Vellin can take the Disengage or Hide action."
+						"Vellin can take the {@action Disengage} or {@action Hide} action."
 					]
 				}
 			],
@@ -8669,7 +8670,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"drow"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -9636,6 +9641,9 @@
 			],
 			"spellcastingTags": [
 				"O"
+			],
+			"miscTags": [
+				"AOE"
 			],
 			"conditionInflictSpell": [
 				"poisoned"

--- a/json/bestiary/bestiary-mcv1sc.json
+++ b/json/bestiary/bestiary-mcv1sc.json
@@ -139,6 +139,9 @@
 			"name": "Clockwork Horror",
 			"source": "MCV1SC",
 			"page": 4,
+			"referenceSources": [
+				"SjA"
+			],
 			"size": [
 				"S"
 			],
@@ -1101,6 +1104,9 @@
 			"name": "Star Lancer",
 			"source": "MCV1SC",
 			"page": 12,
+			"referenceSources": [
+				"SjA"
+			],
 			"size": [
 				"L"
 			],

--- a/json/bestiary/bestiary-mcv2dc.json
+++ b/json/bestiary/bestiary-mcv2dc.json
@@ -110,6 +110,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Incorporeal Movement",
 				"Magic Resistance"
@@ -278,6 +279,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances"
 			],
@@ -463,6 +465,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Magic Resistance"
@@ -632,6 +635,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Incorporeal Movement",
 				"Unusual Nature"
@@ -746,6 +750,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D",
 				"U"
@@ -885,6 +890,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D",
 				"U"
@@ -1013,6 +1019,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -1150,6 +1157,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Spider Climb"
 			],
@@ -1272,6 +1280,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Hold Breath",
 				"Pack Tactics"
@@ -1395,6 +1404,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Death Burst"
 			],
@@ -1585,6 +1595,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"nightbringer|mcv2dc"
 			],

--- a/json/bestiary/bestiary-mcv3mc.json
+++ b/json/bestiary/bestiary-mcv3mc.json
@@ -4,10 +4,8 @@
 			"name": "Blaze",
 			"source": "MCV3MC",
 			"page": 3,
-			"otherSources": [
-				{
-					"source": "LK"
-				}
+			"referenceSources": [
+				"LK"
 			],
 			"size": [
 				"M"
@@ -134,10 +132,8 @@
 			"name": "Creeper",
 			"source": "MCV3MC",
 			"page": 4,
-			"otherSources": [
-				{
-					"source": "LK"
-				}
+			"referenceSources": [
+				"LK"
 			],
 			"size": [
 				"M"
@@ -244,10 +240,8 @@
 			"name": "Ender Dragon",
 			"source": "MCV3MC",
 			"page": 5,
-			"otherSources": [
-				{
-					"source": "LK"
-				}
+			"referenceSources": [
+				"LK"
 			],
 			"size": [
 				"G"
@@ -384,10 +378,8 @@
 			"name": "Enderman",
 			"source": "MCV3MC",
 			"page": 6,
-			"otherSources": [
-				{
-					"source": "LK"
-				}
+			"referenceSources": [
+				"LK"
 			],
 			"size": [
 				"M"
@@ -500,10 +492,8 @@
 			"name": "Wolf of the Overworld",
 			"source": "MCV3MC",
 			"page": 7,
-			"otherSources": [
-				{
-					"source": "LK"
-				}
+			"referenceSources": [
+				"LK"
 			],
 			"size": [
 				"M"

--- a/json/bestiary/bestiary-mcv4ec.json
+++ b/json/bestiary/bestiary-mcv4ec.json
@@ -856,7 +856,7 @@
 				{
 					"name": "Mischievous Stealth",
 					"entries": [
-						"The faerie takes the Hide action."
+						"The faerie takes the {@action Hide} action."
 					]
 				}
 			],
@@ -1983,7 +1983,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the nightmare haunt takes the Hide action."
+						"While in dim light or darkness, the nightmare haunt takes the {@action Hide} action."
 					]
 				}
 			],
@@ -2248,7 +2248,7 @@
 				{
 					"name": "Vulpine Nimbleness (Fox or Hybrid Form Only)",
 					"entries": [
-						"The werefox takes the Dash or Disengage action."
+						"The werefox takes the {@action Dash} or {@action Disengage} action."
 					]
 				}
 			],

--- a/json/bestiary/bestiary-mff.json
+++ b/json/bestiary/bestiary-mff.json
@@ -345,7 +345,7 @@
 				{
 					"name": "Dire Cacophony",
 					"entries": [
-						"Any creature other than a dire corby that starts its turn within 60 feet of a dire corby and can hear it must make a {@dc 11} Wisdom saving throw. On a failed save, the creature is unable to use the Dash action, cannot climb, or cast spells other than cantrips until the start of its next turn."
+						"Any creature other than a dire corby that starts its turn within 60 feet of a dire corby and can hear it must make a {@dc 11} Wisdom saving throw. On a failed save, the creature is unable to use the {@action Dash} action, cannot climb, or cast spells other than cantrips until the start of its next turn."
 					]
 				},
 				{
@@ -398,10 +398,8 @@
 			"name": "Eye of Fear and Flame",
 			"source": "MFF",
 			"page": 8,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"size": [
 				"M"

--- a/json/bestiary/bestiary-mgelft.json
+++ b/json/bestiary/bestiary-mgelft.json
@@ -10,7 +10,7 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"Dwarf"
+					"dwarf"
 				]
 			},
 			"alignment": [
@@ -112,7 +112,7 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"Grung"
+					"grung"
 				]
 			},
 			"alignment": [
@@ -167,7 +167,7 @@
 				{
 					"name": "Poisonous Skin",
 					"entries": [
-						"Any creature that grapples the grung or otherwise comes into direct contact with the grung's skin must succeed on a {@dc 12} Constitution saving throw or become {@condition poisoned} for 1 minute. A {@condition poisoned} creature no longer indirect contact with the grung can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Any creature that grapples the grung or otherwise comes into direct contact with the grung's skin must succeed on a {@dc 12} Constitution saving throw or become {@condition poisoned} for 1 minute. A {@condition poisoned} creature no longer in direct contact with the grung can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
@@ -179,7 +179,7 @@
 			],
 			"action": [
 				{
-					"name": "Grumpy Grung Growl.",
+					"name": "Grumpy Grung Growl",
 					"entries": [
 						"A ferocious gurgling issues from the throat of the Dankwood grung, warning those within 15 feet that they are indeed grumpy. Creatures in that area must succeed at a {@dc 12} Charisma saving throw or be {@condition frightened} until the end of their next turn."
 					]
@@ -228,7 +228,7 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"Grung"
+					"grung"
 				]
 			},
 			"alignment": [
@@ -296,7 +296,7 @@
 			],
 			"action": [
 				{
-					"name": "Grumpy Grung Growl.",
+					"name": "Grumpy Grung Growl",
 					"entries": [
 						"A ferocious gurgling issues from the throat of the Dankwood grung, warning those within 15 feet that they are indeed grumpy. Creatures in that area must succeed at a {@dc 12} Charisma saving throw or be {@condition frightened} until the end of their next turn."
 					]
@@ -430,7 +430,7 @@
 				{
 					"name": "Sludge Slap",
 					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}12 ({@damage 1d8 + 8}) bludgeoning damage, plus 4 ({@damage 1d8}) acid damage. Sludge Slap does both bludgeoning and acid damage"
+						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}12 ({@damage 1d8 + 8}) bludgeoning damage, plus 4 ({@damage 1d8}) acid damage. Sludge Slap does both bludgeoning and acid damage."
 					]
 				}
 			],
@@ -629,6 +629,7 @@
 				"D"
 			],
 			"languageTags": [
+				"CS",
 				"OTH"
 			],
 			"damageTags": [

--- a/json/bestiary/bestiary-mismv1.json
+++ b/json/bestiary/bestiary-mismv1.json
@@ -449,7 +449,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Rain takes either the Disengage or the Hide action."
+						"Rain takes either the {@action Disengage} or the {@action Hide} action."
 					]
 				}
 			],

--- a/json/bestiary/bestiary-mm.json
+++ b/json/bestiary/bestiary-mm.json
@@ -4,31 +4,15 @@
 			"name": "Aarakocra",
 			"source": "MM",
 			"page": 12,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"EGW",
+				"IDRotF",
+				"LoX",
+				"PotA",
+				"QftIS",
+				"SKT",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Aarakocra Skirmisher|XMM"
@@ -105,7 +89,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/aarakocra.mp3"
+				"path": "bestiary/aarakocra.opus"
 			},
 			"attachedItems": [
 				"javelin|phb"
@@ -133,37 +117,18 @@
 			"source": "MM",
 			"page": 13,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"GoS",
+				"JttRC",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"ToA",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Aboleth|XMM"
@@ -292,7 +257,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/aboleth.mp3"
+				"path": "bestiary/aboleth.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -344,22 +309,12 @@
 			"name": "Abominable Yeti",
 			"source": "MM",
 			"page": 306,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"CM",
+				"EGW",
+				"IDRotF",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Abominable Yeti|XMM"
@@ -460,7 +415,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/abominable-yeti.mp3"
+				"path": "bestiary/abominable-yeti.opus"
 			},
 			"traitTags": [
 				"Camouflage",
@@ -500,67 +455,33 @@
 			"page": 342,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SjA"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"DSotDQ",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"SjA",
+				"SKT",
+				"TftYP-TFoF",
+				"TftYP-TSC",
+				"ToA",
+				"ToR",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Priest Acolyte|XMM"
@@ -607,7 +528,7 @@
 					"name": "Spellcasting",
 					"type": "spellcasting",
 					"headerEntries": [
-						"The acolyte is a 1st-level spellcaster. Its spellcasting ability is Wisdom (spell save {@dc 12}, {@hit 4} to hit with spell attacks). The acolyte has following cleric spells prepared:"
+						"The acolyte is a 1st-level spellcaster. Its spellcasting ability is Wisdom (spell save {@dc 12}, {@hit 4} to hit with spell attacks). The acolyte has the following cleric spells prepared:"
 					],
 					"spells": {
 						"0": {
@@ -642,7 +563,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/acolyte.mp3"
+				"path": "bestiary/acolyte.opus"
 			},
 			"attachedItems": [
 				"club|phb"
@@ -679,34 +600,15 @@
 			"source": "MM",
 			"page": 88,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"DSotDQ",
+				"GoS",
+				"KftGV",
+				"PotA",
+				"QftIS",
+				"RoT"
 			],
 			"reprintedAs": [
 				"Adult Black Dragon|XMM"
@@ -924,7 +826,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-dragon.mp3"
+				"path": "bestiary/black-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -983,19 +885,11 @@
 			"name": "Adult Blue Dracolich",
 			"source": "MM",
 			"page": 84,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"CM",
+				"JttRC",
+				"SatO",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Dracolich|XMM"
@@ -1146,7 +1040,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-dracolich.mp3"
+				"path": "bestiary/blue-dracolich.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -1209,25 +1103,13 @@
 			"source": "MM",
 			"page": 91,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "JttRC"
-				}
+			"referenceSources": [
+				"GoS",
+				"HotDQ",
+				"JttRC",
+				"MOT",
+				"RoT",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Adult Blue Dragon|XMM"
@@ -1447,7 +1329,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-dragon.mp3"
+				"path": "bestiary/blue-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -1509,10 +1391,8 @@
 			"source": "MM",
 			"page": 105,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS"
 			],
 			"reprintedAs": [
 				"Adult Brass Dragon|XMM"
@@ -1758,7 +1638,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brass-dragon.mp3"
+				"path": "bestiary/brass-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -1820,31 +1700,16 @@
 			"source": "MM",
 			"page": 108,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "DSotDQ"
-				}
+			"referenceSources": [
+				"DoSI",
+				"DSotDQ",
+				"EGW",
+				"GoS",
+				"JttRC",
+				"PotA",
+				"SDW",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Adult Bronze Dragon|XMM"
@@ -2095,7 +1960,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bronze-dragon.mp3"
+				"path": "bestiary/bronze-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -2160,19 +2025,11 @@
 			"source": "MM",
 			"page": 112,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"CM",
+				"GoS",
+				"SatO",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Adult Copper Dragon|XMM"
@@ -2410,7 +2267,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/copper-dragon.mp3"
+				"path": "bestiary/copper-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -2471,16 +2328,11 @@
 			"source": "MM",
 			"page": 114,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "JttRC"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"JttRC",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Adult Gold Dragon|XMM"
@@ -2741,7 +2593,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gold-dragon.mp3"
+				"path": "bestiary/gold-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -2800,16 +2652,10 @@
 			"source": "MM",
 			"page": 94,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"CM",
+				"GoS",
+				"RoT"
 			],
 			"reprintedAs": [
 				"Adult Green Dragon|XMM"
@@ -3033,7 +2879,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-dragon.mp3"
+				"path": "bestiary/green-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -3099,31 +2945,18 @@
 			"page": 98,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "GotSF"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"EGW",
+				"GoS",
+				"GotSF",
+				"LRDT",
+				"MOT",
+				"OotA",
+				"TftYP",
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Adult Red Dragon|XMM"
@@ -3344,7 +3177,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-dragon.mp3"
+				"path": "bestiary/red-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -3405,13 +3238,10 @@
 			"source": "MM",
 			"page": 117,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Adult Silver Dragon|XMM"
@@ -3657,7 +3487,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/silver-dragon.mp3"
+				"path": "bestiary/silver-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -3718,28 +3548,14 @@
 			"source": "MM",
 			"page": 101,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"EGW",
+				"GoS",
+				"HotDQ",
+				"RoT",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Adult White Dragon|XMM"
@@ -3965,7 +3781,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/white-dragon.mp3"
+				"path": "bestiary/white-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -4023,76 +3839,34 @@
 			"page": 124,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "GotSF"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AitFR-FCD",
+				"BMT",
+				"CM",
+				"DIP",
+				"DSotDQ",
+				"ERLW",
+				"GoS",
+				"GotSF",
+				"HotDQ",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"MOT",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SCC-ARiR",
+				"SCC-TMM",
+				"SKT",
+				"SLW",
+				"TCE",
+				"TftYP",
+				"TftYP-WPM",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Air Elemental|XMM"
@@ -4193,7 +3967,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/air-elemental.mp3"
+				"path": "bestiary/air-elemental.opus"
 			},
 			"senseTags": [
 				"D"
@@ -4228,19 +4002,12 @@
 			"source": "MM",
 			"page": 79,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"JttRC",
+				"KftGV",
+				"ToA",
+				"WDH",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Allosaurus|XMM"
@@ -4305,7 +4072,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/allosaurus.mp3"
+				"path": "bestiary/allosaurus.opus"
 			},
 			"traitTags": [
 				"Pounce"
@@ -4551,7 +4318,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-dragon.mp3"
+				"path": "bestiary/black-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -4614,13 +4381,10 @@
 			"source": "MM",
 			"page": 90,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				}
+			"referenceSources": [
+				"MOT",
+				"SKT",
+				"TCE"
 			],
 			"reprintedAs": [
 				"Ancient Blue Dragon|XMM"
@@ -4840,7 +4604,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-dragon.mp3"
+				"path": "bestiary/blue-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -4902,13 +4666,9 @@
 			"source": "MM",
 			"page": 104,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"JttRC"
 			],
 			"reprintedAs": [
 				"Ancient Brass Dragon|XMM"
@@ -5161,7 +4921,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brass-dragon.mp3"
+				"path": "bestiary/brass-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -5224,10 +4984,8 @@
 			"source": "MM",
 			"page": 107,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS"
 			],
 			"reprintedAs": [
 				"Ancient Bronze Dragon|XMM"
@@ -5478,7 +5236,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bronze-dragon.mp3"
+				"path": "bestiary/bronze-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -5543,10 +5301,8 @@
 			"source": "MM",
 			"page": 110,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA"
 			],
 			"reprintedAs": [
 				"Ancient Copper Dragon|XMM"
@@ -5791,7 +5547,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/copper-dragon.mp3"
+				"path": "bestiary/copper-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -5853,10 +5609,8 @@
 			"source": "MM",
 			"page": 113,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"reprintedAs": [
 				"Ancient Gold Dragon|XMM"
@@ -6117,7 +5871,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gold-dragon.mp3"
+				"path": "bestiary/gold-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -6176,13 +5930,9 @@
 			"source": "MM",
 			"page": 93,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "DIP"
-				}
+			"referenceSources": [
+				"DIP",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Ancient Green Dragon|XMM"
@@ -6406,7 +6156,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-dragon.mp3"
+				"path": "bestiary/green-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -6471,22 +6221,12 @@
 			"source": "MM",
 			"page": 97,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"MOT",
+				"SatO",
+				"SKT",
+				"TCE",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Ancient Red Dragon|XMM"
@@ -6707,7 +6447,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-dragon.mp3"
+				"path": "bestiary/red-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -6768,10 +6508,8 @@
 			"source": "MM",
 			"page": 116,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"reprintedAs": [
 				"Ancient Silver Dragon|XMM"
@@ -7017,7 +6755,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/silver-dragon.mp3"
+				"path": "bestiary/silver-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -7078,16 +6816,10 @@
 			"source": "MM",
 			"page": 100,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"EGW",
+				"IDRotF",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Ancient White Dragon|XMM"
@@ -7313,7 +7045,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/white-dragon.mp3"
+				"path": "bestiary/white-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -7373,19 +7105,11 @@
 			"source": "MM",
 			"page": 281,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"CM",
+				"EGW",
+				"MOT",
+				"SatO"
 			],
 			"reprintedAs": [
 				"Sphinx of Valor|XMM"
@@ -7601,7 +7325,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/androsphinx.mp3"
+				"path": "bestiary/androsphinx.opus"
 			},
 			"traitTags": [
 				"Magic Weapons"
@@ -7669,61 +7393,31 @@
 			"page": 19,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"EGW",
+				"FS",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"PaBTSO",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SatO",
+				"SCC-CK",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-TFoF",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Animated Armor|XMM"
@@ -7805,7 +7499,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/animated-armor.mp3"
+				"path": "bestiary/animated-armor.opus"
 			},
 			"traitTags": [
 				"Antimagic Susceptibility",
@@ -7832,34 +7526,17 @@
 			"source": "MM",
 			"page": 21,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"DIP",
+				"GoS",
+				"JttRC",
+				"KftGV",
+				"PotA",
+				"QftIS",
+				"SCC-HfMT",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Ankheg|XMM"
@@ -7923,7 +7600,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ankheg.mp3"
+				"path": "bestiary/ankheg.opus"
 			},
 			"senseTags": [
 				"D",
@@ -7954,13 +7631,11 @@
 			"source": "MM",
 			"page": 79,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "CRCotN"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"SKT",
+				"ToA",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Ankylosaurus|XMM"
@@ -8008,7 +7683,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ankylosaurus.mp3"
+				"path": "bestiary/ankylosaurus.opus"
 			},
 			"damageTags": [
 				"B"
@@ -8033,22 +7708,13 @@
 			"page": 317,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"CM",
+				"GoS",
+				"TftYP",
+				"TftYP-AtG",
+				"ToA",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Ape|XMM"
@@ -8108,7 +7774,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ape.mp3"
+				"path": "bestiary/ape.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -8126,40 +7792,18 @@
 			"name": "Arcanaloth",
 			"source": "MM",
 			"page": 313,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"CoS",
+				"IDRotF",
+				"KftGV",
+				"PaBTSO",
+				"PSI",
+				"SatO",
+				"TCE",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Arcanaloth|XMM"
@@ -8387,7 +8031,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/arcanaloth.mp3"
+				"path": "bestiary/arcanaloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -8449,73 +8093,33 @@
 			"source": "MM",
 			"page": 342,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"DSotDQ",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"LoX",
+				"MOT",
+				"NRH-TLT",
+				"OotA",
+				"OoW",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Archmage|XMM"
@@ -8707,7 +8311,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/archmage.mp3"
+				"path": "bestiary/archmage.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -8770,76 +8374,33 @@
 			"source": "MM",
 			"page": 343,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"RoT",
+				"SatO",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-AtG",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Assassin|XMM"
@@ -8944,7 +8505,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/assassin.mp3"
+				"path": "bestiary/assassin.opus"
 			},
 			"attachedItems": [
 				"light crossbow|phb",
@@ -8983,31 +8544,19 @@
 			"page": 317,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AZfyT",
+				"IDRotF",
+				"IMR",
+				"MOT",
+				"NRH-AVitW",
+				"PSI",
+				"QftIS",
+				"SCC-CK",
+				"SKT",
+				"WBtW",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Awakened Shrub|XMM"
@@ -9067,7 +8616,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/awakened-shrub.mp3"
+				"path": "bestiary/awakened-shrub.opus"
 			},
 			"traitTags": [
 				"False Appearance"
@@ -9087,43 +8636,22 @@
 			"page": 317,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AZfyT",
+				"CM",
+				"GoS",
+				"IDRotF",
+				"LRDT",
+				"MOT",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"RoT",
+				"SCC-HfMT",
+				"SKT",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Awakened Tree|XMM"
@@ -9189,7 +8717,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/awakened-tree.mp3"
+				"path": "bestiary/awakened-tree.opus"
 			},
 			"traitTags": [
 				"False Appearance"
@@ -9210,22 +8738,13 @@
 			"page": 317,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"GoS",
+				"IDRotF",
+				"SKT",
+				"ToA",
+				"TTP",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Axe Beak|XMM"
@@ -9269,7 +8788,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/axe-beak.mp3"
+				"path": "bestiary/axe-beak.opus"
 			},
 			"damageTags": [
 				"S"
@@ -9285,19 +8804,12 @@
 			"source": "MM",
 			"page": 22,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"FRAiF",
+				"KftGV",
+				"PotA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Azer Sentinel|XMM"
@@ -9377,7 +8889,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/azer.mp3"
+				"path": "bestiary/azer.opus"
 			},
 			"attachedItems": [
 				"warhammer|phb"
@@ -9407,25 +8919,15 @@
 			"page": 318,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"KftGV",
+				"TftYP",
+				"TftYP-THSoT",
+				"ToA",
+				"TTP",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Baboon|XMM"
@@ -9479,7 +8981,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/baboon.mp3"
+				"path": "bestiary/baboon.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -9498,13 +9000,9 @@
 			"page": 318,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"QftIS",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Badger|XMM"
@@ -9560,7 +9058,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/badger.mp3"
+				"path": "bestiary/badger.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -9582,28 +9080,15 @@
 			"source": "MM",
 			"page": 55,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"CRCotN",
+				"EGW",
+				"IMR",
+				"OotA",
+				"TCE",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Balor|XMM"
@@ -9747,7 +9232,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/balor.mp3"
+				"path": "bestiary/balor.opus"
 			},
 			"attachedItems": [
 				"longsword|phb",
@@ -9775,6 +9260,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW",
 				"RCH"
@@ -9793,88 +9279,41 @@
 			"page": 343,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SjA"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"FS",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"SatO",
+				"SjA",
+				"SKT",
+				"SLW",
+				"TLK",
+				"ToA",
+				"ToR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bandit|XMM"
@@ -9945,7 +9384,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bandit.mp3"
+				"path": "bestiary/bandit.opus"
 			},
 			"altArt": [
 				{
@@ -9984,79 +9423,37 @@
 			"source": "MM",
 			"page": 344,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AitFR-ISF",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"LLK",
+				"LoX",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"SLW",
+				"TLK",
+				"ToA",
+				"ToFW",
+				"ToR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bandit Captain|XMM"
@@ -10150,7 +9547,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bandit-captain.mp3"
+				"path": "bestiary/bandit-captain.opus"
 			},
 			"altArt": [
 				{
@@ -10189,43 +9586,21 @@
 			"source": "MM",
 			"page": 23,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoS",
+				"DIP",
+				"EGW",
+				"GoS",
+				"HoL",
+				"JttRC",
+				"PaBTSO",
+				"QftIS",
+				"RtG",
+				"TCE",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Banshee|XMM"
@@ -10343,7 +9718,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/banshee.mp3"
+				"path": "bestiary/banshee.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement"
@@ -10376,37 +9751,17 @@
 			"source": "MM",
 			"page": 70,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"EGW",
+				"IDRotF",
+				"RoT",
+				"TCE",
+				"ToA",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Barbed Devil|XMM"
@@ -10547,7 +9902,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/barbed-devil.mp3"
+				"path": "bestiary/barbed-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -10578,46 +9933,21 @@
 			"name": "Barlgura",
 			"source": "MM",
 			"page": 56,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"CRCotN",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Barlgura|XMM"
@@ -10757,7 +10087,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/barlgura.mp3"
+				"path": "bestiary/barlgura.opus"
 			},
 			"traitTags": [
 				"Reckless"
@@ -10800,31 +10130,19 @@
 			"page": 24,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "PSZ"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"DitLCoT",
+				"IDRotF",
+				"MOT",
+				"OotA",
+				"PaBTSO",
+				"PSZ",
+				"QftIS",
+				"SCC-CK",
+				"SCC-HfMT",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Basilisk|XMM"
@@ -10866,7 +10184,7 @@
 				{
 					"name": "Petrifying Gaze",
 					"entries": [
-						"If a creature starts its turn within 30 feet of the basilisk and the two of them can see each other, the basilisk can force the creature to make a {@dc 12} Constitution saving throw if the basilisk isn't {@condition incapacitated}. On a failed save, the creature magically begins to turn to stone and is {@condition restrained}. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is {@condition petrified} until freed by the  {@spell greater restoration} spell or other magic.",
+						"If a creature starts its turn within 30 feet of the basilisk and the two of them can see each other, the basilisk can force the creature to make a {@dc 12} Constitution saving throw if the basilisk isn't {@condition incapacitated}. On a failed save, the creature magically begins to turn to stone and is {@condition restrained}. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is {@condition petrified} until freed by the {@spell greater restoration} spell or other magic.",
 						"A creature that isn't {@status surprised} can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the basilisk until the start of its next turn, when it can avert its eyes again. If it looks at the basilisk in the meantime, it must immediately make the save.",
 						"If the basilisk sees its reflection within 30 feet of it in bright light, it mistakes itself for a rival and targets itself with its gaze."
 					]
@@ -10885,7 +10203,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/basilisk.mp3"
+				"path": "bestiary/basilisk.opus"
 			},
 			"senseTags": [
 				"D"
@@ -10914,25 +10232,15 @@
 			"page": 318,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PSX"
-				}
+			"referenceSources": [
+				"CoS",
+				"IDRotF",
+				"PSX",
+				"SKT",
+				"ToA",
+				"TTP",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bat|XMM"
@@ -10991,7 +10299,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bat.mp3"
+				"path": "bestiary/bat.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -11013,37 +10321,18 @@
 			"source": "MM",
 			"page": 70,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"EGW",
+				"IDRotF",
+				"OoW",
+				"QftIS",
+				"RoT",
+				"ToA",
+				"VEoR",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Bearded Devil|XMM"
@@ -11172,7 +10461,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bearded-devil.mp3"
+				"path": "bestiary/bearded-devil.opus"
 			},
 			"attachedItems": [
 				"glaive|phb"
@@ -11215,37 +10504,22 @@
 			"source": "MM",
 			"page": 25,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"DitLCoT",
+				"EGW",
+				"JttRC",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"TftYP",
+				"TftYP-DiT",
+				"ToFW",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Behir|XMM"
@@ -11333,7 +10607,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/behir.mp3"
+				"path": "bestiary/behir.opus"
 			},
 			"senseTags": [
 				"D"
@@ -11377,52 +10651,26 @@
 			],
 			"source": "MM",
 			"page": 28,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"CoA",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"JttRC",
+				"KftGV",
+				"LoX",
+				"NRH-AT",
+				"OotA",
+				"PaBTSO",
+				"SatO",
+				"TCE",
+				"TftYP-DiT",
+				"ToA",
+				"ToFW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Beholder|XMM"
@@ -11508,69 +10756,59 @@
 							"style": "list-hang-notitle",
 							"items": [
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "1. Charm Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 16} Wisdom saving throw or be {@condition charmed} by the beholder for 1 hour, or until the beholder harms the creature."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "2. Paralyzing Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 16} Constitution saving throw or be {@condition paralyzed} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "3. Fear Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 16} Wisdom saving throw or be {@condition frightened} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "4. Slowing Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 16} Dexterity saving throw. On a failed save, the target's speed is halved for 1 minute. In addition, the creature can't take reactions, and it can take either an action or a bonus action on its turn, not both. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "5. Enervation Ray",
-									"style": "italic",
 									"entry": "The targeted creature must make a {@dc 16} Constitution saving throw, taking 36 ({@damage 8d8}) necrotic damage on a failed save, or half as much damage on a successful one."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "6. Telekinetic Ray",
-									"style": "italic",
 									"entries": [
 										"If the target is a creature, it must succeed on a {@dc 16} Strength saving throw or the beholder moves it up to 30 feet in any direction. It is {@condition restrained} by the ray's telekinetic grip until the start of the beholder's next turn or until the beholder is {@condition incapacitated}.",
 										"If the target is an object weighing 300 pounds or less that isn't being worn or carried, it is moved up to 30 feet in any direction. The beholder can also exert fine control on objects with this ray, such as manipulating a simple tool or opening a door or a container."
 									]
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "7. Sleep Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 16} Wisdom saving throw or fall asleep and remain {@condition unconscious} for 1 minute. The target awakens if it takes damage or another creature takes an action to wake it. This ray has no effect on constructs and undead."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "8. Petrification Ray",
-									"style": "italic",
-									"entry": "The targeted creature must make a {@dc 16} Dexterity saving throw. On a failed save, the creature begins to turn to stone and is {@condition restrained}. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is {@condition petrified} until freed by the  {@spell greater restoration} spell or other magic."
+									"entry": "The targeted creature must make a {@dc 16} Dexterity saving throw. On a failed save, the creature begins to turn to stone and is {@condition restrained}. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is {@condition petrified} until freed by the {@spell greater restoration} spell or other magic."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "9. Disintegration Ray",
-									"style": "italic",
 									"entries": [
 										"If the target is a creature, it must succeed on a {@dc 16} Dexterity saving throw or take 45 ({@damage 10d8}) force damage. If this damage reduces the creature to 0 hit points, its body becomes a pile of fine gray dust.",
 										"If the target is a Large or smaller nonmagical object or creation of magical force, it is disintegrated without a saving throw. If the target is a Huge or larger object or creation of magical force, this ray disintegrates a 10-foot cube of it."
 									]
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "10. Death Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 16} Dexterity saving throw or take 55 ({@damage 10d10}) necrotic damage. The target dies if the ray reduces it to 0 hit points."
 								}
 							]
@@ -11676,7 +10914,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/beholder.mp3"
+				"path": "bestiary/beholder.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -11722,19 +10960,12 @@
 			"name": "Beholder Zombie",
 			"source": "MM",
 			"page": 316,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"RtG",
+				"ToFW",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Beholder Zombie|XMM"
@@ -11815,27 +11046,23 @@
 							"style": "list-hang-notitle",
 							"items": [
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "1. Paralyzing Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 14} Constitution saving throw or be {@condition paralyzed} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "2. Fear Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 14} Wisdom saving throw or be {@condition frightened} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "3. Enervation Ray",
-									"style": "italic",
 									"entry": "The targeted creature must make a {@dc 14} Constitution saving throw, taking 36 ({@damage 8d8}) necrotic damage on a failed save, or half as much damage on a successful one."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "4. Disintegration Ray",
-									"style": "italic",
 									"entries": [
 										"If the target is a creature, it must succeed on a {@dc 14} Dexterity saving throw or take 45 ({@damage 10d8}) force damage. If this damage reduces the creature to 0 hit points, its body becomes a pile of fine gray dust.",
 										"If the target is a Large or smaller nonmagical object or creation of magical force, it is disintegrated without a saving throw. If the target is a Huge or larger nonmagical object or creation of magical force, this ray disintegrates a 10-foot cube of it."
@@ -11851,7 +11078,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/beholder-zombie.mp3"
+				"path": "bestiary/beholder-zombie.opus"
 			},
 			"traitTags": [
 				"Undead Fortitude"
@@ -11892,61 +11119,29 @@
 			"page": 344,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"EGW",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"LLK",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"SKT",
+				"SLW",
+				"ToA",
+				"ToFW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Berserker|XMM"
@@ -12018,7 +11213,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/berserker.mp3"
+				"path": "bestiary/berserker.opus"
 			},
 			"altArt": [
 				{
@@ -12053,31 +11248,15 @@
 			"page": 318,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"GoS",
+				"IMR",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Black Bear|XMM"
@@ -12149,7 +11328,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-bear.mp3"
+				"path": "bestiary/black-bear.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -12174,13 +11353,10 @@
 			"source": "MM",
 			"page": 88,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"TftYP",
+				"TftYP-DiT",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Black Dragon Wyrmling|XMM"
@@ -12339,7 +11515,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-dragon-wyrmling.mp3"
+				"path": "bestiary/black-dragon-wyrmling.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -12374,55 +11550,31 @@
 			"source": "MM",
 			"page": 241,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"CoS",
+				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LRDT",
+				"OotA",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"SatO",
+				"SCC-ARiR",
+				"SCC-HfMT",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-WPM",
+				"ToFW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Black Pudding|XMM"
@@ -12511,7 +11663,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-pudding.mp3"
+				"path": "bestiary/black-pudding.opus"
 			},
 			"traitTags": [
 				"Amorphous",
@@ -12537,34 +11689,16 @@
 			"page": 318,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"BMT",
+				"ERLW",
+				"GoS",
+				"MOT",
+				"SatO",
+				"TCE",
+				"VEoR",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Blink Dog|XMM"
@@ -12630,7 +11764,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blink-dog.mp3"
+				"path": "bestiary/blink-dog.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -12659,22 +11793,13 @@
 			"page": 319,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"CM",
+				"EGW",
+				"GoS",
+				"PotA",
+				"SKT",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Blood Hawk|XMM"
@@ -12740,7 +11865,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blood-hawk.mp3"
+				"path": "bestiary/blood-hawk.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -12763,13 +11888,9 @@
 			"source": "MM",
 			"page": 91,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "DoSI"
-				}
+			"referenceSources": [
+				"DoSI",
+				"MOT"
 			],
 			"reprintedAs": [
 				"Blue Dragon Wyrmling|XMM"
@@ -12927,7 +12048,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-dragon-wyrmling.mp3"
+				"path": "bestiary/blue-dragon-wyrmling.opus"
 			},
 			"altArt": [
 				{
@@ -12964,22 +12085,15 @@
 			"name": "Blue Slaad",
 			"source": "MM",
 			"page": 276,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"PaBTSO",
+				"QftIS",
+				"SatO",
+				"SCC-CK",
+				"SCC-HfMT",
+				"SCC-TMM",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Blue Slaad|XMM"
@@ -13084,7 +12198,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-slaad.mp3"
+				"path": "bestiary/blue-slaad.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -13122,31 +12236,18 @@
 			"source": "MM",
 			"page": 319,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AZfyT",
+				"CM",
+				"DIP",
+				"MOT",
+				"OoW",
+				"QftIS",
+				"SKT",
+				"ToA",
+				"TTP",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Boar|XMM"
@@ -13210,7 +12311,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/boar.mp3"
+				"path": "bestiary/boar.opus"
 			},
 			"traitTags": [
 				"Charge"
@@ -13234,37 +12335,19 @@
 			"source": "MM",
 			"page": 71,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"HotDQ",
+				"LLK",
+				"RoT",
+				"SatO",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bone Devil|XMM"
@@ -13417,7 +12500,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bone-devil.mp3"
+				"path": "bestiary/bone-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -13457,13 +12540,9 @@
 			"name": "Bone Naga (Guardian)",
 			"source": "MM",
 			"page": 233,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				}
+			"referenceSources": [
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bone Naga|XMM"
@@ -13566,7 +12645,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bone-naga.mp3"
+				"path": "bestiary/bone-naga.opus"
 			},
 			"senseTags": [
 				"D"
@@ -13603,13 +12682,11 @@
 			"name": "Bone Naga (Spirit)",
 			"source": "MM",
 			"page": 233,
-			"otherSources": [
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"DSotDQ",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bone Naga|XMM"
@@ -13712,7 +12789,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bone-naga.mp3"
+				"path": "bestiary/bone-naga.opus"
 			},
 			"senseTags": [
 				"D"
@@ -13752,6 +12829,9 @@
 			"source": "MM",
 			"page": 106,
 			"srd": true,
+			"referenceSources": [
+				"OoW"
+			],
 			"reprintedAs": [
 				"Brass Dragon Wyrmling|XMM"
 			],
@@ -13933,7 +13013,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brass-dragon-wyrmling.mp3"
+				"path": "bestiary/brass-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -13972,10 +13052,8 @@
 			"source": "MM",
 			"page": 109,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "DoSI"
-				}
+			"referenceSources": [
+				"DoSI"
 			],
 			"reprintedAs": [
 				"Bronze Dragon Wyrmling|XMM"
@@ -14159,7 +13237,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bronze-dragon-wyrmling.mp3"
+				"path": "bestiary/bronze-dragon-wyrmling.opus"
 			},
 			"altArt": [
 				{
@@ -14202,37 +13280,20 @@
 			"page": 319,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"MOT",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"SKT",
+				"TftYP",
+				"TftYP-TFoF",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Brown Bear|XMM"
@@ -14306,7 +13367,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brown-bear.mp3"
+				"path": "bestiary/brown-bear.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -14329,61 +13390,31 @@
 			"page": 33,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HftT",
+				"IDRotF",
+				"KftGV",
+				"LMoP",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-TSC",
+				"TftYP-WPM",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bugbear Warrior|XMM"
@@ -14471,7 +13502,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bugbear.mp3"
+				"path": "bestiary/bugbear.opus"
 			},
 			"attachedItems": [
 				"javelin|phb",
@@ -14504,13 +13535,11 @@
 			"name": "Bugbear Chief",
 			"source": "MM",
 			"page": 33,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "CRCotN"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"NRH-AT",
+				"TftYP",
+				"TftYP-AtG"
 			],
 			"size": [
 				"M"
@@ -14608,7 +13637,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bugbear-chief.mp3"
+				"path": "bestiary/bugbear-chief.opus"
 			},
 			"attachedItems": [
 				"javelin|phb",
@@ -14645,28 +13674,16 @@
 			"source": "MM",
 			"page": 34,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"DSotDQ",
+				"IDRotF",
+				"JttRC",
+				"LoX",
+				"PotA",
+				"QftIS",
+				"SCC-ARiR",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bulette|XMM"
@@ -14738,7 +13755,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bulette.mp3"
+				"path": "bestiary/bulette.opus"
 			},
 			"senseTags": [
 				"D",
@@ -14763,22 +13780,15 @@
 			"name": "Bullywug",
 			"source": "MM",
 			"page": 35,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"HotDQ",
+				"OoW",
+				"SCC-ARiR",
+				"US",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bullywug Warrior|XMM"
@@ -14878,14 +13888,8 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bullywug.mp3"
+				"path": "bestiary/bullywug.opus"
 			},
-			"altArt": [
-				{
-					"name": "Blacktongue Bullywug",
-					"source": "WDMM"
-				}
-			],
 			"attachedItems": [
 				"spear|phb"
 			],
@@ -14917,25 +13921,13 @@
 			"name": "Cambion",
 			"source": "MM",
 			"page": 36,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"KftGV",
+				"SKT",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Cambion|XMM"
@@ -15110,7 +14102,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cambion.mp3"
+				"path": "bestiary/cambion.opus"
 			},
 			"altArt": [
 				{
@@ -15240,16 +14232,10 @@
 			"page": 320,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CM",
+				"GoS",
+				"QftIS"
 			],
 			"reprintedAs": [
 				"Camel|XMM"
@@ -15292,7 +14278,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/camel.mp3"
+				"path": "bestiary/camel.opus"
 			},
 			"damageTags": [
 				"B"
@@ -15306,34 +14292,20 @@
 			"name": "Carrion Crawler",
 			"source": "MM",
 			"page": 37,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"DIP",
+				"IDRotF",
+				"OotA",
+				"OoW",
+				"QftIS",
+				"TftYP",
+				"TftYP-AtG",
+				"ToA",
+				"TTP",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Carrion Crawler|XMM"
@@ -15414,7 +14386,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/carrion-crawler.mp3"
+				"path": "bestiary/carrion-crawler.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -15452,40 +14424,19 @@
 			"page": 320,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				}
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"HotDQ",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"OoW",
+				"SKT",
+				"TCE",
+				"ToA",
+				"WBtW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Cat|XMM"
@@ -15545,7 +14496,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cat.mp3"
+				"path": "bestiary/cat.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -15562,13 +14513,11 @@
 			"name": "Cave Bear",
 			"source": "MM",
 			"page": 334,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				}
+			"referenceSources": [
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Polar Bear|XMM"
@@ -15644,7 +14593,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cave-bear.mp3"
+				"path": "bestiary/cave-bear.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -15670,31 +14619,16 @@
 			"page": 38,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"DIP",
+				"GoS",
+				"MOT",
+				"QftIS",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Centaur Trooper|XMM"
@@ -15774,7 +14708,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/centaur.mp3"
+				"path": "bestiary/centaur.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -15810,22 +14744,12 @@
 			"source": "MM",
 			"page": 72,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"PaBTSO",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Chain Devil|XMM"
@@ -15942,7 +14866,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/chain-devil.mp3"
+				"path": "bestiary/chain-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -15982,25 +14906,14 @@
 			"name": "Chasme",
 			"source": "MM",
 			"page": 57,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"CRCotN",
+				"KftGV",
+				"OotA",
+				"QftIS",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Chasme|XMM"
@@ -16072,7 +14985,7 @@
 				{
 					"name": "Drone",
 					"entries": [
-						"The chasme produces a horrid droning sound to which demons are immune. Any other creature that starts its turn with in 30 feet of the chasme must succeed on a {@dc 12} Constitution saving throw or fall {@condition unconscious} for 10 minutes. A creature that can't hear the drone automatically succeeds on the save. The effect on the creature ends if it takes damage or if another creature takes an action to splash it with holy water. If a creature's saving throw is successful or the effect ends for it, it is immune to the drone for the next 24 hours."
+						"The chasme produces a horrid droning sound to which demons are immune. Any other creature that starts its turn within 30 feet of the chasme must succeed on a {@dc 12} Constitution saving throw or fall {@condition unconscious} for 10 minutes. A creature that can't hear the drone automatically succeeds on the save. The effect on the creature ends if it takes damage or if another creature takes an action to splash it with {@item Holy Water (Flask)|PHB|holy water}. If a creature's saving throw is successful or the effect ends for it, it is immune to the drone for the next 24 hours."
 					]
 				},
 				{
@@ -16092,7 +15005,7 @@
 				{
 					"name": "Proboscis",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one creature. {@h}16 ({@damage 4d6 + 2}) piercing damage plus 24 ({@damage 7d6}) necrotic damage, and the target's hit point maximum is reduced by an amount equal to the necrotic damage taken. If this effect reduces a creature's hit point maximum to 0, the creature dies. This reduction to a creature's hit point maximum lasts until the creature finishes a long rest or until it is affected by a spell like  {@spell greater restoration}."
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one creature. {@h}16 ({@damage 4d6 + 2}) piercing damage plus 24 ({@damage 7d6}) necrotic damage, and the target's hit point maximum is reduced by an amount equal to the necrotic damage taken. If this effect reduces a creature's hit point maximum to 0, the creature dies. This reduction to a creature's hit point maximum lasts until the creature finishes a long rest or until it is affected by a spell like {@spell greater restoration}."
 					]
 				}
 			],
@@ -16113,7 +15026,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/chasme.mp3"
+				"path": "bestiary/chasme.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -16151,31 +15064,18 @@
 			"page": 39,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SCC-HfMT",
+				"SDW",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Chimera|XMM"
@@ -16261,7 +15161,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/chimera.mp3"
+				"path": "bestiary/chimera.opus"
 			},
 			"senseTags": [
 				"D"
@@ -16296,31 +15196,18 @@
 			"source": "MM",
 			"page": 40,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"CRCotN",
+				"DitLCoT",
+				"GoS",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Chuul|XMM"
@@ -16411,7 +15298,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/chuul.mp3"
+				"path": "bestiary/chuul.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -16451,37 +15338,20 @@
 			"source": "MM",
 			"page": 168,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoS",
+				"DitLCoT",
+				"DSotDQ",
+				"KftGV",
+				"PaBTSO",
+				"QftIS",
+				"RoT",
+				"SCC-ARiR",
+				"TftYP",
+				"TftYP-DiT",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Clay Golem|XMM"
@@ -16586,7 +15456,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}16 ({@damage 2d10 + 5}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 15} Constitution saving throw or have its hit point maximum reduced by an amount equal to the damage taken. The target dies if this attack reduces its hit point maximum to 0. The reduction lasts until removed by the  {@spell greater restoration} spell or other magic."
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}16 ({@damage 2d10 + 5}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 15} Constitution saving throw or have its hit point maximum reduced by an amount equal to the damage taken. The target dies if this attack reduces its hit point maximum to 0. The reduction lasts until removed by the {@spell greater restoration} spell or other magic."
 					]
 				},
 				{
@@ -16598,7 +15468,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/clay-golem.mp3"
+				"path": "bestiary/clay-golem.opus"
 			},
 			"traitTags": [
 				"Damage Absorption",
@@ -16633,37 +15503,22 @@
 			"source": "MM",
 			"page": 41,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"CRCotN",
+				"DitLCoT",
+				"EGW",
+				"JttRC",
+				"KftGV",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"SCC-ARiR",
+				"SCC-TMM",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Cloaker|XMM"
@@ -16714,7 +15569,7 @@
 				{
 					"name": "Damage Transfer",
 					"entries": [
-						"While attached to a creature, the cloaker takes only half the damage dealt to it (rounded down). and that creature takes the other half."
+						"While attached to a creature, the cloaker takes only half the damage dealt to it (rounded down), and that creature takes the other half."
 					]
 				},
 				{
@@ -16769,7 +15624,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cloaker.mp3"
+				"path": "bestiary/cloaker.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -16790,6 +15645,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -16809,28 +15665,16 @@
 			"source": "MM",
 			"page": 154,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"GoS",
+				"JttRC",
+				"MOT",
+				"PotA",
+				"SatO",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Cloud Giant|XMM"
@@ -16980,7 +15824,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cloud-giant.mp3"
+				"path": "bestiary/cloud-giant.opus"
 			},
 			"attachedItems": [
 				"morningstar|phb"
@@ -17030,22 +15874,15 @@
 			"page": 42,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"ERLW",
+				"MOT",
+				"OoW",
+				"SCC-CK",
+				"TftYP",
+				"TftYP-DiT",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Cockatrice|XMM"
@@ -17092,7 +15929,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cockatrice.mp3"
+				"path": "bestiary/cockatrice.opus"
 			},
 			"senseTags": [
 				"D"
@@ -17120,121 +15957,60 @@
 			"page": 345,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "GotSF"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "HFStCM"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DD",
+				"DIP",
+				"DSotDQ",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"FS",
+				"GoS",
+				"GotSF",
+				"HFStCM",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"LMoP",
+				"LoX",
+				"MOT",
+				"NRH-CoI",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"RoT",
+				"SatO",
+				"SCC-CK",
+				"SCC-TMM",
+				"SKT",
+				"SLW",
+				"TCE",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-TSC",
+				"ToA",
+				"ToFW",
+				"ToR",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Commoner|XMM"
@@ -17291,7 +16067,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/commoner.mp3"
+				"path": "bestiary/commoner.opus"
 			},
 			"altArt": [
 				{
@@ -17322,16 +16098,11 @@
 			"page": 320,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				}
+			"referenceSources": [
+				"TftYP",
+				"TftYP-THSoT",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Constrictor Snake|XMM"
@@ -17387,7 +16158,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/constrictor-snake.mp3"
+				"path": "bestiary/constrictor-snake.opus"
 			},
 			"senseTags": [
 				"B"
@@ -17587,7 +16358,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/copper-dragon-wyrmling.mp3"
+				"path": "bestiary/copper-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -17620,37 +16391,18 @@
 			"source": "MM",
 			"page": 43,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"EGW",
+				"IDRotF",
+				"PSX",
+				"SKT",
+				"TftYP",
+				"TftYP-THSoT",
+				"ToA",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Couatl|XMM"
@@ -17788,7 +16540,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/couatl.mp3"
+				"path": "bestiary/couatl.opus"
 			},
 			"traitTags": [
 				"Magic Weapons"
@@ -17839,19 +16591,12 @@
 			"page": 320,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"GoS",
+				"ToA",
+				"TTP",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Crab|XMM"
@@ -17915,7 +16660,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/crab.mp3"
+				"path": "bestiary/crab.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -17935,40 +16680,22 @@
 			"name": "Crawling Claw",
 			"source": "MM",
 			"page": 44,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"OoW",
+				"PotA",
+				"RtG",
+				"SCC-ARiR",
+				"ToA",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Crawling Claw|XMM"
@@ -18032,7 +16759,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/crawling-claw.mp3"
+				"path": "bestiary/crawling-claw.opus"
 			},
 			"traitTags": [
 				"Turn Immunity"
@@ -18061,40 +16788,20 @@
 			"page": 320,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "PSA"
-				}
+			"referenceSources": [
+				"DIP",
+				"EGW",
+				"GoS",
+				"HotDQ",
+				"IMR",
+				"PotA",
+				"PSA",
+				"PSX",
+				"SCC-TMM",
+				"SLW",
+				"ToA",
+				"US",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Crocodile|XMM"
@@ -18155,7 +16862,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/crocodile.mp3"
+				"path": "bestiary/crocodile.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -18177,97 +16884,43 @@
 			"source": "MM",
 			"page": 345,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"EGW",
+				"FS",
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"LoX",
+				"MOT",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"RoT",
+				"SKT",
+				"SLW",
+				"TCE",
+				"TftYP",
+				"TftYP-THSoT",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"VNotEE",
+				"WDH",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Cultist Fanatic|XMM"
@@ -18380,7 +17033,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cult-fanatic.mp3"
+				"path": "bestiary/cult-fanatic.opus"
 			},
 			"altArt": [
 				{
@@ -18434,88 +17087,41 @@
 			"page": 345,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"DC",
+				"DD",
+				"DIP",
+				"EGW",
+				"FS",
+				"GoS",
+				"HftT",
+				"HotDQ",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"KKW",
+				"LLK",
+				"LMoP",
+				"MOT",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"RoT",
+				"SKT",
+				"SLW",
+				"US",
+				"VEoR",
+				"VNotEE",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Cultist|XMM"
@@ -18587,7 +17193,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cultist.mp3"
+				"path": "bestiary/cultist.opus"
 			},
 			"altArt": [
 				{
@@ -18623,37 +17229,17 @@
 			"source": "MM",
 			"page": 45,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"CM",
+				"DSotDQ",
+				"EGW",
+				"GoS",
+				"MOT",
+				"RoT",
+				"SatO",
+				"ToA",
+				"VEoR",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Cyclops Sentry|XMM"
@@ -18730,7 +17316,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cyclops.mp3"
+				"path": "bestiary/cyclops.opus"
 			},
 			"attachedItems": [
 				"greatclub|phb"
@@ -18761,34 +17347,17 @@
 			],
 			"source": "MM",
 			"page": 143,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"DitLCoT",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"TCE",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Dao|XMM"
@@ -18939,10 +17508,13 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dao.mp3"
+				"path": "bestiary/dao.opus"
 			},
 			"attachedItems": [
 				"maul|phb"
+			],
+			"traitTags": [
+				"Sure-Footed"
 			],
 			"senseTags": [
 				"SD"
@@ -19041,19 +17613,13 @@
 			"source": "MM",
 			"page": 46,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PotA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Darkmantle|XMM"
@@ -19125,7 +17691,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/darkmantle.mp3"
+				"path": "bestiary/darkmantle.opus"
 			},
 			"traitTags": [
 				"False Appearance"
@@ -19153,25 +17719,15 @@
 			"page": 321,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "AATM"
-				}
+			"referenceSources": [
+				"AATM",
+				"LoX",
+				"MOT",
+				"OotA",
+				"OoW",
+				"SKT",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Death Dog|XMM"
@@ -19236,7 +17792,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/death-dog.mp3"
+				"path": "bestiary/death-dog.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -19265,46 +17821,21 @@
 			"name": "Death Knight",
 			"source": "MM",
 			"page": 47,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"GoS",
+				"SatO",
+				"TCE",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Death Knight|XMM"
@@ -19453,7 +17984,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/death-knight.mp3"
+				"path": "bestiary/death-knight.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -19516,37 +18047,19 @@
 			"name": "Death Slaad",
 			"source": "MM",
 			"page": 278,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"DSotDQ",
+				"EGW",
+				"GoS",
+				"OotA",
+				"PSI",
+				"SCC-CK",
+				"TCE",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Death Slaad|XMM"
@@ -19705,7 +18218,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/death-slaad.mp3"
+				"path": "bestiary/death-slaad.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -19765,22 +18278,13 @@
 			],
 			"source": "MM",
 			"page": 29,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"AATM",
+				"BMT",
+				"CM",
+				"OotA",
+				"SatO",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Death Tyrant|XMM"
@@ -19877,69 +18381,59 @@
 							"style": "list-hang-notitle",
 							"items": [
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "1. Charm Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 17} Wisdom saving throw or be {@condition charmed} by the death tyrant for 1 hour, or until the death tyrant harms the creature."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "2. Paralyzing Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 17} Constitution saving throw or be {@condition paralyzed} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "3. Fear Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 17} Wisdom saving throw or be {@condition frightened} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "4. Slowing Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 17} Dexterity saving throw. On a failed save, the target's speed is halved for 1 minute. In addition, the creature can't take reactions, and it can take either an action or a bonus action on its turn, not both. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "5. Enervation Ray",
-									"style": "italic",
 									"entry": "The targeted creature must make a {@dc 17} Constitution saving throw, taking 36 ({@damage 8d8}) necrotic damage on a failed save, or half as much damage on a successful one."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "6. Telekinetic Ray",
-									"style": "italic",
 									"entries": [
 										"If the target is a creature, it must succeed on a {@dc 17} Strength saving throw or the death tyrant moves it up to 30 feet in any direction. It is {@condition restrained} by the ray's telekinetic grip until the start of the death tyrant's next turn or until the death tyrant is {@condition incapacitated}.",
 										"If the target is an object weighing 300 pounds or less that isn't being worn or carried, it is moved up to 30 feet in any direction. The death tyrant can also exert fine control on objects with this ray, such as manipulating a simple tool or opening a door or a container."
 									]
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "7. Sleep Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 17} Wisdom saving throw or fall asleep and remain {@condition unconscious} for 1 minute. The target awakens if it takes damage or another creature takes an action to wake it. This ray has no effect on constructs and undead."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "8. Petrification Ray",
-									"style": "italic",
-									"entry": "The targeted creature must make a {@dc 17} Dexterity saving throw. On a failed save, the creature begins to turn to stone and is {@condition restrained}. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is {@condition petrified} until freed by the  {@spell greater restoration} spell or other magic."
+									"entry": "The targeted creature must make a {@dc 17} Dexterity saving throw. On a failed save, the creature begins to turn to stone and is {@condition restrained}. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is {@condition petrified} until freed by the {@spell greater restoration} spell or other magic."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "9. Disintegration Ray",
-									"style": "italic",
 									"entries": [
 										"If the target is a creature, it must succeed on a {@dc 17} Dexterity saving throw or take 45 ({@damage 10d8}) force damage. If this damage reduces the creature to 0 hit points, its body becomes a pile of fine gray dust.",
 										"If the target is a Large or smaller nonmagical object or creation of magical force, it is disintegrated without a saving throw. If the target is a Huge or larger object or creation of magical force, this ray disintegrates a 10-foot cube of it."
 									]
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "10. Death Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 17} Dexterity saving throw or take 55 ({@damage 10d10}) necrotic damage. The target dies if the ray reduces it to 0 hit points."
 								}
 							]
@@ -19964,7 +18458,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/death-tyrant.mp3"
+				"path": "bestiary/death-tyrant.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -20008,25 +18502,17 @@
 			"source": "MM",
 			"page": 164,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"KftGV",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"WDH",
+				"WDMM"
+			],
+			"reprintedAs": [
+				"Scout|XMM"
 			],
 			"size": [
 				"S"
@@ -20130,7 +18616,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/svirfneblin.mp3"
+				"path": "bestiary/svirfneblin.opus"
 			},
 			"altArt": [
 				{
@@ -20187,13 +18673,9 @@
 			"page": 321,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "DIP"
-				}
+			"referenceSources": [
+				"DIP",
+				"HotDQ"
 			],
 			"reprintedAs": [
 				"Deer|XMM"
@@ -20238,7 +18720,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deer.mp3"
+				"path": "bestiary/deer.opus"
 			},
 			"damageTags": [
 				"P"
@@ -20252,28 +18734,16 @@
 			"name": "Demilich",
 			"source": "MM",
 			"page": 48,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-ToH",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Demilich|XMM"
@@ -20412,7 +18882,7 @@
 				{
 					"name": "Energy Drain (Costs 2 Actions)",
 					"entries": [
-						"Each creature with in 30 feet of the demilich must make a {@dc 15} Constitution saving throw. On a failed save, the creature's hit point maximum is magically reduced by 10 ({@dice 3d6}). If a creature's hit point maximum is reduced to 0 by this effect, the creature dies. A creature's hit point maximum can be restored with the  {@spell greater restoration} spell or similar magic."
+						"Each creature within 30 feet of the demilich must make a {@dc 15} Constitution saving throw. On a failed save, the creature's hit point maximum is magically reduced by 10 ({@dice 3d6}). If a creature's hit point maximum is reduced to 0 by this effect, the creature dies. A creature's hit point maximum can be restored with the {@spell greater restoration} spell or similar magic."
 					]
 				},
 				{
@@ -20453,7 +18923,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/demilich.mp3"
+				"path": "bestiary/demilich.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -20469,6 +18939,7 @@
 				"N"
 			],
 			"miscTags": [
+				"AOE",
 				"CUR",
 				"HPR"
 			],
@@ -20522,40 +18993,19 @@
 			"source": "MM",
 			"page": 16,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"JttRC",
+				"KftGV",
+				"QftIS",
+				"SatO",
+				"TftYP-DiT",
+				"ToFW",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Deva|XMM"
@@ -20686,7 +19136,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deva.mp3"
+				"path": "bestiary/deva.opus"
 			},
 			"attachedItems": [
 				"mace|phb"
@@ -20726,34 +19176,19 @@
 			"page": 321,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CoS",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-TFoF",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Dire Wolf|XMM"
@@ -20820,7 +19255,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dire-wolf.mp3"
+				"path": "bestiary/dire-wolf.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -20845,37 +19280,19 @@
 			"name": "Displacer Beast",
 			"source": "MM",
 			"page": 81,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"ERLW",
+				"JttRC",
+				"KftGV",
+				"LRDT",
+				"QftIS",
+				"SatO",
+				"TftYP",
+				"TftYP-DiT",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Displacer Beast|XMM"
@@ -20947,7 +19364,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/displacer-beast.mp3"
+				"path": "bestiary/displacer-beast.opus"
 			},
 			"senseTags": [
 				"D"
@@ -20976,31 +19393,16 @@
 			"source": "MM",
 			"page": 144,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"GoS",
+				"JttRC",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"SCC-TMM",
+				"TCE"
 			],
 			"reprintedAs": [
 				"Djinni|XMM"
@@ -21140,7 +19542,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/djinni.mp3"
+				"path": "bestiary/djinni.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -21248,70 +19650,31 @@
 			"page": 82,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"EGW",
+				"HftT",
+				"HotDQ",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"LMoP",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"TftYP",
+				"TftYP-THSoT",
+				"ToA",
+				"ToFW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Doppelganger|XMM"
@@ -21405,7 +19768,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/doppelganger.mp3"
+				"path": "bestiary/doppelganger.opus"
 			},
 			"traitTags": [
 				"Ambusher",
@@ -21436,28 +19799,15 @@
 			"page": 321,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"GoS",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"SKT",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Draft Horse|XMM"
@@ -21500,7 +19850,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/draft-horse.mp3"
+				"path": "bestiary/draft-horse.opus"
 			},
 			"damageTags": [
 				"B"
@@ -21515,31 +19865,15 @@
 			"source": "MM",
 			"page": 119,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"EGW",
+				"GoS",
+				"JttRC",
+				"MOT",
+				"PotA",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Dragon Turtle|XMM"
@@ -21637,7 +19971,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dragon-turtle.mp3"
+				"path": "bestiary/dragon-turtle.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -21680,37 +20014,18 @@
 			"source": "MM",
 			"page": 57,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"CoS",
+				"EGW",
+				"GoS",
+				"IMR",
+				"OotA",
+				"PSI",
+				"SatO",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Dretch|XMM"
@@ -21797,7 +20112,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dretch.mp3"
+				"path": "bestiary/dretch.opus"
 			},
 			"senseTags": [
 				"D"
@@ -21832,19 +20147,12 @@
 			"source": "MM",
 			"page": 120,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"OotA",
+				"SatO",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Drider|XMM"
@@ -21989,7 +20297,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drider.mp3"
+				"path": "bestiary/drider.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -22091,40 +20399,22 @@
 			"source": "MM",
 			"page": 128,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CRCotN",
+				"DC",
+				"DD",
+				"DIP",
+				"EGW",
+				"OotA",
+				"PaBTSO",
+				"TftYP",
+				"TftYP-AtG",
+				"US",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Priest Acolyte|XMM"
@@ -22135,7 +20425,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -22243,7 +20537,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow.mp3"
+				"path": "bestiary/drow.opus"
 			},
 			"attachedItems": [
 				"hand crossbow|phb",
@@ -22326,37 +20620,19 @@
 			"name": "Drow Elite Warrior",
 			"source": "MM",
 			"page": 128,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "PaBTSO"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"DC",
+				"DIP",
+				"IDRotF",
+				"OotA",
+				"PaBTSO",
+				"SKT",
+				"SLW",
+				"TftYP",
+				"TftYP-AtG",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gladiator|XMM"
@@ -22367,7 +20643,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -22496,7 +20776,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-elite-warrior.mp3"
+				"path": "bestiary/drow-elite-warrior.opus"
 			},
 			"attachedItems": [
 				"hand crossbow|phb",
@@ -22586,46 +20866,22 @@
 			"name": "Drow Mage",
 			"source": "MM",
 			"page": 129,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"DC",
+				"DIP",
+				"IDRotF",
+				"OotA",
+				"PotA",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bandit Deceiver|XMM"
@@ -22636,7 +20892,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -22787,7 +21047,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-mage.mp3"
+				"path": "bestiary/drow-mage.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry",
@@ -22837,16 +21097,12 @@
 			"name": "Drow Priestess of Lolth",
 			"source": "MM",
 			"page": 129,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS",
+				"OotA",
+				"TftYP",
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Fiend Cultist|XMM"
@@ -22857,7 +21113,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -23036,7 +21296,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-priestess-of-lolth.mp3"
+				"path": "bestiary/drow-priestess-of-lolth.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry",
@@ -23114,73 +21374,37 @@
 			"source": "MM",
 			"page": 346,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DD",
+				"DIP",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"LoX",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SDW",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-TSC",
+				"ToA",
+				"ToR",
+				"VEoR",
+				"WBtW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Druid|XMM"
@@ -23284,7 +21508,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/druid.mp3"
+				"path": "bestiary/druid.opus"
 			},
 			"altArt": [
 				{
@@ -23327,55 +21551,26 @@
 			"source": "MM",
 			"page": 121,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CRCotN",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"MOT",
+				"PSI",
+				"QftIS",
+				"SCC-ARiR",
+				"SCC-CK",
+				"SKT",
+				"ToFW",
+				"VEoR",
+				"WBtW",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Dryad|XMM"
@@ -23486,7 +21681,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dryad.mp3"
+				"path": "bestiary/dryad.opus"
 			},
 			"attachedItems": [
 				"club|phb"
@@ -23533,37 +21728,22 @@
 			"source": "MM",
 			"page": 122,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"DD",
+				"EGW",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"TftYP",
+				"TftYP-TFoF",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Spy|XMM"
@@ -23660,7 +21840,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar.mp3"
+				"path": "bestiary/duergar.opus"
 			},
 			"attachedItems": [
 				"javelin|phb",
@@ -23699,16 +21879,13 @@
 			],
 			"source": "MM",
 			"page": 225,
-			"otherSources": [
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"KftGV",
+				"OotA",
+				"OoW",
+				"QftIS",
+				"SCC-CK",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Modron Duodrone|XMM"
@@ -23796,7 +21973,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duodrone.mp3"
+				"path": "bestiary/duodrone.opus"
 			},
 			"attachedItems": [
 				"javelin|phb"
@@ -23845,22 +22022,13 @@
 			"source": "MM",
 			"page": 215,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Dust Mephit|XMM"
@@ -23968,7 +22136,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mephit.mp3"
+				"path": "bestiary/mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -24013,13 +22181,10 @@
 			"page": 322,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CM"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"CM",
+				"DSotDQ",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Eagle|XMM"
@@ -24078,7 +22243,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/eagle.mp3"
+				"path": "bestiary/eagle.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -24098,40 +22263,23 @@
 			"page": 124,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AitFR-FCD",
+				"CRCotN",
+				"DitLCoT",
+				"MOT",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SKT",
+				"TCE",
+				"ToA",
+				"VEoR",
+				"WDH",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Earth Elemental|XMM"
@@ -24231,7 +22379,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/earth-elemental.mp3"
+				"path": "bestiary/earth-elemental.opus"
 			},
 			"traitTags": [
 				"Siege Monster"
@@ -24265,40 +22413,21 @@
 			"source": "MM",
 			"page": 145,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"EGW",
+				"JttRC",
+				"KftGV",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Efreeti|XMM"
@@ -24433,7 +22562,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/efreeti.mp3"
+				"path": "bestiary/efreeti.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -24530,16 +22659,9 @@
 			"page": 322,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Elephant|XMM"
@@ -24601,7 +22723,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/elephant.mp3"
+				"path": "bestiary/elephant.opus"
 			},
 			"damageTags": [
 				"B",
@@ -24624,25 +22746,14 @@
 			"page": 322,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"EGW",
+				"HotDQ",
+				"IDRotF",
+				"PotA",
+				"QftIS",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Elk|XMM"
@@ -24701,7 +22812,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/elk.mp3"
+				"path": "bestiary/elk.opus"
 			},
 			"traitTags": [
 				"Charge"
@@ -24724,34 +22835,17 @@
 			"name": "Empyrean",
 			"source": "MM",
 			"page": 130,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"MOT",
+				"QftIS",
+				"SatO",
+				"TftYP",
+				"TftYP-AtG",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Empyrean|XMM"
@@ -24914,7 +23008,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/empyrean.mp3"
+				"path": "bestiary/empyrean.opus"
 			},
 			"attachedItems": [
 				"maul|phb"
@@ -24970,28 +23064,14 @@
 			"source": "MM",
 			"page": 73,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"EGW",
+				"KftGV",
+				"SatO",
+				"ToA",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Erinyes|XMM"
@@ -25131,7 +23211,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/erinyes.mp3"
+				"path": "bestiary/erinyes.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -25205,46 +23285,20 @@
 			"source": "MM",
 			"page": 131,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"EGW",
+				"GoS",
+				"HotDQ",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SKT",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ettercap|XMM"
@@ -25353,7 +23407,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ettercap.mp3"
+				"path": "bestiary/ettercap.opus"
 			},
 			"traitTags": [
 				"Spider Climb",
@@ -25393,31 +23447,18 @@
 			"source": "MM",
 			"page": 132,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"JttRC",
+				"OotA",
+				"PotA",
+				"RoT",
+				"SCC-HfMT",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"ToFW",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ettin|XMM"
@@ -25504,7 +23545,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ettin.mp3"
+				"path": "bestiary/ettin.opus"
 			},
 			"attachedItems": [
 				"battleaxe|phb",
@@ -25658,7 +23699,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/faerie-dragon.mp3"
+				"path": "bestiary/faerie-dragon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -25705,10 +23746,8 @@
 			"name": "Faerie Dragon (Green)",
 			"source": "MM",
 			"page": 133,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Faerie Dragon Adult|XMM"
@@ -25831,7 +23870,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/faerie-dragon.mp3"
+				"path": "bestiary/faerie-dragon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -26001,7 +24040,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/faerie-dragon.mp3"
+				"path": "bestiary/faerie-dragon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -26048,6 +24087,9 @@
 			"name": "Faerie Dragon (Orange)",
 			"source": "MM",
 			"page": 133,
+			"referenceSources": [
+				"CM"
+			],
 			"reprintedAs": [
 				"Faerie Dragon Youth|XMM"
 			],
@@ -26163,7 +24205,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/faerie-dragon.mp3"
+				"path": "bestiary/faerie-dragon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -26204,13 +24246,9 @@
 			"name": "Faerie Dragon (Red)",
 			"source": "MM",
 			"page": 133,
-			"otherSources": [
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"CM",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Faerie Dragon Youth|XMM"
@@ -26326,7 +24364,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/faerie-dragon.mp3"
+				"path": "bestiary/faerie-dragon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -26364,22 +24402,13 @@
 			"name": "Faerie Dragon (Violet)",
 			"source": "MM",
 			"page": 133,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"EGW",
+				"FS",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Faerie Dragon Adult|XMM"
@@ -26505,7 +24534,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/faerie-dragon.mp3"
+				"path": "bestiary/faerie-dragon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -26668,7 +24697,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/faerie-dragon.mp3"
+				"path": "bestiary/faerie-dragon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -26711,49 +24740,23 @@
 			"page": 125,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"EGW",
+				"IMR",
+				"MOT",
+				"OotA",
+				"PotA",
+				"PSI",
+				"RoT",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"ToA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Fire Elemental|XMM"
@@ -26853,7 +24856,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fire-elemental.mp3"
+				"path": "bestiary/fire-elemental.opus"
 			},
 			"traitTags": [
 				"Illumination"
@@ -26885,49 +24888,22 @@
 			"page": 154,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "GotSF"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "HFStCM"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"EGW",
+				"GotSF",
+				"HFStCM",
+				"JttRC",
+				"MOT",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Fire Giant|XMM"
@@ -27033,7 +25009,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fire-giant.mp3"
+				"path": "bestiary/fire-giant.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -27068,25 +25044,16 @@
 			"name": "Fire Snake",
 			"source": "MM",
 			"page": 265,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"DoSI",
+				"JttRC",
+				"OotA",
+				"PotA",
+				"SCC-CK",
+				"TftYP",
+				"TftYP-TSC",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Salamander Fire Snake|XMM"
@@ -27178,7 +25145,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fire-snake.mp3"
+				"path": "bestiary/fire-snake.opus"
 			},
 			"senseTags": [
 				"D"
@@ -27207,73 +25174,32 @@
 			"source": "MM",
 			"page": 134,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DSotDQ",
+				"GoS",
+				"HftT",
+				"IDRotF",
+				"JttRC",
+				"LMoP",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"RtG",
+				"SatO",
+				"SCC-ARiR",
+				"SDW",
+				"TCE",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Flameskull|XMM"
@@ -27389,7 +25315,7 @@
 				{
 					"name": "Rejuvenation",
 					"entries": [
-						"If the flameskull is destroyed, it regains all its hit points in 1 hour unless holy water is sprinkled on its remains or a {@spell dispel magic} or {@spell remove curse} spell is cast on them."
+						"If the flameskull is destroyed, it regains all its hit points in 1 hour unless {@item Holy Water (Flask)|PHB|holy water} is sprinkled on its remains or a {@spell dispel magic} or {@spell remove curse} spell is cast on them."
 					]
 				}
 			],
@@ -27412,7 +25338,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flameskull.mp3"
+				"path": "bestiary/flameskull.opus"
 			},
 			"altArt": [
 				{
@@ -27460,52 +25386,26 @@
 			"page": 169,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"CoS",
+				"DIP",
+				"EGW",
+				"FS",
+				"GoS",
+				"IDRotF",
+				"MOT",
+				"RoT",
+				"RtG",
+				"SDW",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-WPM",
+				"ToA",
+				"ToFW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Flesh Golem|XMM"
@@ -27617,7 +25517,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flesh-golem.mp3"
+				"path": "bestiary/flesh-golem.opus"
 			},
 			"traitTags": [
 				"Damage Absorption",
@@ -27648,19 +25548,14 @@
 			"name": "Flumph",
 			"source": "MM",
 			"page": 135,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"LoX",
+				"NRH-AT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Flumph|XMM"
@@ -27746,7 +25641,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flumph.mp3"
+				"path": "bestiary/flumph.opus"
 			},
 			"senseTags": [
 				"D"
@@ -27782,22 +25677,14 @@
 			"page": 322,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"SKT",
+				"ToA",
+				"TTP",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Flying Snake|XMM"
@@ -27856,7 +25743,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flying-snake.mp3"
+				"path": "bestiary/flying-snake.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -27884,55 +25771,27 @@
 			"page": 20,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"EGW",
+				"FS",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"PotA",
+				"RtG",
+				"SCC-CK",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-ToH",
+				"ToA",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Animated Flying Sword|XMM"
@@ -28015,7 +25874,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flying-sword.mp3"
+				"path": "bestiary/flying-sword.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -28042,37 +25901,20 @@
 			"name": "Fomorian",
 			"source": "MM",
 			"page": 136,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"DitLCoT",
+				"JttRC",
+				"OotA",
+				"PaBTSO",
+				"QftIS",
+				"SatO",
+				"TLK",
+				"ToFW",
+				"VEoR",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Fomorian|XMM"
@@ -28151,7 +25993,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fomorian.mp3"
+				"path": "bestiary/fomorian.opus"
 			},
 			"attachedItems": [
 				"greatclub|phb"
@@ -28189,25 +26031,14 @@
 			"page": 322,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CoS",
+				"KftGV",
+				"PSX",
+				"QftIS",
+				"SCC-CK",
+				"ToA",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Frog|XMM"
@@ -28265,7 +26096,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/frog.mp3"
+				"path": "bestiary/frog.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -28283,31 +26114,15 @@
 			"page": 155,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"EGW",
+				"IDRotF",
+				"SatO",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Frost Giant|XMM"
@@ -28406,7 +26221,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/frost-giant.mp3"
+				"path": "bestiary/frost-giant.opus"
 			},
 			"attachedItems": [
 				"greataxe|phb"
@@ -28438,28 +26253,18 @@
 			"name": "Galeb Duhr",
 			"source": "MM",
 			"page": 139,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"KftGV",
+				"LLK",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"SCC-HfMT",
+				"TCE",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Galeb Duhr|XMM"
@@ -28558,7 +26363,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/galeb-duhr.mp3"
+				"path": "bestiary/galeb-duhr.opus"
 			},
 			"traitTags": [
 				"False Appearance"
@@ -28592,52 +26397,27 @@
 			"page": 140,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"ERLW",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"SCC-HfMT",
+				"SKT",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-WPM",
+				"ToA",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gargoyle|XMM"
@@ -28733,7 +26513,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gargoyle.mp3"
+				"path": "bestiary/gargoyle.opus"
 			},
 			"traitTags": [
 				"False Appearance"
@@ -28762,19 +26542,13 @@
 			"name": "Gas Spore",
 			"source": "MM",
 			"page": 138,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"OotA",
+				"QftIS",
+				"TftYP",
+				"TftYP-THSoT",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gas Spore Fungus|XMM"
@@ -28851,7 +26625,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gas-spore.mp3"
+				"path": "bestiary/gas-spore.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -28863,6 +26637,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"DIS",
 				"MW"
 			],
@@ -28881,31 +26656,20 @@
 			"source": "MM",
 			"page": 242,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"ERLW",
+				"GoS",
+				"IDRotF",
+				"LLK",
+				"LRDT",
+				"NRH-ASS",
+				"OotA",
+				"QftIS",
+				"TftYP",
+				"TftYP-DiT",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gelatinous Cube|XMM"
@@ -28985,7 +26749,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gelatinous-cube.mp3"
+				"path": "bestiary/gelatinous-cube.opus"
 			},
 			"senseTags": [
 				"B"
@@ -29011,46 +26775,23 @@
 			"source": "MM",
 			"page": 148,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"DC",
+				"DIP",
+				"DitLCoT",
+				"DSotDQ",
+				"GoS",
+				"OoW",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"SCC-ARiR",
+				"SDW",
+				"ToA",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ghast|XMM"
@@ -29133,7 +26874,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ghast.mp3"
+				"path": "bestiary/ghast.opus"
 			},
 			"altArt": [
 				{
@@ -29174,97 +26915,46 @@
 			"page": 147,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SatO",
+				"SDW",
+				"SKT",
+				"SLW",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"ToFW",
+				"TTP",
+				"VEoR",
+				"VNotEE",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ghost|XMM"
@@ -29366,7 +27056,7 @@
 				{
 					"name": "Horrifying Visage",
 					"entries": [
-						"Each non-undead creature within 60 feet of the ghost that can see it must succeed on a {@dc 13} Wisdom saving throw or be {@condition frightened} for 1 minute. If the save fails by 5 or more, the target also ages {@dice 1d4 × 10} years. A {@condition frightened} target can repeat the saving throw at the end of each of its turns, ending the {@condition frightened} condition on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this ghost's Horrifying Visage for the next 24 hours. The aging effect can be reversed with a  {@spell greater restoration} spell, but only within 24 hours of it occurring."
+						"Each non-undead creature within 60 feet of the ghost that can see it must succeed on a {@dc 13} Wisdom saving throw or be {@condition frightened} for 1 minute. If the save fails by 5 or more, the target also ages {@dice 1d4 × 10} years. A {@condition frightened} target can repeat the saving throw at the end of each of its turns, ending the {@condition frightened} condition on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this ghost's Horrifying Visage for the next 24 hours. The aging effect can be reversed with a {@spell greater restoration} spell, but only within 24 hours of it occurring."
 					]
 				},
 				{
@@ -29383,9 +27073,10 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ghost.mp3"
+				"path": "bestiary/ghost.opus"
 			},
 			"traitTags": [
+				"Ethereal Sight",
 				"Incorporeal Movement"
 			],
 			"senseTags": [
@@ -29419,91 +27110,41 @@
 			"page": 148,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"DC",
+				"DIP",
+				"DoSI",
+				"GoS",
+				"HftT",
+				"HoL",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LMoP",
+				"NRH-AT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"RMBRE",
+				"SatO",
+				"SDW",
+				"SLW",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-WPM",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ghoul|XMM"
@@ -29569,7 +27210,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ghoul.mp3"
+				"path": "bestiary/ghoul.opus"
 			},
 			"altArt": [
 				{
@@ -29606,10 +27247,9 @@
 			"page": 323,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Giant Ape|XMM"
@@ -29669,7 +27309,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-ape.mp3"
+				"path": "bestiary/giant-ape.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -29690,19 +27330,11 @@
 			"page": 323,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"JttRC",
+				"PaBTSO",
+				"QftIS",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Giant Badger|XMM"
@@ -29769,7 +27401,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-badger.mp3"
+				"path": "bestiary/giant-badger.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -29796,25 +27428,16 @@
 			"page": 323,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"MOT",
+				"PotA",
+				"PSX",
+				"QftIS",
+				"RtG",
+				"TCE",
+				"TftYP-THSoT",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Giant Bat|XMM"
@@ -29876,7 +27499,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-bat.mp3"
+				"path": "bestiary/giant-bat.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -29898,25 +27521,14 @@
 			"page": 323,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"GoS",
+				"MOT",
+				"PSI",
+				"SCC-HfMT",
+				"SKT",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Giant Boar|XMM"
@@ -29980,7 +27592,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-boar.mp3"
+				"path": "bestiary/giant-boar.opus"
 			},
 			"traitTags": [
 				"Charge"
@@ -30005,34 +27617,18 @@
 			"page": 323,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "PSA"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"GoS",
+				"HotDQ",
+				"PSA",
+				"PSX",
+				"QftIS",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Giant Centipede|XMM"
@@ -30085,7 +27681,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-centipede.mp3"
+				"path": "bestiary/giant-centipede.opus"
 			},
 			"senseTags": [
 				"B"
@@ -30112,31 +27708,18 @@
 			"page": 324,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"DIP",
+				"EGW",
+				"GoS",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"SLW",
+				"TftYP-THSoT",
+				"ToA",
+				"US",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Giant Constrictor Snake|XMM"
@@ -30196,7 +27779,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-constrictor-snake.mp3"
+				"path": "bestiary/giant-constrictor-snake.opus"
 			},
 			"senseTags": [
 				"B"
@@ -30221,40 +27804,24 @@
 			"page": 324,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"DIP",
+				"EGW",
+				"FS",
+				"GoS",
+				"MOT",
+				"PotA",
+				"SKT",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-WPM",
+				"ToR",
+				"TTP",
+				"VEoR",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Giant Crab|XMM"
@@ -30317,7 +27884,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-crab.mp3"
+				"path": "bestiary/giant-crab.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -30342,25 +27909,16 @@
 			"page": 324,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"DIP",
+				"JttRC",
+				"PotA",
+				"SCC-TMM",
+				"SLW",
+				"TftYP-AtG",
+				"ToA",
+				"ToFW",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Giant Crocodile|XMM"
@@ -30432,7 +27990,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-crocodile.mp3"
+				"path": "bestiary/giant-crocodile.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -30464,22 +28022,12 @@
 			"page": 324,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"GoS",
+				"QftIS",
+				"SatO",
+				"ToFW",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Giant Eagle|XMM"
@@ -30554,7 +28102,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-eagle.mp3"
+				"path": "bestiary/giant-eagle.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -30585,10 +28133,9 @@
 			"page": 325,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				}
+			"referenceSources": [
+				"SCC-HfMT",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Giant Elk|XMM"
@@ -30660,7 +28207,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-elk.mp3"
+				"path": "bestiary/giant-elk.opus"
 			},
 			"traitTags": [
 				"Charge"
@@ -30694,22 +28241,15 @@
 			"page": 325,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"OotA",
+				"PSX",
+				"QftIS",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-THSoT",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Giant Fire Beetle|XMM"
@@ -30769,7 +28309,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-fire-beetle.mp3"
+				"path": "bestiary/giant-fire-beetle.opus"
 			},
 			"traitTags": [
 				"Illumination"
@@ -30794,34 +28334,22 @@
 			"page": 325,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PSA"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"DitLCoT",
+				"EGW",
+				"FS",
+				"GoS",
+				"HftT",
+				"HotDQ",
+				"PSA",
+				"QftIS",
+				"SCC-CK",
+				"TftYP",
+				"TftYP-THSoT",
+				"TftYP-TSC",
+				"ToA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Giant Frog|XMM"
@@ -30893,7 +28421,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-frog.mp3"
+				"path": "bestiary/giant-frog.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -30925,25 +28453,13 @@
 			"page": 326,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CoS",
+				"IDRotF",
+				"QftIS",
+				"SKT",
+				"SLW",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Giant Goat|XMM"
@@ -31007,10 +28523,11 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-goat.mp3"
+				"path": "bestiary/giant-goat.opus"
 			},
 			"traitTags": [
-				"Charge"
+				"Charge",
+				"Sure-Footed"
 			],
 			"damageTags": [
 				"B"
@@ -31032,16 +28549,11 @@
 			"page": 326,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"GoS",
+				"TftYP",
+				"TftYP-THSoT"
 			],
 			"reprintedAs": [
 				"Giant Hyena|XMM"
@@ -31098,7 +28610,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-hyena.mp3"
+				"path": "bestiary/giant-hyena.opus"
 			},
 			"traitTags": [
 				"Rampage"
@@ -31117,40 +28629,22 @@
 			"page": 326,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSA"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"OotA",
+				"PSA",
+				"QftIS",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-TFoF",
+				"ToA",
+				"TTP",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Giant Lizard|XMM"
@@ -31229,7 +28723,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-lizard.mp3"
+				"path": "bestiary/giant-lizard.opus"
 			},
 			"senseTags": [
 				"D"
@@ -31280,34 +28774,19 @@
 			"page": 326,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PaBTSO"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"DSotDQ",
+				"EGW",
+				"FS",
+				"GoS",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"RoT",
+				"TCE"
 			],
 			"reprintedAs": [
 				"Giant Octopus|XMM"
@@ -31375,7 +28854,7 @@
 				{
 					"name": "Ink Cloud (Recharges after a Short or Long Rest)",
 					"entries": [
-						"A 20-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action."
+						"A 20-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is {@quickref Vision and Light||2||heavily obscured} for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the {@action Dash} action as a bonus action."
 					]
 				}
 			],
@@ -31384,7 +28863,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-octopus.mp3"
+				"path": "bestiary/giant-octopus.opus"
 			},
 			"traitTags": [
 				"Camouflage",
@@ -31418,22 +28897,12 @@
 			"page": 327,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"EGW",
+				"ERLW",
+				"IMR",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Giant Owl|XMM"
@@ -31504,7 +28973,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-owl.mp3"
+				"path": "bestiary/giant-owl.opus"
 			},
 			"traitTags": [
 				"Flyby",
@@ -31536,34 +29005,19 @@
 			"page": 327,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CoS",
+				"DitLCoT",
+				"GoS",
+				"MOT",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"SKT",
+				"TCE",
+				"ToA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Giant Venomous Snake|XMM"
@@ -31618,7 +29072,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-poisonous-snake.mp3"
+				"path": "bestiary/giant-poisonous-snake.opus"
 			},
 			"senseTags": [
 				"B"
@@ -31642,43 +29096,24 @@
 			"page": 327,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"DIP",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"KKW",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"SCC-CK",
+				"SKT",
+				"TftYP",
+				"TftYP-TSC",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Giant Rat|XMM"
@@ -31757,7 +29192,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-rat.mp3"
+				"path": "bestiary/giant-rat.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -31800,34 +29235,19 @@
 			"page": 327,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSA"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"DSotDQ",
+				"EGW",
+				"JttRC",
+				"PSA",
+				"SCC-CK",
+				"SCC-HfMT",
+				"TftYP",
+				"TftYP-WPM",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Giant Scorpion|XMM"
@@ -31890,7 +29310,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-scorpion.mp3"
+				"path": "bestiary/giant-scorpion.opus"
 			},
 			"senseTags": [
 				"B"
@@ -31920,13 +29340,9 @@
 			"page": 328,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "JttRC"
-				}
+			"referenceSources": [
+				"GoS",
+				"JttRC"
 			],
 			"reprintedAs": [
 				"Giant Seahorse|XMM"
@@ -31989,7 +29405,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-sea-horse.mp3"
+				"path": "bestiary/giant-sea-horse.opus"
 			},
 			"traitTags": [
 				"Charge",
@@ -32016,43 +29432,20 @@
 			"page": 328,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "LR"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"DIP",
+				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"LR",
+				"PSX",
+				"SDW",
+				"SKT",
+				"ToA",
+				"VEoR",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Giant Shark|XMM"
@@ -32120,7 +29513,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-shark.mp3"
+				"path": "bestiary/giant-shark.opus"
 			},
 			"traitTags": [
 				"Water Breathing"
@@ -32143,85 +29536,39 @@
 			"page": 328,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HftT",
+				"HotDQ",
+				"LMoP",
+				"LRDT",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PSX",
+				"QftIS",
+				"RMBRE",
+				"RoT",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"ToA",
+				"US",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Giant Spider|XMM"
@@ -32307,7 +29654,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-spider.mp3"
+				"path": "bestiary/giant-spider.opus"
 			},
 			"traitTags": [
 				"Spider Climb",
@@ -32344,28 +29691,16 @@
 			"page": 329,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"EGW",
+				"FS",
+				"GoS",
+				"KftGV",
+				"QftIS",
+				"TCE",
+				"US",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Giant Toad|XMM"
@@ -32437,7 +29772,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-toad.mp3"
+				"path": "bestiary/giant-toad.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -32469,28 +29804,14 @@
 			"page": 329,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"CRCotN",
+				"IDRotF",
+				"MOT",
+				"PotA",
+				"SKT",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Giant Vulture|XMM"
@@ -32568,7 +29889,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-vulture.mp3"
+				"path": "bestiary/giant-vulture.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -32597,22 +29918,14 @@
 			"page": 329,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "PSA"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"OoW",
+				"PSA",
+				"PSX",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Giant Wasp|XMM"
@@ -32658,7 +29971,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-wasp.mp3"
+				"path": "bestiary/giant-wasp.opus"
 			},
 			"damageTags": [
 				"I",
@@ -32682,16 +29995,11 @@
 			"page": 329,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"GoS",
+				"QftIS",
+				"TftYP",
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				"Giant Weasel|XMM"
@@ -32751,7 +30059,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-weasel.mp3"
+				"path": "bestiary/giant-weasel.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -32773,28 +30081,17 @@
 			"page": 330,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PSX"
-				}
+			"referenceSources": [
+				"CoS",
+				"GoS",
+				"LRDT",
+				"OotA",
+				"PSX",
+				"TCE",
+				"TftYP",
+				"TftYP-THSoT",
+				"ToA",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Giant Wolf Spider|XMM"
@@ -32870,7 +30167,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-wolf-spider.mp3"
+				"path": "bestiary/giant-wolf-spider.opus"
 			},
 			"traitTags": [
 				"Spider Climb",
@@ -32903,46 +30200,25 @@
 			"source": "MM",
 			"page": 157,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"CRCotN",
+				"ERLW",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gibbering Mouther|XMM"
@@ -33018,7 +30294,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gibbering-mouther.mp3"
+				"path": "bestiary/gibbering-mouther.opus"
 			},
 			"senseTags": [
 				"D"
@@ -33050,34 +30326,16 @@
 			"name": "Githyanki Knight",
 			"source": "MM",
 			"page": 160,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AATM",
+				"BMT",
+				"CoA",
+				"LoX",
+				"PaBTSO",
+				"QftIS",
+				"SatO",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Githyanki Knight|XMM"
@@ -33167,7 +30425,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githyanki-knight.mp3"
+				"path": "bestiary/githyanki-knight.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -33198,31 +30456,15 @@
 			"name": "Githyanki Warrior",
 			"source": "MM",
 			"page": 160,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "SjA"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"BMT",
+				"LoX",
+				"PaBTSO",
+				"QftIS",
+				"SatO",
+				"SjA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Githyanki Warrior|XMM"
@@ -33307,7 +30549,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githyanki-warrior.mp3"
+				"path": "bestiary/githyanki-warrior.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -33338,10 +30580,8 @@
 			"name": "Githzerai Monk",
 			"source": "MM",
 			"page": 161,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"reprintedAs": [
 				"Githzerai Monk|XMM"
@@ -33435,7 +30675,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githzerai-monk.mp3"
+				"path": "bestiary/githzerai-monk.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -33462,16 +30702,10 @@
 			"name": "Githzerai Zerth",
 			"source": "MM",
 			"page": 161,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Githzerai Zerth|XMM"
@@ -33570,7 +30804,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githzerai-zerth.mp3"
+				"path": "bestiary/githzerai-zerth.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -33605,37 +30839,19 @@
 			"source": "MM",
 			"page": 58,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"CRCotN",
+				"EGW",
+				"GoS",
+				"SatO",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-ToH",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Glabrezu|XMM"
@@ -33776,7 +30992,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/glabrezu.mp3"
+				"path": "bestiary/glabrezu.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -33820,61 +31036,27 @@
 			"source": "MM",
 			"page": 346,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AitFR-FCD",
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"MOT",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SCC-CK",
+				"SKT",
+				"SLW",
+				"ToA",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Gladiator|XMM"
@@ -33974,7 +31156,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gladiator.mp3"
+				"path": "bestiary/gladiator.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -34015,37 +31197,22 @@
 			"page": 163,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"IDRotF",
+				"OotA",
+				"OoW",
+				"PotA",
+				"SatO",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Gnoll Warrior|XMM"
@@ -34129,7 +31296,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll.mp3"
+				"path": "bestiary/gnoll.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -34162,22 +31329,13 @@
 			"name": "Gnoll Fang of Yeenoghu",
 			"source": "MM",
 			"page": 163,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"IDRotF",
+				"OotA",
+				"SatO",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Gnoll Fang of Yeenoghu|XMM"
@@ -34266,7 +31424,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll-fang-of-yeenoghu.mp3"
+				"path": "bestiary/gnoll-fang-of-yeenoghu.opus"
 			},
 			"traitTags": [
 				"Rampage"
@@ -34300,22 +31458,13 @@
 			"name": "Gnoll Pack Lord",
 			"source": "MM",
 			"page": 163,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"GoS",
+				"OotA",
+				"PotA",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Gnoll Pack Lord|XMM"
@@ -34410,7 +31559,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll-pack-lord.mp3"
+				"path": "bestiary/gnoll-pack-lord.opus"
 			},
 			"attachedItems": [
 				"glaive|phb",
@@ -34449,40 +31598,18 @@
 			"page": 330,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PaBTSO"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"GoS",
+				"IDRotF",
+				"PaBTSO",
+				"PotA",
+				"RoT",
+				"SKT",
+				"ToA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Goat|XMM"
@@ -34543,10 +31670,11 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/goat.mp3"
+				"path": "bestiary/goat.opus"
 			},
 			"traitTags": [
-				"Charge"
+				"Charge",
+				"Sure-Footed"
 			],
 			"damageTags": [
 				"B"
@@ -34568,70 +31696,34 @@
 			"page": 166,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CRCotN",
+				"DSotDQ",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HftT",
+				"IDRotF",
+				"KKW",
+				"LMoP",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"RMBRE",
+				"SatO",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-TSC",
+				"ToA",
+				"US",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Goblin Warrior|XMM"
@@ -34687,7 +31779,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+						"The goblin can take the {@action Disengage} or {@action Hide} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -34713,7 +31805,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/goblin.mp3"
+				"path": "bestiary/goblin.opus"
 			},
 			"altArt": [
 				{
@@ -34750,37 +31842,19 @@
 			"name": "Goblin Boss",
 			"source": "MM",
 			"page": 166,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"KKW",
+				"OotA",
+				"PaBTSO",
+				"SKT",
+				"TCE",
+				"ToA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Goblin Boss|XMM"
@@ -34836,7 +31910,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+						"The goblin can take the {@action Disengage} or {@action Hide} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -34876,7 +31950,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/goblin-boss.mp3"
+				"path": "bestiary/goblin-boss.opus"
 			},
 			"attachedItems": [
 				"javelin|phb",
@@ -34914,10 +31988,8 @@
 			"source": "MM",
 			"page": 115,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT"
 			],
 			"reprintedAs": [
 				"Gold Dragon Wyrmling|XMM"
@@ -35109,7 +32181,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gold-dragon-wyrmlin.mp3"
+				"path": "bestiary/gold-dragon-wyrmlin.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -35145,34 +32217,19 @@
 			"source": "MM",
 			"page": 171,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"GoS",
+				"LoX",
+				"QftIS",
+				"RoT",
+				"SCC-ARiR",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gorgon|XMM"
@@ -35240,7 +32297,7 @@
 				{
 					"name": "Petrifying Breath {@recharge 5}",
 					"entries": [
-						"The gorgon exhales petrifying gas in a 30-foot cone. Each creature in that area must succeed on a {@dc 13} Constitution saving throw. On a failed save, a target begins to turn to stone and is {@condition restrained}. The {@condition restrained} target must repeat the saving throw at the end of its next turn. On a success, the effect ends on the target. On a failure, the target is {@condition petrified} until freed by the  {@spell greater restoration} spell or other magic."
+						"The gorgon exhales petrifying gas in a 30-foot cone. Each creature in that area must succeed on a {@dc 13} Constitution saving throw. On a failed save, a target begins to turn to stone and is {@condition restrained}. The {@condition restrained} target must repeat the saving throw at the end of its next turn. On a success, the effect ends on the target. On a failure, the target is {@condition petrified} until freed by the {@spell greater restoration} spell or other magic."
 					]
 				}
 			],
@@ -35251,7 +32308,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gorgon.mp3"
+				"path": "bestiary/gorgon.opus"
 			},
 			"senseTags": [
 				"D"
@@ -35284,19 +32341,11 @@
 			"name": "Goristro",
 			"source": "MM",
 			"page": 59,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"QftIS",
+				"SatO",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Goristro|XMM"
@@ -35426,7 +32475,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/goristro.mp3"
+				"path": "bestiary/goristro.opus"
 			},
 			"traitTags": [
 				"Charge",
@@ -35465,28 +32514,24 @@
 			"source": "MM",
 			"page": 243,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				}
+			"referenceSources": [
+				"CoS",
+				"GoS",
+				"HotDQ",
+				"KftGV",
+				"KKW",
+				"NRH-ASS",
+				"OotA",
+				"PaBTSO",
+				"SCC-CK",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-WPM",
+				"VNotEE",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gray Ooze|XMM",
@@ -35588,7 +32633,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gray-ooze.mp3"
+				"path": "bestiary/gray-ooze.opus"
 			},
 			"traitTags": [
 				"Amorphous",
@@ -35635,31 +32680,16 @@
 			"name": "Gray Slaad",
 			"source": "MM",
 			"page": 277,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"KftGV",
+				"PaBTSO",
+				"QftIS",
+				"SCC-CK",
+				"ToA",
+				"ToFW",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gray Slaad|XMM"
@@ -35820,7 +32850,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gray-slaad.mp3"
+				"path": "bestiary/gray-slaad.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -35878,10 +32908,8 @@
 			"source": "MM",
 			"page": 95,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Green Dragon Wyrmling|XMM"
@@ -36043,7 +33071,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-dragon-wyrmling.mp3"
+				"path": "bestiary/green-dragon-wyrmling.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -36078,43 +33106,21 @@
 			"source": "MM",
 			"page": 177,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"EGW",
+				"GoS",
+				"IMR",
+				"JttRC",
+				"MOT",
+				"OotA",
+				"PSI",
+				"SatO",
+				"SCC-TMM",
+				"TCE",
+				"ToA",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Green Hag|XMM"
@@ -36300,7 +33306,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-hag.mp3"
+				"path": "bestiary/green-hag.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -36415,28 +33421,16 @@
 			"name": "Green Slaad",
 			"source": "MM",
 			"page": 277,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"BMT",
+				"DSotDQ",
+				"IDRotF",
+				"OotA",
+				"SatO",
+				"SCC-CK",
+				"ToFW",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Green Slaad|XMM"
@@ -36590,7 +33584,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-slaad.mp3"
+				"path": "bestiary/green-slaad.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -36640,46 +33634,23 @@
 			"name": "Grell",
 			"source": "MM",
 			"page": 172,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"CoA",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"TftYP",
+				"TftYP-DiT",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Grell|XMM"
@@ -36743,7 +33714,7 @@
 					"name": "Tentacles",
 					"entries": [
 						"{@atk mw} {@hit 4} to hit, reach 10 ft., one creature. {@h}7 ({@damage 1d10 + 2}) piercing damage, and the target must succeed on a {@dc 11} Constitution saving throw or be {@condition poisoned} for 1 minute. The {@condition poisoned} target is {@condition paralyzed}, and it can repeat the saving throw at the end of each of its turns, ending the effect on a success.",
-						"The target is also {@condition grappled} (escape {@dc 15}). If the target is Medium or smaller, it is also {@condition restrained} until this grapple ends. While grappling the target, the grell has advantage on attack rolls against it and can 't use this attack against other targets. When the grell moves, any Medium or smaller target it is grappling moves with it."
+						"The target is also {@condition grappled} (escape {@dc 15}). If the target is Medium or smaller, it is also {@condition restrained} until this grapple ends. While grappling the target, the grell has advantage on attack rolls against it and can't use this attack against other targets. When the grell moves, any Medium or smaller target it is grappling moves with it."
 					]
 				},
 				{
@@ -36758,7 +33729,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grell.mp3"
+				"path": "bestiary/grell.opus"
 			},
 			"senseTags": [
 				"B"
@@ -36796,37 +33767,20 @@
 			"page": 173,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"DSotDQ",
+				"KftGV",
+				"LMoP",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Grick|XMM"
@@ -36910,7 +33864,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grick.mp3"
+				"path": "bestiary/grick.opus"
 			},
 			"altArt": [
 				{
@@ -36943,19 +33897,13 @@
 			"name": "Grick Alpha",
 			"source": "MM",
 			"page": 173,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PaBTSO"
-				}
+			"referenceSources": [
+				"CM",
+				"DSotDQ",
+				"OotA",
+				"PaBTSO",
+				"SCC-HfMT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Grick Ancient|XMM"
@@ -37045,7 +33993,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grick-alpha.mp3"
+				"path": "bestiary/grick-alpha.opus"
 			},
 			"traitTags": [
 				"Camouflage"
@@ -37076,40 +34024,19 @@
 			"page": 174,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"EGW",
+				"ERLW",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"MOT",
+				"PotA",
+				"QftIS",
+				"SKT",
+				"WDH",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Griffon|XMM"
@@ -37183,7 +34110,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/griffon.mp3"
+				"path": "bestiary/griffon.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -37210,19 +34137,12 @@
 			"source": "MM",
 			"page": 175,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"OotA",
+				"PaBTSO",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Grimlock|XMM"
@@ -37305,7 +34225,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grimlock.mp3"
+				"path": "bestiary/grimlock.opus"
 			},
 			"traitTags": [
 				"Camouflage",
@@ -37335,82 +34255,41 @@
 			"page": 347,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DD",
+				"DIP",
+				"DSotDQ",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HotDQ",
+				"JttRC",
+				"KftGV",
+				"LoX",
+				"MOT",
+				"NRH-ASS",
+				"NRH-TCMC",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SKT",
+				"SLW",
+				"TftYP-TSC",
+				"ToA",
+				"ToFW",
+				"US",
+				"WDH",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Guard|XMM"
@@ -37476,7 +34355,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guard.mp3"
+				"path": "bestiary/guard.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -37502,25 +34381,14 @@
 			"source": "MM",
 			"page": 234,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AATM",
+				"BMT",
+				"CoA",
+				"GoS",
+				"ToA",
+				"TTP",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Guardian Naga|XMM"
@@ -37666,7 +34534,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guardian-naga.mp3"
+				"path": "bestiary/guardian-naga.opus"
 			},
 			"traitTags": [
 				"Rejuvenation"
@@ -37716,22 +34584,14 @@
 			"source": "MM",
 			"page": 282,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"IMR",
+				"JttRC",
+				"LLK",
+				"MOT",
+				"QftIS",
+				"TftYP",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Sphinx of Lore|XMM"
@@ -37912,7 +34772,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gynosphinx.mp3"
+				"path": "bestiary/gynosphinx.opus"
 			},
 			"traitTags": [
 				"Magic Weapons"
@@ -37954,28 +34814,15 @@
 			"name": "Half-Ogre (Ogrillon)",
 			"source": "MM",
 			"page": 238,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "DSotDQ"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"DSotDQ",
+				"EFR",
+				"ERLW",
+				"IDRotF",
+				"PotA",
+				"SKT",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Ogrillon Ogre|XMM"
@@ -38045,7 +34892,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/half-ogre.mp3"
+				"path": "bestiary/half-ogre.opus"
 			},
 			"attachedItems": [
 				"battleaxe|phb",
@@ -38077,19 +34924,11 @@
 			"source": "MM",
 			"page": 180,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"GoS",
+				"IMR",
+				"RoT",
+				"SLW"
 			],
 			"reprintedAs": [
 				"Half-Dragon|XMM"
@@ -38178,7 +35017,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/half-red-dragon-veteran.mp3"
+				"path": "bestiary/half-red-dragon-veteran.opus"
 			},
 			"attachedItems": [
 				"heavy crossbow|phb",
@@ -38222,40 +35061,20 @@
 			"page": 181,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"DIP",
+				"DoSI",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"IDRotF",
+				"MOT",
+				"PotA",
+				"SKT",
+				"US"
 			],
 			"reprintedAs": [
 				"Harpy|XMM"
@@ -38326,7 +35145,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/harpy.mp3"
+				"path": "bestiary/harpy.opus"
 			},
 			"attachedItems": [
 				"club|phb"
@@ -38362,28 +35181,15 @@
 			"page": 330,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"QftIS",
+				"WBtW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Hawk|XMM"
@@ -38436,7 +35242,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hawk.mp3"
+				"path": "bestiary/hawk.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -38456,64 +35262,27 @@
 			"page": 182,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "HFStCM"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"EGW",
+				"HFStCM",
+				"IMR",
+				"KftGV",
+				"MOT",
+				"OoW",
+				"PotA",
+				"PSI",
+				"SatO",
+				"SKT",
+				"SLW",
+				"TftYP",
+				"TftYP-AtG",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Hell Hound|XMM"
@@ -38595,7 +35364,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hell-hound.mp3"
+				"path": "bestiary/hell-hound.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -38630,52 +35399,25 @@
 			"name": "Helmed Horror",
 			"source": "MM",
 			"page": 183,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SCC-TMM",
+				"SKT",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Helmed Horror|XMM"
@@ -38777,7 +35519,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/helmed-horror.mp3"
+				"path": "bestiary/helmed-horror.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -38811,40 +35553,21 @@
 			"source": "MM",
 			"page": 60,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"CRCotN",
+				"EGW",
+				"OotA",
+				"PotA",
+				"QftIS",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-ToH",
+				"VEoR",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Hezrou|XMM"
@@ -38968,7 +35691,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hezrou.mp3"
+				"path": "bestiary/hezrou.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -39006,34 +35729,17 @@
 			"page": 155,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"EGW",
+				"ERLW",
+				"GoS",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				"Hill Giant|XMM"
@@ -39122,7 +35828,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hill-giant.mp3"
+				"path": "bestiary/hill-giant.opus"
 			},
 			"attachedItems": [
 				"greatclub|phb"
@@ -39156,22 +35862,14 @@
 			"page": 184,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				}
+			"referenceSources": [
+				"DD",
+				"EGW",
+				"ERLW",
+				"OoW",
+				"PotA",
+				"SKT",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Hippogriff|XMM"
@@ -39240,7 +35938,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hippogriff.mp3"
+				"path": "bestiary/hippogriff.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -39265,52 +35963,25 @@
 			"page": 186,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"DSotDQ",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HotDQ",
+				"LMoP",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"SKT",
+				"TftYP",
+				"TftYP-TSC",
+				"US",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Hobgoblin Warrior|XMM"
@@ -39390,7 +36061,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hobgoblin.mp3"
+				"path": "bestiary/hobgoblin.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -39421,25 +36092,14 @@
 			"name": "Hobgoblin Captain",
 			"source": "MM",
 			"page": 186,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "DSotDQ"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"DSotDQ",
+				"HotDQ",
+				"OoW",
+				"PotA",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Hobgoblin Captain|XMM"
@@ -39530,7 +36190,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hobgoblin-captain.mp3"
+				"path": "bestiary/hobgoblin-captain.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb",
@@ -39564,25 +36224,13 @@
 			"name": "Hobgoblin Warlord",
 			"source": "MM",
 			"page": 187,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"DSotDQ",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Hobgoblin Warlord|XMM"
@@ -39693,7 +36341,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hobgoblin-warlord.mp3"
+				"path": "bestiary/hobgoblin-warlord.opus"
 			},
 			"attachedItems": [
 				"javelin|phb",
@@ -39736,31 +36384,15 @@
 			"source": "MM",
 			"page": 188,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"ERLW",
+				"IMR",
+				"MOT",
+				"PaBTSO",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Homunculus|XMM"
@@ -39827,7 +36459,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/homunculus.mp3"
+				"path": "bestiary/homunculus.opus"
 			},
 			"senseTags": [
 				"D"
@@ -39856,31 +36488,17 @@
 			"name": "Hook Horror",
 			"source": "MM",
 			"page": 189,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"TftYP",
+				"TftYP-DiT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Hook Horror|XMM"
@@ -39959,7 +36577,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hook-horror.mp3"
+				"path": "bestiary/hook-horror.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -39990,22 +36608,13 @@
 			"source": "MM",
 			"page": 74,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"RtG",
+				"SatO",
+				"ToA",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Horned Devil|XMM"
@@ -40136,7 +36745,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/horned-devil.mp3"
+				"path": "bestiary/horned-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -40173,34 +36782,19 @@
 			"page": 330,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"DIP",
+				"EGW",
+				"GoS",
+				"PotA",
+				"PSX",
+				"SatO",
+				"SKT",
+				"TftYP",
+				"TftYP-DiT",
+				"ToA",
+				"ToR",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Hunter Shark|XMM"
@@ -40268,7 +36862,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hunter-shark.mp3"
+				"path": "bestiary/hunter-shark.opus"
 			},
 			"traitTags": [
 				"Water Breathing"
@@ -40291,52 +36885,24 @@
 			"page": 190,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "PSZ"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"DIP",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"LoX",
+				"MOT",
+				"PaBTSO",
+				"PotA",
+				"PSZ",
+				"SatO",
+				"SCC-ARiR",
+				"SLW",
+				"TftYP",
+				"TftYP-AtG",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Hydra|XMM"
@@ -40425,7 +36991,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hydra.mp3"
+				"path": "bestiary/hydra.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -40453,16 +37019,11 @@
 			"page": 331,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"OotA",
+				"PotA"
 			],
 			"reprintedAs": [
 				"Hyena|XMM"
@@ -40520,7 +37081,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hyena.mp3"
+				"path": "bestiary/hyena.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -40539,22 +37100,13 @@
 			"source": "MM",
 			"page": 75,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"SatO",
+				"TCE",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ice Devil|XMM"
@@ -40718,7 +37270,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ice-devil.mp3"
+				"path": "bestiary/ice-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -40758,28 +37310,16 @@
 			"source": "MM",
 			"page": 215,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"CM",
+				"EGW",
+				"FS",
+				"IDRotF",
+				"KftGV",
+				"PotA",
+				"SKT",
+				"TftYP",
+				"TftYP-TSC"
 			],
 			"reprintedAs": [
 				"Ice Mephit|XMM"
@@ -40895,7 +37435,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ice-mephit.mp3"
+				"path": "bestiary/ice-mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst",
@@ -40934,58 +37474,24 @@
 			"source": "MM",
 			"page": 76,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"EGW",
+				"GoS",
+				"KftGV",
+				"NRH-CoI",
+				"PSI",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"TCE",
+				"ToFW",
+				"VEoR",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Imp|XMM"
@@ -41110,7 +37616,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/imp.mp3"
+				"path": "bestiary/imp.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -41146,43 +37652,20 @@
 			"source": "MM",
 			"page": 285,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"CRCotN",
+				"EGW",
+				"ERLW",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"TCE",
+				"ToA",
+				"ToFW",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Incubus|XMM"
@@ -41301,7 +37784,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/succubus-incubus.mp3"
+				"path": "bestiary/succubus-incubus.opus"
 			},
 			"traitTags": [
 				"Shapechanger"
@@ -41338,25 +37821,15 @@
 			"name": "Intellect Devourer",
 			"source": "MM",
 			"page": 191,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"ERLW",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Intellect Devourer|XMM"
@@ -41452,7 +37925,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/intellect-devourer.mp3"
+				"path": "bestiary/intellect-devourer.opus"
 			},
 			"senseTags": [
 				"B"
@@ -41487,61 +37960,27 @@
 			"source": "MM",
 			"page": 192,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"MOT",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SCC-TMM",
+				"SKT",
+				"SLW",
+				"TftYP",
+				"TftYP-WPM",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Invisible Stalker|XMM"
@@ -41644,7 +38083,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/invisible-stalker.mp3"
+				"path": "bestiary/invisible-stalker.opus"
 			},
 			"senseTags": [
 				"D"
@@ -41674,40 +38113,19 @@
 			"source": "MM",
 			"page": 170,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"CoS",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"MOT",
+				"OoW",
+				"SatO",
+				"SKT",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Iron Golem|XMM"
@@ -41824,7 +38242,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/iron-golem.mp3"
+				"path": "bestiary/iron-golem.opus"
 			},
 			"traitTags": [
 				"Damage Absorption",
@@ -41865,10 +38283,10 @@
 			"page": 331,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS",
+				"OoW",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Jackal|XMM"
@@ -41930,7 +38348,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/jackal.mp3"
+				"path": "bestiary/jackal.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -41948,25 +38366,14 @@
 			"name": "Jackalwere",
 			"source": "MM",
 			"page": 193,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"GoS",
+				"JttRC",
+				"OoW",
+				"PotA",
+				"QftIS"
 			],
 			"reprintedAs": [
 				"Jackalwere|XMM"
@@ -42067,7 +38474,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/jackalwere.mp3"
+				"path": "bestiary/jackalwere.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -42103,31 +38510,17 @@
 			"name": "Kenku",
 			"source": "MM",
 			"page": 194,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"EFR",
+				"ERLW",
+				"JttRC",
+				"LLK",
+				"PotA",
+				"ToFW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Kenku|XMM"
@@ -42205,7 +38598,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kenku.mp3"
+				"path": "bestiary/kenku.opus"
 			},
 			"attachedItems": [
 				"shortbow|phb",
@@ -42238,22 +38631,13 @@
 			"page": 331,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"MOT",
+				"SKT",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Killer Whale|XMM"
@@ -42327,7 +38711,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/killer-whale.mp3"
+				"path": "bestiary/killer-whale.opus"
 			},
 			"traitTags": [
 				"Hold Breath",
@@ -42350,85 +38734,38 @@
 			"page": 347,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "GotSF"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"GoS",
+				"GotSF",
+				"HotDQ",
+				"JttRC",
+				"KftGV",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-WPM",
+				"ToA",
+				"ToFW",
+				"WBtW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Knight|XMM"
@@ -42522,7 +38859,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/knight.mp3"
+				"path": "bestiary/knight.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb",
@@ -42555,43 +38892,27 @@
 			"page": 195,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"DD",
+				"DoSI",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HotDQ",
+				"NRH-TCMC",
+				"OotA",
+				"RoT",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-TSC",
+				"TLK",
+				"ToA",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Kobold Warrior|XMM"
@@ -42675,7 +38996,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kobold.mp3"
+				"path": "bestiary/kobold.opus"
 			},
 			"attachedItems": [
 				"dagger|phb",
@@ -42711,34 +39032,17 @@
 			"source": "MM",
 			"page": 197,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"EGW",
+				"GoS",
+				"MOT",
+				"PaBTSO",
+				"SatO",
+				"SKT",
+				"SLW",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Kraken|XMM"
@@ -42881,7 +39185,7 @@
 				{
 					"name": "Ink Cloud (Costs 3 Actions)",
 					"entries": [
-						"While underwater, the kraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than the kraken. Each creature other than the kraken that ends its turn there must succeed on a {@dc 23} Constitution saving throw, taking 16 ({@damage 3d10}) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn."
+						"While underwater, the kraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is {@quickref Vision and Light||2||heavily obscured} to creatures other than the kraken. Each creature other than the kraken that ends its turn there must succeed on a {@dc 23} Constitution saving throw, taking 16 ({@damage 3d10}) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn."
 					]
 				}
 			],
@@ -42894,7 +39198,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kraken.mp3"
+				"path": "bestiary/kraken.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -42953,31 +39257,18 @@
 			"name": "Kuo-toa",
 			"source": "MM",
 			"page": 199,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"OotA",
+				"PotA",
+				"PSI",
+				"RtG",
+				"SatO",
+				"TftYP",
+				"TftYP-DiT",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Kuo-toa|XMM"
@@ -43088,7 +39379,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kuo-toa.mp3"
+				"path": "bestiary/kuo-toa.opus"
 			},
 			"attachedItems": [
 				"net|phb",
@@ -43129,16 +39420,12 @@
 			"name": "Kuo-toa Archpriest",
 			"source": "MM",
 			"page": 200,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"OotA",
+				"PotA",
+				"RtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Kuo-toa Archpriest|XMM"
@@ -43296,7 +39583,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kuo-toa-archpriest.mp3"
+				"path": "bestiary/kuo-toa-archpriest.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -43343,16 +39630,11 @@
 			"name": "Kuo-toa Monitor",
 			"source": "MM",
 			"page": 198,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"GoS",
+				"OotA",
+				"PotA"
 			],
 			"reprintedAs": [
 				"Kuo-toa Monitor|XMM"
@@ -43462,7 +39744,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kuo-toa-monitor.mp3"
+				"path": "bestiary/kuo-toa-monitor.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -43493,19 +39775,12 @@
 			"name": "Kuo-toa Whip",
 			"source": "MM",
 			"page": 200,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS",
+				"OotA",
+				"PotA",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Kuo-toa Whip|XMM"
@@ -43633,7 +39908,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kuo-toa-whip.mp3"
+				"path": "bestiary/kuo-toa-whip.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -43677,22 +39952,12 @@
 			"source": "MM",
 			"page": 201,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CM",
+				"GoS",
+				"MOT",
+				"QftIS",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Lamia|XMM"
@@ -43796,7 +40061,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lamia.mp3"
+				"path": "bestiary/lamia.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -43838,22 +40103,12 @@
 			"source": "MM",
 			"page": 76,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"PSI",
+				"VEoR",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Lemure|XMM"
@@ -43917,7 +40172,7 @@
 				{
 					"name": "Hellish Rejuvenation",
 					"entries": [
-						"A lemure that dies in the Nine Hells comes back to life with all its hit points in {@dice 1d10} days unless it is killed by a good-aligned creature with a {@spell bless} spell cast on that creature or its remains are sprinkled with holy water."
+						"A lemure that dies in the Nine Hells comes back to life with all its hit points in {@dice 1d10} days unless it is killed by a good-aligned creature with a {@spell bless} spell cast on that creature or its remains are sprinkled with {@item Holy Water (Flask)|PHB|holy water}."
 					]
 				}
 			],
@@ -43925,13 +40180,13 @@
 				{
 					"name": "Fist",
 					"entries": [
-						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}2 ({@damage 1d4}) bludgeoning damage"
+						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}2 ({@damage 1d4}) bludgeoning damage."
 					]
 				}
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lemure.mp3"
+				"path": "bestiary/lemure.opus"
 			},
 			"traitTags": [
 				"Devil's Sight"
@@ -43958,37 +40213,21 @@
 			"source": "MM",
 			"page": 202,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"CoS",
+				"GoS",
+				"IDRotF",
+				"OoW",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"SatO",
+				"TCE",
+				"ToA",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Lich|XMM"
@@ -44217,7 +40456,7 @@
 			},
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lich.mp3"
+				"path": "bestiary/lich.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -44282,16 +40521,11 @@
 			"page": 331,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"KftGV",
+				"TftYP",
+				"TftYP-AtG",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Lion|XMM"
@@ -44373,7 +40607,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lion.mp3"
+				"path": "bestiary/lion.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -44401,16 +40635,11 @@
 			"page": 332,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"JttRC",
+				"KftGV",
+				"ToA",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Lizard|XMM"
@@ -44455,7 +40684,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lizard.mp3"
+				"path": "bestiary/lizard.opus"
 			},
 			"senseTags": [
 				"D"
@@ -44472,16 +40701,10 @@
 			"name": "Lizard King",
 			"source": "MM",
 			"page": 205,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "TCE"
-				}
+			"referenceSources": [
+				"GoS",
+				"PotA",
+				"TCE"
 			],
 			"reprintedAs": [
 				"Lizardfolk Sovereign|XMM"
@@ -44588,7 +40811,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lizard-king-_-queen.mp3"
+				"path": "bestiary/lizard-king-_-queen.opus"
 			},
 			"attachedItems": [
 				"trident|phb"
@@ -44729,7 +40952,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lizard-king-_-queen.mp3"
+				"path": "bestiary/lizard-king-_-queen.opus"
 			},
 			"attachedItems": [
 				"trident|phb"
@@ -44767,46 +40990,22 @@
 			"page": 204,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"DIP",
+				"EGW",
+				"GoS",
+				"HotDQ",
+				"IMR",
+				"JttRC",
+				"OoW",
+				"PotA",
+				"RoT",
+				"SLW",
+				"TCE",
+				"ToA",
+				"ToFW",
+				"US",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Scout|XMM"
@@ -44902,7 +41101,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lizardfolk.mp3"
+				"path": "bestiary/lizardfolk.opus"
 			},
 			"attachedItems": [
 				"javelin|phb"
@@ -44934,22 +41133,14 @@
 			"name": "Lizardfolk Shaman",
 			"source": "MM",
 			"page": 205,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"IMR",
+				"PotA",
+				"SCC-TMM",
+				"ToA",
+				"US"
 			],
 			"reprintedAs": [
 				"Lizardfolk Geomancer|XMM"
@@ -45078,7 +41269,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lizardfolk-shaman.mp3"
+				"path": "bestiary/lizardfolk-shaman.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -45126,112 +41317,48 @@
 			"page": 347,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"ERLW",
+				"FS",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LoX",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SatO",
+				"SCC-CK",
+				"SDW",
+				"SKT",
+				"SLW",
+				"TCE",
+				"ToA",
+				"ToFW",
+				"ToR",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mage|XMM"
@@ -45361,7 +41488,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mage.mp3"
+				"path": "bestiary/mage.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -45419,28 +41546,15 @@
 			"source": "MM",
 			"page": 216,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "SjA"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"OotA",
+				"PotA",
+				"SjA",
+				"SKT",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Magma Mephit|XMM"
@@ -45554,7 +41668,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/magma-mephit.mp3"
+				"path": "bestiary/magma-mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst",
@@ -45599,25 +41713,14 @@
 			"source": "MM",
 			"page": 212,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"OotA",
+				"PotA",
+				"SatO",
+				"SKT",
+				"ToA",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Magmin|XMM"
@@ -45697,7 +41800,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/magmin.mp3"
+				"path": "bestiary/magmin.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -45728,22 +41831,12 @@
 			"page": 332,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"CRCotN",
+				"EGW",
+				"IDRotF",
+				"QftIS"
 			],
 			"reprintedAs": [
 				"Mammoth|XMM"
@@ -45805,7 +41898,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mammoth.mp3"
+				"path": "bestiary/mammoth.opus"
 			},
 			"damageTags": [
 				"B",
@@ -45828,34 +41921,18 @@
 			"name": "Manes",
 			"source": "MM",
 			"page": 60,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"CRCotN",
+				"GoS",
+				"IMR",
+				"OotA",
+				"PSI",
+				"TftYP",
+				"TftYP-DiT",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Manes|XMM"
@@ -45925,7 +42002,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/manes.mp3"
+				"path": "bestiary/manes.opus"
 			},
 			"senseTags": [
 				"D"
@@ -45950,49 +42027,23 @@
 			"page": 213,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"DIP",
+				"DSotDQ",
+				"GoS",
+				"JttRC",
+				"MOT",
+				"PotA",
+				"SatO",
+				"SKT",
+				"SLW",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-WPM",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Manticore|XMM"
@@ -46078,7 +42129,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/manticore.mp3"
+				"path": "bestiary/manticore.opus"
 			},
 			"senseTags": [
 				"D"
@@ -46108,43 +42159,20 @@
 			],
 			"source": "MM",
 			"page": 146,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"DIP",
+				"DitLCoT",
+				"DSotDQ",
+				"EGW",
+				"GoS",
+				"JttRC",
+				"QftIS",
+				"SatO",
+				"SLW",
+				"TCE",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Marid|XMM"
@@ -46294,7 +42322,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/marid.mp3"
+				"path": "bestiary/marid.opus"
 			},
 			"attachedItems": [
 				"trident|phb"
@@ -46405,28 +42433,14 @@
 			"source": "MM",
 			"page": 61,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"EGW",
+				"GoS",
+				"TCE",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Marilith|XMM"
@@ -46571,7 +42585,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/marilith.mp3"
+				"path": "bestiary/marilith.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -46615,43 +42629,22 @@
 			"page": 332,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoS",
+				"DSotDQ",
+				"EGW",
+				"ERLW",
+				"KftGV",
+				"OoW",
+				"QftIS",
+				"SKT",
+				"TftYP",
+				"TftYP-THSoT",
+				"ToFW",
+				"US",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Mastiff|XMM"
@@ -46707,7 +42700,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mastiff.mp3"
+				"path": "bestiary/mastiff.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -46734,31 +42727,19 @@
 			"page": 214,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"ERLW",
+				"GoS",
+				"IMR",
+				"LLK",
+				"OotA",
+				"PaBTSO",
+				"SatO",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Medusa|XMM"
@@ -46810,7 +42791,7 @@
 				{
 					"name": "Petrifying Gaze",
 					"entries": [
-						"When a creature that can see the medusa's eyes starts its turn within 30 feet of the medusa, the medusa can force it to make a {@dc 14} Constitution saving throw if the medusa isn't {@condition incapacitated} and can see the creature. If the saving throw fails by 5 or more, the creature is instantly {@condition petrified}. Otherwise, a creature that fails the save begins to turn to stone and is {@condition restrained}. The {@condition restrained} creature must repeat the saving throw at the end of its next turn, becoming {@condition petrified} on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the  {@spell greater restoration} spell or other magic.",
+						"When a creature that can see the medusa's eyes starts its turn within 30 feet of the medusa, the medusa can force it to make a {@dc 14} Constitution saving throw if the medusa isn't {@condition incapacitated} and can see the creature. If the saving throw fails by 5 or more, the creature is instantly {@condition petrified}. Otherwise, a creature that fails the save begins to turn to stone and is {@condition restrained}. The {@condition restrained} creature must repeat the saving throw at the end of its next turn, becoming {@condition petrified} on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the {@spell greater restoration} spell or other magic.",
 						"Unless {@status surprised}, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save.",
 						"If the medusa sees itself reflected on a polished surface within 30 feet of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze."
 					]
@@ -46847,7 +42828,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/medusa.mp3"
+				"path": "bestiary/medusa.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -46889,19 +42870,13 @@
 			"page": 218,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				}
+			"referenceSources": [
+				"GoS",
+				"JttRC",
+				"SKT",
+				"TTP",
+				"WBtW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Merfolk Skirmisher|XMM"
@@ -46966,7 +42941,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/merfolk.mp3"
+				"path": "bestiary/merfolk.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -46996,37 +42971,19 @@
 			"source": "MM",
 			"page": 219,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"OotA",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SKT",
+				"TftYP",
+				"TftYP-DiT",
+				"WBtW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Merrow|XMM"
@@ -47110,7 +43067,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/merrow.mp3"
+				"path": "bestiary/merrow.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -47141,28 +43098,14 @@
 			"name": "Mezzoloth",
 			"source": "MM",
 			"page": 313,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"PaBTSO",
+				"PotA",
+				"RoT",
+				"ToA",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mezzoloth|XMM"
@@ -47319,7 +43262,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mezzoloth.mp3"
+				"path": "bestiary/mezzoloth.opus"
 			},
 			"attachedItems": [
 				"trident|phb"
@@ -47369,58 +43312,29 @@
 			"source": "MM",
 			"page": 220,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"DIP",
+				"EGW",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"LRDT",
+				"OotA",
+				"OoW",
+				"QftIS",
+				"RMBRE",
+				"SatO",
+				"SCC-CK",
+				"ToA",
+				"TTP",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mimic|XMM"
@@ -47518,7 +43432,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mimic.mp3"
+				"path": "bestiary/mimic.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -47549,55 +43463,28 @@
 			],
 			"source": "MM",
 			"page": 222,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "SjA"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"ERLW",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"SatO",
+				"SjA",
+				"TCE",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"ToFW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mind Flayer|XMM"
@@ -47707,7 +43594,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mind-flayer.mp3"
+				"path": "bestiary/mind-flayer.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -47761,13 +43648,10 @@
 			],
 			"source": "MM",
 			"page": 222,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"LLK",
+				"SatO",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mind Flayer Arcanist|XMM"
@@ -47934,7 +43818,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mind-flayer-arcanist.mp3"
+				"path": "bestiary/mind-flayer-arcanist.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -47995,43 +43879,20 @@
 			"page": 223,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "PSZ"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CRCotN",
+				"EGW",
+				"ERLW",
+				"MOT",
+				"OotA",
+				"PotA",
+				"PSZ",
+				"QftIS",
+				"SatO",
+				"ToA",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Minotaur of Baphomet|XMM"
@@ -48115,7 +43976,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/minotaur.mp3"
+				"path": "bestiary/minotaur.opus"
 			},
 			"attachedItems": [
 				"greataxe|phb"
@@ -48153,43 +44014,20 @@
 			"source": "MM",
 			"page": 273,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"DIP",
+				"DSotDQ",
+				"GoS",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"SDW",
+				"ToA",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Minotaur Skeleton|XMM"
@@ -48268,7 +44106,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/minotaur-skeleton.mp3"
+				"path": "bestiary/minotaur-skeleton.opus"
 			},
 			"attachedItems": [
 				"greataxe|phb"
@@ -48308,25 +44146,16 @@
 			],
 			"source": "MM",
 			"page": 224,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"KftGV",
+				"LLK",
+				"OotA",
+				"OoW",
+				"SatO",
+				"ToA",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Modron Monodrone|XMM"
@@ -48409,7 +44238,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/monodrone.mp3"
+				"path": "bestiary/monodrone.opus"
 			},
 			"attachedItems": [
 				"dagger|phb",
@@ -48454,25 +44283,16 @@
 			"name": "Mud Mephit",
 			"source": "MM",
 			"page": 216,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				}
+			"referenceSources": [
+				"GoS",
+				"JttRC",
+				"OotA",
+				"PotA",
+				"SCC-ARiR",
+				"ToA",
+				"TTP",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mud Mephit|XMM"
@@ -48567,7 +44387,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mud-mephit.mp3"
+				"path": "bestiary/mud-mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst",
@@ -48605,19 +44425,13 @@
 			"page": 333,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"CoS",
+				"GoS",
+				"KftGV",
+				"SKT",
+				"TTP",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mule|XMM"
@@ -48676,10 +44490,11 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mule.mp3"
+				"path": "bestiary/mule.opus"
 			},
 			"traitTags": [
-				"Beast of Burden"
+				"Beast of Burden",
+				"Sure-Footed"
 			],
 			"damageTags": [
 				"B"
@@ -48695,52 +44510,25 @@
 			"page": 228,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"AitFR-ISF",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"OotA",
+				"PaBTSO",
+				"PSI",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"TCE",
+				"ToA",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mummy|XMM"
@@ -48835,7 +44623,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mummy.mp3"
+				"path": "bestiary/mummy.opus"
 			},
 			"senseTags": [
 				"D"
@@ -48852,6 +44640,7 @@
 			],
 			"miscTags": [
 				"CUR",
+				"HPR",
 				"MW"
 			],
 			"conditionInflict": [
@@ -48871,28 +44660,16 @@
 			"source": "MM",
 			"page": 229,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AATM",
+				"CM",
+				"CoA",
+				"RoT",
+				"SatO",
+				"SKT",
+				"TCE",
+				"TftYP-ToH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mummy Lord|XMM"
@@ -49106,7 +44883,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mummy-lord.mp3"
+				"path": "bestiary/mummy-lord.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -49135,7 +44912,9 @@
 				"CC"
 			],
 			"miscTags": [
+				"AOE",
 				"CUR",
+				"HPR",
 				"MW"
 			],
 			"conditionInflict": [
@@ -49172,22 +44951,14 @@
 			"name": "Myconid Adult",
 			"source": "MM",
 			"page": 232,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"DoSI",
+				"GoS",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Myconid Adult|XMM"
@@ -49301,7 +45072,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/myconid-adult.mp3"
+				"path": "bestiary/myconid-adult.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -49333,25 +45104,14 @@
 			"name": "Myconid Sovereign",
 			"source": "MM",
 			"page": 232,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"QftIS",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Myconid Sovereign|XMM"
@@ -49483,7 +45243,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/myconid-sovere.mp3"
+				"path": "bestiary/myconid-sovere.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -49519,16 +45279,13 @@
 			"name": "Myconid Sprout",
 			"source": "MM",
 			"page": 230,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"DoSI",
+				"LRDT",
+				"OotA",
+				"OoW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Myconid Sprout|XMM"
@@ -49595,7 +45352,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/myconid-sprout.mp3"
+				"path": "bestiary/myconid-sprout.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -49617,34 +45374,18 @@
 			"source": "MM",
 			"page": 62,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"OotA",
+				"QftIS",
+				"TftYP",
+				"TftYP-ToH",
+				"ToA",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Nalfeshnee|XMM"
@@ -49776,7 +45517,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nalfeshnee.mp3"
+				"path": "bestiary/nalfeshnee.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -49797,6 +45538,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -49814,25 +45556,14 @@
 			"name": "Needle Blight",
 			"source": "MM",
 			"page": 32,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "DIP"
-				}
+			"referenceSources": [
+				"CoS",
+				"DIP",
+				"GoS",
+				"IDRotF",
+				"PaBTSO",
+				"PSI",
+				"SCC-CK"
 			],
 			"reprintedAs": [
 				"Needle Blight|XMM"
@@ -49897,7 +45628,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/needle-blight.mp3"
+				"path": "bestiary/needle-blight.opus"
 			},
 			"altArt": [
 				{
@@ -49928,55 +45659,23 @@
 			"source": "MM",
 			"page": 178,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"MOT",
+				"SatO",
+				"TCE",
+				"ToA",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Night Hag|XMM"
@@ -50078,8 +45777,20 @@
 					"name": "Night Hag Items",
 					"entries": [
 						"A night hag carries two very rare magic items that she must craft for herself. If either object is lost, the night hag will go to great lengths to retrieve it, as creating a new tool takes time and effort.",
-						"Heartstone: This lustrous black gem allows a night hag to become ethereal while it is in her possession. The touch of a heartstone also cures any disease. Crafting a heartstone takes 30 days.",
-						"Soul Bag: When an evil humanoid dies as a result of a night hag's Nightmare Haunting, the hag catches the soul in this black sack made of stitched flesh. A soul bag can hold only one evil soul at a time, and only the night hag who crafted the bag can catch a soul with it. Crafting a soul bag takes 7 days and a humanoid sacrifice (whose flesh is used to make the bag)."
+						{
+							"type": "entries",
+							"name": "Heartstone",
+							"entries": [
+								"This lustrous black gem allows a night hag to become ethereal while it is in her possession. The touch of a {@item heartstone|MM} also cures any disease. Crafting a heartstone takes 30 days."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Soul Bag",
+							"entries": [
+								"When an evil humanoid dies as a result of a night hag's Nightmare Haunting, the hag catches the soul in this black sack made of stitched flesh. A {@item soul bag|MM} can hold only one evil soul at a time, and only the night hag who crafted the bag can catch a soul with it. Crafting a soul bag takes 7 days and a humanoid sacrifice (whose flesh is used to make the bag)."
+							]
+						}
 					]
 				}
 			],
@@ -50105,7 +45816,7 @@
 				{
 					"name": "Nightmare Haunting (1/Day)",
 					"entries": [
-						"While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. A {@spell protection from evil and good} spell cast on the target prevents this contact, as does a magic circle. As long as the contact persists, the target has dreadful visions. If these visions last for at least 1 hour, the target gains no benefit from its rest, and its hit point maximum is reduced by 5 ({@dice 1d10}). If this effect reduces the target's hit point maximum to 0, the target dies, and if the target was evil, its soul is trapped in the hag's soul bag. The reduction to the target's hit point maximum lasts until removed by the  {@spell greater restoration} spell or similar magic."
+						"While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. A {@spell protection from evil and good} spell cast on the target prevents this contact, as does a magic circle. As long as the contact persists, the target has dreadful visions. If these visions last for at least 1 hour, the target gains no benefit from its rest, and its hit point maximum is reduced by 5 ({@dice 1d10}). If this effect reduces the target's hit point maximum to 0, the target dies, and if the target was evil, its soul is trapped in the hag's soul bag. The reduction to the target's hit point maximum lasts until removed by the {@spell greater restoration} spell or similar magic."
 					]
 				}
 			],
@@ -50187,7 +45898,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/night-hag.mp3"
+				"path": "bestiary/night-hag.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -50309,34 +46020,16 @@
 			"source": "MM",
 			"page": 235,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CoS",
+				"CRCotN",
+				"IMR",
+				"MOT",
+				"SatO",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Nightmare|XMM"
@@ -50409,7 +46102,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nightmare.mp3"
+				"path": "bestiary/nightmare.opus"
 			},
 			"traitTags": [
 				"Illumination"
@@ -50437,94 +46130,45 @@
 			"source": "MM",
 			"page": 348,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AZfyT",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"KKW",
+				"MOT",
+				"NRH-CoI",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-TFoF",
+				"TftYP-TSC",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Noble|XMM"
@@ -50593,7 +46237,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/noble.mp3"
+				"path": "bestiary/noble.opus"
 			},
 			"attachedItems": [
 				"rapier|phb"
@@ -50620,58 +46264,27 @@
 			"source": "MM",
 			"page": 236,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"CoS",
+				"EGW",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LMoP",
+				"MOT",
+				"NRH-AT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"RMBRE",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Nothic|XMM"
@@ -50758,7 +46371,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nothic.mp3"
+				"path": "bestiary/nothic.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -50790,37 +46403,17 @@
 			"name": "Nycaloth",
 			"source": "MM",
 			"page": 314,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"KftGV",
+				"PaBTSO",
+				"PotA",
+				"RoT",
+				"SatO",
+				"TCE",
+				"ToA",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Nycaloth|XMM"
@@ -50978,7 +46571,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nycaloth.mp3"
+				"path": "bestiary/nycaloth.opus"
 			},
 			"attachedItems": [
 				"greataxe|phb"
@@ -51023,52 +46616,27 @@
 			"page": 243,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CRCotN",
+				"DIP",
+				"ERLW",
+				"GoS",
+				"HftT",
+				"JttRC",
+				"LMoP",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"SCC-CK",
+				"SCC-HfMT",
+				"TftYP",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ochre Jelly|XMM"
@@ -51152,7 +46720,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ochre-jelly.mp3"
+				"path": "bestiary/ochre-jelly.opus"
 			},
 			"traitTags": [
 				"Amorphous",
@@ -51178,22 +46746,13 @@
 			"page": 333,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"SKT",
+				"TTP",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Octopus|XMM"
@@ -51261,14 +46820,14 @@
 				{
 					"name": "Ink Cloud (Recharges after a Short or Long Rest)",
 					"entries": [
-						"A 5-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action."
+						"A 5-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is {@quickref Vision and Light||2||heavily obscured} for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the {@action Dash} action as a bonus action."
 					]
 				}
 			],
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/octopus.mp3"
+				"path": "bestiary/octopus.opus"
 			},
 			"traitTags": [
 				"Camouflage",
@@ -51300,79 +46859,39 @@
 			"page": 237,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "SjA"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSZ"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CRCotN",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HftT",
+				"HotDQ",
+				"IDRotF",
+				"KftGV",
+				"LMoP",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"PSZ",
+				"QftIS",
+				"RMBRE",
+				"RoT",
+				"SatO",
+				"SjA",
+				"SKT",
+				"SLW",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-TFoF",
+				"TftYP-WPM",
+				"US",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ogre|XMM"
@@ -51442,7 +46961,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre.mp3"
+				"path": "bestiary/ogre.opus"
 			},
 			"attachedItems": [
 				"greatclub|phb",
@@ -51474,37 +46993,20 @@
 			"source": "MM",
 			"page": 316,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"DIP",
+				"GoS",
+				"IDRotF",
+				"LoX",
+				"OoW",
+				"PaBTSO",
+				"RtG",
+				"SDW",
+				"TftYP",
+				"TftYP-DiT",
+				"ToA",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ogre Zombie|XMM"
@@ -51568,7 +47070,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre-zombie.mp3"
+				"path": "bestiary/ogre-zombie.opus"
 			},
 			"attachedItems": [
 				"morningstar|phb"
@@ -51600,46 +47102,24 @@
 			"source": "MM",
 			"page": 239,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSZ"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"EGW",
+				"ERLW",
+				"GoS",
+				"JttRC",
+				"KftGV",
+				"PotA",
+				"PSZ",
+				"SCC-TMM",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-THSoT",
+				"TftYP-WPM",
+				"ToFW",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Oni|XMM"
@@ -51762,7 +47242,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/oni.mp3"
+				"path": "bestiary/oni.opus"
 			},
 			"attachedItems": [
 				"glaive|phb"
@@ -51810,52 +47290,27 @@
 			"page": 246,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"DIP",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HftT",
+				"HotDQ",
+				"IDRotF",
+				"LMoP",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"RMBRE",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"ToA",
+				"US"
 			],
 			"reprintedAs": [
 				"Tough|XMM"
@@ -51939,7 +47394,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orc.mp3"
+				"path": "bestiary/orc.opus"
 			},
 			"altArt": [
 				{
@@ -51979,22 +47434,14 @@
 			"name": "Orc Eye of Gruumsh",
 			"source": "MM",
 			"page": 247,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"EGW",
+				"IDRotF",
+				"OotA",
+				"PotA",
+				"SKT",
+				"TftYP",
+				"TftYP-TFoF"
 			],
 			"reprintedAs": [
 				"Cultist Fanatic|XMM"
@@ -52113,7 +47560,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orc-eye-of-gruumsh.mp3"
+				"path": "bestiary/orc-eye-of-gruumsh.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -52154,28 +47601,14 @@
 			"name": "Orc War Chief",
 			"source": "MM",
 			"page": 246,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"GoS",
+				"IDRotF",
+				"SKT",
+				"ToA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Tough Boss|XMM"
@@ -52267,7 +47700,7 @@
 				{
 					"name": "Battle Cry (1/Day)",
 					"entries": [
-						"Each creature of the war chief's choice that is within 30 feet of it, can hear it, and not already affected by Battle Cry gain advantage on attack rolls until the start of the war chief's next turn. The war chief can then make one attack as a bonus action."
+						"Each creature of the war chief's choice that is within 30 feet of it, can hear it, and not already affected by Battle Cry gains advantage on attack rolls until the start of the war chief's next turn. The war chief can then make one attack as a bonus action."
 					]
 				}
 			],
@@ -52282,7 +47715,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orc-war-chief.mp3"
+				"path": "bestiary/orc-war-chief.opus"
 			},
 			"attachedItems": [
 				"greataxe|phb",
@@ -52318,28 +47751,17 @@
 			"name": "Orog",
 			"source": "MM",
 			"page": 247,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"OotA",
+				"PotA",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-TFoF",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Berserker|XMM"
@@ -52429,7 +47851,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orog.mp3"
+				"path": "bestiary/orog.opus"
 			},
 			"attachedItems": [
 				"greataxe|phb",
@@ -52467,37 +47889,23 @@
 			"source": "MM",
 			"page": 248,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"HotDQ",
+				"IMR",
+				"JttRC",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"RoT",
+				"RtG",
+				"SCC-CK",
+				"SCC-HfMT",
+				"SKT",
+				"TftYP",
+				"TftYP-DiT",
+				"ToA",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Otyugh|XMM"
@@ -52580,7 +47988,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/otyugh.mp3"
+				"path": "bestiary/otyugh.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -52620,22 +48028,12 @@
 			"page": 333,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"CM",
+				"IDRotF",
+				"IMR",
+				"RoT",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Owl|XMM"
@@ -52702,7 +48100,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/owl.mp3"
+				"path": "bestiary/owl.opus"
 			},
 			"traitTags": [
 				"Flyby",
@@ -52725,67 +48123,32 @@
 			"page": 249,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"CRCotN",
+				"DIP",
+				"DoSI",
+				"EGW",
+				"GoS",
+				"HftT",
+				"IDRotF",
+				"IMR",
+				"LMoP",
+				"LRDT",
+				"NRH-AT",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"RtG",
+				"SCC-CK",
+				"SDW",
+				"SKT",
+				"TftYP",
+				"TftYP-DiT",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Owlbear|XMM"
@@ -52859,7 +48222,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/owlbear.mp3"
+				"path": "bestiary/owlbear.opus"
 			},
 			"altArt": [
 				{
@@ -52893,16 +48256,11 @@
 			"page": 333,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				}
+			"referenceSources": [
+				"TftYP",
+				"TftYP-THSoT",
+				"ToA",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Panther|XMM"
@@ -52972,7 +48330,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/panther.mp3"
+				"path": "bestiary/panther.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -52999,25 +48357,13 @@
 			"page": 250,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"ERLW",
+				"JttRC",
+				"MOT",
+				"SatO",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Pegasus|XMM"
@@ -53078,7 +48424,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pegasus.mp3"
+				"path": "bestiary/pegasus.opus"
 			},
 			"languageTags": [
 				"C",
@@ -53104,22 +48450,13 @@
 			],
 			"source": "MM",
 			"page": 226,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"KftGV",
+				"OoW",
+				"SatO",
+				"ToA",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Modron Pentadrone|XMM"
@@ -53210,7 +48547,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pentadrone.mp3"
+				"path": "bestiary/pentadrone.opus"
 			},
 			"senseTags": [
 				"U"
@@ -53258,28 +48595,17 @@
 			"name": "Peryton",
 			"source": "MM",
 			"page": 251,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				}
+			"referenceSources": [
+				"GoS",
+				"HoL",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"PotA",
+				"SCC-ARiR",
+				"TftYP",
+				"TftYP-DiT",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Peryton|XMM"
@@ -53379,7 +48705,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/peryton.mp3"
+				"path": "bestiary/peryton.opus"
 			},
 			"traitTags": [
 				"Flyby",
@@ -53409,34 +48735,16 @@
 			"page": 334,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"DIP",
+				"GoS",
+				"IDRotF",
+				"MOT",
+				"PaBTSO",
+				"QftIS",
+				"SDW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Phase Spider|XMM"
@@ -53516,7 +48824,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/phase-spider.mp3"
+				"path": "bestiary/phase-spider.opus"
 			},
 			"traitTags": [
 				"Spider Climb",
@@ -53547,25 +48855,15 @@
 			"name": "Piercer",
 			"source": "MM",
 			"page": 252,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"OotA",
+				"PotA",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Piercer|XMM"
@@ -53635,7 +48933,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/piercer.mp3"
+				"path": "bestiary/piercer.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -53660,31 +48958,15 @@
 			"source": "MM",
 			"page": 77,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"EGW",
+				"SatO",
+				"TCE",
+				"ToFW",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Pit Fiend|XMM"
@@ -53846,7 +49128,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pit-fiend.mp3"
+				"path": "bestiary/pit-fiend.opus"
 			},
 			"attachedItems": [
 				"mace|phb"
@@ -53906,37 +49188,17 @@
 			"name": "Pixie",
 			"source": "MM",
 			"page": 253,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"IMR",
+				"KftGV",
+				"QftIS",
+				"SatO",
+				"ToFW",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Pixie|XMM"
@@ -54023,7 +49285,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pixie.mp3"
+				"path": "bestiary/pixie.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -54061,25 +49323,14 @@
 			"source": "MM",
 			"page": 17,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"CoA",
+				"CRCotN",
+				"JttRC",
+				"SatO",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Planetar|XMM"
@@ -54217,7 +49468,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/planetar.mp3"
+				"path": "bestiary/planetar.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -54273,19 +49524,12 @@
 			"page": 80,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "DSotDQ"
-				}
+			"referenceSources": [
+				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"ToA",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Plesiosaurus|XMM"
@@ -54347,7 +49591,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/plesiosaurus.mp3"
+				"path": "bestiary/plesiosaurus.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -54369,22 +49613,16 @@
 			"page": 334,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"GoS",
+				"IMR",
+				"OoW",
+				"QftIS",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-ToH",
+				"ToA",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Venomous Snake|XMM"
@@ -54437,7 +49675,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/poisonous-snake.mp3"
+				"path": "bestiary/poisonous-snake.opus"
 			},
 			"senseTags": [
 				"B"
@@ -54460,28 +49698,17 @@
 			"page": 334,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"EGW",
+				"IDRotF",
+				"IMR",
+				"OotA",
+				"RoT",
+				"SKT",
+				"TftYP-AtG",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Polar Bear|XMM"
@@ -54554,7 +49781,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/polar-bear.mp3"
+				"path": "bestiary/polar-bear.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -54575,28 +49802,17 @@
 			"name": "Poltergeist",
 			"source": "MM",
 			"page": 279,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"HoL",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"PSI",
+				"QftIS",
+				"RtG",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Poltergeist|XMM"
@@ -54711,7 +49927,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/poltergeist.mp3"
+				"path": "bestiary/poltergeist.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -54743,16 +49959,10 @@
 			"page": 335,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO",
+				"SKT",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Pony|XMM"
@@ -54795,7 +50005,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pony.mp3"
+				"path": "bestiary/pony.opus"
 			},
 			"damageTags": [
 				"B"
@@ -54811,97 +50021,44 @@
 			"page": 348,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"SatO",
+				"SDW",
+				"SKT",
+				"SLW",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-TSC",
+				"ToA",
+				"ToFW",
+				"US",
+				"VEoR",
+				"WDH",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Priest|XMM"
@@ -55011,7 +50168,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/priest.mp3"
+				"path": "bestiary/priest.opus"
 			},
 			"attachedItems": [
 				"mace|phb"
@@ -55047,31 +50204,15 @@
 			"source": "MM",
 			"page": 254,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"EGW",
+				"ERLW",
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"RoT",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Pseudodragon|XMM"
@@ -55178,7 +50319,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pseudodragon.mp3"
+				"path": "bestiary/pseudodragon.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -55218,22 +50359,14 @@
 			"source": "MM",
 			"page": 80,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"ERLW",
+				"GoS",
+				"SCC-CK",
+				"ToA",
+				"ToFW",
+				"TTP",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Pteranodon|XMM"
@@ -55284,7 +50417,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}6 ({@damage 2d4 + 1}) piercing damage"
+						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}6 ({@damage 2d4 + 1}) piercing damage."
 					]
 				}
 			],
@@ -55295,7 +50428,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pteranodon.mp3"
+				"path": "bestiary/pteranodon.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -55315,37 +50448,19 @@
 			"source": "MM",
 			"page": 255,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"DSotDQ",
+				"EGW",
+				"JttRC",
+				"LoX",
+				"OotA",
+				"PaBTSO",
+				"PSI",
+				"ToFW",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Purple Worm|XMM"
@@ -55424,7 +50539,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/purple-worm.mp3"
+				"path": "bestiary/purple-worm.opus"
 			},
 			"traitTags": [
 				"Tunneler"
@@ -55465,25 +50580,15 @@
 			],
 			"source": "MM",
 			"page": 226,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"KftGV",
+				"OoW",
+				"SatO",
+				"SCC-CK",
+				"ToA",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Modron Quadrone|XMM"
@@ -55575,7 +50680,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quadrone.mp3"
+				"path": "bestiary/quadrone.opus"
 			},
 			"attachedItems": [
 				"shortbow|phb"
@@ -55622,19 +50727,12 @@
 			"name": "Quaggoth",
 			"source": "MM",
 			"page": 256,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "PaBTSO"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"LoX",
+				"OotA",
+				"PaBTSO",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Quaggoth|XMM"
@@ -55718,7 +50816,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quaggoth.mp3"
+				"path": "bestiary/quaggoth.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -55743,13 +50841,10 @@
 			"name": "Quaggoth Spore Servant",
 			"source": "MM",
 			"page": 230,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"OotA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Myconid Spore Servant|XMM"
@@ -55817,7 +50912,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quaggoth-spore-servant.mp3"
+				"path": "bestiary/quaggoth-spore-servant.opus"
 			},
 			"senseTags": [
 				"B"
@@ -55838,13 +50933,9 @@
 			"name": "Quaggoth Thonot",
 			"source": "MM",
 			"page": 256,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Quaggoth Thonot|XMM"
@@ -55950,7 +51041,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quaggoth-thonot.mp3"
+				"path": "bestiary/quaggoth-thonot.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -55986,46 +51077,24 @@
 			"source": "MM",
 			"page": 63,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"EGW",
+				"KftGV",
+				"LLK",
+				"OotA",
+				"PaBTSO",
+				"PSI",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-TSC",
+				"VEoR",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Quasit|XMM"
@@ -56095,7 +51164,7 @@
 				{
 					"name": "Shapechanger",
 					"entries": [
-						"The quasit can use its action to polymorph into a beast form that resembles a bat (speed 10 feet fly 40 ft.), a centipede (40 ft., climb 40 ft.), or a toad (40 ft., swim 40 ft.), or back into its true form. Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+						"The quasit can use its action to polymorph into a beast form that resembles a bat (speed 10 ft. fly 40 ft.), a centipede (40 ft., climb 40 ft.), or a toad (40 ft., swim 40 ft.), or back into its true form. Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
 					]
 				},
 				{
@@ -56147,7 +51216,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quasit.mp3"
+				"path": "bestiary/quasit.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -56186,31 +51255,16 @@
 			"page": 335,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "PSA"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"GoS",
+				"IDRotF",
+				"MOT",
+				"PotA",
+				"PSA",
+				"ToA",
+				"ToFW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Piranha|XMM"
@@ -56271,7 +51325,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quipper.mp3"
+				"path": "bestiary/quipper.opus"
 			},
 			"traitTags": [
 				"Water Breathing"
@@ -56294,28 +51348,16 @@
 			"source": "MM",
 			"page": 257,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"CM",
+				"ERLW",
+				"GoS",
+				"TCE",
+				"TftYP",
+				"TftYP-AtG",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Rakshasa|XMM"
@@ -56440,7 +51482,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rakshasa.mp3"
+				"path": "bestiary/rakshasa.opus"
 			},
 			"senseTags": [
 				"D"
@@ -56476,34 +51518,20 @@
 			"page": 335,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"QftIS",
+				"SKT",
+				"TftYP",
+				"TftYP-TFoF",
+				"ToA",
+				"TTP",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Rat|XMM"
@@ -56559,7 +51587,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rat.mp3"
+				"path": "bestiary/rat.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -56582,25 +51610,15 @@
 			"page": 335,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"IDRotF",
+				"KftGV",
+				"TTP",
+				"VEoR",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Raven|XMM"
@@ -56658,7 +51676,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/raven.mp3"
+				"path": "bestiary/raven.opus"
 			},
 			"traitTags": [
 				"Mimicry"
@@ -56680,19 +51698,12 @@
 			"source": "MM",
 			"page": 98,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "DSotDQ"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"DSotDQ",
+				"OotA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Red Dragon Wyrmling|XMM"
@@ -56851,7 +51862,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-dragon-wyrmling.mp3"
+				"path": "bestiary/red-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -56882,28 +51893,17 @@
 			"name": "Red Slaad",
 			"source": "MM",
 			"page": 276,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"PaBTSO",
+				"RtG",
+				"SCC-ARiR",
+				"SCC-CK",
+				"ToFW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Red Slaad|XMM"
@@ -57010,7 +52010,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-slaad.mp3"
+				"path": "bestiary/red-slaad.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -57047,22 +52047,16 @@
 			"page": 336,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"DD",
+				"EGW",
+				"GoS",
+				"JttRC",
+				"RtG",
+				"ToA",
+				"ToR",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Reef Shark|XMM"
@@ -57130,7 +52124,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/reef-shark.mp3"
+				"path": "bestiary/reef-shark.opus"
 			},
 			"traitTags": [
 				"Pack Tactics",
@@ -57153,40 +52147,19 @@
 			"source": "MM",
 			"page": 258,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"EGW",
+				"IDRotF",
+				"IMR",
+				"LoX",
+				"PaBTSO",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Remorhaz|XMM"
@@ -57258,7 +52231,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/remorhaz.mp3"
+				"path": "bestiary/remorhaz.opus"
 			},
 			"senseTags": [
 				"D",
@@ -57292,43 +52265,20 @@
 			"name": "Revenant",
 			"source": "MM",
 			"page": 259,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoS",
+				"CRCotN",
+				"EGW",
+				"ERLW",
+				"HoL",
+				"JttRC",
+				"MOT",
+				"PaBTSO",
+				"PotA",
+				"SatO",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Revenant|XMM"
@@ -57455,7 +52405,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/revenant.mp3"
+				"path": "bestiary/revenant.opus"
 			},
 			"traitTags": [
 				"Regeneration",
@@ -57494,22 +52444,12 @@
 			"page": 336,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"PotA",
+				"QftIS",
+				"ToFW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Rhinoceros|XMM"
@@ -57565,7 +52505,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rhinoceros.mp3"
+				"path": "bestiary/rhinoceros.opus"
 			},
 			"traitTags": [
 				"Charge"
@@ -57590,40 +52530,19 @@
 			"page": 336,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"EGW",
+				"JttRC",
+				"KftGV",
+				"QftIS",
+				"SKT",
+				"ToA",
+				"WDH",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Riding Horse|XMM"
@@ -57667,7 +52586,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/riding-horse.mp3"
+				"path": "bestiary/riding-horse.opus"
 			},
 			"damageTags": [
 				"B"
@@ -57683,43 +52602,19 @@
 			"source": "MM",
 			"page": 260,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"DC",
+				"DIP",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"MOT",
+				"SatO",
+				"SKT",
+				"VEoR",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Roc|XMM"
@@ -57801,7 +52696,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/roc.mp3"
+				"path": "bestiary/roc.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -57830,40 +52725,22 @@
 			"source": "MM",
 			"page": 261,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"CRCotN",
+				"HotDQ",
+				"JttRC",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Roper|XMM"
@@ -57958,7 +52835,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/roper.mp3"
+				"path": "bestiary/roper.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -57993,49 +52870,26 @@
 			"source": "MM",
 			"page": 20,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"DIP",
+				"EGW",
+				"FS",
+				"GoS",
+				"HotDQ",
+				"KftGV",
+				"QftIS",
+				"RtG",
+				"SCC-TMM",
+				"SDW",
+				"SKT",
+				"TftYP-TFoF",
+				"ToA",
+				"TTP",
+				"WBtW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Animated Rug of Smothering|XMM"
@@ -58111,7 +52965,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/run-of-smothering.mp3"
+				"path": "bestiary/run-of-smothering.opus"
 			},
 			"traitTags": [
 				"Antimagic Susceptibility",
@@ -58140,34 +52994,18 @@
 			"source": "MM",
 			"page": 262,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"EGW",
+				"IDRotF",
+				"IMR",
+				"OotA",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"TftYP-ToH",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Rust Monster|XMM"
@@ -58239,7 +53077,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rust-monster.mp3"
+				"path": "bestiary/rust-monster.opus"
 			},
 			"senseTags": [
 				"D"
@@ -58264,31 +53102,15 @@
 			"page": 336,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CoS",
+				"EGW",
+				"IDRotF",
+				"JttRC",
+				"MOT",
+				"QftIS",
+				"SatO",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Saber-Toothed Tiger|XMM"
@@ -58356,7 +53178,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/saber-toothed-tiger.mp3"
+				"path": "bestiary/saber-toothed-tiger.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -58382,28 +53204,17 @@
 			"source": "MM",
 			"page": 263,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"DIP",
+				"EGW",
+				"FRAiF",
+				"GoS",
+				"SatO",
+				"SDW",
+				"TftYP",
+				"TftYP-DiT",
+				"ToR"
 			],
 			"reprintedAs": [
 				"Sahuagin Warrior|XMM"
@@ -58506,7 +53317,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sahuagin.mp3"
+				"path": "bestiary/sahuagin.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -58538,22 +53349,13 @@
 			"name": "Sahuagin Baron",
 			"source": "MM",
 			"page": 264,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"GoS",
+				"JttRC",
+				"SatO",
+				"TftYP",
+				"TftYP-DiT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Sahuagin Baron|XMM"
@@ -58662,7 +53464,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sahuagin-baron.mp3"
+				"path": "bestiary/sahuagin-baron.opus"
 			},
 			"attachedItems": [
 				"trident|phb"
@@ -58694,19 +53496,12 @@
 			"name": "Sahuagin Priestess",
 			"source": "MM",
 			"page": 264,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"GoS",
+				"SDW",
+				"TftYP",
+				"TftYP-DiT"
 			],
 			"reprintedAs": [
 				"Sahuagin Priest|XMM"
@@ -58844,7 +53639,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sahuagin-priestess.mp3"
+				"path": "bestiary/sahuagin-priestess.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -58881,40 +53676,20 @@
 			"source": "MM",
 			"page": 266,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "GotSF"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"DoSI",
+				"GotSF",
+				"JttRC",
+				"KftGV",
+				"OotA",
+				"PotA",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Salamander|XMM"
@@ -59012,7 +53787,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/salamander.mp3"
+				"path": "bestiary/salamander.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -59052,34 +53827,17 @@
 			"page": 267,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"IMR",
+				"KftGV",
+				"OoW",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"ToFW",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Satyr|XMM"
@@ -59163,7 +53921,7 @@
 							"type": "entries",
 							"name": "Panpipes",
 							"entries": [
-								"The satyr plays its pipes and chooses one of the following magical effects: a charming melody, a frightening strain, or a gentle lullaby. Any creature within 60 feet of the satyr that can hear the pipes must succeed on a {@dc 13} Wisdom saving throw or be affected as described below. Other satyrs and creature that can't be {@condition charmed} are unaffected",
+								"The satyr plays its pipes and chooses one of the following magical effects: a charming melody, a frightening strain, or a gentle lullaby. Any creature within 60 feet of the satyr that can hear the pipes must succeed on a {@dc 13} Wisdom saving throw or be affected as described below. Other satyrs and creatures that can't be {@condition charmed} are unaffected.",
 								"An affected creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to these panpipes for the next 24 hours.",
 								{
 									"type": "variantSub",
@@ -59200,7 +53958,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/satyr.mp3"
+				"path": "bestiary/satyr.opus"
 			},
 			"attachedItems": [
 				"shortbow|phb",
@@ -59240,19 +53998,14 @@
 			"name": "Scarecrow",
 			"source": "MM",
 			"page": 268,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"HoL",
+				"KftGV",
+				"OoW",
+				"ToA",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Scarecrow|XMM"
@@ -59347,7 +54100,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/scarecrow.mp3"
+				"path": "bestiary/scarecrow.opus"
 			},
 			"traitTags": [
 				"False Appearance"
@@ -59384,13 +54137,10 @@
 			"page": 337,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "PSX"
-				}
+			"referenceSources": [
+				"PSX",
+				"TTP",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Scorpion|XMM"
@@ -59442,7 +54192,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/scorpion.mp3"
+				"path": "bestiary/scorpion.opus"
 			},
 			"senseTags": [
 				"B"
@@ -59464,82 +54214,42 @@
 			"source": "MM",
 			"page": 349,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AZfyT",
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"FS",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SDW",
+				"SKT",
+				"SLW",
+				"TftYP",
+				"TftYP-THSoT",
+				"TftYP-TSC",
+				"ToA",
+				"ToR",
+				"VNotEE",
+				"WBtW",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Scout|XMM"
@@ -59629,7 +54339,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/scout.mp3"
+				"path": "bestiary/scout.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -59663,43 +54373,21 @@
 			"source": "MM",
 			"page": 179,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"DIP",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"MOT",
+				"PotA",
+				"SatO",
+				"SLW",
+				"TftYP",
+				"TftYP-DiT",
+				"ToA",
+				"TTP",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Sea Hag|XMM"
@@ -59865,7 +54553,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sea-hag.mp3"
+				"path": "bestiary/sea-hag.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -60019,7 +54707,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sea-horse.mp3"
+				"path": "bestiary/sea-horse.opus"
 			},
 			"traitTags": [
 				"Water Breathing"
@@ -60031,64 +54719,34 @@
 			"source": "MM",
 			"page": 269,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "SjA"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"GoS",
+				"HoL",
+				"IDRotF",
+				"IMR",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"SatO",
+				"SjA",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-TSC",
+				"TftYP-WPM",
+				"TTP",
+				"VEoR",
+				"VNotEE",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Shadow|XMM"
@@ -60168,7 +54826,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the shadow can take the Hide action as a bonus action. Its stealth bonus is also improved to +6."
+						"While in dim light or darkness, the shadow can take the {@action Hide} action as a bonus action. Its stealth bonus is also improved to +6."
 					]
 				},
 				{
@@ -60183,7 +54841,7 @@
 					"name": "Strength Drain",
 					"entries": [
 						"{@atk mw} {@hit 4} to hit, reach 5 ft., one creature. {@h}9 ({@damage 2d6 + 2}) necrotic damage, and the target's Strength score is reduced by {@dice 1d4}. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest.",
-						"If a non-evil humanoid dies from this attack, a new shadow rises from the corpse {@dice 1d4} hours later."
+						"If a non-evil humanoid dies from this attack, a new {@creature shadow} rises from the corpse {@dice 1d4} hours later."
 					]
 				}
 			],
@@ -60193,7 +54851,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shadow.mp3"
+				"path": "bestiary/shadow.opus"
 			},
 			"traitTags": [
 				"Amorphous"
@@ -60215,58 +54873,27 @@
 			"name": "Shadow Demon",
 			"source": "MM",
 			"page": 64,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"HoL",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"MOT",
+				"OotA",
+				"PotA",
+				"SatO",
+				"SCC-ARiR",
+				"SKT",
+				"ToA",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Shadow Demon|XMM"
@@ -60365,7 +54992,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the demon can take the Hide action as a bonus action."
+						"While in dim light or darkness, the demon can take the {@action Hide} action as a bonus action."
 					]
 				}
 			],
@@ -60379,7 +55006,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shadow-demon.mp3"
+				"path": "bestiary/shadow-demon.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -60408,58 +55035,27 @@
 			"source": "MM",
 			"page": 270,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "HFStCM"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"GoS",
+				"HFStCM",
+				"HotDQ",
+				"JttRC",
+				"KftGV",
+				"MOT",
+				"OotA",
+				"PSI",
+				"QftIS",
+				"SCC-TMM",
+				"TftYP",
+				"TftYP-DiT",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Shambling Mound|XMM"
@@ -60547,7 +55143,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shambling-mound.mp3"
+				"path": "bestiary/shambling-mound.opus"
 			},
 			"traitTags": [
 				"Damage Absorption"
@@ -60584,52 +55180,25 @@
 			"source": "MM",
 			"page": 271,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"RtG",
+				"SCC-CK",
+				"SKT",
+				"ToA",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Shield Guardian|XMM"
@@ -60728,7 +55297,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shield-guardian.mp3"
+				"path": "bestiary/shield-guardian.opus"
 			},
 			"traitTags": [
 				"Regeneration"
@@ -60759,25 +55328,15 @@
 			"source": "MM",
 			"page": 138,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"GoS",
+				"OotA",
+				"PaBTSO",
+				"QftIS",
+				"SCC-ARiR",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Shrieker Fungus|XMM"
@@ -60836,7 +55395,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shrieker.mp3"
+				"path": "bestiary/shrieker.opus"
 			},
 			"traitTags": [
 				"False Appearance"
@@ -60856,13 +55415,9 @@
 			"source": "MM",
 			"page": 118,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Silver Dragon Wyrmling|XMM"
@@ -61037,7 +55592,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/silver-dragon-wyrmling.mp3"
+				"path": "bestiary/silver-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -61073,94 +55628,47 @@
 			"page": 272,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"GoS",
+				"HftT",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"LMoP",
+				"LRDT",
+				"NRH-ASS",
+				"NRH-AT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"RtG",
+				"SatO",
+				"SDW",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-TSC",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Skeleton|XMM"
@@ -61231,7 +55739,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/skeleton.mp3"
+				"path": "bestiary/skeleton.opus"
 			},
 			"attachedItems": [
 				"shortbow|phb",
@@ -61261,28 +55769,16 @@
 			"name": "Slaad Tadpole",
 			"source": "MM",
 			"page": 276,
-			"otherSources": [
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"CM",
+				"DSotDQ",
+				"EGW",
+				"IDRotF",
+				"KftGV",
+				"PaBTSO",
+				"RtG",
+				"SatO",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Slaad Tadpole|XMM"
@@ -61347,7 +55843,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/slaad-tadpole.mp3"
+				"path": "bestiary/slaad-tadpole.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -61373,28 +55869,15 @@
 			"name": "Smoke Mephit",
 			"source": "MM",
 			"page": 217,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"CoS",
+				"KftGV",
+				"OoW",
+				"PotA",
+				"SKT",
+				"ToA",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Smoke Mephit|XMM"
@@ -61464,7 +55947,7 @@
 				{
 					"name": "Death Burst",
 					"entries": [
-						"When the mephit dies, it leaves behind a cloud of smoke that fills a 5-foot-radius sphere centered on its space. The sphere is heavily obscured. Wind disperses the cloud, which otherwise lasts for 1 minute."
+						"When the mephit dies, it leaves behind a cloud of smoke that fills a 5-foot-radius sphere centered on its space. The sphere is {@quickref Vision and Light||2||heavily obscured}. Wind disperses the cloud, which otherwise lasts for 1 minute."
 					]
 				}
 			],
@@ -61500,7 +55983,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/smoke-mephit.mp3"
+				"path": "bestiary/smoke-mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -61543,25 +56026,15 @@
 			"source": "MM",
 			"page": 18,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CRCotN",
+				"JttRC",
+				"SatO",
+				"TftYP-ToH",
+				"TftYP-TSC"
 			],
 			"reprintedAs": [
 				"Solar|XMM"
@@ -61734,7 +56207,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/solar.mp3"
+				"path": "bestiary/solar.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -61797,37 +56270,19 @@
 			"source": "MM",
 			"page": 30,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "SjA"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"KftGV",
+				"LMoP",
+				"OotA",
+				"PaBTSO",
+				"QftIS",
+				"RMBRE",
+				"SCC-ARiR",
+				"SjA",
+				"ToFW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Spectator|XMM"
@@ -61898,27 +56353,23 @@
 							"style": "list-hang-notitle",
 							"items": [
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "1. Confusion Ray",
-									"style": "italic",
 									"entry": "The target must succeed on a {@dc 13} Wisdom saving throw, or it can't take reactions until the end of its next turn. On its turn, the target can't move, and it uses its action to make a melee or ranged attack against a randomly determined creature within range. If the target can't attack, it does nothing on its turn."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "2. Paralyzing Ray",
-									"style": "italic",
 									"entry": "The target must succeed on a {@dc 13} Constitution saving throw or be {@condition paralyzed} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "3. Fear Ray",
-									"style": "italic",
 									"entry": "The target must succeed on a {@dc 13} Wisdom saving throw or be {@condition frightened} for 1 minute. The target can repeat the saving throw at the end of each of its turns, with disadvantage if the spectator is visible to the target, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "4. Wounding Ray",
-									"style": "italic",
 									"entry": "The target must make a {@dc 13} Constitution saving throw, taking 16 ({@damage 3d10}) necrotic damage on a failed save, or half as much damage on a successful one."
 								}
 							]
@@ -61945,7 +56396,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spectator.mp3"
+				"path": "bestiary/spectator.opus"
 			},
 			"altArt": [
 				{
@@ -61989,94 +56440,39 @@
 			"source": "MM",
 			"page": 279,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"DIP",
+				"EGW",
+				"GoS",
+				"HoL",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"MOT",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SDW",
+				"SKT",
+				"SLW",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Specter|XMM"
@@ -62177,7 +56573,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/specter.mp3"
+				"path": "bestiary/specter.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -62210,19 +56606,15 @@
 			"page": 337,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"GoS",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PotA",
+				"PSX",
+				"TTP",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Spider|XMM"
@@ -62290,7 +56682,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spider.mp3"
+				"path": "bestiary/spider.opus"
 			},
 			"traitTags": [
 				"Spider Climb",
@@ -62317,25 +56709,13 @@
 			"name": "Spined Devil",
 			"source": "MM",
 			"page": 78,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"KftGV",
+				"PSI",
+				"ToA",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Spined Devil|XMM"
@@ -62457,7 +56837,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spined-devil.mp3"
+				"path": "bestiary/spined-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -62492,31 +56872,17 @@
 			"source": "MM",
 			"page": 234,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"JttRC",
+				"MOT",
+				"OotA",
+				"PaBTSO",
+				"TftYP",
+				"TftYP-DiT",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Spirit Naga|XMM"
@@ -62647,7 +57013,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spirit-naga.mp3"
+				"path": "bestiary/spirit-naga.opus"
 			},
 			"traitTags": [
 				"Rejuvenation"
@@ -62693,43 +57059,22 @@
 			"source": "MM",
 			"page": 283,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"EFR",
+				"ERLW",
+				"GoS",
+				"IMR",
+				"KftGV",
+				"LLK",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"UtHftLH",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Sprite|XMM"
@@ -62807,7 +57152,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sprite.mp3"
+				"path": "bestiary/sprite.opus"
 			},
 			"attachedItems": [
 				"longsword|phb",
@@ -62845,85 +57190,39 @@
 			"source": "MM",
 			"page": 349,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AitFR-ISF",
+				"AZfyT",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"SKT",
+				"SLW",
+				"TftYP-DiT",
+				"ToA",
+				"ToFW",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Spy|XMM"
@@ -62974,7 +57273,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of its turns, the spy can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of its turns, the spy can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -63009,7 +57308,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spy.mp3"
+				"path": "bestiary/spy.opus"
 			},
 			"attachedItems": [
 				"hand crossbow|phb",
@@ -63042,25 +57341,16 @@
 			"source": "MM",
 			"page": 217,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"EGW",
+				"LLK",
+				"PotA",
+				"SCC-CK",
+				"SKT",
+				"TftYP",
+				"TftYP-TSC",
+				"ToA",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Steam Mephit|XMM"
@@ -63162,7 +57452,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/steam-mephit.mp3"
+				"path": "bestiary/steam-mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -63201,61 +57491,31 @@
 			"page": 284,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"DIP",
+				"DoSI",
+				"EGW",
+				"GoS",
+				"HftT",
+				"HotDQ",
+				"IMR",
+				"KftGV",
+				"LLK",
+				"LMoP",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"SCC-CK",
+				"TftYP",
+				"TftYP-TFoF",
+				"ToA",
+				"TTP",
+				"US",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Stirge|XMM"
@@ -63316,7 +57576,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stirge.mp3"
+				"path": "bestiary/stirge.opus"
 			},
 			"senseTags": [
 				"D"
@@ -63336,25 +57596,16 @@
 			"source": "MM",
 			"page": 156,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"HotDQ",
+				"MOT",
+				"OotA",
+				"QftIS",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Stone Giant|XMM"
@@ -63476,7 +57727,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stone-giant.mp3"
+				"path": "bestiary/stone-giant.opus"
 			},
 			"attachedItems": [
 				"greatclub|phb"
@@ -63519,76 +57770,34 @@
 			"page": 170,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"DSotDQ",
+				"GoS",
+				"HotDQ",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SKT",
+				"SLW",
+				"TftYP-THSoT",
+				"ToA",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Stone Golem|XMM"
@@ -63692,7 +57901,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stone-golem.mp3"
+				"path": "bestiary/stone-golem.opus"
 			},
 			"traitTags": [
 				"Immutable Form",
@@ -63726,25 +57935,14 @@
 			"source": "MM",
 			"page": 156,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"GoS",
+				"JttRC",
+				"MOT",
+				"SatO",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				"Storm Giant|XMM"
@@ -63888,7 +58086,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/storm-giant.mp3"
+				"path": "bestiary/storm-giant.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -63913,6 +58111,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW",
 				"RCH",
@@ -63938,43 +58137,22 @@
 			"source": "MM",
 			"page": 285,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CoA",
+				"CRCotN",
+				"EGW",
+				"ERLW",
+				"OotA",
+				"RoT",
+				"SatO",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Succubus|XMM"
@@ -64093,7 +58271,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/succubus-incubus.mp3"
+				"path": "bestiary/succubus-incubus.opus"
 			},
 			"traitTags": [
 				"Shapechanger"
@@ -64132,40 +58310,24 @@
 			"page": 337,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"CM",
+				"CoS",
+				"DitLCoT",
+				"EGW",
+				"FS",
+				"HotDQ",
+				"LLK",
+				"OotA",
+				"PotA",
+				"QftIS",
+				"TftYP",
+				"TftYP-THSoT",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Swarm of Bats|XMM"
@@ -64253,7 +58415,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-bats.mp3"
+				"path": "bestiary/swarm-of-bats.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -64374,16 +58536,13 @@
 			"source": "MM",
 			"page": 338,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "WDMM"
-				}
+			"referenceSources": [
+				"CoS",
+				"HotDQ",
+				"KKW",
+				"OotA",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Swarm of Insects|XMM"
@@ -64484,37 +58643,21 @@
 			"page": 338,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "PSX"
-				},
-				{
-					"source": "PSA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"EGW",
+				"GoS",
+				"IMR",
+				"LoX",
+				"NRH-AWoL",
+				"OotA",
+				"OoW",
+				"PSA",
+				"PSX",
+				"SKT",
+				"ToA",
+				"US",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Swarm of Insects|XMM"
@@ -64598,7 +58741,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-insects.mp3"
+				"path": "bestiary/swarm-of-insects.opus"
 			},
 			"senseTags": [
 				"B"
@@ -64618,40 +58761,24 @@
 			"page": 338,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CoS",
+				"DIP",
+				"EGW",
+				"FS",
+				"JttRC",
+				"MOT",
+				"OoW",
+				"QftIS",
+				"RoT",
+				"SCC-CK",
+				"SDW",
+				"TftYP",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"ToA",
+				"US",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Swarm of Venomous Snakes|XMM"
@@ -64725,7 +58852,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-poisonous-snakes.mp3"
+				"path": "bestiary/swarm-of-poisonous-snakes.opus"
 			},
 			"senseTags": [
 				"B"
@@ -64749,49 +58876,22 @@
 			"page": 338,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "LR"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSA"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"DIP",
+				"DSotDQ",
+				"GoS",
+				"JttRC",
+				"KftGV",
+				"LR",
+				"OotA",
+				"PotA",
+				"PSA",
+				"QftIS",
+				"SDW",
+				"ToA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Swarm of Piranhas|XMM"
@@ -64876,7 +58976,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-quippers.mp3"
+				"path": "bestiary/swarm-of-quippers.opus"
 			},
 			"traitTags": [
 				"Water Breathing"
@@ -64900,34 +59000,18 @@
 			"page": 339,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"GoS",
+				"HotDQ",
+				"TCE",
+				"TftYP",
+				"TftYP-THSoT",
+				"TftYP-TSC",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Swarm of Rats|XMM"
@@ -65006,7 +59090,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-rats.mp3"
+				"path": "bestiary/swarm-of-rats.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -65030,31 +59114,17 @@
 			"page": 339,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"DIP",
+				"EGW",
+				"IDRotF",
+				"OoW",
+				"RoT",
+				"SDW",
+				"TCE",
+				"US"
 			],
 			"reprintedAs": [
 				"Swarm of Ravens|XMM"
@@ -65130,7 +59200,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-ravens.mp3"
+				"path": "bestiary/swarm-of-ravens.opus"
 			},
 			"damageTags": [
 				"P"
@@ -65147,34 +59217,19 @@
 			"source": "MM",
 			"page": 338,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoS",
+				"DC",
+				"DIP",
+				"GoS",
+				"MOT",
+				"OoW",
+				"QftIS",
+				"RtG",
+				"SKT",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Swarm of Insects|XMM"
@@ -65296,22 +59351,13 @@
 			"source": "MM",
 			"page": 338,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CoS",
+				"GoS",
+				"QftIS",
+				"ToA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Swarm of Insects|XMM"
@@ -65410,25 +59456,13 @@
 			"source": "MM",
 			"page": 286,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"IDRotF",
+				"IMR",
+				"LoX",
+				"MOT",
+				"TCE"
 			],
 			"reprintedAs": [
 				"Tarrasque|XMM"
@@ -65591,7 +59625,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tarrasque.mp3"
+				"path": "bestiary/tarrasque.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -65636,16 +59670,10 @@
 			"name": "Thri-kreen",
 			"source": "MM",
 			"page": 288,
-			"otherSources": [
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"JttRC",
+				"LoX",
+				"QftIS"
 			],
 			"reprintedAs": [
 				"Thri-kreen Marauder|XMM"
@@ -65789,7 +59817,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/thri-kreen.mp3"
+				"path": "bestiary/thri-kreen.opus"
 			},
 			"senseTags": [
 				"D"
@@ -65881,73 +59909,34 @@
 			"page": 350,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"EGW",
+				"FS",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"LoX",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"SKT",
+				"SLW",
+				"TCE",
+				"ToA",
+				"ToFW",
+				"ToR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Tough|XMM"
@@ -66030,7 +60019,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/thug.mp3"
+				"path": "bestiary/thug.opus"
 			},
 			"attachedItems": [
 				"heavy crossbow|phb",
@@ -66066,22 +60055,14 @@
 			"page": 339,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"GoS",
+				"MOT",
+				"OoW",
+				"TftYP",
+				"TftYP-AtG",
+				"ToA",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Tiger|XMM"
@@ -66152,7 +60133,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tiger.mp3"
+				"path": "bestiary/tiger.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -66181,70 +60162,31 @@
 			"source": "MM",
 			"page": 289,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"DSotDQ",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"LLK",
+				"LoX",
+				"MOT",
+				"OoW",
+				"PSI",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SCC-ARiR",
+				"SKT",
+				"TCE",
+				"VEoR",
+				"WBtW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Treant|XMM"
@@ -66338,7 +60280,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/treant.mp3"
+				"path": "bestiary/treant.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -66369,34 +60311,19 @@
 			"source": "MM",
 			"page": 350,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"MOT",
+				"PotA",
+				"RoT",
+				"SKT",
+				"TftYP",
+				"TftYP-THSoT",
+				"ToA",
+				"ToR",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Warrior Infantry|XMM"
@@ -66468,7 +60395,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tribal-warrior.mp3"
+				"path": "bestiary/tribal-warrior.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -66500,16 +60427,10 @@
 			"page": 80,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"ToA",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Triceratops|XMM"
@@ -66562,7 +60483,7 @@
 				{
 					"name": "Stomp",
 					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 5 ft., one {@condition prone} creature. {@h}22 ({@damage 3d10 + 6}) bludgeoning damage"
+						"{@atk mw} {@hit 9} to hit, reach 5 ft., one {@condition prone} creature. {@h}22 ({@damage 3d10 + 6}) bludgeoning damage."
 					]
 				}
 			],
@@ -66571,7 +60492,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/triceratops.mp3"
+				"path": "bestiary/triceratops.opus"
 			},
 			"damageTags": [
 				"B",
@@ -66597,22 +60518,13 @@
 			],
 			"source": "MM",
 			"page": 225,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"QftIS"
 			],
 			"reprintedAs": [
 				"Modron Tridrone|XMM"
@@ -66700,7 +60612,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tridrone.mp3"
+				"path": "bestiary/tridrone.opus"
 			},
 			"attachedItems": [
 				"javelin|phb"
@@ -66748,37 +60660,22 @@
 			"name": "Troglodyte",
 			"source": "MM",
 			"page": 290,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BMT",
+				"HftT",
+				"HotDQ",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-ToH",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Troglodyte|XMM"
@@ -66873,7 +60770,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/troglodyte.mp3"
+				"path": "bestiary/troglodyte.opus"
 			},
 			"altArt": [
 				{
@@ -66920,49 +60817,30 @@
 			"page": 291,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "PSZ"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AitFR-AVT",
+				"DitLCoT",
+				"EGW",
+				"GoS",
+				"HotDQ",
+				"OotA",
+				"PotA",
+				"PSZ",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"SCC-HfMT",
+				"SCC-TMM",
+				"SKT",
+				"SLW",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"ToA",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Troll|XMM"
@@ -67102,7 +60980,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/troll.mp3"
+				"path": "bestiary/troll.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -67234,37 +61112,19 @@
 			"source": "MM",
 			"page": 32,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "DIP"
-				}
+			"referenceSources": [
+				"CoS",
+				"DIP",
+				"GoS",
+				"HftT",
+				"LMoP",
+				"NRH-AVitW",
+				"PaBTSO",
+				"PSI",
+				"RMBRE",
+				"TftYP",
+				"TftYP-TSC",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Twig Blight|XMM"
@@ -67337,7 +61197,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/twig-blight.mp3"
+				"path": "bestiary/twig-blight.opus"
 			},
 			"altArt": [
 				{
@@ -67374,19 +61234,11 @@
 			"page": 80,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"EGW",
+				"QftIS",
+				"SatO",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Tyrannosaurus Rex|XMM"
@@ -67449,7 +61301,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tyrannosaurus-rex.mp3"
+				"path": "bestiary/tyrannosaurus-rex.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -67474,19 +61326,11 @@
 			"name": "Ultroloth",
 			"source": "MM",
 			"page": 314,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "JttRC"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"EGW",
+				"JttRC",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ultroloth|XMM"
@@ -67659,7 +61503,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ultroloth.mp3"
+				"path": "bestiary/ultroloth.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -67721,37 +61565,19 @@
 			"name": "Umber Hulk",
 			"source": "MM",
 			"page": 292,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"IDRotF",
+				"IMR",
+				"LLK",
+				"LoX",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Umber Hulk|XMM"
@@ -67836,7 +61662,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/umber-hulk.mp3"
+				"path": "bestiary/umber-hulk.opus"
 			},
 			"traitTags": [
 				"Tunneler"
@@ -67869,37 +61695,18 @@
 			"source": "MM",
 			"page": 294,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"GoS",
+				"IMR",
+				"KftGV",
+				"MOT",
+				"OoW",
+				"QftIS",
+				"SatO",
+				"TCE",
+				"VEoR",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Unicorn|XMM"
@@ -68050,7 +61857,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/unicorn.mp3"
+				"path": "bestiary/unicorn.opus"
 			},
 			"traitTags": [
 				"Charge",
@@ -68102,58 +61909,28 @@
 			"source": "MM",
 			"page": 297,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"DSotDQ",
+				"EGW",
+				"GoS",
+				"HotDQ",
+				"LLK",
+				"RoT",
+				"SatO",
+				"SKT",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-WPM",
+				"ToFW",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Vampire|XMM"
@@ -68246,7 +62023,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+						"The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from {@item Holy Water (Flask)|PHB|holy water}, this trait doesn't function at the start of the vampire's next turn."
 					]
 				},
 				{
@@ -68350,7 +62127,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vampire.mp3"
+				"path": "bestiary/vampire.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -68392,49 +62169,24 @@
 			"source": "MM",
 			"page": 298,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"CoS",
+				"DIP",
+				"EGW",
+				"GoS",
+				"HotDQ",
+				"LLK",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"SLW",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Vampire Spawn|XMM"
@@ -68500,7 +62252,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+						"The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from {@item Holy Water (Flask)|PHB|holy water}, this trait doesn't function at the start of the vampire's next turn."
 					]
 				},
 				{
@@ -68568,7 +62320,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vampire-spawn.mp3"
+				"path": "bestiary/vampire-spawn.opus"
 			},
 			"traitTags": [
 				"Regeneration",
@@ -68601,10 +62353,8 @@
 			"name": "Vampire Spellcaster",
 			"source": "MM",
 			"page": 298,
-			"otherSources": [
-				{
-					"source": "RoT"
-				}
+			"referenceSources": [
+				"RoT"
 			],
 			"reprintedAs": [
 				"Vampire|XMM"
@@ -68753,7 +62503,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+						"The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from {@item Holy Water (Flask)|PHB|holy water}, this trait doesn't function at the start of the vampire's next turn."
 					]
 				},
 				{
@@ -68857,7 +62607,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vampire-spellcaster.mp3"
+				"path": "bestiary/vampire-spellcaster.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -69006,7 +62756,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+						"The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from {@item Holy Water (Flask)|PHB|holy water}, this trait doesn't function at the start of the vampire's next turn."
 					]
 				},
 				{
@@ -69122,7 +62872,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vampire-warrior.mp3"
+				"path": "bestiary/vampire-warrior.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -69169,100 +62919,51 @@
 			"source": "MM",
 			"page": 350,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "SjA"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DD",
+				"DIP",
+				"DSotDQ",
+				"EFR",
+				"EGW",
+				"ERLW",
+				"FS",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"KKW",
+				"LoX",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"SatO",
+				"SDW",
+				"SjA",
+				"SKT",
+				"SLW",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-TFoF",
+				"TftYP-TSC",
+				"TftYP-WPM",
+				"ToA",
+				"ToFW",
+				"ToR",
+				"US",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Warrior Veteran|XMM"
@@ -69347,7 +63048,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/veteran.mp3"
+				"path": "bestiary/veteran.opus"
 			},
 			"attachedItems": [
 				"heavy crossbow|phb",
@@ -69378,25 +63079,14 @@
 			"name": "Vine Blight",
 			"source": "MM",
 			"page": 32,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoS",
+				"DIP",
+				"EGW",
+				"GoS",
+				"PSI",
+				"US"
 			],
 			"reprintedAs": [
 				"Vine Blight|XMM"
@@ -69472,7 +63162,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vine-blight.mp3"
+				"path": "bestiary/vine-blight.opus"
 			},
 			"altArt": [
 				{
@@ -69513,19 +63203,13 @@
 			"source": "MM",
 			"page": 138,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DoSI"
-				}
+			"referenceSources": [
+				"DoSI",
+				"GoS",
+				"HotDQ",
+				"OotA",
+				"PotA",
+				"SCC-CK"
 			],
 			"reprintedAs": [
 				"Violet Fungus|XMM"
@@ -69590,7 +63274,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/violet-fungus.mp3"
+				"path": "bestiary/violet-fungus.opus"
 			},
 			"traitTags": [
 				"False Appearance"
@@ -69617,46 +63301,25 @@
 			"source": "MM",
 			"page": 64,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"GoS",
+				"OotA",
+				"PotA",
+				"PSI",
+				"SatO",
+				"SCC-ARiR",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-ToH",
+				"VEoR",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Vrock|XMM"
@@ -69760,7 +63423,7 @@
 				{
 					"name": "Spores {@recharge}",
 					"entries": [
-						"A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must succeed on a {@dc 14} Constitution saving throw or become {@condition poisoned}. While {@condition poisoned} in this way, a target takes 5 ({@damage 1d10}) poison damage at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Emptying a vial of holy water on the target also ends the effect on it."
+						"A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must succeed on a {@dc 14} Constitution saving throw or become {@condition poisoned}. While {@condition poisoned} in this way, a target takes 5 ({@damage 1d10}) poison damage at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Emptying a {@item Holy Water (Flask)|PHB|vial of holy water} on the target also ends the effect on it."
 					]
 				},
 				{
@@ -69787,7 +63450,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vrock.mp3"
+				"path": "bestiary/vrock.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -69828,25 +63491,13 @@
 			"page": 339,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"RoT",
+				"ToA",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Vulture|XMM"
@@ -69910,7 +63561,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vulture.mp3"
+				"path": "bestiary/vulture.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -69930,34 +63581,16 @@
 			"page": 340,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "DSotDQ"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CRCotN",
+				"DSotDQ",
+				"EGW",
+				"PotA",
+				"RoT",
+				"SKT",
+				"ToA",
+				"UtHftLH"
 			],
 			"reprintedAs": [
 				"Warhorse|XMM"
@@ -70058,7 +63691,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/war-horse.mp3"
+				"path": "bestiary/war-horse.opus"
 			},
 			"damageTags": [
 				"B"
@@ -70172,22 +63805,13 @@
 			"source": "MM",
 			"page": 273,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"CoS",
+				"DSotDQ",
+				"OoW",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Warhorse Skeleton|XMM"
@@ -70246,7 +63870,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/warhorse-skeleton.mp3"
+				"path": "bestiary/warhorse-skeleton.opus"
 			},
 			"senseTags": [
 				"D"
@@ -70266,55 +63890,27 @@
 			"page": 125,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AitFR-FCD",
+				"BGDIA",
+				"CM",
+				"DIP",
+				"DSotDQ",
+				"GoS",
+				"IMR",
+				"JttRC",
+				"MOT",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SKT",
+				"SLW",
+				"TCE",
+				"TTP",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Water Elemental|XMM"
@@ -70423,7 +64019,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/water-elemental.mp3"
+				"path": "bestiary/water-elemental.opus"
 			},
 			"senseTags": [
 				"D"
@@ -70455,46 +64051,31 @@
 			"name": "Water Weird",
 			"source": "MM",
 			"page": 299,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "LK"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AitFR-AVT",
+				"CM",
+				"DIP",
+				"DitLCoT",
+				"DSotDQ",
+				"IDRotF",
+				"JttRC",
+				"LK",
+				"MOT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"SCC-ARiR",
+				"SCC-HfMT",
+				"SLW",
+				"TftYP",
+				"TftYP-THSoT",
+				"ToA",
+				"VEoR",
+				"VNotEE",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Water Weird|XMM"
@@ -70583,7 +64164,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/water-weird.mp3"
+				"path": "bestiary/water-weird.opus"
 			},
 			"senseTags": [
 				"B"
@@ -70613,19 +64194,11 @@
 			"page": 340,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"PaBTSO",
+				"QftIS",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Weasel|XMM"
@@ -70678,7 +64251,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/weasel.mp3"
+				"path": "bestiary/weasel.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -70699,16 +64272,11 @@
 			"source": "MM",
 			"page": 208,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"EGW",
+				"FS",
+				"GoS",
+				"KftGV"
 			],
 			"reprintedAs": [
 				"Werebear|XMM"
@@ -70799,7 +64367,7 @@
 				{
 					"name": "Bite (Bear or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}15 ({@damage 2d10 + 4}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 14} Constitution saving throw or be cursed with werebear lycanthropy."
+						"{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}15 ({@damage 2d10 + 4}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 14} Constitution saving throw or be cursed with werebear {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				},
 				{
@@ -70831,7 +64399,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/werebear.mp3"
+				"path": "bestiary/werebear.opus"
 			},
 			"attachedItems": [
 				"greataxe|phb"
@@ -70871,34 +64439,17 @@
 			"source": "MM",
 			"page": 209,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"DC",
+				"DIP",
+				"EGW",
+				"IMR",
+				"PotA",
+				"TCE",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Wereboar|XMM"
@@ -71001,7 +64552,7 @@
 				{
 					"name": "Tusks (Boar or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) slashing damage. If the target is a humanoid, it must succeed on a {@dc 12} Constitution saving throw or be cursed with wereboar lycanthropy."
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) slashing damage. If the target is a humanoid, it must succeed on a {@dc 12} Constitution saving throw or be cursed with wereboar {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				}
 			],
@@ -71021,7 +64572,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wereboar.mp3"
+				"path": "bestiary/wereboar.opus"
 			},
 			"attachedItems": [
 				"maul|phb"
@@ -71065,43 +64616,22 @@
 			"source": "MM",
 			"page": 209,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"DIP",
+				"EGW",
+				"GoS",
+				"IMR",
+				"OotA",
+				"OoW",
+				"QftIS",
+				"SatO",
+				"TftYP",
+				"TftYP-AtG",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Wererat|XMM"
@@ -71183,7 +64713,7 @@
 				{
 					"name": "Bite (Rat or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 11} Constitution saving throw or be cursed with wererat lycanthropy."
+						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 11} Constitution saving throw or be cursed with wererat {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				},
 				{
@@ -71214,7 +64744,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wererat.mp3"
+				"path": "bestiary/wererat.opus"
 			},
 			"attachedItems": [
 				"hand crossbow|phb",
@@ -71259,19 +64789,13 @@
 			"source": "MM",
 			"page": 210,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"EGW",
+				"JttRC",
+				"TftYP-THSoT",
+				"ToA",
+				"ToFW",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Weretiger|XMM"
@@ -71361,7 +64885,7 @@
 				{
 					"name": "Bite (Tiger or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}8 ({@damage 1d10 + 3}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 13} Constitution saving throw or be cursed with weretiger lycanthropy."
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}8 ({@damage 1d10 + 3}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 13} Constitution saving throw or be cursed with weretiger {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				},
 				{
@@ -71399,7 +64923,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/weretiger.mp3"
+				"path": "bestiary/weretiger.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -71451,46 +64975,21 @@
 			"page": 211,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"EGW",
+				"ERLW",
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"PotA",
+				"SKT",
+				"TftYP-WPM",
+				"VEoR",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Werewolf|XMM"
@@ -71582,7 +65081,7 @@
 				{
 					"name": "Bite (Wolf or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 12} Constitution saving throw or be cursed with werewolf lycanthropy."
+						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 12} Constitution saving throw or be cursed with werewolf {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				},
 				{
@@ -71613,7 +65112,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/werewolf.mp3"
+				"path": "bestiary/werewolf.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -71655,16 +65154,11 @@
 			"source": "MM",
 			"page": 102,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"EGW",
+				"IDRotF",
+				"SKT",
+				"TftYP-TSC"
 			],
 			"reprintedAs": [
 				"White Dragon Wyrmling|XMM"
@@ -71823,7 +65317,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/white-dragon-wyrmling.mp3"
+				"path": "bestiary/white-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -71856,73 +65350,40 @@
 			"page": 300,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"FS",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"PaBTSO",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SatO",
+				"SCC-ARiR",
+				"SDW",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"ToA",
+				"TTP",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Wight|XMM"
@@ -72030,7 +65491,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wight.mp3"
+				"path": "bestiary/wight.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -72072,70 +65533,32 @@
 			"source": "MM",
 			"page": 301,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"AitFR-AVT",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"LoX",
+				"OoW",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"SatO",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Will-o'-Wisp|XMM"
@@ -72253,7 +65676,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/will-o-wisp.mp3"
+				"path": "bestiary/will-o-wisp.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement"
@@ -72285,22 +65708,13 @@
 			"name": "Winged Kobold",
 			"source": "MM",
 			"page": 195,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "DoSI"
-				}
+			"referenceSources": [
+				"CM",
+				"DoSI",
+				"GoS",
+				"HotDQ",
+				"OotA",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Winged Kobold|XMM"
@@ -72385,7 +65799,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/winged-kobold.mp3"
+				"path": "bestiary/winged-kobold.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -72420,22 +65834,13 @@
 			"page": 340,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "KftGV"
-				}
+			"referenceSources": [
+				"IDRotF",
+				"KftGV",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Winter Wolf|XMM"
@@ -72522,7 +65927,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/winter-wolf.mp3"
+				"path": "bestiary/winter-wolf.opus"
 			},
 			"traitTags": [
 				"Camouflage",
@@ -72562,58 +65967,27 @@
 			"page": 341,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "LK"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"CoA",
+				"CoS",
+				"DD",
+				"EGW",
+				"FS",
+				"GoS",
+				"HftT",
+				"HotDQ",
+				"IDRotF",
+				"LK",
+				"LMoP",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SKT",
+				"TCE",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Wolf|XMM"
@@ -72681,7 +66055,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wolf.mp3"
+				"path": "bestiary/wolf.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -72708,28 +66082,16 @@
 			"page": 341,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"CM",
+				"EFR",
+				"ERLW",
+				"IDRotF",
+				"PotA",
+				"SCC-CK",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Worg|XMM"
@@ -72798,7 +66160,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/worg.mp3"
+				"path": "bestiary/worg.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -72831,85 +66193,38 @@
 			"source": "MM",
 			"page": 302,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CM",
+				"CoS",
+				"DC",
+				"DIP",
+				"DSotDQ",
+				"EGW",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"MOT",
+				"OotA",
+				"PaBTSO",
+				"PSI",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SatO",
+				"SCC-ARiR",
+				"SDW",
+				"SLW",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"ToA",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Wraith|XMM"
@@ -73014,7 +66329,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wraith.mp3"
+				"path": "bestiary/wraith.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -73047,43 +66362,19 @@
 			"page": 303,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"CM",
+				"DIP",
+				"HotDQ",
+				"JttRC",
+				"PotA",
+				"QftIS",
+				"SKT",
+				"SLW",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Wyvern|XMM"
@@ -73157,7 +66448,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wyvern.mp3"
+				"path": "bestiary/wyvern.opus"
 			},
 			"senseTags": [
 				"D"
@@ -73186,25 +66477,17 @@
 			"source": "MM",
 			"page": 304,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"CoA",
+				"DitLCoT",
+				"LLK",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SatO",
+				"TTP",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Xorn|XMM"
@@ -73306,7 +66589,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/xorn.mp3"
+				"path": "bestiary/xorn.opus"
 			},
 			"traitTags": [
 				"Camouflage"
@@ -73337,25 +66620,15 @@
 			"source": "MM",
 			"page": 305,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"EGW",
+				"IDRotF",
+				"LoX",
+				"SKT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Yeti|XMM"
@@ -73450,7 +66723,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yeti.mp3"
+				"path": "bestiary/yeti.opus"
 			},
 			"traitTags": [
 				"Camouflage",
@@ -73486,22 +66759,13 @@
 			"name": "Yochlol",
 			"source": "MM",
 			"page": 65,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "CRCotN"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"CRCotN",
+				"EGW",
+				"OotA",
+				"PaBTSO",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Yochlol|XMM"
@@ -73666,7 +66930,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yochlol.mp3"
+				"path": "bestiary/yochlol.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -73726,22 +66990,12 @@
 			"source": "MM",
 			"page": 88,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "LK"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"GoS",
+				"LK",
+				"TftYP",
+				"TftYP-TFoF"
 			],
 			"reprintedAs": [
 				"Young Black Dragon|XMM"
@@ -73917,7 +67171,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-dragon.mp3"
+				"path": "bestiary/black-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -73959,31 +67213,15 @@
 			"source": "MM",
 			"page": 91,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "MOT"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "LK"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"DSotDQ",
+				"LK",
+				"MOT",
+				"QftIS",
+				"RoT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Young Blue Dragon|XMM"
@@ -74159,7 +67397,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-dragon.mp3"
+				"path": "bestiary/blue-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -74198,10 +67436,8 @@
 			"source": "MM",
 			"page": 105,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				}
+			"referenceSources": [
+				"SKT"
 			],
 			"reprintedAs": [
 				"Young Brass Dragon|XMM"
@@ -74402,7 +67638,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brass-dragon.mp3"
+				"path": "bestiary/brass-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -74445,19 +67681,11 @@
 			"source": "MM",
 			"page": 108,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"CM",
+				"GoS",
+				"QftIS",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Young Bronze Dragon|XMM"
@@ -74659,7 +67887,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bronze-dragon.mp3"
+				"path": "bestiary/bronze-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -74702,13 +67930,9 @@
 			"source": "MM",
 			"page": 112,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Young Copper Dragon|XMM"
@@ -74902,7 +68126,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/copper-dragon.mp3"
+				"path": "bestiary/copper-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -75152,7 +68376,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gold-dragon.mp3"
+				"path": "bestiary/gold-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -75196,34 +68420,17 @@
 			"page": 94,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "LK"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"BMT",
+				"HftT",
+				"LK",
+				"LMoP",
+				"OoW",
+				"PaBTSO",
+				"RMBRE",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Young Green Dragon|XMM"
@@ -75403,7 +68610,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-dragon.mp3"
+				"path": "bestiary/green-dragon.opus"
 			},
 			"altArt": [
 				{
@@ -75451,46 +68658,20 @@
 			"source": "MM",
 			"page": 98,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "LoX"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "LK"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"BMT",
+				"CoA",
+				"DSotDQ",
+				"JttRC",
+				"KftGV",
+				"LK",
+				"LoX",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SatO",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Young Red Dragon|XMM"
@@ -75667,7 +68848,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-dragon.mp3"
+				"path": "bestiary/red-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -75702,16 +68883,10 @@
 			"name": "Young Red Shadow Dragon",
 			"source": "MM",
 			"page": 85,
-			"otherSources": [
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
-				}
+			"referenceSources": [
+				"AATM",
+				"CoA",
+				"QftIS"
 			],
 			"reprintedAs": [
 				"Shadow Dragon|XMM"
@@ -75783,7 +68958,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the dragon can take the Hide action as a bonus action."
+						"While in dim light or darkness, the dragon can take the {@action Hide} action as a bonus action."
 					]
 				},
 				{
@@ -75910,7 +69085,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-shadow-dragon.mp3"
+				"path": "bestiary/red-shadow-dragon.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity"
@@ -75948,16 +69123,10 @@
 			"name": "Young Remorhaz",
 			"source": "MM",
 			"page": 258,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"EGW",
+				"IDRotF",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Young Remorhaz|XMM"
@@ -76022,7 +69191,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/remorhaz.mp3"
+				"path": "bestiary/remorhaz.opus"
 			},
 			"senseTags": [
 				"D",
@@ -76047,13 +69216,9 @@
 			"source": "MM",
 			"page": 118,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "DSotDQ"
-				}
+			"referenceSources": [
+				"DSotDQ",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Young Silver Dragon|XMM"
@@ -76248,7 +69413,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/silver-dragon.mp3"
+				"path": "bestiary/silver-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -76290,28 +69455,14 @@
 			"source": "MM",
 			"page": 101,
 			"srd": true,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "IDRotF"
-				},
-				{
-					"source": "LK"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT",
+				"DIP",
+				"IDRotF",
+				"LK",
+				"TftYP",
+				"TftYP-AtG",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Young White Dragon|XMM"
@@ -76495,7 +69646,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/white-dragon.mp3"
+				"path": "bestiary/white-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -76530,25 +69681,14 @@
 			"name": "Yuan-ti Abomination",
 			"source": "MM",
 			"page": 308,
-			"otherSources": [
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"CM",
+				"DIP",
+				"RoT",
+				"SLW",
+				"ToA",
+				"TTP",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Yuan-ti Abomination|XMM"
@@ -76682,7 +69822,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-abomination.mp3"
+				"path": "bestiary/yuan-ti-abomination.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -76739,22 +69879,12 @@
 			"name": "Yuan-ti Malison (Type 1)",
 			"source": "MM",
 			"page": 309,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"CM",
+				"HotDQ",
+				"RoT",
+				"SKT",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Yuan-ti Malison (Type 1)|XMM"
@@ -76901,7 +70031,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-malison.mp3"
+				"path": "bestiary/yuan-ti-malison.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -76948,19 +70078,10 @@
 			"name": "Yuan-ti Malison (Type 2)",
 			"source": "MM",
 			"page": 309,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"HotDQ",
+				"SKT",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Yuan-ti Malison (Type 2)|XMM"
@@ -77095,7 +70216,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-malison.mp3"
+				"path": "bestiary/yuan-ti-malison.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -77134,22 +70255,12 @@
 			"name": "Yuan-ti Malison (Type 3)",
 			"source": "MM",
 			"page": 309,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"CM",
+				"HotDQ",
+				"SKT",
+				"TftYP-DiT",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Yuan-ti Malison (Type 3)|XMM"
@@ -77302,7 +70413,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-malison.mp3"
+				"path": "bestiary/yuan-ti-malison.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -77357,28 +70468,15 @@
 			"name": "Yuan-ti Pureblood",
 			"source": "MM",
 			"page": 310,
-			"otherSources": [
-				{
-					"source": "HotDQ"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "SKT"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "CM"
-				},
-				{
-					"source": "PSI"
-				}
+			"referenceSources": [
+				"CM",
+				"HotDQ",
+				"PSI",
+				"RoT",
+				"SKT",
+				"ToA",
+				"TTP",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Yuan-ti Infiltrator|XMM"
@@ -77488,7 +70586,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-pureblood.mp3"
+				"path": "bestiary/yuan-ti-pureblood.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb",
@@ -77539,100 +70637,45 @@
 			"page": 316,
 			"srd": true,
 			"basicRules": true,
-			"otherSources": [
-				{
-					"source": "CoS"
-				},
-				{
-					"source": "LMoP"
-				},
-				{
-					"source": "PotA"
-				},
-				{
-					"source": "RoT"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "ERLW"
-				},
-				{
-					"source": "RMBRE"
-				},
-				{
-					"source": "EGW"
-				},
-				{
-					"source": "TCE"
-				},
-				{
-					"source": "WBtW"
-				},
-				{
-					"source": "JttRC"
-				},
-				{
-					"source": "DoSI"
-				},
-				{
-					"source": "DSotDQ"
-				},
-				{
-					"source": "KftGV"
-				},
-				{
-					"source": "PSI"
-				},
-				{
-					"source": "HftT"
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				},
-				{
-					"source": "BMT"
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "QftIS"
-				}
+			"referenceSources": [
+				"AATM",
+				"BGDIA",
+				"BMT",
+				"CoS",
+				"DC",
+				"DIP",
+				"DoSI",
+				"DSotDQ",
+				"EGW",
+				"ERLW",
+				"FS",
+				"GoS",
+				"HftT",
+				"JttRC",
+				"KftGV",
+				"KKW",
+				"LMoP",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"PSI",
+				"QftIS",
+				"RMBRE",
+				"RtG",
+				"SatO",
+				"SDW",
+				"SLW",
+				"TCE",
+				"TftYP",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"VNotEE",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Zombie|XMM"
@@ -77699,7 +70742,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/zombie.mp3"
+				"path": "bestiary/zombie.opus"
 			},
 			"altArt": [
 				{

--- a/json/bestiary/bestiary-mot.json
+++ b/json/bestiary/bestiary-mot.json
@@ -1053,6 +1053,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW",
 				"RCH"
@@ -1432,6 +1433,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"greataxe|phb"
 			],
@@ -1668,7 +1670,8 @@
 				}
 			],
 			"traitTags": [
-				"Charge"
+				"Charge",
+				"Sure-Footed"
 			],
 			"senseTags": [
 				"SD"
@@ -2230,6 +2233,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -3153,6 +3157,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -3626,10 +3631,8 @@
 			],
 			"source": "MOT",
 			"page": 236,
-			"otherSources": [
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"CM"
 			],
 			"size": [
 				"M"
@@ -3998,7 +4001,8 @@
 			],
 			"traitTags": [
 				"Charge",
-				"Magic Resistance"
+				"Magic Resistance",
+				"Sure-Footed"
 			],
 			"damageTags": [
 				"B",
@@ -4575,6 +4579,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -5605,6 +5610,9 @@
 			"spellcastingTags": [
 				"I"
 			],
+			"miscTags": [
+				"AOE"
+			],
 			"savingThrowForcedSpell": [
 				"constitution",
 				"strength"
@@ -5690,7 +5698,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The triton can take the Disengage or Hide actions as a bonus action on each of its turns."
+						"The triton can take the {@action Disengage} or {@action Hide} actions as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -5948,6 +5956,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],

--- a/json/bestiary/bestiary-mpmm.json
+++ b/json/bestiary/bestiary-mpmm.json
@@ -103,7 +103,7 @@
 				{
 					"name": "Arcane Burst",
 					"entries": [
-						"{@atk ms,rs} {@hit 6} to hit, reach 5 ft. or range 120 ft., one target. {@h}20 ({@damage 3d10 + 4}) force damage."
+						"{@atk ms,rs} {@hit 8} to hit, reach 5 ft. or range 120 ft., one target. {@h}20 ({@damage 3d10 + 4}) force damage."
 					]
 				},
 				{
@@ -126,7 +126,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/abjurer.mp3"
+				"path": "bestiary/abjurer.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -254,7 +254,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/adult-kruthik.mp3"
+				"path": "bestiary/adult-kruthik.opus"
 			},
 			"traitTags": [
 				"Pack Tactics",
@@ -424,7 +424,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/oblex-adult.mp3"
+				"path": "bestiary/oblex-adult.opus"
 			},
 			"traitTags": [
 				"Amorphous",
@@ -566,7 +566,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/air-elemental-myrmidon.mp3"
+				"path": "bestiary/air-elemental-myrmidon.opus"
 			},
 			"attachedItems": [
 				"flail|phb"
@@ -606,10 +606,10 @@
 				{
 					"source": "VGM",
 					"page": 172
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"M"
@@ -773,7 +773,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/alhoon.mp3"
+				"path": "bestiary/alhoon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -969,7 +969,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/alkilith.mp3"
+				"path": "bestiary/alkilith.opus"
 			},
 			"traitTags": [
 				"Amorphous",
@@ -1130,7 +1130,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/allip.mp3"
+				"path": "bestiary/allip.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -1167,10 +1167,10 @@
 				{
 					"source": "MTF",
 					"page": 164
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"M"
@@ -1339,7 +1339,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/amnizu.mp3"
+				"path": "bestiary/amnizu.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -1490,7 +1490,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/the-angry.mp3"
+				"path": "bestiary/the-angry.opus"
 			},
 			"senseTags": [
 				"D"
@@ -1624,7 +1624,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/annis-hag.mp3"
+				"path": "bestiary/annis-hag.opus"
 			},
 			"senseTags": [
 				"D"
@@ -1663,10 +1663,10 @@
 				{
 					"source": "VGM",
 					"page": 209
-				},
-				{
-					"source": "SjA"
 				}
+			],
+			"referenceSources": [
+				"SjA"
 			],
 			"size": [
 				"M"
@@ -1742,7 +1742,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/apprentice-wizard.mp3"
+				"path": "bestiary/apprentice-wizard.opus"
 			},
 			"languageTags": [
 				"C",
@@ -1772,10 +1772,6 @@
 				{
 					"source": "VGM",
 					"page": 210
-				},
-				{
-					"source": "WDMM",
-					"page": 311
 				}
 			],
 			"size": [
@@ -1891,7 +1887,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/archdruid.mp3"
+				"path": "bestiary/archdruid.opus"
 			},
 			"actionTags": [
 				"Multiattack",
@@ -2009,7 +2005,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/archer.mp3"
+				"path": "bestiary/archer.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -2145,7 +2141,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/armanite.mp3"
+				"path": "bestiary/armanite.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -2189,10 +2185,10 @@
 				{
 					"source": "MTF",
 					"page": 117
-				},
-				{
-					"source": "VEoR"
 				}
+			],
+			"referenceSources": [
+				"VEoR"
 			],
 			"size": [
 				"G"
@@ -2345,7 +2341,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/astral-dreadnought.mp3"
+				"path": "bestiary/astral-dreadnought.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -2438,7 +2434,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/aurochs.mp3"
+				"path": "bestiary/aurochs.opus"
 			},
 			"damageTags": [
 				"P"
@@ -2598,7 +2594,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/autumn-eladrin.mp3"
+				"path": "bestiary/autumn-eladrin.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -2769,7 +2765,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/babau.mp3"
+				"path": "bestiary/babau.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -2939,7 +2935,7 @@
 				{
 					"name": "Magic Resistance",
 					"entries": [
-						"Bael have advantage on saving throws against spells and other magical effects."
+						"Bael has advantage on saving throws against spells and other magical effects."
 					]
 				},
 				{
@@ -2997,7 +2993,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bael.mp3"
+				"path": "bestiary/bael.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -3170,7 +3166,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/balhannoth.mp3"
+				"path": "bestiary/balhannoth.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -3319,7 +3315,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/banderhobb.mp3"
+				"path": "bestiary/banderhobb.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -3360,10 +3356,10 @@
 				{
 					"source": "MTF",
 					"page": 143
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"H"
@@ -3586,10 +3582,10 @@
 				{
 					"source": "VGM",
 					"page": 211
-				},
-				{
-					"source": "AATM"
 				}
+			],
+			"referenceSources": [
+				"AATM"
 			],
 			"size": [
 				"M"
@@ -3695,7 +3691,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bard.mp3"
+				"path": "bestiary/bard.opus"
 			},
 			"attachedItems": [
 				"shortbow|phb",
@@ -3893,7 +3889,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/barghest.mp3"
+				"path": "bestiary/barghest.opus"
 			},
 			"senseTags": [
 				"B",
@@ -4051,7 +4047,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/berbalang.mp3"
+				"path": "bestiary/berbalang.opus"
 			},
 			"senseTags": [
 				"U"
@@ -4187,7 +4183,7 @@
 				{
 					"name": "Ice Walk",
 					"entries": [
-						"The hag can move across and climb icy surfaces without needing to make an ability check, and {@quickref difficult terrain||3} composed of ice or snow doesn't cost the hag extra moment."
+						"The hag can move across and climb icy surfaces without needing to make an ability check, and {@quickref difficult terrain||3} composed of ice or snow doesn't cost the hag extra movement."
 					]
 				}
 			],
@@ -4222,7 +4218,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bheur-hag.mp3"
+				"path": "bestiary/bheur-hag.opus"
 			},
 			"senseTags": [
 				"D"
@@ -4276,10 +4272,10 @@
 				{
 					"source": "MTF",
 					"page": 160
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"M"
@@ -4421,7 +4417,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-abishai.mp3"
+				"path": "bestiary/black-abishai.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -4583,7 +4579,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blackguard.mp3"
+				"path": "bestiary/blackguard.opus"
 			},
 			"attachedItems": [
 				"glaive|phb",
@@ -4638,13 +4634,11 @@
 				{
 					"source": "MTF",
 					"page": 161
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA",
+				"VEoR"
 			],
 			"size": [
 				"M"
@@ -4792,7 +4786,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-abishai.mp3"
+				"path": "bestiary/blue-abishai.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -4838,10 +4832,10 @@
 				{
 					"source": "VGM",
 					"page": 127
-				},
-				{
-					"source": "SatO"
 				}
+			],
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"M"
@@ -4958,7 +4952,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bodak.mp3"
+				"path": "bestiary/bodak.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity",
@@ -4974,7 +4968,6 @@
 			"damageTags": [
 				"B",
 				"N",
-				"R",
 				"Y"
 			],
 			"miscTags": [
@@ -5118,7 +5111,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/boggle.mp3"
+				"path": "bestiary/boggle.opus"
 			},
 			"senseTags": [
 				"D"
@@ -5270,7 +5263,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/boneclaw.mp3"
+				"path": "bestiary/boneclaw.opus"
 			},
 			"traitTags": [
 				"Rejuvenation",
@@ -5361,7 +5354,7 @@
 				{
 					"name": "Tail",
 					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 20 ft., one target. {@h}32 ({@damage 6d8 + 5}) bludgeoning damage"
+						"{@atk mw} {@hit 8} to hit, reach 20 ft., one target. {@h}32 ({@damage 6d8 + 5}) bludgeoning damage."
 					]
 				}
 			],
@@ -5371,7 +5364,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brontosaurus.mp3"
+				"path": "bestiary/brontosaurus.opus"
 			},
 			"damageTags": [
 				"B"
@@ -5486,8 +5479,11 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bulezau.mp3"
+				"path": "bestiary/bulezau.opus"
 			},
+			"traitTags": [
+				"Sure-Footed"
+			],
 			"senseTags": [
 				"SD"
 			],
@@ -5522,13 +5518,11 @@
 				{
 					"source": "MTF",
 					"page": 122
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "VEoR"
 				}
+			],
+			"referenceSources": [
+				"AATM",
+				"VEoR"
 			],
 			"size": [
 				"L"
@@ -5637,7 +5631,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cadaver-collector.mp3"
+				"path": "bestiary/cadaver-collector.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -5805,7 +5799,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/canoloth.mp3"
+				"path": "bestiary/canoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -5911,7 +5905,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/catoblepas.mp3"
+				"path": "bestiary/catoblepas.opus"
 			},
 			"senseTags": [
 				"D"
@@ -6030,7 +6024,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cave-fisher.mp3"
+				"path": "bestiary/cave-fisher.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -6062,10 +6056,6 @@
 				{
 					"source": "VGM",
 					"page": 212
-				},
-				{
-					"source": "WDMM",
-					"page": 312
 				}
 			],
 			"size": [
@@ -6152,7 +6142,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/champion.mp3"
+				"path": "bestiary/champion.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb",
@@ -6277,7 +6267,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/chitine.mp3"
+				"path": "bestiary/chitine.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -6402,7 +6392,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/choker.mp3"
+				"path": "bestiary/choker.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -6572,7 +6562,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/choldrith.mp3"
+				"path": "bestiary/choldrith.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -6721,7 +6711,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bronze-scout.mp3"
+				"path": "bestiary/bronze-scout.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -6859,7 +6849,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/iron-cobra.mp3"
+				"path": "bestiary/iron-cobra.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -7005,7 +6995,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/oaken-bolter.mp3"
+				"path": "bestiary/oaken-bolter.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -7139,7 +7129,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stone-defender.mp3"
+				"path": "bestiary/stone-defender.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -7302,7 +7292,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cloud-giant-smiling-one.mp3"
+				"path": "bestiary/cloud-giant-smiling-one.opus"
 			},
 			"actionTags": [
 				"Multiattack",
@@ -7449,7 +7439,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/conjurer.mp3"
+				"path": "bestiary/conjurer.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -7584,7 +7574,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/corpse-flower.mp3"
+				"path": "bestiary/corpse-flower.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -7685,7 +7675,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cranium-rat.mp3"
+				"path": "bestiary/cranium-rat.opus"
 			},
 			"senseTags": [
 				"D"
@@ -7790,7 +7780,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/darkling.mp3"
+				"path": "bestiary/darkling.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -7932,7 +7922,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/darkling-elder.mp3"
+				"path": "bestiary/darkling-elder.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -8073,7 +8063,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/death-kiss.mp3"
+				"path": "bestiary/death-kiss.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -8113,13 +8103,11 @@
 				{
 					"source": "MTF",
 					"page": 128
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"AATM",
+				"BMT"
 			],
 			"size": [
 				"M"
@@ -8250,7 +8238,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deathlock.mp3"
+				"path": "bestiary/deathlock.opus"
 			},
 			"traitTags": [
 				"Turn Resistance",
@@ -8297,10 +8285,10 @@
 				{
 					"source": "MTF",
 					"page": 129
-				},
-				{
-					"source": "AATM"
 				}
+			],
+			"referenceSources": [
+				"AATM"
 			],
 			"size": [
 				"M"
@@ -8439,7 +8427,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deathlock-mastermind.mp3"
+				"path": "bestiary/deathlock-mastermind.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -8613,7 +8601,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deathlock-wight.mp3"
+				"path": "bestiary/deathlock-wight.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity",
@@ -8733,7 +8721,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rothe.mp3"
+				"path": "bestiary/rothe.opus"
 			},
 			"traitTags": [
 				"Beast of Burden"
@@ -8863,7 +8851,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deep-scion.mp3"
+				"path": "bestiary/deep-scion.opus"
 			},
 			"attachedItems": [
 				"battleaxe|phb"
@@ -8984,7 +8972,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deinonychus.mp3"
+				"path": "bestiary/deinonychus.opus"
 			},
 			"traitTags": [
 				"Pounce"
@@ -9275,10 +9263,10 @@
 				{
 					"source": "MTF",
 					"page": 158
-				},
-				{
-					"source": "QftIS"
 				}
+			],
+			"referenceSources": [
+				"QftIS"
 			],
 			"size": [
 				"S"
@@ -9356,7 +9344,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/derro.mp3"
+				"path": "bestiary/derro.opus"
 			},
 			"attachedItems": [
 				"light crossbow|phb"
@@ -9501,7 +9489,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/derro-savant.mp3"
+				"path": "bestiary/derro-savant.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -9638,7 +9626,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/devourer.mp3"
+				"path": "bestiary/devourer.opus"
 			},
 			"traitTags": [
 				"Unusual Nature"
@@ -9805,7 +9793,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dhergoloth.mp3"
+				"path": "bestiary/dhergoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -9909,7 +9897,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dimetrodon.mp3"
+				"path": "bestiary/dimetrodon.opus"
 			},
 			"damageTags": [
 				"P"
@@ -10033,7 +10021,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dire-troll.mp3"
+				"path": "bestiary/dire-troll.opus"
 			},
 			"traitTags": [
 				"Regeneration"
@@ -10181,7 +10169,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/diviner.mp3"
+				"path": "bestiary/diviner.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -10285,7 +10273,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dolphin.mp3"
+				"path": "bestiary/dolphin.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -10547,7 +10535,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/draegloth.mp3"
+				"path": "bestiary/draegloth.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry"
@@ -10598,7 +10586,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -10744,7 +10736,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-arachnomancer.mp3"
+				"path": "bestiary/drow-arachnomancer.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry",
@@ -10814,7 +10806,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf",
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					},
 					"wizard"
 				]
 			},
@@ -10933,7 +10929,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-favored-consort.mp3"
+				"path": "bestiary/drow-favored-consort.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -10995,7 +10991,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -11122,7 +11122,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-house-captain.mp3"
+				"path": "bestiary/drow-house-captain.opus"
 			},
 			"attachedItems": [
 				"hand crossbow|phb",
@@ -11191,7 +11191,11 @@
 				"type": "humanoid",
 				"tags": [
 					"cleric",
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -11248,7 +11252,7 @@
 					"name": "Spellcasting",
 					"type": "spellcasting",
 					"headerEntries": [
-						"The drow's casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save {@dc 18}):"
+						"The drow casts one of the following spells, requiring no material components and using Charisma as the spellcasting ability (spell save {@dc 18}):"
 					],
 					"will": [
 						"{@spell dancing lights}",
@@ -11334,7 +11338,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-inquisitor.mp3"
+				"path": "bestiary/drow-inquisitor.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry",
@@ -11393,7 +11397,11 @@
 				"type": "humanoid",
 				"tags": [
 					"cleric",
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -11573,7 +11581,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-matron-mother.mp3"
+				"path": "bestiary/drow-matron-mother.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry",
@@ -11653,7 +11661,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -11785,7 +11797,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-shadowblade.mp3"
+				"path": "bestiary/drow-shadowblade.opus"
 			},
 			"attachedItems": [
 				"hand crossbow|phb"
@@ -11971,7 +11983,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-despot.mp3"
+				"path": "bestiary/duergar-despot.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -12116,7 +12128,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-hammerer.mp3"
+				"path": "bestiary/duergar-hammerer.opus"
 			},
 			"traitTags": [
 				"Siege Monster"
@@ -12250,7 +12262,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-kavalrachni.mp3"
+				"path": "bestiary/duergar-kavalrachni.opus"
 			},
 			"attachedItems": [
 				"heavy crossbow|phb",
@@ -12402,7 +12414,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-mind-master.mp3"
+				"path": "bestiary/duergar-mind-master.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity"
@@ -12532,7 +12544,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-screamer.mp3"
+				"path": "bestiary/duergar-screamer.opus"
 			},
 			"senseTags": [
 				"D"
@@ -12658,7 +12670,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-soulblade.mp3"
+				"path": "bestiary/duergar-soulblade.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity"
@@ -12796,7 +12808,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-stone-guard.mp3"
+				"path": "bestiary/duergar-stone-guard.opus"
 			},
 			"attachedItems": [
 				"javelin|phb",
@@ -12955,7 +12967,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-warlord.mp3"
+				"path": "bestiary/duergar-warlord.opus"
 			},
 			"attachedItems": [
 				"javelin|phb"
@@ -13094,7 +13106,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-xarrorn.mp3"
+				"path": "bestiary/duergar-xarrorn.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity"
@@ -13134,10 +13146,10 @@
 				{
 					"source": "MTF",
 					"page": 132
-				},
-				{
-					"source": "AATM"
 				}
+			],
+			"referenceSources": [
+				"AATM"
 			],
 			"size": [
 				"M"
@@ -13278,7 +13290,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dybbuk.mp3"
+				"path": "bestiary/dybbuk.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -13413,7 +13425,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/earth-elemental-myrmidon.mp3"
+				"path": "bestiary/earth-elemental-myrmidon.opus"
 			},
 			"attachedItems": [
 				"maul|phb"
@@ -13572,7 +13584,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/eidolon.mp3"
+				"path": "bestiary/eidolon.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -13610,13 +13622,11 @@
 				{
 					"source": "VGM",
 					"page": 173
-				},
-				{
-					"source": "PaBTSO"
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA",
+				"PaBTSO"
 			],
 			"size": [
 				"L"
@@ -13785,7 +13795,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/elder-brain.mp3"
+				"path": "bestiary/elder-brain.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -13982,7 +13992,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/elder-oblex.mp3"
+				"path": "bestiary/elder-oblex.opus"
 			},
 			"traitTags": [
 				"Amorphous",
@@ -14187,7 +14197,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/elder-tempest.mp3"
+				"path": "bestiary/elder-tempest.opus"
 			},
 			"traitTags": [
 				"Flyby",
@@ -14327,7 +14337,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/enchanter.mp3"
+				"path": "bestiary/enchanter.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -14460,7 +14470,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/evoker.mp3"
+				"path": "bestiary/evoker.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -14577,7 +14587,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/female-steeder.mp3"
+				"path": "bestiary/female-steeder.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -14607,10 +14617,10 @@
 				{
 					"source": "MTF",
 					"page": 203
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"M"
@@ -14707,7 +14717,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fire-elemental-myrmidon.mp3"
+				"path": "bestiary/fire-elemental-myrmidon.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -14836,7 +14846,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fire-giant-dreadnought.mp3"
+				"path": "bestiary/fire-giant-dreadnought.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -15091,7 +15101,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/firenewt-warrior.mp3"
+				"path": "bestiary/firenewt-warrior.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -15214,7 +15224,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flail-snail.mp3"
+				"path": "bestiary/flail-snail.opus"
 			},
 			"senseTags": [
 				"D",
@@ -15354,7 +15364,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flind.mp3"
+				"path": "bestiary/flind.opus"
 			},
 			"attachedItems": [
 				"longbow|phb"
@@ -15644,13 +15654,11 @@
 				{
 					"source": "VGM",
 					"page": 145
-				},
-				{
-					"source": "QftIS"
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA",
+				"QftIS"
 			],
 			"size": [
 				"H"
@@ -15745,7 +15753,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/froghemoth.mp3"
+				"path": "bestiary/froghemoth.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -15895,7 +15903,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/frost-giant-everlasting-one.mp3"
+				"path": "bestiary/frost-giant-everlasting-one.opus"
 			},
 			"attachedItems": [
 				"greataxe|phb"
@@ -15992,8 +16000,7 @@
 				{
 					"name": "Burning Fury",
 					"entries": [
-						"When the salamander takes fire damage, its",
-						"Freezing Breath automatically recharges."
+						"When the salamander takes fire damage, its Freezing Breath automatically recharges."
 					]
 				}
 			],
@@ -16028,7 +16035,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/frost-salamander.mp3"
+				"path": "bestiary/frost-salamander.opus"
 			},
 			"senseTags": [
 				"D",
@@ -16209,7 +16216,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gauth.mp3"
+				"path": "bestiary/gauth.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -16254,10 +16261,10 @@
 				{
 					"source": "VGM",
 					"page": 126
-				},
-				{
-					"source": "SjA"
 				}
+			],
+			"referenceSources": [
+				"SjA"
 			],
 			"size": [
 				"T"
@@ -16398,7 +16405,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gazer.mp3"
+				"path": "bestiary/gazer.opus"
 			},
 			"traitTags": [
 				"Mimicry"
@@ -16634,7 +16641,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/geryon.mp3"
+				"path": "bestiary/geryon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -16776,7 +16783,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-strider.mp3"
+				"path": "bestiary/giant-strider.opus"
 			},
 			"traitTags": [
 				"Damage Absorption"
@@ -16804,10 +16811,10 @@
 				{
 					"source": "MTF",
 					"page": 204
-				},
-				{
-					"source": "SjA"
 				}
+			],
+			"referenceSources": [
+				"SjA"
 			],
 			"size": [
 				"M"
@@ -16893,7 +16900,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giff.mp3"
+				"path": "bestiary/giff.opus"
 			},
 			"attachedItems": [
 				"longsword|phb",
@@ -17004,7 +17011,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/girallon.mp3"
+				"path": "bestiary/girallon.opus"
 			},
 			"senseTags": [
 				"D"
@@ -17032,14 +17039,10 @@
 				{
 					"source": "MTF",
 					"page": 205
-				},
-				{
-					"source": "WDMM",
-					"page": 312
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"M"
@@ -17153,7 +17156,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githyanki-gish.mp3"
+				"path": "bestiary/githyanki-gish.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -17316,7 +17319,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githyanki-kith_rak.mp3"
+				"path": "bestiary/githyanki-kith_rak.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -17491,7 +17494,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githyanki-supreme-commander.mp3"
+				"path": "bestiary/githyanki-supreme-commander.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -17676,7 +17679,7 @@
 			},
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githzerai-anarch.mp3"
+				"path": "bestiary/githzerai-anarch.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -17832,7 +17835,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githzerai-enlightened.mp3"
+				"path": "bestiary/githzerai-enlightened.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -17953,7 +17956,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll-flesh-gnawer.mp3"
+				"path": "bestiary/gnoll-flesh-gnawer.opus"
 			},
 			"attachedItems": [
 				"shortsword|phb"
@@ -18072,7 +18075,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll-hunter.mp3"
+				"path": "bestiary/gnoll-hunter.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -18207,7 +18210,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll-witherling.mp3"
+				"path": "bestiary/gnoll-witherling.opus"
 			},
 			"traitTags": [
 				"Unusual Nature"
@@ -18242,10 +18245,10 @@
 				{
 					"source": "MTF",
 					"page": 209
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"L"
@@ -18323,7 +18326,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gray-render.mp3"
+				"path": "bestiary/gray-render.opus"
 			},
 			"senseTags": [
 				"D"
@@ -18360,6 +18363,9 @@
 					"source": "MTF",
 					"page": 149
 				}
+			],
+			"referenceSources": [
+				"KftGV"
 			],
 			"size": [
 				"L"
@@ -18587,13 +18593,11 @@
 				{
 					"source": "MTF",
 					"page": 162
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA",
+				"VEoR"
 			],
 			"size": [
 				"M"
@@ -18730,7 +18734,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-abishai.mp3"
+				"path": "bestiary/green-abishai.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -18923,7 +18927,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grung.mp3"
+				"path": "bestiary/grung.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -19216,7 +19220,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grung-elite-warrior.mp3"
+				"path": "bestiary/grung-elite-warrior.opus"
 			},
 			"attachedItems": [
 				"dagger|phb",
@@ -19535,7 +19539,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grung-wildling.mp3"
+				"path": "bestiary/grung-wildling.opus"
 			},
 			"attachedItems": [
 				"dagger|phb",
@@ -19804,7 +19808,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guard-drake.mp3"
+				"path": "bestiary/guard-drake.opus"
 			},
 			"senseTags": [
 				"D"
@@ -19974,7 +19978,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hadrosaurus.mp3"
+				"path": "bestiary/hadrosaurus.opus"
 			},
 			"damageTags": [
 				"B"
@@ -20129,7 +20133,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hellfire-engine.mp3"
+				"path": "bestiary/hellfire-engine.opus"
 			},
 			"traitTags": [
 				"Immutable Form",
@@ -20281,7 +20285,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hobgoblin-devastator.mp3"
+				"path": "bestiary/hobgoblin-devastator.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -20445,7 +20449,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hobgoblin-iron-shadow.mp3"
+				"path": "bestiary/hobgoblin-iron-shadow.opus"
 			},
 			"attachedItems": [
 				"dart|phb"
@@ -20584,7 +20588,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/howler.mp3"
+				"path": "bestiary/howler.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -20711,7 +20715,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/the-hungry.mp3"
+				"path": "bestiary/the-hungry.opus"
 			},
 			"senseTags": [
 				"D"
@@ -20943,7 +20947,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hutijin.mp3"
+				"path": "bestiary/hutijin.opus"
 			},
 			"attachedItems": [
 				"mace|phb"
@@ -21155,7 +21159,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target.  {@h}14 ({@damage 2d8 + 5}) force damage plus 9 ({@damage 2d10}) psychic damage."
+						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}14 ({@damage 2d8 + 5}) force damage plus 9 ({@damage 2d10}) psychic damage."
 					]
 				},
 				{
@@ -21173,7 +21177,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hydroloth.mp3"
+				"path": "bestiary/hydroloth.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -21328,7 +21332,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/illusionist.mp3"
+				"path": "bestiary/illusionist.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -21768,7 +21772,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ki-rin.mp3"
+				"path": "bestiary/ki-rin.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -21911,7 +21915,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kobold-dragonshield.mp3"
+				"path": "bestiary/kobold-dragonshield.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -22090,7 +22094,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kobold-inventor.mp3"
+				"path": "bestiary/kobold-inventor.opus"
 			},
 			"attachedItems": [
 				"dagger|phb",
@@ -22247,7 +22251,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kobold-scale-sorcerer.mp3"
+				"path": "bestiary/kobold-scale-sorcerer.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -22422,7 +22426,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/korred.mp3"
+				"path": "bestiary/korred.opus"
 			},
 			"attachedItems": [
 				"greatclub|phb"
@@ -22590,7 +22594,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kraken-priest.mp3"
+				"path": "bestiary/kraken-priest.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -22730,7 +22734,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kruthik-hive-lord.mp3"
+				"path": "bestiary/kruthik-hive-lord.opus"
 			},
 			"traitTags": [
 				"Pack Tactics",
@@ -22864,7 +22868,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/leucrotta.mp3"
+				"path": "bestiary/leucrotta.opus"
 			},
 			"traitTags": [
 				"Mimicry"
@@ -23037,7 +23041,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/leviathan.mp3"
+				"path": "bestiary/leviathan.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -23076,10 +23080,10 @@
 				{
 					"source": "MTF",
 					"page": 232
-				},
-				{
-					"source": "VEoR"
 				}
+			],
+			"referenceSources": [
+				"VEoR"
 			],
 			"size": [
 				"M"
@@ -23173,7 +23177,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/the-lonely.mp3"
+				"path": "bestiary/the-lonely.opus"
 			},
 			"senseTags": [
 				"D"
@@ -23211,13 +23215,11 @@
 				{
 					"source": "MTF",
 					"page": 233
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "VEoR"
 				}
+			],
+			"referenceSources": [
+				"AATM",
+				"VEoR"
 			],
 			"size": [
 				"M"
@@ -23310,7 +23312,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/the-lost.mp3"
+				"path": "bestiary/the-lost.opus"
 			},
 			"senseTags": [
 				"D"
@@ -23418,7 +23420,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/male-steeder.mp3"
+				"path": "bestiary/male-steeder.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -23544,7 +23546,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/martial-arts-adept.mp3"
+				"path": "bestiary/martial-arts-adept.opus"
 			},
 			"attachedItems": [
 				"dart|phb"
@@ -23584,10 +23586,10 @@
 				{
 					"source": "MTF",
 					"page": 213
-				},
-				{
-					"source": "SatO"
 				}
+			],
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"L"
@@ -23736,7 +23738,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/marut.mp3"
+				"path": "bestiary/marut.opus"
 			},
 			"traitTags": [
 				"Immutable Form",
@@ -23877,7 +23879,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/master-thief.mp3"
+				"path": "bestiary/master-thief.opus"
 			},
 			"attachedItems": [
 				"shortbow|phb",
@@ -24032,7 +24034,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/maurezhi.mp3"
+				"path": "bestiary/maurezhi.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -24073,10 +24075,10 @@
 				{
 					"source": "VGM",
 					"page": 137
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"M"
@@ -24153,7 +24155,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/maw-demon.mp3"
+				"path": "bestiary/maw-demon.opus"
 			},
 			"senseTags": [
 				"D"
@@ -24237,7 +24239,7 @@
 				{
 					"name": "Shortsword",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage plus 3 ({@damage 1d6}) necrotic damage"
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage plus 3 ({@damage 1d6}) necrotic damage."
 					]
 				},
 				{
@@ -24268,7 +24270,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/meazel.mp3"
+				"path": "bestiary/meazel.opus"
 			},
 			"attachedItems": [
 				"shortsword|phb"
@@ -24388,7 +24390,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/meenlock.mp3"
+				"path": "bestiary/meenlock.opus"
 			},
 			"traitTags": [
 				"Light Sensitivity"
@@ -24425,10 +24427,10 @@
 				{
 					"source": "MTF",
 					"page": 166
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"M"
@@ -24538,7 +24540,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/merregon.mp3"
+				"path": "bestiary/merregon.opus"
 			},
 			"attachedItems": [
 				"halberd|phb",
@@ -24725,7 +24727,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/merrenoloth.mp3"
+				"path": "bestiary/merrenoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -24930,7 +24932,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mindwitness.mp3"
+				"path": "bestiary/mindwitness.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -25158,7 +25160,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/moloch.mp3"
+				"path": "bestiary/moloch.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -25407,7 +25409,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/molydeus.mp3"
+				"path": "bestiary/molydeus.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -25593,7 +25595,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/morkoth.mp3"
+				"path": "bestiary/morkoth.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -25756,7 +25758,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mouth-of-grolantor.mp3"
+				"path": "bestiary/mouth-of-grolantor.opus"
 			},
 			"languageTags": [
 				"GI"
@@ -25908,7 +25910,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nabassu.mp3"
+				"path": "bestiary/nabassu.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -26079,7 +26081,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nagpa.mp3"
+				"path": "bestiary/nagpa.opus"
 			},
 			"senseTags": [
 				"U"
@@ -26136,10 +26138,10 @@
 				{
 					"source": "MTF",
 					"page": 167
-				},
-				{
-					"source": "AATM"
 				}
+			],
+			"referenceSources": [
+				"AATM"
 			],
 			"size": [
 				"M"
@@ -26265,7 +26267,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/narzugon.mp3"
+				"path": "bestiary/narzugon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -26309,10 +26311,10 @@
 				{
 					"source": "VGM",
 					"page": 217
-				},
-				{
-					"source": "VEoR"
 				}
+			],
+			"referenceSources": [
+				"VEoR"
 			],
 			"size": [
 				"M"
@@ -26423,7 +26425,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/necromancer.mp3"
+				"path": "bestiary/necromancer.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -26462,10 +26464,10 @@
 				{
 					"source": "VGM",
 					"page": 180
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"S"
@@ -26560,7 +26562,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/neogi.mp3"
+				"path": "bestiary/neogi.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -26604,10 +26606,10 @@
 				{
 					"source": "VGM",
 					"page": 179
-				},
-				{
-					"source": "SjA"
 				}
+			],
+			"referenceSources": [
+				"SjA"
 			],
 			"size": [
 				"T"
@@ -26668,7 +26670,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/neogi-hatchling.mp3"
+				"path": "bestiary/neogi-hatchling.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -26701,10 +26703,10 @@
 				{
 					"source": "VGM",
 					"page": 180
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"M"
@@ -26847,7 +26849,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/neogi-master.mp3"
+				"path": "bestiary/neogi-master.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -26908,10 +26910,6 @@
 				{
 					"source": "VGM",
 					"page": 181
-				},
-				{
-					"source": "WDMM",
-					"page": 315
 				}
 			],
 			"size": [
@@ -27009,7 +27007,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/neothelid.mp3"
+				"path": "bestiary/neothelid.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -27034,6 +27032,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -27180,7 +27179,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nightwalker.mp3"
+				"path": "bestiary/nightwalker.opus"
 			},
 			"traitTags": [
 				"Unusual Nature"
@@ -27329,7 +27328,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nilbog.mp3"
+				"path": "bestiary/nilbog.opus"
 			},
 			"senseTags": [
 				"D"
@@ -27374,10 +27373,10 @@
 				{
 					"source": "MTF",
 					"page": 168
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"M"
@@ -27463,7 +27462,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nupperibo.mp3"
+				"path": "bestiary/nupperibo.opus"
 			},
 			"senseTags": [
 				"B"
@@ -27572,7 +27571,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/oblex-spawn.mp3"
+				"path": "bestiary/oblex-spawn.opus"
 			},
 			"traitTags": [
 				"Amorphous",
@@ -27674,7 +27673,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre-battering-ram.mp3"
+				"path": "bestiary/ogre-battering-ram.opus"
 			},
 			"traitTags": [
 				"Siege Monster"
@@ -27769,7 +27768,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre-bolt-launcher.mp3"
+				"path": "bestiary/ogre-bolt-launcher.opus"
 			},
 			"senseTags": [
 				"D"
@@ -27865,7 +27864,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre-chain-brute.mp3"
+				"path": "bestiary/ogre-chain-brute.opus"
 			},
 			"senseTags": [
 				"D"
@@ -27964,7 +27963,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre-howdah.mp3"
+				"path": "bestiary/ogre-howdah.opus"
 			},
 			"attachedItems": [
 				"mace|phb"
@@ -28147,7 +28146,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/oinoloth.mp3"
+				"path": "bestiary/oinoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -28470,10 +28469,10 @@
 				{
 					"source": "MTF",
 					"page": 169
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"L"
@@ -28634,7 +28633,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orthon.mp3"
+				"path": "bestiary/orthon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -28739,7 +28738,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ox.mp3"
+				"path": "bestiary/ox.opus"
 			},
 			"traitTags": [
 				"Beast of Burden"
@@ -28761,10 +28760,10 @@
 				{
 					"source": "MTF",
 					"page": 199
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"G"
@@ -28912,7 +28911,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/phoenix.mp3"
+				"path": "bestiary/phoenix.opus"
 			},
 			"traitTags": [
 				"Flyby",
@@ -29013,7 +29012,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quetzalcoatlus.mp3"
+				"path": "bestiary/quetzalcoatlus.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -29111,7 +29110,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quickling.mp3"
+				"path": "bestiary/quickling.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -29147,13 +29146,11 @@
 				{
 					"source": "MTF",
 					"page": 160
-				},
-				{
-					"source": "VEoR"
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA",
+				"VEoR"
 			],
 			"size": [
 				"M"
@@ -29288,7 +29285,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-abishai.mp3"
+				"path": "bestiary/red-abishai.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -29420,7 +29417,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/redcap.mp3"
+				"path": "bestiary/redcap.opus"
 			},
 			"senseTags": [
 				"D"
@@ -29591,7 +29588,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/retriever.mp3"
+				"path": "bestiary/retriever.opus"
 			},
 			"senseTags": [
 				"B",
@@ -29728,7 +29725,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rot-troll.mp3"
+				"path": "bestiary/rot-troll.opus"
 			},
 			"senseTags": [
 				"D"
@@ -29831,7 +29828,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rutterkin.mp3"
+				"path": "bestiary/rutterkin.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -29985,7 +29982,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sacred-statue.mp3"
+				"path": "bestiary/sacred-statue.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -30122,7 +30119,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sea-spawn.mp3"
+				"path": "bestiary/sea-spawn.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -30286,7 +30283,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gloom-weaver.mp3"
+				"path": "bestiary/gloom-weaver.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry"
@@ -30456,7 +30453,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shadow-dancer.mp3"
+				"path": "bestiary/shadow-dancer.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry"
@@ -30633,7 +30630,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/soul-monger.mp3"
+				"path": "bestiary/soul-monger.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry",
@@ -30774,7 +30771,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shadow-mastiff.mp3"
+				"path": "bestiary/shadow-mastiff.opus"
 			},
 			"senseTags": [
 				"D"
@@ -30893,7 +30890,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shadow-mastiff.mp3"
+				"path": "bestiary/shadow-mastiff.opus"
 			},
 			"senseTags": [
 				"D"
@@ -30923,10 +30920,10 @@
 				{
 					"source": "VGM",
 					"page": 137
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"L"
@@ -31027,7 +31024,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shoosuva.mp3"
+				"path": "bestiary/shoosuva.opus"
 			},
 			"senseTags": [
 				"D"
@@ -31345,7 +31342,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sibriex.mp3"
+				"path": "bestiary/sibriex.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -31507,7 +31504,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/skulk.mp3"
+				"path": "bestiary/skulk.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -31538,10 +31535,10 @@
 				{
 					"source": "MTF",
 					"page": 230
-				},
-				{
-					"source": "AATM"
 				}
+			],
+			"referenceSources": [
+				"AATM"
 			],
 			"size": [
 				"M"
@@ -31716,7 +31713,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/skull-lord.mp3"
+				"path": "bestiary/skull-lord.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -31881,7 +31878,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/slithering-tracker.mp3"
+				"path": "bestiary/slithering-tracker.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -31919,10 +31916,10 @@
 				{
 					"source": "VGM",
 					"page": 192
-				},
-				{
-					"source": "AATM"
 				}
+			],
+			"referenceSources": [
+				"AATM"
 			],
 			"size": [
 				"M"
@@ -32013,7 +32010,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spawn-of-kyuss.mp3"
+				"path": "bestiary/spawn-of-kyuss.opus"
 			},
 			"traitTags": [
 				"Regeneration",
@@ -32163,7 +32160,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spirit-troll.mp3"
+				"path": "bestiary/spirit-troll.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -32326,7 +32323,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spring-eladrin.mp3"
+				"path": "bestiary/spring-eladrin.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -32385,10 +32382,10 @@
 				{
 					"source": "MTF",
 					"page": 234
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"S"
@@ -32448,7 +32445,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/star-spawn-grue.mp3"
+				"path": "bestiary/star-spawn-grue.opus"
 			},
 			"senseTags": [
 				"D"
@@ -32477,10 +32474,10 @@
 				{
 					"source": "MTF",
 					"page": 234
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"L"
@@ -32572,7 +32569,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/star-spawn-hulk.mp3"
+				"path": "bestiary/star-spawn-hulk.opus"
 			},
 			"senseTags": [
 				"D"
@@ -32612,10 +32609,10 @@
 				{
 					"source": "MTF",
 					"page": 235
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"M"
@@ -32774,7 +32771,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/star-spawn-larva-mage.mp3"
+				"path": "bestiary/star-spawn-larva-mage.opus"
 			},
 			"senseTags": [
 				"D"
@@ -32824,10 +32821,10 @@
 				{
 					"source": "MTF",
 					"page": 236
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"M"
@@ -32923,7 +32920,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/star-spawn-mangler.mp3"
+				"path": "bestiary/star-spawn-mangler.opus"
 			},
 			"traitTags": [
 				"Ambusher"
@@ -32956,10 +32953,10 @@
 				{
 					"source": "MTF",
 					"page": 236
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"M"
@@ -33080,7 +33077,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/star-spawn-seer.mp3"
+				"path": "bestiary/star-spawn-seer.opus"
 			},
 			"senseTags": [
 				"D"
@@ -33257,7 +33254,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/steel-predator.mp3"
+				"path": "bestiary/steel-predator.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -33310,10 +33307,10 @@
 				{
 					"source": "VGM",
 					"page": 140
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"H"
@@ -33364,7 +33361,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stegosaurus.mp3"
+				"path": "bestiary/stegosaurus.opus"
 			},
 			"damageTags": [
 				"P"
@@ -33385,10 +33382,10 @@
 				{
 					"source": "VGM",
 					"page": 208
-				},
-				{
-					"source": "AATM"
 				}
+			],
+			"referenceSources": [
+				"AATM"
 			],
 			"size": [
 				"L"
@@ -33450,7 +33447,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stench-cow.mp3"
+				"path": "bestiary/stench-cow.opus"
 			},
 			"senseTags": [
 				"D"
@@ -33563,7 +33560,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stone-cursed.mp3"
+				"path": "bestiary/stone-cursed.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -33692,7 +33689,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stone-giant-dreamwalker.mp3"
+				"path": "bestiary/stone-giant-dreamwalker.opus"
 			},
 			"attachedItems": [
 				"greatclub|phb"
@@ -33873,7 +33870,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/storm-giant-quintessent.mp3"
+				"path": "bestiary/storm-giant-quintessent.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -34029,7 +34026,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/summer-eladrin.mp3"
+				"path": "bestiary/summer-eladrin.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -34190,7 +34187,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-cranium-rats.mp3"
+				"path": "bestiary/swarm-of-cranium-rats.opus"
 			},
 			"senseTags": [
 				"D"
@@ -34228,10 +34225,10 @@
 				{
 					"source": "VGM",
 					"page": 208
-				},
-				{
-					"source": "AATM"
 				}
+			],
+			"referenceSources": [
+				"AATM"
 			],
 			"size": [
 				"M"
@@ -34303,7 +34300,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-rot-grubs.mp3"
+				"path": "bestiary/swarm-of-rot-grubs.opus"
 			},
 			"senseTags": [
 				"B"
@@ -34416,7 +34413,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swashbuckler.mp3"
+				"path": "bestiary/swashbuckler.opus"
 			},
 			"attachedItems": [
 				"dagger|phb",
@@ -34451,6 +34448,9 @@
 					"source": "MTF",
 					"page": 241
 				}
+			],
+			"referenceSources": [
+				"CRCotN"
 			],
 			"size": [
 				"M"
@@ -34569,7 +34569,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sword-wraith-commander.mp3"
+				"path": "bestiary/sword-wraith-commander.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -34611,6 +34611,9 @@
 					"source": "MTF",
 					"page": 241
 				}
+			],
+			"referenceSources": [
+				"CRCotN"
 			],
 			"size": [
 				"M"
@@ -34708,7 +34711,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sword-wraith-warrior.mp3"
+				"path": "bestiary/sword-wraith-warrior.opus"
 			},
 			"attachedItems": [
 				"battleaxe|phb",
@@ -34851,7 +34854,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tanarukk.mp3"
+				"path": "bestiary/tanarukk.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -34968,7 +34971,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/thorny.mp3"
+				"path": "bestiary/thorny.opus"
 			},
 			"traitTags": [
 				"Camouflage",
@@ -35180,7 +35183,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/titivilus.mp3"
+				"path": "bestiary/titivilus.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -35319,7 +35322,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tlincalli.mp3"
+				"path": "bestiary/tlincalli.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -35443,7 +35446,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tortle.mp3"
+				"path": "bestiary/tortle.opus"
 			},
 			"attachedItems": [
 				"light crossbow|phb",
@@ -35582,7 +35585,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tortle-druid.mp3"
+				"path": "bestiary/tortle-druid.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -35759,7 +35762,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/transmuter.mp3"
+				"path": "bestiary/transmuter.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -35862,7 +35865,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/trapper.mp3"
+				"path": "bestiary/trapper.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -35896,10 +35899,6 @@
 				{
 					"source": "VGM",
 					"page": 175
-				},
-				{
-					"source": "WDMM",
-					"page": 316
 				}
 			],
 			"size": [
@@ -36029,7 +36028,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ulitharid.mp3"
+				"path": "bestiary/ulitharid.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -36093,13 +36092,11 @@
 				{
 					"source": "MTF",
 					"page": 246
-				},
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"AATM",
+				"BMT"
 			],
 			"size": [
 				"M"
@@ -36220,7 +36217,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vampiric-mist.mp3"
+				"path": "bestiary/vampiric-mist.opus"
 			},
 			"altArt": [
 				{
@@ -36236,8 +36233,7 @@
 				"D"
 			],
 			"damageTags": [
-				"N",
-				"R"
+				"N"
 			],
 			"miscTags": [
 				"HPR"
@@ -36257,10 +36253,10 @@
 				{
 					"source": "VGM",
 					"page": 195
-				},
-				{
-					"source": "AATM"
 				}
+			],
+			"referenceSources": [
+				"AATM"
 			],
 			"size": [
 				"T"
@@ -36336,7 +36332,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vargouille.mp3"
+				"path": "bestiary/vargouille.opus"
 			},
 			"senseTags": [
 				"D"
@@ -36455,7 +36451,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vegepygmy.mp3"
+				"path": "bestiary/vegepygmy.opus"
 			},
 			"attachedItems": [
 				"sling|phb"
@@ -36583,7 +36579,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vegepygmy-chief.mp3"
+				"path": "bestiary/vegepygmy-chief.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -36705,7 +36701,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/velociraptor.mp3"
+				"path": "bestiary/velociraptor.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -36827,7 +36823,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/venom-troll.mp3"
+				"path": "bestiary/venom-troll.opus"
 			},
 			"traitTags": [
 				"Regeneration"
@@ -36978,7 +36974,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/war-priest.mp3"
+				"path": "bestiary/war-priest.opus"
 			},
 			"attachedItems": [
 				"maul|phb"
@@ -37146,7 +37142,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/warlock-of-the-archfey.mp3"
+				"path": "bestiary/warlock-of-the-archfey.opus"
 			},
 			"attachedItems": [
 				"rapier|phb"
@@ -37315,7 +37311,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/warlock-of-the-fiend.mp3"
+				"path": "bestiary/warlock-of-the-fiend.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -37368,10 +37364,10 @@
 				{
 					"source": "VGM",
 					"page": 220
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"M"
@@ -37485,7 +37481,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/warlock-of-the-great-old-one.mp3"
+				"path": "bestiary/warlock-of-the-great-old-one.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -37647,7 +37643,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/warlord.mp3"
+				"path": "bestiary/warlord.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb",
@@ -37822,7 +37818,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wastrilith.mp3"
+				"path": "bestiary/wastrilith.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -37951,7 +37947,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/water-elemental-myrmidon.mp3"
+				"path": "bestiary/water-elemental-myrmidon.opus"
 			},
 			"attachedItems": [
 				"trident|phb"
@@ -37987,10 +37983,10 @@
 				{
 					"source": "MTF",
 					"page": 163
-				},
-				{
-					"source": "CoA"
 				}
+			],
+			"referenceSources": [
+				"CoA"
 			],
 			"size": [
 				"M"
@@ -38120,7 +38116,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/white-abishai.mp3"
+				"path": "bestiary/white-abishai.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -38164,6 +38160,9 @@
 					"source": "MTF",
 					"page": 197
 				}
+			],
+			"referenceSources": [
+				"FRAiF"
 			],
 			"size": [
 				"M"
@@ -38286,7 +38285,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/winter-eladrin.mp3"
+				"path": "bestiary/winter-eladrin.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -38444,7 +38443,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wood-woad.mp3"
+				"path": "bestiary/wood-woad.opus"
 			},
 			"attachedItems": [
 				"club|phb"
@@ -38554,7 +38553,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/the-wretched.mp3"
+				"path": "bestiary/the-wretched.opus"
 			},
 			"senseTags": [
 				"D"
@@ -38657,7 +38656,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/xvart.mp3"
+				"path": "bestiary/xvart.opus"
 			},
 			"attachedItems": [
 				"shortsword|phb",
@@ -38800,7 +38799,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/xvart-warlock-of-raxivort.mp3"
+				"path": "bestiary/xvart-warlock-of-raxivort.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -39000,7 +38999,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yagnoloth.mp3"
+				"path": "bestiary/yagnoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -39324,10 +39323,10 @@
 				{
 					"source": "VGM",
 					"page": 201
-				},
-				{
-					"source": "BMT"
 				}
+			],
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"L"
@@ -39426,7 +39425,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yeth-hound.mp3"
+				"path": "bestiary/yeth-hound.opus"
 			},
 			"senseTags": [
 				"D"
@@ -39535,7 +39534,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/young-kruthik.mp3"
+				"path": "bestiary/young-kruthik.opus"
 			},
 			"traitTags": [
 				"Pack Tactics",
@@ -39710,7 +39709,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-anathema.mp3"
+				"path": "bestiary/yuan-ti-anathema.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -39864,7 +39863,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-broodguard.mp3"
+				"path": "bestiary/yuan-ti-broodguard.opus"
 			},
 			"traitTags": [
 				"Reckless"
@@ -40047,7 +40046,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-mind-whisperer.mp3"
+				"path": "bestiary/yuan-ti-mind-whisperer.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -40247,7 +40246,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-nightmare-speaker.mp3"
+				"path": "bestiary/yuan-ti-nightmare-speaker.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -40450,7 +40449,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-pit-master.mp3"
+				"path": "bestiary/yuan-ti-pit-master.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -40672,7 +40671,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/zaratan.mp3"
+				"path": "bestiary/zaratan.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",

--- a/json/bestiary/bestiary-mpp.json
+++ b/json/bestiary/bestiary-mpp.json
@@ -4,10 +4,8 @@
 			"name": "Adult Time Dragon",
 			"source": "MPP",
 			"page": 50,
-			"otherSources": [
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"ToFW"
 			],
 			"size": [
 				"H"
@@ -157,13 +155,9 @@
 			"name": "Ancient Time Dragon",
 			"source": "MPP",
 			"page": 48,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"G"
@@ -325,13 +319,9 @@
 			"name": "Athar Null",
 			"source": "MPP",
 			"page": 53,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S",
@@ -402,7 +392,7 @@
 				{
 					"name": "Defier's Whim",
 					"entries": [
-						"The null takes the Dash, Disengage, or Use an Object action."
+						"The null takes the {@action Dash}, {@action Disengage}, or Use an Object action."
 					]
 				}
 			],
@@ -602,10 +592,8 @@
 			"name": "Avoral Guardinal",
 			"source": "MPP",
 			"page": 32,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"M"
@@ -747,13 +735,9 @@
 			"name": "Baernaloth",
 			"source": "MPP",
 			"page": 20,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"L"
@@ -986,13 +970,9 @@
 			"name": "Bariaur Wanderer",
 			"source": "MPP",
 			"page": 21,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -1147,13 +1127,9 @@
 			"name": "Bleak Cabal Void Soother",
 			"source": "MPP",
 			"page": 54,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S",
@@ -1279,13 +1255,9 @@
 			"name": "Cranium Rat Squeaker",
 			"source": "MPP",
 			"page": 22,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"T"
@@ -1369,13 +1341,9 @@
 			"name": "Cranium Rat Squeaker Swarm",
 			"source": "MPP",
 			"page": 22,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -1520,13 +1488,9 @@
 			"name": "Cuprilach Rilmani",
 			"source": "MPP",
 			"page": 44,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -1623,7 +1587,7 @@
 				{
 					"name": "Assassin's Agility",
 					"entries": [
-						"The cuprilach takes the Dash or Disengage action, or it makes one Burnished Blade attack."
+						"The cuprilach takes the {@action Dash} or {@action Disengage} action, or it makes one Burnished Blade attack."
 					]
 				}
 			],
@@ -1672,13 +1636,9 @@
 			"name": "Dabus",
 			"source": "MPP",
 			"page": 23,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -1790,13 +1750,9 @@
 			"name": "Darkweaver",
 			"source": "MPP",
 			"page": 25,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -1940,13 +1896,9 @@
 			"name": "Decaton Modron",
 			"source": "MPP",
 			"page": 36,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"L"
@@ -2105,10 +2057,8 @@
 			"name": "Doomguard Doom Lord",
 			"source": "MPP",
 			"page": 54,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"S",
@@ -2219,13 +2169,9 @@
 			"name": "Doomguard Rot Blade",
 			"source": "MPP",
 			"page": 56,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S",
@@ -2321,13 +2267,9 @@
 			"name": "Eater of Knowledge",
 			"source": "MPP",
 			"page": 29,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"L"
@@ -2484,13 +2426,9 @@
 			"name": "Equinal Guardinal",
 			"source": "MPP",
 			"page": 33,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"L"
@@ -2609,13 +2547,9 @@
 			"name": "Farastu Demodand",
 			"source": "MPP",
 			"page": 26,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -2782,10 +2716,8 @@
 			"name": "Fated Shaker",
 			"source": "MPP",
 			"page": 56,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"S",
@@ -2937,10 +2869,8 @@
 			"name": "Ferrumach Rilmani",
 			"source": "MPP",
 			"page": 44,
-			"otherSources": [
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -3086,10 +3016,8 @@
 			"name": "Fraternity of Order Law Bender",
 			"source": "MPP",
 			"page": 57,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"S",
@@ -3214,13 +3142,9 @@
 			"name": "Githzerai Futurist",
 			"source": "MPP",
 			"page": 30,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -3372,10 +3296,8 @@
 			"name": "Githzerai Traveler",
 			"source": "MPP",
 			"page": 31,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"M"
@@ -3533,13 +3455,9 @@
 			"name": "Githzerai Uniter",
 			"source": "MPP",
 			"page": 31,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -3641,7 +3559,7 @@
 				{
 					"name": "Pacifying Touch",
 					"entries": [
-						"The githzerai touches one creature it can see within 5 feet of itself. The target must succeed on a {@dc 14} Intelligence saving throw, or the githzerai chooses an action for that target: Attack, Cast a Spell, or Dash. The affected target can't take that action for 1 minute. At the end of each of the target's turns, it can repeat the saving throw, ending the effect on itself on a successful save. A target that succeeds on the saving throw becomes immune to this githzerai's Pacifying Touch for 24 hours."
+						"The githzerai touches one creature it can see within 5 feet of itself. The target must succeed on a {@dc 14} Intelligence saving throw, or the githzerai chooses an action for that target: Attack, Cast a Spell, or {@action Dash}. The affected target can't take that action for 1 minute. At the end of each of the target's turns, it can repeat the saving throw, ending the effect on itself on a successful save. A target that succeeds on the saving throw becomes immune to this githzerai's Pacifying Touch for 24 hours."
 					]
 				}
 			],
@@ -3679,13 +3597,9 @@
 			"name": "Hands of Havoc Fire Starter",
 			"source": "MPP",
 			"page": 58,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S",
@@ -3774,13 +3688,9 @@
 			"name": "Harmonium Captain",
 			"source": "MPP",
 			"page": 58,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S",
@@ -3885,13 +3795,9 @@
 			"name": "Harmonium Peacekeeper",
 			"source": "MPP",
 			"page": 59,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S",
@@ -3968,16 +3874,10 @@
 			"name": "Heralds of Dust Remnant",
 			"source": "MPP",
 			"page": 59,
-			"otherSources": [
-				{
-					"source": "AATM"
-				},
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"AATM",
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S",
@@ -4097,10 +3997,8 @@
 			"name": "Hexton Modron",
 			"source": "MPP",
 			"page": 37,
-			"otherSources": [
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"ToFW"
 			],
 			"size": [
 				"H"
@@ -4291,10 +4189,8 @@
 			"name": "Hound Archon",
 			"source": "MPP",
 			"page": 16,
-			"otherSources": [
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -4448,10 +4344,8 @@
 			"name": "Kelubar Demodand",
 			"source": "MPP",
 			"page": 27,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"M"
@@ -4584,7 +4478,7 @@
 				{
 					"name": "Nauseating Fog {@recharge}",
 					"entries": [
-						"The kelubar magically creates a cloud of greenish fog that fills a 20-foot-radius sphere centered on a point within 120 feet of itself. The cloud remains for 1 minute or until the kelubar uses this bonus action again. The cloud is heavily obscured and difficult terrain. Any creature that starts its turn in the cloud or enters the cloud for the first time on a turn must succeed on a {@dc 17} Constitution saving throw or have the {@condition poisoned} condition until the end of its next turn."
+						"The kelubar magically creates a cloud of greenish fog that fills a 20-foot-radius sphere centered on a point within 120 feet of itself. The cloud remains for 1 minute or until the kelubar uses this bonus action again. The cloud is {@quickref Vision and Light||2||heavily obscured} and difficult terrain. Any creature that starts its turn in the cloud or enters the cloud for the first time on a turn must succeed on a {@dc 17} Constitution saving throw or have the {@condition poisoned} condition until the end of its next turn."
 					]
 				}
 			],
@@ -4630,13 +4524,9 @@
 			"name": "Kolyarut",
 			"source": "MPP",
 			"page": 34,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -4832,13 +4722,9 @@
 			"name": "Lantern Archon",
 			"source": "MPP",
 			"page": 17,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S"
@@ -5010,13 +4896,9 @@
 			"name": "Maelephant",
 			"source": "MPP",
 			"page": 35,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"L"
@@ -5149,13 +5031,9 @@
 			"name": "Mercykiller Bloodhound",
 			"source": "MPP",
 			"page": 60,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S",
@@ -5250,13 +5128,9 @@
 			"name": "Mind's Eye Matter Smith",
 			"source": "MPP",
 			"page": 60,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S",
@@ -5391,13 +5265,9 @@
 			"name": "Musteval Guardinal",
 			"source": "MPP",
 			"page": 33,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S"
@@ -5514,13 +5384,9 @@
 			"name": "Nonaton Modron",
 			"source": "MPP",
 			"page": 38,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"L"
@@ -5675,10 +5541,8 @@
 			"name": "Octon Modron",
 			"source": "MPP",
 			"page": 40,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"L"
@@ -5837,6 +5701,9 @@
 			"name": "Planar Incarnate",
 			"source": "MPP",
 			"page": 41,
+			"referenceSources": [
+				"ToFW"
+			],
 			"size": [
 				"G"
 			],
@@ -6018,10 +5885,8 @@
 			"name": "Razorvine Blight",
 			"source": "MPP",
 			"page": 42,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"M"
@@ -6131,13 +5996,9 @@
 			"name": "Septon Modron",
 			"source": "MPP",
 			"page": 40,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"L"
@@ -6301,10 +6162,8 @@
 			"name": "Shator Demodand",
 			"source": "MPP",
 			"page": 28,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"L"
@@ -6509,13 +6368,9 @@
 			"isNamedCreature": true,
 			"source": "MPP",
 			"page": 46,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -6748,13 +6603,9 @@
 			"name": "Society of Sensation Muse",
 			"source": "MPP",
 			"page": 61,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"S",
@@ -6881,13 +6732,9 @@
 			"name": "Sunfly",
 			"source": "MPP",
 			"page": 47,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"T"
@@ -7077,10 +6924,8 @@
 			"name": "Time Dragon Wyrmling",
 			"source": "MPP",
 			"page": 51,
-			"otherSources": [
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"ToFW"
 			],
 			"size": [
 				"M"
@@ -7187,10 +7032,8 @@
 			"name": "Transcendent Order Conduit",
 			"source": "MPP",
 			"page": 62,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"S",
@@ -7329,10 +7172,8 @@
 			"name": "Transcendent Order Instinct",
 			"source": "MPP",
 			"page": 62,
-			"otherSources": [
-				{
-					"source": "SatO"
-				}
+			"referenceSources": [
+				"SatO"
 			],
 			"size": [
 				"S",
@@ -7430,13 +7271,9 @@
 			"name": "Vargouille Reflection",
 			"source": "MPP",
 			"page": 52,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"T"
@@ -7549,13 +7386,9 @@
 			"name": "Warden Archon",
 			"source": "MPP",
 			"page": 18,
-			"otherSources": [
-				{
-					"source": "SatO"
-				},
-				{
-					"source": "ToFW"
-				}
+			"referenceSources": [
+				"SatO",
+				"ToFW"
 			],
 			"size": [
 				"L"
@@ -7789,6 +7622,7 @@
 				}
 			],
 			"dragonAge": "young",
+			"tokenCustom": true,
 			"senseTags": [
 				"B",
 				"SD"

--- a/json/bestiary/bestiary-mtf.json
+++ b/json/bestiary/bestiary-mtf.json
@@ -4,10 +4,8 @@
 			"name": "Abyssal Wretch",
 			"source": "MTF",
 			"page": 136,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA"
 			],
 			"size": [
 				"M"
@@ -69,7 +67,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/abyssal-wretch.mp3"
+				"path": "bestiary/abyssal-wretch.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -179,7 +177,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/adult-kruthik.mp3"
+				"path": "bestiary/adult-kruthik.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -211,10 +209,8 @@
 			"name": "Adult Oblex",
 			"source": "MTF",
 			"page": 218,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"reprintedAs": [
 				"Adult Oblex|MPMM"
@@ -343,7 +339,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/oblex-adult.mp3"
+				"path": "bestiary/oblex-adult.opus"
 			},
 			"traitTags": [
 				"Amorphous"
@@ -392,18 +388,15 @@
 			"page": 202,
 			"otherSources": [
 				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
 					"source": "PotA",
 					"page": 212
 				}
+			],
+			"referenceSources": [
+				"DC",
+				"DIP",
+				"PotA",
+				"SLW"
 			],
 			"reprintedAs": [
 				"Air Elemental Myrmidon|MPMM"
@@ -502,7 +495,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/air-elemental-myrmidon.mp3"
+				"path": "bestiary/air-elemental-myrmidon.opus"
 			},
 			"attachedItems": [
 				"flail|phb"
@@ -541,13 +534,9 @@
 			"name": "Alkilith",
 			"source": "MTF",
 			"page": 130,
-			"otherSources": [
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"DIP",
+				"SDW"
 			],
 			"reprintedAs": [
 				"Alkilith|MPMM"
@@ -671,7 +660,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/alkilith.mp3"
+				"path": "bestiary/alkilith.opus"
 			},
 			"traitTags": [
 				"Amorphous",
@@ -707,13 +696,9 @@
 			"name": "Allip",
 			"source": "MTF",
 			"page": 116,
-			"otherSources": [
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				}
+			"referenceSources": [
+				"DIP",
+				"SLW"
 			],
 			"reprintedAs": [
 				"Allip|MPMM"
@@ -828,7 +813,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/allip.mp3"
+				"path": "bestiary/allip.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement"
@@ -842,6 +827,9 @@
 			"damageTags": [
 				"O",
 				"Y"
+			],
+			"miscTags": [
+				"AOE"
 			],
 			"conditionInflict": [
 				"stunned"
@@ -857,10 +845,8 @@
 			"name": "Amnizu",
 			"source": "MTF",
 			"page": 164,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA"
 			],
 			"reprintedAs": [
 				"Amnizu|MPMM"
@@ -1039,7 +1025,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/amnizu.mp3"
+				"path": "bestiary/amnizu.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -1206,7 +1192,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/armanite.mp3"
+				"path": "bestiary/armanite.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -1398,7 +1384,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/astral-dreadnought.mp3"
+				"path": "bestiary/astral-dreadnought.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -1571,7 +1557,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/autumn-eladrin.mp3"
+				"path": "bestiary/autumn-eladrin.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -1820,7 +1806,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bael.mp3"
+				"path": "bestiary/bael.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -1884,6 +1870,9 @@
 			"name": "Balhannoth",
 			"source": "MTF",
 			"page": 119,
+			"referenceSources": [
+				"RtG"
+			],
 			"reprintedAs": [
 				"Balhannoth|MPMM"
 			],
@@ -1994,7 +1983,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/balhannoth.mp3"
+				"path": "bestiary/balhannoth.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -2042,10 +2031,11 @@
 				{
 					"source": "OotA",
 					"page": 235
-				},
-				{
-					"source": "BGDIA"
 				}
+			],
+			"referenceSources": [
+				"BGDIA",
+				"OotA"
 			],
 			"reprintedAs": [
 				"Baphomet|MPMM"
@@ -2398,7 +2388,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/berbalang.mp3"
+				"path": "bestiary/berbalang.opus"
 			},
 			"senseTags": [
 				"U"
@@ -2528,7 +2518,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the abishai can take the Hide action as a bonus action."
+						"While in dim light or darkness, the abishai can take the {@action Hide} action as a bonus action."
 					]
 				}
 			],
@@ -2563,7 +2553,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-abishai.mp3"
+				"path": "bestiary/black-abishai.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -2797,7 +2787,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-abishai.mp3"
+				"path": "bestiary/blue-abishai.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -2853,13 +2843,9 @@
 			"name": "Boneclaw",
 			"source": "MTF",
 			"page": 121,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				}
+			"referenceSources": [
+				"DC",
+				"DIP"
 			],
 			"reprintedAs": [
 				"Boneclaw|MPMM"
@@ -2940,7 +2926,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the boneclaw can take the Hide action as a bonus action."
+						"While in dim light or darkness, the boneclaw can take the {@action Hide} action as a bonus action."
 					]
 				}
 			],
@@ -2980,7 +2966,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/boneclaw.mp3"
+				"path": "bestiary/boneclaw.opus"
 			},
 			"traitTags": [
 				"Rejuvenation"
@@ -3016,6 +3002,9 @@
 			"name": "Bronze Scout",
 			"source": "MTF",
 			"page": 125,
+			"referenceSources": [
+				"RtG"
+			],
 			"reprintedAs": [
 				"Clockwork Bronze Scout|MPMM"
 			],
@@ -3111,7 +3100,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bronze-scout.mp3"
+				"path": "bestiary/bronze-scout.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -3140,10 +3129,8 @@
 			"name": "Bulezau",
 			"source": "MTF",
 			"page": 131,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA"
 			],
 			"reprintedAs": [
 				"Bulezau|MPMM"
@@ -3234,8 +3221,11 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bulezau.mp3"
+				"path": "bestiary/bulezau.opus"
 			},
+			"traitTags": [
+				"Sure-Footed"
+			],
 			"senseTags": [
 				"SD"
 			],
@@ -3367,7 +3357,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cadaver-collector.mp3"
+				"path": "bestiary/cadaver-collector.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -3537,7 +3527,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/canoloth.mp3"
+				"path": "bestiary/canoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -3580,6 +3570,15 @@
 					"source": "TftYP",
 					"page": 232
 				}
+			],
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Choker|MPMM"
@@ -3665,7 +3664,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/choker.mp3"
+				"path": "bestiary/choker.opus"
 			},
 			"altArt": [
 				{
@@ -3798,7 +3797,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/corpse-flower.mp3"
+				"path": "bestiary/corpse-flower.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -3982,7 +3981,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deathlock.mp3"
+				"path": "bestiary/deathlock.opus"
 			},
 			"traitTags": [
 				"Turn Resistance"
@@ -4141,10 +4140,8 @@
 			"name": "Deathlock Mastermind",
 			"source": "MTF",
 			"page": 129,
-			"otherSources": [
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"SDW"
 			],
 			"reprintedAs": [
 				"Deathlock Mastermind|MPMM"
@@ -4308,7 +4305,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deathlock-mastermind.mp3"
+				"path": "bestiary/deathlock-mastermind.opus"
 			},
 			"traitTags": [
 				"Turn Resistance"
@@ -4498,6 +4495,15 @@
 					"page": 233
 				}
 			],
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"reprintedAs": [
 				"Deathlock Wight|MPMM"
 			],
@@ -4617,7 +4623,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deathlock-wight.mp3"
+				"path": "bestiary/deathlock-wight.opus"
 			},
 			"altArt": [
 				{
@@ -4667,6 +4673,9 @@
 					"source": "OotA",
 					"page": 236
 				}
+			],
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Demogorgon|MPMM"
@@ -4985,7 +4994,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/derro.mp3"
+				"path": "bestiary/derro.opus"
 			},
 			"attachedItems": [
 				"light crossbow|phb"
@@ -5139,7 +5148,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/derro-savant.mp3"
+				"path": "bestiary/derro-savant.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -5320,7 +5329,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dhergoloth.mp3"
+				"path": "bestiary/dhergoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -5346,6 +5355,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"savingThrowForced": [
@@ -5473,7 +5483,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dire-troll.mp3"
+				"path": "bestiary/dire-troll.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -5494,6 +5504,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -5517,7 +5528,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -5698,7 +5713,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-arachnomancer.mp3"
+				"path": "bestiary/drow-arachnomancer.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry",
@@ -5775,7 +5790,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -5952,7 +5971,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-favored-consort.mp3"
+				"path": "bestiary/drow-favored-consort.opus"
 			},
 			"attachedItems": [
 				"hand crossbow|phb",
@@ -6011,13 +6030,15 @@
 				"strength"
 			],
 			"hasToken": true,
-			"hasFluff": true,
-			"hasFluffImages": true
+			"hasFluff": true
 		},
 		{
 			"name": "Drow House Captain",
 			"source": "MTF",
 			"page": 184,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Drow House Captain|MPMM"
 			],
@@ -6027,7 +6048,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -6097,7 +6122,7 @@
 				{
 					"name": "Battle Command",
 					"entries": [
-						"As a bonus action, the drow targets one ally he can see within 30 feet of him. If the target can see or hear the drow, the target can use its reaction to make one melee attack or to take the Dodge or Hide action."
+						"As a bonus action, the drow targets one ally he can see within 30 feet of him. If the target can see or hear the drow, the target can use its reaction to make one melee attack or to take the {@action Dodge} or {@action Hide} action."
 					]
 				},
 				{
@@ -6152,7 +6177,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-house-captain.mp3"
+				"path": "bestiary/drow-house-captain.opus"
 			},
 			"attachedItems": [
 				"hand crossbow|phb",
@@ -6216,7 +6241,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -6423,7 +6452,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-inquisitor.mp3"
+				"path": "bestiary/drow-inquisitor.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry",
@@ -6489,7 +6518,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -6733,7 +6766,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-matron-mother.mp3"
+				"path": "bestiary/drow-matron-mother.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry",
@@ -6809,7 +6842,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -6940,7 +6977,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drow-shadowblade.mp3"
+				"path": "bestiary/drow-shadowblade.opus"
 			},
 			"attachedItems": [
 				"hand crossbow|phb"
@@ -7125,7 +7162,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-despot.mp3"
+				"path": "bestiary/duergar-despot.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -7151,6 +7188,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -7170,10 +7208,8 @@
 			"name": "Duergar Hammerer",
 			"source": "MTF",
 			"page": 188,
-			"otherSources": [
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"IDRotF"
 			],
 			"reprintedAs": [
 				"Duergar Hammerer|MPMM"
@@ -7266,7 +7302,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-hammerer.mp3"
+				"path": "bestiary/duergar-hammerer.opus"
 			},
 			"traitTags": [
 				"Siege Monster"
@@ -7288,7 +7324,8 @@
 				"MW"
 			],
 			"hasToken": true,
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Duergar Kavalrachni",
@@ -7299,6 +7336,9 @@
 					"source": "OotA",
 					"page": 226
 				}
+			],
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Duergar Kavalrachni|MPMM"
@@ -7402,7 +7442,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-kavalrachni.mp3"
+				"path": "bestiary/duergar-kavalrachni.opus"
 			},
 			"attachedItems": [
 				"heavy crossbow|phb",
@@ -7441,10 +7481,8 @@
 			"name": "Duergar Mind Master",
 			"source": "MTF",
 			"page": 189,
-			"otherSources": [
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"IDRotF"
 			],
 			"reprintedAs": [
 				"Duergar Mind Master|MPMM"
@@ -7549,7 +7587,7 @@
 				{
 					"name": "Reduce (Recharges after a Short or Long Rest)",
 					"entries": [
-						"For 1 minute, the duergar magically decreases in size, along with anything it is wearing or carrying. While reduced, the duergar is Tiny, reduces its weapon damage to 1, and makes attacks, checks, and saving throws with disadvantage if they use Strength. It gains a +5 bonus to all Dexterity ({@skill Stealth}) checks and a +5 bonus to its AC. It can also take a bonus action on each of its turns to take the Hide action."
+						"For 1 minute, the duergar magically decreases in size, along with anything it is wearing or carrying. While reduced, the duergar is Tiny, reduces its weapon damage to 1, and makes attacks, checks, and saving throws with disadvantage if they use Strength. It gains a +5 bonus to all Dexterity ({@skill Stealth}) checks and a +5 bonus to its AC. It can also take a bonus action on each of its turns to take the {@action Hide} action."
 					]
 				}
 			],
@@ -7559,7 +7597,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-mind-master.mp3"
+				"path": "bestiary/duergar-mind-master.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity"
@@ -7681,7 +7719,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-screamer.mp3"
+				"path": "bestiary/duergar-screamer.opus"
 			},
 			"senseTags": [
 				"D"
@@ -7719,6 +7757,9 @@
 					"source": "OotA",
 					"page": 227
 				}
+			],
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Duergar Soulblade|MPMM"
@@ -7835,7 +7876,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-soulblade.mp3"
+				"path": "bestiary/duergar-soulblade.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity"
@@ -7872,6 +7913,9 @@
 					"source": "OotA",
 					"page": 227
 				}
+			],
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Duergar Stone Guard|MPMM"
@@ -7975,7 +8019,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-stone-guard.mp3"
+				"path": "bestiary/duergar-stone-guard.opus"
 			},
 			"attachedItems": [
 				"javelin|phb"
@@ -8126,7 +8170,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-warlord.mp3"
+				"path": "bestiary/duergar-warlord.opus"
 			},
 			"attachedItems": [
 				"javelin|phb"
@@ -8170,6 +8214,9 @@
 					"source": "OotA",
 					"page": 226
 				}
+			],
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Duergar Xarrorn|MPMM"
@@ -8266,7 +8313,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/duergar-xarrorn.mp3"
+				"path": "bestiary/duergar-xarrorn.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity"
@@ -8444,7 +8491,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dybbuk.mp3"
+				"path": "bestiary/dybbuk.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -8498,6 +8545,9 @@
 					"source": "PotA",
 					"page": 212
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"reprintedAs": [
 				"Earth Elemental Myrmidon|MPMM"
@@ -8589,7 +8639,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/earth-elemental-myrmidon.mp3"
+				"path": "bestiary/earth-elemental-myrmidon.opus"
 			},
 			"attachedItems": [
 				"maul|phb"
@@ -8628,16 +8678,10 @@
 			"name": "Eidolon",
 			"source": "MTF",
 			"page": 194,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"DC",
+				"DIP",
+				"IMR"
 			],
 			"reprintedAs": [
 				"Eidolon|MPMM"
@@ -8739,7 +8783,7 @@
 				{
 					"name": "Divine Dread",
 					"entries": [
-						"Each creature within 60 feet of the eidolon that can see it must succeed on a {@dc 15} Wisdom saving throw or be {@condition frightened} for 1 minute. While {@condition frightened} in this way, the creature must take the Dash action and move away from the eidolon by the safest available route at the start of each of its turns, unless there is nowhere for it to move, in which case the creature also becomes {@condition stunned} until it can move again. A {@condition frightened} target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to any eidolon's Divine Dread for the next 24 hours."
+						"Each creature within 60 feet of the eidolon that can see it must succeed on a {@dc 15} Wisdom saving throw or be {@condition frightened} for 1 minute. While {@condition frightened} in this way, the creature must take the {@action Dash} action and move away from the eidolon by the safest available route at the start of each of its turns, unless there is nowhere for it to move, in which case the creature also becomes {@condition stunned} until it can move again. A {@condition frightened} target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to any eidolon's Divine Dread for the next 24 hours."
 					]
 				}
 			],
@@ -8753,7 +8797,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/eidolon.mp3"
+				"path": "bestiary/eidolon.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -8767,6 +8811,9 @@
 			],
 			"damageTags": [
 				"O"
+			],
+			"miscTags": [
+				"AOE"
 			],
 			"conditionInflict": [
 				"frightened",
@@ -8912,7 +8959,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/elder-oblex.mp3"
+				"path": "bestiary/elder-oblex.opus"
 			},
 			"traitTags": [
 				"Amorphous"
@@ -9113,7 +9160,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/elder-tempest.mp3"
+				"path": "bestiary/elder-tempest.opus"
 			},
 			"traitTags": [
 				"Flyby",
@@ -9132,6 +9179,7 @@
 				"T"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -9150,11 +9198,8 @@
 			"name": "Female Steeder",
 			"source": "MTF",
 			"page": 238,
-			"otherSources": [
-				{
-					"source": "OotA",
-					"page": 231
-				}
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Female Steeder|MPMM"
@@ -9230,7 +9275,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/female-steeder.mp3"
+				"path": "bestiary/female-steeder.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -9261,6 +9306,9 @@
 					"source": "PotA",
 					"page": 213
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"reprintedAs": [
 				"Fire Elemental Myrmidon|MPMM"
@@ -9365,7 +9413,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fire-elemental-myrmidon.mp3"
+				"path": "bestiary/fire-elemental-myrmidon.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -9407,6 +9455,9 @@
 					"source": "OotA",
 					"page": 238
 				}
+			],
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Fraz-Urb'luu|MPMM"
@@ -9742,7 +9793,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/frost-salamander.mp3"
+				"path": "bestiary/frost-salamander.opus"
 			},
 			"senseTags": [
 				"D",
@@ -9980,7 +10031,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/geryon.mp3"
+				"path": "bestiary/geryon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -10154,7 +10205,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giff.mp3"
+				"path": "bestiary/giff.opus"
 			},
 			"attachedItems": [
 				"longsword|phb",
@@ -10173,6 +10224,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW",
 				"RW"
@@ -10194,8 +10246,12 @@
 			"page": 205,
 			"otherSources": [
 				{
-					"source": "WDMM"
+					"source": "WDMM",
+					"page": 312
 				}
+			],
+			"referenceSources": [
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Githyanki Gish|MPMM"
@@ -10351,7 +10407,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githyanki-gish.mp3"
+				"path": "bestiary/githyanki-gish.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -10506,7 +10562,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githyanki-kith_rak.mp3"
+				"path": "bestiary/githyanki-kith_rak.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -10672,7 +10728,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githyanki-supreme-commander.mp3"
+				"path": "bestiary/githyanki-supreme-commander.opus"
 			},
 			"actionTags": [
 				"Multiattack",
@@ -10840,7 +10896,7 @@
 			},
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githzerai-anarch.mp3"
+				"path": "bestiary/githzerai-anarch.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -10987,7 +11043,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githzerai-enlightened.mp3"
+				"path": "bestiary/githzerai-enlightened.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -11180,7 +11236,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gloom-weaver.mp3"
+				"path": "bestiary/gloom-weaver.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry"
@@ -11312,7 +11368,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gray-render.mp3"
+				"path": "bestiary/gray-render.opus"
 			},
 			"senseTags": [
 				"D"
@@ -11349,6 +11405,9 @@
 					"source": "OotA",
 					"page": 241
 				}
+			],
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Graz'zt|MPMM"
@@ -11737,7 +11796,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-abishai.mp3"
+				"path": "bestiary/green-abishai.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -11919,7 +11978,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hellfire-engine.mp3"
+				"path": "bestiary/hellfire-engine.opus"
 			},
 			"traitTags": [
 				"Immutable Form",
@@ -12055,7 +12114,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/howler.mp3"
+				"path": "bestiary/howler.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -12300,7 +12359,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hutijin.mp3"
+				"path": "bestiary/hutijin.opus"
 			},
 			"attachedItems": [
 				"mace|phb"
@@ -12541,7 +12600,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hydroloth.mp3"
+				"path": "bestiary/hydroloth.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -12594,12 +12653,13 @@
 			"page": 125,
 			"otherSources": [
 				{
-					"source": "GoS"
-				},
-				{
 					"source": "RtG",
 					"page": 33
 				}
+			],
+			"referenceSources": [
+				"GoS",
+				"RtG"
 			],
 			"reprintedAs": [
 				"Clockwork Iron Cobra|MPMM"
@@ -12672,7 +12732,7 @@
 					"entries": [
 						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage. If the target is a creature, it must succeed on a {@dc 13} Constitution saving throw or suffer one random poison effect:",
 						"1. Poison Damage: The target takes 13 ({@damage 3d8}) poison damage.",
-						"2. Confusion: On its next turn, the target must use its action to make one weapon attack against a random creature it can see within 30 feet of it, using whatever weapon it has in hand and moving beforehand if necessary to get in range. If it's holding no weapon, it makes an unarmed strike. If no creature is visible within 30 feet, it takes the Dash action, moving toward the nearest creature.",
+						"2. Confusion: On its next turn, the target must use its action to make one weapon attack against a random creature it can see within 30 feet of it, using whatever weapon it has in hand and moving beforehand if necessary to get in range. If it's holding no weapon, it makes an unarmed strike. If no creature is visible within 30 feet, it takes the {@action Dash} action, moving toward the nearest creature.",
 						"3. Paralysis: The target is {@condition paralyzed} until the end of its next turn."
 					]
 				}
@@ -12685,7 +12745,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/iron-cobra.mp3"
+				"path": "bestiary/iron-cobra.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -12723,6 +12783,9 @@
 					"source": "OotA",
 					"page": 243
 				}
+			],
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Juiblex|MPMM"
@@ -13076,7 +13139,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kruthik-hive-lord.mp3"
+				"path": "bestiary/kruthik-hive-lord.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -13249,7 +13312,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/leviathan.mp3"
+				"path": "bestiary/leviathan.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -13281,11 +13344,8 @@
 			"name": "Male Steeder",
 			"source": "MTF",
 			"page": 238,
-			"otherSources": [
-				{
-					"source": "OotA",
-					"page": 231
-				}
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Male Steeder|MPMM"
@@ -13361,7 +13421,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/male-steeder.mp3"
+				"path": "bestiary/male-steeder.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -13531,7 +13591,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/marut.mp3"
+				"path": "bestiary/marut.opus"
 			},
 			"traitTags": [
 				"Immutable Form",
@@ -13695,7 +13755,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/maurezhi.mp3"
+				"path": "bestiary/maurezhi.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -13780,7 +13840,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the meazel can take the Hide action as a bonus action."
+						"While in dim light or darkness, the meazel can take the {@action Hide} action as a bonus action."
 					]
 				}
 			],
@@ -13817,7 +13877,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/meazel.mp3"
+				"path": "bestiary/meazel.opus"
 			},
 			"attachedItems": [
 				"shortsword|phb"
@@ -13848,10 +13908,8 @@
 			"name": "Merregon",
 			"source": "MTF",
 			"page": 166,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA"
 			],
 			"reprintedAs": [
 				"Merregon|MPMM"
@@ -13963,7 +14021,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/merregon.mp3"
+				"path": "bestiary/merregon.opus"
 			},
 			"attachedItems": [
 				"halberd|phb",
@@ -14003,6 +14061,9 @@
 			"name": "Merrenoloth",
 			"source": "MTF",
 			"page": 250,
+			"referenceSources": [
+				"LLK"
+			],
 			"reprintedAs": [
 				"Merrenoloth|MPMM"
 			],
@@ -14152,7 +14213,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/merrenoloth.mp3"
+				"path": "bestiary/merrenoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -14372,7 +14433,7 @@
 				{
 					"name": "Breath of Despair {@recharge 5}",
 					"entries": [
-						"Moloch exhales in a 30-foot cube. Each creature in that area must succeed on a {@dc 21} Wisdom saving throw or take 27 ({@damage 5d10}) psychic damage, drop whatever it is holding, and become {@condition frightened} for 1 minute. While {@condition frightened} in this way, a creature must take the Dash action and move away from Moloch by the safest available route on each of its turns, unless there is nowhere to move, in which case it needn't take the Dash action. If the creature ends its turn in a location where it doesn't have line of sight to Moloch, the creature can repeat the saving throw. On a success, the effect ends."
+						"Moloch exhales in a 30-foot cube. Each creature in that area must succeed on a {@dc 21} Wisdom saving throw or take 27 ({@damage 5d10}) psychic damage, drop whatever it is holding, and become {@condition frightened} for 1 minute. While {@condition frightened} in this way, a creature must take the {@action Dash} action and move away from Moloch by the safest available route on each of its turns, unless there is nowhere to move, in which case it needn't take the {@action Dash} action. If the creature ends its turn in a location where it doesn't have line of sight to Moloch, the creature can repeat the saving throw. On a success, the effect ends."
 					]
 				},
 				{
@@ -14404,7 +14465,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/moloch.mp3"
+				"path": "bestiary/moloch.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -14669,7 +14730,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/molydeus.mp3"
+				"path": "bestiary/molydeus.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -14848,7 +14909,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nabassu.mp3"
+				"path": "bestiary/nabassu.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -15055,7 +15116,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nagpa.mp3"
+				"path": "bestiary/nagpa.opus"
 			},
 			"senseTags": [
 				"U"
@@ -15081,6 +15142,7 @@
 				"CW"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -15112,10 +15174,8 @@
 			"name": "Narzugon",
 			"source": "MTF",
 			"page": 167,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA"
 			],
 			"reprintedAs": [
 				"Narzugon|MPMM"
@@ -15251,7 +15311,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/narzugon.mp3"
+				"path": "bestiary/narzugon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -15398,7 +15458,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nightwalker.mp3"
+				"path": "bestiary/nightwalker.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -15430,10 +15490,8 @@
 			"name": "Nupperibo",
 			"source": "MTF",
 			"page": 168,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA"
 			],
 			"reprintedAs": [
 				"Nupperibo|MPMM"
@@ -15530,7 +15588,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nupperibo.mp3"
+				"path": "bestiary/nupperibo.opus"
 			},
 			"senseTags": [
 				"B"
@@ -15556,6 +15614,10 @@
 			"name": "Oaken Bolter",
 			"source": "MTF",
 			"page": 126,
+			"referenceSources": [
+				"LLK",
+				"RtG"
+			],
 			"reprintedAs": [
 				"Clockwork Oaken Bolter|MPMM"
 			],
@@ -15657,7 +15719,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/oaken-bolter.mp3"
+				"path": "bestiary/oaken-bolter.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -15677,6 +15739,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RW"
 			],
@@ -15766,7 +15829,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/oblex-spawn.mp3"
+				"path": "bestiary/oblex-spawn.opus"
 			},
 			"traitTags": [
 				"Amorphous"
@@ -15859,7 +15922,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre-battering-ram.mp3"
+				"path": "bestiary/ogre-battering-ram.opus"
 			},
 			"traitTags": [
 				"Siege Monster"
@@ -15950,7 +16013,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre-bolt-launcher.mp3"
+				"path": "bestiary/ogre-bolt-launcher.opus"
 			},
 			"senseTags": [
 				"D"
@@ -16042,7 +16105,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre-chain-brute.mp3"
+				"path": "bestiary/ogre-chain-brute.opus"
 			},
 			"senseTags": [
 				"D"
@@ -16136,7 +16199,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre-howdah.mp3"
+				"path": "bestiary/ogre-howdah.opus"
 			},
 			"attachedItems": [
 				"mace|phb"
@@ -16325,7 +16388,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/oinoloth.mp3"
+				"path": "bestiary/oinoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -16392,6 +16455,9 @@
 					"source": "OotA",
 					"page": 245
 				}
+			],
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Orcus|MPMM"
@@ -16621,10 +16687,8 @@
 			"name": "Orthon",
 			"source": "MTF",
 			"page": 169,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA"
 			],
 			"reprintedAs": [
 				"Orthon|MPMM"
@@ -16785,7 +16849,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orthon.mp3"
+				"path": "bestiary/orthon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -16810,6 +16874,7 @@
 				"T"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW",
 				"RW"
@@ -16832,10 +16897,8 @@
 			"name": "Phoenix",
 			"source": "MTF",
 			"page": 199,
-			"otherSources": [
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"MOT"
 			],
 			"reprintedAs": [
 				"Phoenix|MPMM"
@@ -16983,7 +17046,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/phoenix.mp3"
+				"path": "bestiary/phoenix.opus"
 			},
 			"traitTags": [
 				"Flyby",
@@ -17162,7 +17225,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-abishai.mp3"
+				"path": "bestiary/red-abishai.opus"
 			},
 			"attachedItems": [
 				"morningstar|phb"
@@ -17341,7 +17404,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/retriever.mp3"
+				"path": "bestiary/retriever.opus"
 			},
 			"senseTags": [
 				"B",
@@ -17394,15 +17457,14 @@
 			"page": 244,
 			"otherSources": [
 				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
 					"source": "RtG",
 					"page": 34
 				}
+			],
+			"referenceSources": [
+				"DIP",
+				"RtG",
+				"SLW"
 			],
 			"reprintedAs": [
 				"Rot Troll|MPMM"
@@ -17486,7 +17548,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rot-troll.mp3"
+				"path": "bestiary/rot-troll.opus"
 			},
 			"senseTags": [
 				"D"
@@ -17503,6 +17565,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"hasToken": true,
@@ -17584,7 +17647,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rutterkin.mp3"
+				"path": "bestiary/rutterkin.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -17617,16 +17680,10 @@
 			"name": "Sacred Statue",
 			"source": "MTF",
 			"page": 194,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"DC",
+				"DIP",
+				"IMR"
 			],
 			"reprintedAs": [
 				"Sacred Statue|MPMM"
@@ -17740,7 +17797,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sacred-statue.mp3"
+				"path": "bestiary/sacred-statue.opus"
 			},
 			"traitTags": [
 				"False Appearance"
@@ -17872,7 +17929,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shadow-dancer.mp3"
+				"path": "bestiary/shadow-dancer.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry"
@@ -17911,10 +17968,8 @@
 			"name": "Sibriex",
 			"source": "MTF",
 			"page": 137,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA"
 			],
 			"reprintedAs": [
 				"Sibriex|MPMM"
@@ -18202,7 +18257,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sibriex.mp3"
+				"path": "bestiary/sibriex.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -18345,7 +18400,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/skulk.mp3"
+				"path": "bestiary/skulk.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -18581,7 +18636,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/skull-lord.mp3"
+				"path": "bestiary/skull-lord.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -18766,7 +18821,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/soul-monger.mp3"
+				"path": "bestiary/soul-monger.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry",
@@ -18936,7 +18991,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spirit-troll.mp3"
+				"path": "bestiary/spirit-troll.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -19106,7 +19161,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spring-eladrin.mp3"
+				"path": "bestiary/spring-eladrin.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -19162,6 +19217,9 @@
 			"name": "Star Spawn Grue",
 			"source": "MTF",
 			"page": 234,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Star Spawn Grue|MPMM"
 			],
@@ -19222,7 +19280,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/star-spawn-grue.mp3"
+				"path": "bestiary/star-spawn-grue.opus"
 			},
 			"senseTags": [
 				"D"
@@ -19246,6 +19304,9 @@
 			"name": "Star Spawn Hulk",
 			"source": "MTF",
 			"page": 234,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Star Spawn Hulk|MPMM"
 			],
@@ -19338,7 +19399,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/star-spawn-hulk.mp3"
+				"path": "bestiary/star-spawn-hulk.opus"
 			},
 			"senseTags": [
 				"D"
@@ -19354,6 +19415,7 @@
 				"Y"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -19372,10 +19434,8 @@
 			"name": "Star Spawn Larva Mage",
 			"source": "MTF",
 			"page": 235,
-			"otherSources": [
-				{
-					"source": "WDMM"
-				}
+			"referenceSources": [
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Star Spawn Larva Mage|MPMM"
@@ -19528,7 +19588,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/star-spawn-larva-mage.mp3"
+				"path": "bestiary/star-spawn-larva-mage.opus"
 			},
 			"senseTags": [
 				"D"
@@ -19575,16 +19635,8 @@
 			"name": "Star Spawn Mangler",
 			"source": "MTF",
 			"page": 236,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				}
+			"referenceSources": [
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Star Spawn Mangler|MPMM"
@@ -19650,7 +19702,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the mangler can take the Hide action as a bonus action."
+						"While in dim light or darkness, the mangler can take the {@action Hide} action as a bonus action."
 					]
 				}
 			],
@@ -19676,7 +19728,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/star-spawn-mangler.mp3"
+				"path": "bestiary/star-spawn-mangler.opus"
 			},
 			"traitTags": [
 				"Ambusher"
@@ -19704,6 +19756,9 @@
 			"name": "Star Spawn Seer",
 			"source": "MTF",
 			"page": 236,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Star Spawn Seer|MPMM"
 			],
@@ -19823,7 +19878,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/star-spawn-seer.mp3"
+				"path": "bestiary/star-spawn-seer.opus"
 			},
 			"senseTags": [
 				"D"
@@ -19993,7 +20048,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/steel-predator.mp3"
+				"path": "bestiary/steel-predator.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -20121,7 +20176,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stone-cursed.mp3"
+				"path": "bestiary/stone-cursed.opus"
 			},
 			"traitTags": [
 				"False Appearance"
@@ -20150,6 +20205,9 @@
 			"name": "Stone Defender",
 			"source": "MTF",
 			"page": 126,
+			"referenceSources": [
+				"RtG"
+			],
 			"reprintedAs": [
 				"Clockwork Stone Defender|MPMM"
 			],
@@ -20247,7 +20305,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stone-defender.mp3"
+				"path": "bestiary/stone-defender.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -20392,7 +20450,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/summer-eladrin.mp3"
+				"path": "bestiary/summer-eladrin.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -20438,16 +20496,10 @@
 			"name": "Sword Wraith Commander",
 			"source": "MTF",
 			"page": 241,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"DC",
+				"DIP",
+				"SDW"
 			],
 			"reprintedAs": [
 				"Sword Wraith Commander|MPMM"
@@ -20560,7 +20612,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sword-wraith-commander.mp3"
+				"path": "bestiary/sword-wraith-commander.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -20597,16 +20649,10 @@
 			"name": "Sword Wraith Warrior",
 			"source": "MTF",
 			"page": 241,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"DC",
+				"DIP",
+				"SDW"
 			],
 			"reprintedAs": [
 				"Sword Wraith Warrior|MPMM"
@@ -20698,7 +20744,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sword-wraith-warrior.mp3"
+				"path": "bestiary/sword-wraith-warrior.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -20817,7 +20863,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/the-angry.mp3"
+				"path": "bestiary/the-angry.opus"
 			},
 			"senseTags": [
 				"D"
@@ -20929,7 +20975,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/the-hungry.mp3"
+				"path": "bestiary/the-hungry.opus"
 			},
 			"senseTags": [
 				"D"
@@ -21056,7 +21102,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/the-lonely.mp3"
+				"path": "bestiary/the-lonely.opus"
 			},
 			"senseTags": [
 				"D"
@@ -21072,6 +21118,7 @@
 				"Y"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -21182,7 +21229,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/the-lost.mp3"
+				"path": "bestiary/the-lost.opus"
 			},
 			"senseTags": [
 				"D"
@@ -21212,6 +21259,9 @@
 			"name": "The Wretched",
 			"source": "MTF",
 			"page": 233,
+			"referenceSources": [
+				"LLK"
+			],
 			"reprintedAs": [
 				"Wretched Sorrowsworn|MPMM"
 			],
@@ -21284,7 +21334,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/the-wretched.mp3"
+				"path": "bestiary/the-wretched.opus"
 			},
 			"senseTags": [
 				"D"
@@ -21465,7 +21515,7 @@
 				{
 					"name": "Frightful Word",
 					"entries": [
-						"Titivilus targets one creature he can see within 10 feet of him. The target must succeed on a {@dc 21} Wisdom saving throw or become {@condition frightened} for 1 minute. While {@condition frightened} in this way, the target must take the Dash action and move away from Titivilus by the safest available route on each of its turns, unless there is nowhere to move, in which case it needn't take the Dash action. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Titivilus targets one creature he can see within 10 feet of him. The target must succeed on a {@dc 21} Wisdom saving throw or become {@condition frightened} for 1 minute. While {@condition frightened} in this way, the target must take the {@action Dash} action and move away from Titivilus by the safest available route on each of its turns, unless there is nowhere to move, in which case it needn't take the {@action Dash} action. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
@@ -21503,7 +21553,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/titivilus.mp3"
+				"path": "bestiary/titivilus.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -21577,6 +21627,9 @@
 					"source": "TTP",
 					"page": 23
 				}
+			],
+			"referenceSources": [
+				"TTP"
 			],
 			"reprintedAs": [
 				"Tortle|MPMM"
@@ -21664,7 +21717,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tortle.mp3"
+				"path": "bestiary/tortle.opus"
 			},
 			"attachedItems": [
 				"light crossbow|phb",
@@ -21701,6 +21754,9 @@
 					"source": "TTP",
 					"page": 23
 				}
+			],
+			"referenceSources": [
+				"TTP"
 			],
 			"reprintedAs": [
 				"Tortle Druid|MPMM"
@@ -21818,7 +21874,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tortle-druid.mp3"
+				"path": "bestiary/tortle-druid.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -21866,6 +21922,15 @@
 					"source": "TftYP",
 					"page": 247
 				}
+			],
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Vampiric Mist|MPMM"
@@ -21982,7 +22047,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vampiric-mist.mp3"
+				"path": "bestiary/vampiric-mist.opus"
 			},
 			"altArt": [
 				{
@@ -21997,8 +22062,7 @@
 				"D"
 			],
 			"damageTags": [
-				"N",
-				"R"
+				"N"
 			],
 			"miscTags": [
 				"HPR"
@@ -22116,7 +22180,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/venom-troll.mp3"
+				"path": "bestiary/venom-troll.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -22287,7 +22351,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wastrilith.mp3"
+				"path": "bestiary/wastrilith.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -22330,12 +22394,13 @@
 			"page": 203,
 			"otherSources": [
 				{
-					"source": "LR"
-				},
-				{
 					"source": "PotA",
 					"page": 213
 				}
+			],
+			"referenceSources": [
+				"LR",
+				"PotA"
 			],
 			"reprintedAs": [
 				"Water Elemental Myrmidon|MPMM"
@@ -22429,7 +22494,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/water-elemental-myrmidon.mp3"
+				"path": "bestiary/water-elemental-myrmidon.opus"
 			},
 			"attachedItems": [
 				"trident|phb"
@@ -22464,10 +22529,8 @@
 			"name": "White Abishai",
 			"source": "MTF",
 			"page": 163,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA"
 			],
 			"reprintedAs": [
 				"White Abishai|MPMM"
@@ -22605,7 +22668,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/white-abishai.mp3"
+				"path": "bestiary/white-abishai.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -22772,7 +22835,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/winter-eladrin.mp3"
+				"path": "bestiary/winter-eladrin.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -22987,7 +23050,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yagnoloth.mp3"
+				"path": "bestiary/yagnoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -23048,10 +23111,11 @@
 				{
 					"source": "OotA",
 					"page": 247
-				},
-				{
-					"source": "BGDIA"
 				}
+			],
+			"referenceSources": [
+				"BGDIA",
+				"OotA"
 			],
 			"reprintedAs": [
 				"Yeenoghu|MPMM"
@@ -23257,6 +23321,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MLW",
 				"MW",
 				"RCH"
@@ -23369,7 +23434,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/young-kruthik.mp3"
+				"path": "bestiary/young-kruthik.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -23573,7 +23638,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/zaratan.mp3"
+				"path": "bestiary/zaratan.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -23887,6 +23952,9 @@
 					"source": "OotA",
 					"page": 249
 				}
+			],
+			"referenceSources": [
+				"OotA"
 			],
 			"reprintedAs": [
 				"Zuggtmoy|MPMM"

--- a/json/bestiary/bestiary-nf.json
+++ b/json/bestiary/bestiary-nf.json
@@ -1,0 +1,910 @@
+{
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"FRAiF": "NF",
+				"XMM": "NF"
+			}
+		}
+	},
+	"monster": [
+		{
+			"name": "Caldron Magen",
+			"source": "NF",
+			"size": [
+				"M"
+			],
+			"type": "construct",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				20
+			],
+			"hp": {
+				"average": 67,
+				"formula": "9d8 + 27"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 18,
+			"dex": 13,
+			"con": 16,
+			"int": 10,
+			"wis": 10,
+			"cha": 10,
+			"skill": {
+				"perception": "+4"
+			},
+			"passive": 14,
+			"immune": [
+				"acid",
+				"poison"
+			],
+			"conditionImmune": [
+				"blinded",
+				"charmed",
+				"deafened",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common plus two other languages but can't speak"
+			],
+			"cr": "4",
+			"trait": [
+				{
+					"name": "Disintegration",
+					"entries": [
+						"If the magen dies, it disintegrates into dust, leaving behind anything it was wearing or carrying."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The magen has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The magen makes two attacks, using Extended Fist or Acid Spittle in any combination."
+					]
+				},
+				{
+					"name": "Extended Fist",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 15 ft. {@h}8 ({@damage 1d8 + 4}) Bludgeoning damage plus 5 ({@damage 1d10}) Acid damage. If the target is a Medium or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 14}) from one of two fists."
+					]
+				},
+				{
+					"name": "Acid Spittle",
+					"entries": [
+						"{@atkr r} {@hit 6}, range 60 ft. {@h}13 ({@damage 2d8 + 4}) Acid damage."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"X"
+			],
+			"damageTags": [
+				"A",
+				"B"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"grappled"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Eldritch Eddy",
+			"source": "NF",
+			"size": [
+				"L"
+			],
+			"type": "construct",
+			"alignment": [
+				"C",
+				"N"
+			],
+			"ac": [
+				11
+			],
+			"hp": {
+				"average": 144,
+				"formula": "17d10 + 51"
+			},
+			"speed": {
+				"walk": 10,
+				"fly": {
+					"number": 40,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 10,
+			"dex": 12,
+			"con": 16,
+			"int": 12,
+			"wis": 9,
+			"cha": 17,
+			"save": {
+				"dex": "+4",
+				"int": "+4",
+				"cha": "+6"
+			},
+			"senses": [
+				"Blindsight 60 ft."
+			],
+			"passive": 9,
+			"resist": [
+				"force"
+			],
+			"immune": [
+				"fire",
+				"lightning"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common plus one other language but can't speak"
+			],
+			"cr": "6",
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The eddy has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The eddy makes two attacks, using Searing Swipe or Arcane Bolt in any combination."
+					]
+				},
+				{
+					"name": "Searing Swipe",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 10 ft. {@h}13 ({@damage 3d6 + 3}) Fire or Lightning damage (eddy's choice)."
+					]
+				},
+				{
+					"name": "Arcane Bolt",
+					"entries": [
+						"{@atkr r} {@hit 6}, range 120 ft. {@h}14 ({@damage 2d10 + 3}) Force damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Eldritch Overload",
+					"entries": [
+						"{@actTrigger} The eddy takes damage. {@actResponse d}{@actSave str} {@dc 14}, each creature of the eddy's choice in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the eddy. {@actSaveFail} 7 ({@damage 2d6}) Force damage, and the target has the {@condition Prone|XPHB} condition."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"X"
+			],
+			"damageTags": [
+				"F",
+				"L",
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Phaerimm Elder",
+			"source": "NF",
+			"size": [
+				"H"
+			],
+			"type": "aberration",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 218,
+				"formula": "23d12 + 69"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": {
+					"number": 60,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 18,
+			"dex": 16,
+			"con": 17,
+			"int": 17,
+			"wis": 16,
+			"cha": 18,
+			"save": {
+				"con": "+8",
+				"int": "+8",
+				"wis": "+8",
+				"cha": "+9"
+			},
+			"skill": {
+				"arcana": "+13",
+				"insight": "+8",
+				"perception": "+8"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 18,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"telepathy 120 ft. understands Common and Deep Speech but can't speak"
+			],
+			"cr": "14",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The phaerimm casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save {@dc 17}):"
+					],
+					"will": [
+						"{@spell Command|XPHB} (level 3 version)",
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Mage Hand|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Clairvoyance|XPHB}",
+							"{@spell Geas|XPHB}",
+							"{@spell Major Image|XPHB}",
+							"{@spell Mirage Arcane|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				},
+				{
+					"name": "Protective Magic (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The phaerimm casts {@spell Counterspell|XPHB} or {@spell Shield|XPHB} in response to the spell's trigger, using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"3": [
+							"{@spell Counterspell|XPHB}",
+							"{@spell Shield|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "reaction",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The phaerimm has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The phaerimm makes three Mind Lash attacks. It can replace one attack with either (A) a Vicious Stinger attack or (B) a use of Spellcasting to cast {@spell Command|XPHB} (level 3 version)."
+					]
+				},
+				{
+					"name": "Mind Lash",
+					"entries": [
+						"{@atkr m,r} {@hit 9}, reach 10 ft. or range 120 ft. {@h}32 ({@damage 6d8 + 4}) Psychic damage."
+					]
+				},
+				{
+					"name": "Vicious Stinger",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 5 ft. {@h}11 ({@damage 2d6 + 4}) Piercing damage plus 26 ({@damage 4d12}) Poison damage, and the target's {@variantrule Speed|XPHB} is reduced to 0 feet until the start of the phaerimm's next turn."
+					]
+				},
+				{
+					"name": "Siphon Magic {@recharge 5}",
+					"entries": [
+						"The phaerimm focuses on a magic item it can see within 10 feet. When it does, the phaerimm drains the magic item of any charges. Regardless of whether charges are drained, the phaerimm can cast {@spell Clairvoyance|XPHB}, {@spell Geas|XPHB}, {@spell Major Image|XPHB}, and {@spell Mirage Arcane|XPHB} one additional time that day."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Teleport",
+					"entries": [
+						"The phaerimm teleports up to 30 feet to an unoccupied space it can see."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"arcana",
+				"implements"
+			],
+			"attachedItems": [
+				"mind lash|vgm"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack",
+				"Teleport"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"DS",
+				"TP"
+			],
+			"damageTags": [
+				"I",
+				"P",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RCH"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"prone"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Phaerimm Scout",
+			"source": "NF",
+			"size": [
+				"M"
+			],
+			"type": "aberration",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 44,
+				"formula": "8d8 + 8"
+			},
+			"speed": {
+				"walk": 10,
+				"fly": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 12,
+			"dex": 13,
+			"con": 12,
+			"int": 15,
+			"wis": 16,
+			"cha": 16,
+			"save": {
+				"int": "+4",
+				"cha": "+5"
+			},
+			"skill": {
+				"perception": "+5"
+			},
+			"senses": [
+				"Truesight 60 ft."
+			],
+			"passive": 15,
+			"conditionImmune": [
+				"charmed"
+			],
+			"languages": [
+				"telepathy 120 ft. understands Common and Deep Speech but can't speak"
+			],
+			"cr": "2",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The phaerimm casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save {@dc 13}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Mage Hand|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Clairvoyance|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The phaerimm has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The phaerimm makes two attacks, using Stinger or Mindwarp Ray in any combination."
+					]
+				},
+				{
+					"name": "Stinger",
+					"entries": [
+						"{@atkr m} {@hit 3}, reach 5 ft. {@h}4 ({@damage 1d6 + 1}) Piercing damage plus 9 ({@damage 2d8}) Poison damage."
+					]
+				},
+				{
+					"name": "Mindwarp Ray",
+					"entries": [
+						"{@atkr r} {@hit 5}, range 120 ft. {@h}6 ({@damage 1d6 + 3}) Psychic damage, and the target has the {@condition Charmed|XPHB} condition until the start of the phaerimm's next turn."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Uncanny Dodge",
+					"entries": [
+						"{@actTrigger} The phaerimm is hit by an attack roll. {@actResponse} The phaerimm halves the damage (round down) it takes from that attack."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"arcana",
+				"implements"
+			],
+			"tokenCustom": true,
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"DS",
+				"TP"
+			],
+			"damageTags": [
+				"I",
+				"P",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"charmed"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true
+		},
+		{
+			"name": "Terran Magen",
+			"source": "NF",
+			"size": [
+				"M"
+			],
+			"type": "construct",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				21
+			],
+			"hp": {
+				"average": 121,
+				"formula": "22d8 + 22"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": {
+					"number": 20,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 16,
+			"dex": 10,
+			"con": 12,
+			"int": 10,
+			"wis": 18,
+			"cha": 10,
+			"save": {
+				"wis": "+7"
+			},
+			"skill": {
+				"perception": "+7"
+			},
+			"passive": 17,
+			"immune": [
+				"poison",
+				"thunder"
+			],
+			"conditionImmune": [
+				"blinded",
+				"charmed",
+				"deafened",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common plus two other languages but can't speak"
+			],
+			"cr": "8",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The magen casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save {@dc 15}):"
+					],
+					"will": [
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Mending|XPHB}",
+						"{@spell Prestidigitation|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Disintegrate|XPHB}",
+							"{@spell Move Earth|XPHB}",
+							"{@spell Stone Shape|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Disintegration",
+					"entries": [
+						"If the magen dies, it disintegrates into dust, leaving behind anything it was wearing or carrying."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The magen has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The magen makes two attacks, using Hammer Fist or Thunderous Boom in any combination."
+					]
+				},
+				{
+					"name": "Hammer Fist",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}16 ({@damage 3d8 + 3}) Bludgeoning damage plus 13 ({@damage 3d8}) Force damage."
+					]
+				},
+				{
+					"name": "Thunderous Boom",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 60 ft. {@h}28 ({@damage 8d6}) Thunder damage."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"X"
+			],
+			"damageTags": [
+				"B",
+				"O",
+				"T"
+			],
+			"damageTagsSpell": [
+				"O"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"savingThrowForcedSpell": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Virvos Magen",
+			"source": "NF",
+			"size": [
+				"M"
+			],
+			"type": "construct",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				21
+			],
+			"hp": {
+				"average": 110,
+				"formula": "17d8 + 34"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": {
+					"number": 20,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 12,
+			"dex": 10,
+			"con": 14,
+			"int": 10,
+			"wis": 10,
+			"cha": 16,
+			"skill": {
+				"perception": "+6"
+			},
+			"passive": 16,
+			"immune": [
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"blinded",
+				"charmed",
+				"deafened",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common plus two other languages but can't speak"
+			],
+			"cr": "6",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The magen casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 14}):"
+					],
+					"will": [
+						"{@spell Dancing Lights|XPHB}",
+						"{@spell Minor Illusion|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Hypnotic Pattern|XPHB}",
+							"{@spell Major Image|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Disintegration",
+					"entries": [
+						"If the magen dies, it disintegrates into dust, leaving behind anything it was wearing or carrying."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The magen has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The magen makes two Psychic Blast attacks."
+					]
+				},
+				{
+					"name": "Psychic Blast",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 60 ft. {@h}21 ({@damage 6d6}) Psychic damage."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"X"
+			],
+			"damageTags": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"incapacitated"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		}
+	]
+}

--- a/json/bestiary/bestiary-nrh-ass.json
+++ b/json/bestiary/bestiary-nrh-ass.json
@@ -2,7 +2,8 @@
 	"_meta": {
 		"otherSources": {
 			"monster": {
-				"NRH-TCMC": "NRH-ASS"
+				"NRH-TCMC": "NRH-ASS",
+				"MM": "NRH-ASS"
 			}
 		}
 	},
@@ -16,6 +17,9 @@
 					"source": "NRH-AT",
 					"page": 11
 				}
+			],
+			"referenceSources": [
+				"NRH-AT"
 			],
 			"size": [
 				"M"
@@ -67,10 +71,11 @@
 				{
 					"name": "Scimitar",
 					"entries": [
-						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d6 + 1}) slashing damage"
+						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d6 + 1}) slashing damage."
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"scimitar|phb"
 			],

--- a/json/bestiary/bestiary-nrh-at.json
+++ b/json/bestiary/bestiary-nrh-at.json
@@ -8,7 +8,8 @@
 		"otherSources": {
 			"monster": {
 				"NRH-TCMC": "NRH-AT",
-				"NRH-ASS": "NRH-AT"
+				"NRH-ASS": "NRH-AT",
+				"MM": "NRH-AT"
 			}
 		}
 	},
@@ -123,6 +124,7 @@
 					]
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -143,6 +145,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -234,6 +237,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"club|phb",
 				"hand crossbow|phb"

--- a/json/bestiary/bestiary-nrh-avitw.json
+++ b/json/bestiary/bestiary-nrh-avitw.json
@@ -2,7 +2,8 @@
 	"_meta": {
 		"otherSources": {
 			"monster": {
-				"NRH-TCMC": "NRH-AVitW"
+				"NRH-TCMC": "NRH-AVitW",
+				"MM": "NRH-AVitW"
 			}
 		}
 	},
@@ -67,6 +68,7 @@
 				}
 			],
 			"familiar": true,
+			"tokenCustom": true,
 			"traitTags": [
 				"Keen Senses"
 			],
@@ -149,6 +151,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Immutable Form",
 				"Magic Resistance",

--- a/json/bestiary/bestiary-nrh-awol.json
+++ b/json/bestiary/bestiary-nrh-awol.json
@@ -7,7 +7,8 @@
 		},
 		"otherSources": {
 			"monster": {
-				"NRH-TCMC": "NRH-AWoL"
+				"NRH-TCMC": "NRH-AWoL",
+				"MM": "NRH-AWoL"
 			}
 		}
 	},
@@ -31,6 +32,7 @@
 				}
 			},
 			"int": 8,
+			"tokenCustom": true,
 			"hasToken": true
 		}
 	]

--- a/json/bestiary/bestiary-nrh-coi.json
+++ b/json/bestiary/bestiary-nrh-coi.json
@@ -2,7 +2,8 @@
 	"_meta": {
 		"otherSources": {
 			"monster": {
-				"NRH-TCMC": "NRH-CoI"
+				"NRH-TCMC": "NRH-CoI",
+				"MM": "NRH-CoI"
 			}
 		}
 	},
@@ -60,6 +61,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C"
 			],
@@ -136,6 +138,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Reckless"
 			],
@@ -203,7 +206,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of his turns, Magnifico can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of his turns, Magnifico can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				}
 			],
@@ -221,6 +224,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"hand crossbow|phb",
 				"shortsword|phb"

--- a/json/bestiary/bestiary-nrh-tcmc.json
+++ b/json/bestiary/bestiary-nrh-tcmc.json
@@ -4,6 +4,11 @@
 			"monster": [
 				"MM"
 			]
+		},
+		"otherSources": {
+			"monster": {
+				"MM": "NRH-TCMC"
+			}
 		}
 	},
 	"monster": [
@@ -39,6 +44,13 @@
 					"page": 12
 				}
 			],
+			"referenceSources": [
+				"NRH-ASS",
+				"NRH-AVitW",
+				"NRH-AWoL",
+				"NRH-CoI",
+				"NRH-TLT"
+			],
 			"_copy": {
 				"name": "Wererat",
 				"source": "MM",
@@ -51,6 +63,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -104,7 +117,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Slurmy can take the Disengage or Hide action as a bonus action on each of their turns."
+						"Slurmy can take the {@action Disengage} or {@action Hide} action as a bonus action on each of their turns."
 					]
 				}
 			],
@@ -116,6 +129,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C"
 			],

--- a/json/bestiary/bestiary-nrh-tlt.json
+++ b/json/bestiary/bestiary-nrh-tlt.json
@@ -2,7 +2,8 @@
 	"_meta": {
 		"otherSources": {
 			"monster": {
-				"NRH-TCMC": "NRH-TLT"
+				"NRH-TCMC": "NRH-TLT",
+				"MM": "NRH-TLT"
 			}
 		}
 	},

--- a/json/bestiary/bestiary-oota.json
+++ b/json/bestiary/bestiary-oota.json
@@ -11,7 +11,8 @@
 		],
 		"otherSources": {
 			"monster": {
-				"MTF": "OotA"
+				"MTF": "OotA",
+				"MM": "OotA"
 			}
 		}
 	},
@@ -127,7 +128,7 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				],
@@ -140,6 +141,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"traitTags": [
 				"Fey Ancestry",
 				"Sunlight Sensitivity"
@@ -380,7 +382,7 @@
 			"page": 6,
 			"_copy": {
 				"name": "Derro",
-				"source": "MTF",
+				"source": "OotA",
 				"_mod": {
 					"*": {
 						"mode": "replaceTxt",
@@ -428,6 +430,7 @@
 				"darkvision 30 ft.",
 				"tremorsense 60 ft."
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Keen Senses",
 				"Tunneler"
@@ -1155,11 +1158,45 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				]
 			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"traitTags": [
+				"Fey Ancestry",
+				"Sunlight Sensitivity"
+			],
+			"spellcastingTags": [
+				"CC",
+				"I"
+			],
+			"hasToken": true
+		},
+		{
+			"name": "Drow Assassin",
+			"source": "OotA",
+			"page": 140,
+			"_copy": {
+				"name": "Assassin",
+				"source": "MM",
+				"_templates": [
+					{
+						"name": "Drow (Levitate)",
+						"source": "PHB"
+					}
+				]
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"tokenCredit": "SagaSketchBook",
+			"tokenCustom": true,
 			"traitTags": [
 				"Fey Ancestry",
 				"Sunlight Sensitivity"
@@ -1179,11 +1216,15 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				]
 			},
+			"alignment": [
+				"N",
+				"E"
+			],
 			"traitTags": [
 				"Fey Ancestry",
 				"Sunlight Sensitivity"
@@ -1202,11 +1243,15 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				]
 			},
+			"alignment": [
+				"N",
+				"E"
+			],
 			"traitTags": [
 				"Fey Ancestry",
 				"Sunlight Sensitivity"
@@ -1225,11 +1270,15 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				]
 			},
+			"alignment": [
+				"N",
+				"E"
+			],
 			"traitTags": [
 				"Fey Ancestry",
 				"Sunlight Sensitivity"
@@ -1248,11 +1297,15 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				]
 			},
+			"alignment": [
+				"N",
+				"E"
+			],
 			"traitTags": [
 				"Fey Ancestry",
 				"Sunlight Sensitivity"
@@ -1271,11 +1324,15 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				]
 			},
+			"alignment": [
+				"N",
+				"E"
+			],
 			"traitTags": [
 				"Fey Ancestry",
 				"Sunlight Sensitivity"
@@ -1294,11 +1351,15 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				]
 			},
+			"alignment": [
+				"N",
+				"E"
+			],
 			"traitTags": [
 				"Fey Ancestry",
 				"Keen Senses",
@@ -1384,11 +1445,15 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				]
 			},
+			"alignment": [
+				"N",
+				"E"
+			],
 			"traitTags": [
 				"Fey Ancestry",
 				"Sneak Attack",
@@ -1994,6 +2059,100 @@
 			"hasToken": true
 		},
 		{
+			"name": "Female Steeder",
+			"source": "OotA",
+			"page": 238,
+			"reprintedAs": [
+				"Female Steeder|MTF"
+			],
+			"size": [
+				"L"
+			],
+			"type": "beast",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 14,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 30,
+				"formula": "4d10 + 8"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": 30
+			},
+			"str": 15,
+			"dex": 16,
+			"con": 14,
+			"int": 2,
+			"wis": 10,
+			"cha": 3,
+			"skill": {
+				"stealth": "+7"
+			},
+			"senses": [
+				"darkvision 120 ft."
+			],
+			"passive": 10,
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Spider Climb",
+					"entries": [
+						"The steeder can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+					]
+				},
+				{
+					"name": "Leap",
+					"entries": [
+						"The steeder can expend all its movement on its turn to jump up to 90 feet vertically or horizontally, provided that its speed is at least 30 feet."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one creature. {@h}7 ({@damage 1d8 + 3}) piercing damage, and the target must make a {@dc 12} Constitution saving throw, taking 9 ({@damage 2d8}) acid damage on a failed save, or half as much damage on a successful one."
+					]
+				},
+				{
+					"name": "Sticky Leg (Recharges when the Steeder Has No Creatures Grappled)",
+					"entries": [
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one Medium or smaller creature. {@h}The target is stuck to the steeder's leg and {@condition grappled} until it escapes (escape {@dc 12})."
+					]
+				}
+			],
+			"traitTags": [
+				"Spider Climb"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"damageTags": [
+				"A",
+				"P"
+			],
+			"miscTags": [
+				"MW"
+			],
+			"conditionInflict": [
+				"grappled"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true
+		},
+		{
 			"name": "Fiendish Giant Spider",
 			"source": "OotA",
 			"page": 97,
@@ -2091,6 +2250,14 @@
 			"speed": {
 				"walk": 25
 			},
+			"languages": [
+				"Gnoll",
+				"Abyssal"
+			],
+			"languageTags": [
+				"AB",
+				"OTH"
+			],
 			"hasToken": true,
 			"hasFluffImages": true
 		},
@@ -2252,6 +2419,38 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Glyphic Shroomlight",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "OotA",
+			"page": 103,
+			"_copy": {
+				"name": "Acolyte",
+				"source": "MM",
+				"_templates": [
+					{
+						"name": "Deep Gnome",
+						"source": "DMG"
+					}
+				],
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the veteran",
+						"with": "Glyphic",
+						"flags": "i"
+					}
+				}
+			},
+			"tokenCredit": "Garcia",
+			"tokenCustom": true,
+			"spellcastingTags": [
+				"CC",
+				"I"
+			],
+			"hasToken": true
+		},
+		{
 			"name": "Grazilaxx",
 			"isNpc": true,
 			"isNamedCreature": true,
@@ -2319,7 +2518,8 @@
 				"tags": [
 					{
 						"tag": "human",
-						"prefix": "Damaran"
+						"prefix": "Damaran",
+						"prefixHidden": true
 					}
 				]
 			},
@@ -2420,7 +2620,7 @@
 				{
 					"name": "+1 Flail",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}7 ({@damage 1d8 + 3}) bludgeoning damage"
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}7 ({@damage 1d8 + 3}) bludgeoning damage."
 					]
 				}
 			],
@@ -2520,6 +2720,7 @@
 				"Undercommon",
 				"Common"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2897,7 +3098,8 @@
 				"wisdom"
 			],
 			"hasToken": true,
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Jade Giant Spider",
@@ -3038,7 +3240,7 @@
 						"items": {
 							"name": "Special Equipment",
 							"entries": [
-								"Khalessa owns a {@item hat of disguise}, which she uses to appear as a female drow while in the company of drow."
+								"Khalessa owns a {@item hat of disguise}, which she uses to appear as a female drow while in the company of drow, and she wears a {@item Piwafwi (Cloak of Elvenkind)|OotA|piwafwi}."
 							]
 						}
 					}
@@ -3046,6 +3248,11 @@
 			},
 			"alignment": [
 				"N"
+			],
+			"languages": [
+				"Common",
+				"Elvish",
+				"Undercommon"
 			],
 			"spellcasting": [
 				{
@@ -3077,14 +3284,8 @@
 			"source": "OotA",
 			"page": 134,
 			"_copy": {
-				"name": "Assassin",
-				"source": "MM",
-				"_templates": [
-					{
-						"name": "Drow",
-						"source": "PHB"
-					}
-				],
+				"name": "Drow Assassin",
+				"source": "OotA",
 				"_mod": {
 					"*": {
 						"mode": "replaceTxt",
@@ -3261,7 +3462,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of its turns, the spy can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of its turns, the spy can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -3344,39 +3545,33 @@
 									"style": "list-hang-notitle",
 									"items": [
 										{
-											"type": "item",
+											"type": "itemSub",
 											"name": "1. Charm Ray",
-											"style": "italic",
 											"entry": "The targeted creature must succeed on a {@dc 16} Wisdom saving throw or be {@condition charmed} by the beholder for 1 hour, or until the beholder harms the creature."
 										},
 										{
-											"type": "item",
+											"type": "itemSub",
 											"name": "2. Paralyzing Ray",
-											"style": "italic",
 											"entry": "The targeted creature must succeed on a {@dc 16} Constitution saving throw or be {@condition paralyzed} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 										},
 										{
-											"type": "item",
+											"type": "itemSub",
 											"name": "3. Fear Ray",
-											"style": "italic",
 											"entry": "The targeted creature must succeed on a {@dc 16} Wisdom saving throw or be {@condition frightened} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 										},
 										{
-											"type": "item",
+											"type": "itemSub",
 											"name": "4. Slowing Ray",
-											"style": "italic",
 											"entry": "The targeted creature must succeed on a {@dc 16} Dexterity saving throw. On a failed save, the target's speed is halved for 1 minute. In addition, the creature can't take reactions, and it can take either an action or a bonus action on its turn, not both. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 										},
 										{
-											"type": "item",
+											"type": "itemSub",
 											"name": "5. Enervation Ray",
-											"style": "italic",
 											"entry": "The targeted creature must make a {@dc 16} Constitution saving throw, taking 36 ({@damage 8d8}) necrotic damage on a failed save, or half as much damage on a successful one."
 										},
 										{
-											"type": "item",
+											"type": "itemSub",
 											"name": "6. Telekinetic Ray",
-											"style": "italic",
 											"entries": [
 												"If the target is a creature, it must succeed on a {@dc 16} Strength saving throw or the beholder moves it up to 30 feet in any direction. It is {@condition restrained} by the ray's telekinetic grip until the start of the beholder's next turn or until the beholder is {@condition incapacitated}.",
 												"If the target is an object weighing 300 pounds or less that isn't being worn or carried, it is moved up to 30 feet in any direction. The beholder can also exert fine control on objects with this ray, such as manipulating a simple tool or opening a door or a container."
@@ -3395,6 +3590,100 @@
 				"P"
 			],
 			"hasToken": true
+		},
+		{
+			"name": "Male Steeder",
+			"source": "OotA",
+			"page": 231,
+			"reprintedAs": [
+				"Male Steeder|MTF"
+			],
+			"size": [
+				"M"
+			],
+			"type": "beast",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 12,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 13,
+				"formula": "2d8 + 4"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": 30
+			},
+			"str": 15,
+			"dex": 12,
+			"con": 14,
+			"int": 2,
+			"wis": 10,
+			"cha": 3,
+			"skill": {
+				"stealth": "+5"
+			},
+			"senses": [
+				"darkvision 120 ft."
+			],
+			"passive": 10,
+			"cr": "1/4",
+			"trait": [
+				{
+					"name": "Spider Climb",
+					"entries": [
+						"The steeder can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+					]
+				},
+				{
+					"name": "Leap",
+					"entries": [
+						"The steeder can expend all its movement on its turn to jump up to 60 feet vertically or horizontally, provided that its speed is at least 30 feet."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 4} to hit, reach 5 ft., one creature. {@h}7 ({@damage 1d8 + 2}) piercing damage, and the target must make a {@dc 12} Constitution saving throw, taking 4 ({@damage 1d8}) acid damage on a failed save, or half as much damage on a successful one."
+					]
+				},
+				{
+					"name": "Sticky Leg (Recharges when the Steeder Has No Creatures Grappled)",
+					"entries": [
+						"{@atk mw} {@hit 4} to hit, reach 5 ft., one Small or Tiny creature. {@h}The target is stuck to the steeder's leg and {@condition grappled} until it escapes (escape {@dc 12})."
+					]
+				}
+			],
+			"traitTags": [
+				"Spider Climb"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"damageTags": [
+				"A",
+				"P"
+			],
+			"miscTags": [
+				"MW"
+			],
+			"conditionInflict": [
+				"grappled"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true
 		},
 		{
 			"name": "Mev Flintknapper",
@@ -3420,6 +3709,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"spellcastingTags": [
 				"CC",
 				"I"
@@ -3635,6 +3925,10 @@
 					}
 				}
 			},
+			"alignment": [
+				"N",
+				"E"
+			],
 			"spellcastingTags": [
 				"I"
 			],
@@ -3720,15 +4014,35 @@
 							]
 						}
 					},
-					"action": {
-						"mode": "appendArr",
-						"items": {
-							"name": "Throne Activation",
-							"entries": [
-								"While seated on her throne, Quenthel can use an action on her turn to cast {@spell disintegrate} (save {@dc 19}). A target that fails its saving throw takes {@damage 10d6 + 40} force damage. If this damage reduces the target to 0 hit points, it is disintegrated."
+					"action": [
+						{
+							"mode": "replaceArr",
+							"replace": "Multiattack",
+							"items": {
+								"name": "Multiattack",
+								"entries": [
+									"Quenthel makes three tentacle rod attacks."
+								]
+							}
+						},
+						{
+							"mode": "appendArr",
+							"items": [
+								{
+									"name": "Tentacle Rod",
+									"entries": [
+										"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}5 ({@damage 1d6 + 2}) piercing damage. If she hits a target with all three tentacles, it must make a {@dc 15} Constitution saving throw. On a failure, the creature's speed is halved, it has disadvantage on Dexterity saving throws, and it can't use reactions for 1 minute. Moreover, on each of its turns, it can take either an action or a bonus action, but not both. At the end of each of its turns, it can repeat the saving throw, ending the effect on itself on a success."
+									]
+								},
+								{
+									"name": "Throne Activation",
+									"entries": [
+										"While seated on her throne, Quenthel can use an action on her turn to cast {@spell disintegrate} (save {@dc 19}). A target that fails its saving throw takes {@damage 10d6 + 40} force damage. If this damage reduces the target to 0 hit points, it is disintegrated."
+									]
+								}
 							]
 						}
-					}
+					]
 				}
 			},
 			"ac": [
@@ -3780,66 +4094,161 @@
 					"name": "Spellcasting",
 					"type": "spellcasting",
 					"headerEntries": [
-						"Quenthel is a 20th-level spellcaster. Her spellcasting ability is Wisdom (save {@dc 20}, {@hit 12} to hit with spell attacks). The drow has the following cleric spells prepared:"
+						"Quenthel is a 20th-level spellcaster. Her spellcasting ability is Wisdom (save {@dc 20}, {@hit 12} to hit with spell attacks). Quenthel can cast any {@filter cleric spell up to 9th level|spells|level=0;1;2;3;4;5;6;7;8;9|class=cleric} at will."
 					],
 					"will": [
-						"Any {@filter cleric spell up to 9th level|spells|level=0;1;2;3;4;5;6;7;8;9|class=cleric}."
+						"aid",
+						"animate dead",
+						"antimagic field",
+						"astral projection",
+						"augury",
+						"aura of life",
+						"aura of purity",
+						"aura of vitality",
+						"bane",
+						"banishment",
+						"beacon of hope",
+						"bestow curse",
+						"blade barrier",
+						"bless",
+						"blindness/deafness",
+						"calm emotions",
+						"ceremony",
+						"clairvoyance",
+						"command",
+						"commune",
+						"conjure celestial",
+						"contagion",
+						"continual flame",
+						"control water",
+						"control weather",
+						"create food and water",
+						"create or destroy water",
+						"create undead",
+						"cure wounds",
+						"dawn",
+						"daylight",
+						"death ward",
+						"detect evil and good",
+						"detect magic",
+						"detect poison and disease",
+						"dispel evil and good",
+						"dispel magic",
+						"divination",
+						"divine word",
+						"earthquake",
+						"enhance ability",
+						"etherealness",
+						"feign death",
+						"find the path",
+						"find traps",
+						"fire storm",
+						"flame strike",
+						"forbiddance",
+						"freedom of movement",
+						"gate",
+						"geas",
+						"gentle repose",
+						"glyph of warding",
+						"greater restoration",
+						"guardian of faith",
+						"guidance",
+						"guiding bolt",
+						"hallow",
+						"harm",
+						"heal",
+						"healing word",
+						"heroes' feast",
+						"hold person",
+						"holy aura",
+						"holy weapon",
+						"inflict wounds",
+						"insect plague",
+						"legend lore",
+						"lesser restoration",
+						"life transference",
+						"light",
+						"locate creature",
+						"locate object",
+						"magic circle",
+						"mass cure wounds",
+						"mass heal",
+						"mass healing word",
+						"meld into stone",
+						"mending",
+						"planar ally",
+						"planar binding",
+						"plane shift",
+						"power word heal",
+						"prayer of healing",
+						"protection from energy",
+						"protection from evil and good",
+						"protection from poison",
+						"purify food and drink",
+						"raise dead",
+						"regenerate",
+						"remove curse",
+						"resistance",
+						"resurrection",
+						"revivify",
+						"sacred flame",
+						"sanctuary",
+						"scrying",
+						"sending",
+						"shield of faith",
+						"silence",
+						"spare the dying",
+						"speak with dead",
+						"spirit guardians",
+						"spirit shroud",
+						"spiritual weapon",
+						"stone shape",
+						"summon celestial",
+						"sunbeam",
+						"sunburst",
+						"symbol",
+						"temple of the gods",
+						"thaumaturgy",
+						"toll the dead",
+						"tongues",
+						"true resurrection",
+						"true seeing",
+						"warding bond",
+						"water walk",
+						"word of radiance",
+						"word of recall",
+						"zone of truth"
 					],
-					"spells": {
-						"0": {
-							"spells": [
-								"{@spell guidance}",
-								"{@spell poison spray}",
-								"{@spell resistance}",
-								"{@spell spare the dying}",
-								"{@spell thaumaturgy}"
-							]
-						},
-						"1": {
-							"slots": 4,
-							"spells": [
-								"{@spell animal friendship}",
-								"{@spell cure wounds}",
-								"{@spell detect poison and disease}",
-								"{@spell ray of sickness}"
-							]
-						},
-						"2": {
-							"slots": 3,
-							"spells": [
-								"{@spell lesser restoration}",
-								"{@spell protection from poison}",
-								"{@spell web}"
-							]
-						},
-						"3": {
-							"slots": 3,
-							"spells": [
-								"{@spell conjure animals} (2 giant spiders)",
-								"{@spell dispel magic}"
-							]
-						},
-						"4": {
-							"slots": 3,
-							"spells": [
-								"{@spell divination}",
-								"{@spell freedom of movement}"
-							]
-						},
-						"5": {
-							"slots": 2,
-							"spells": [
-								"{@spell insect plague}",
-								"{@spell mass cure wounds}"
-							]
-						}
-					},
-					"ability": "wis"
+					"ability": "wis",
+					"hidden": [
+						"will"
+					]
 				}
 			],
+			"tokenCustom": true,
+			"conditionInflictSpell": [
+				"blinded",
+				"charmed",
+				"deafened",
+				"exhaustion",
+				"frightened",
+				"grappled",
+				"incapacitated",
+				"invisible",
+				"paralyzed",
+				"petrified",
+				"poisoned",
+				"prone",
+				"restrained",
+				"stunned",
+				"unconscious"
+			],
 			"savingThrowForcedSpell": [
+				"charisma",
 				"constitution",
 				"dexterity",
+				"intelligence",
+				"strength",
 				"wisdom"
 			],
 			"hasToken": true
@@ -3870,6 +4279,57 @@
 				"Regeneration",
 				"Spider Climb"
 			],
+			"hasToken": true
+		},
+		{
+			"name": "Rihuud",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "OotA",
+			"page": 59,
+			"_copy": {
+				"name": "Stone Giant",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the giant",
+						"with": "Rihuud",
+						"flags": "i"
+					},
+					"trait": {
+						"mode": "appendArr",
+						"items": {
+							"name": "Two Heads",
+							"entries": [
+								"Rihuud has advantage on Wisdom ({@skill Perception}) checks and on saving throws against being {@condition blinded}, {@condition charmed}, {@condition deafened}, {@condition frightened}, {@condition stunned}, or knocked {@condition unconscious}."
+							]
+						}
+					},
+					"action": [
+						{
+							"mode": "replaceArr",
+							"replace": "Multiattack",
+							"items": {
+								"name": "Multiattack",
+								"entries": [
+									"Rihuud makes two unarmed strikes."
+								]
+							}
+						},
+						{
+							"mode": "replaceArr",
+							"replace": "Greatclub",
+							"items": {
+								"name": "Unarmed Strike",
+								"entries": [
+									"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}13 ({@damage 2d6 + 6}) bludgeoning damage."
+								]
+							}
+						}
+					]
+				}
+			},
 			"hasToken": true
 		},
 		{
@@ -4262,6 +4722,15 @@
 						"replace": "the goblin",
 						"with": "Spiderbait",
 						"flags": "i"
+					},
+					"trait": {
+						"mode": "appendArr",
+						"items": {
+							"name": "Thrill-Seeker",
+							"entries": [
+								"Spiderbait has advantage on checks made to avoid being {@status surprised}."
+							]
+						}
 					}
 				}
 			},
@@ -4311,6 +4780,10 @@
 					}
 				]
 			},
+			"tokenCustom": true,
+			"senseTags": [
+				"SD"
+			],
 			"spellcastingTags": [
 				"I"
 			],
@@ -4599,6 +5072,9 @@
 				"Terran",
 				"Undercommon"
 			],
+			"senseTags": [
+				"SD"
+			],
 			"hasToken": true,
 			"hasFluffImages": true
 		},
@@ -4705,6 +5181,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"greatclub|phb"
 			],
@@ -4769,8 +5246,29 @@
 				"Terran",
 				"Undercommon"
 			],
+			"senseTags": [
+				"SD"
+			],
 			"hasToken": true,
 			"hasFluffImages": true
+		},
+		{
+			"name": "Two-Headed Troll",
+			"source": "OotA",
+			"page": 211,
+			"_copy": {
+				"name": "Troll",
+				"source": "MM"
+			},
+			"bonus": [
+				{
+					"name": "Extra Bite",
+					"entries": [
+						"As part of its Multiattack routine, the troll can make a Bite attack."
+					]
+				}
+			],
+			"hasToken": true
 		},
 		{
 			"name": "Vampiric Ixitxachitl",
@@ -4850,7 +5348,8 @@
 				"constitution"
 			],
 			"hasToken": true,
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Vampiric Ixitxachitl Cleric",
@@ -4975,7 +5474,8 @@
 				"wisdom"
 			],
 			"hasToken": true,
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Veldyskar",
@@ -5016,6 +5516,7 @@
 					}
 				}
 			],
+			"tokenCustom": true,
 			"spellcastingTags": [
 				"I"
 			],
@@ -5130,7 +5631,7 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				],
@@ -5167,6 +5668,7 @@
 				"E"
 			],
 			"cr": "5",
+			"tokenCustom": true,
 			"traitTags": [
 				"Fey Ancestry",
 				"Sunlight Sensitivity"
@@ -5187,7 +5689,7 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				],
@@ -5245,7 +5747,7 @@
 			"page": 29,
 			"_copy": {
 				"name": "Derro Savant",
-				"source": "MTF",
+				"source": "OotA",
 				"_mod": {
 					"*": {
 						"mode": "replaceTxt",
@@ -5290,6 +5792,73 @@
 			"int": 18,
 			"hasToken": true,
 			"hasFluffImages": true
+		},
+		{
+			"name": "Yantha Coaxrock",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "OotA",
+			"page": 138,
+			"_copy": {
+				"name": "Deep Gnome (Svirfneblin)",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the gnome",
+						"with": "Yantha",
+						"flags": "i"
+					}
+				}
+			},
+			"int": 16,
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Yantha is a 5th-level spellcaster. Her spellcasting ability is Intelligence (spell save {@dc 13}). She has the following wizard spells prepared:"
+					],
+					"spells": {
+						"0": {
+							"spells": [
+								"{@spell dancing lights}",
+								"{@spell friends}",
+								"{@spell mending}",
+								"{@spell prestidigitation}"
+							]
+						},
+						"1": {
+							"slots": 4,
+							"spells": [
+								"{@spell comprehend languages}",
+								"{@spell detect magic}",
+								"{@spell Tenser's floating disk}"
+							]
+						},
+						"2": {
+							"slots": 3,
+							"spells": [
+								"{@spell detect thoughts}",
+								"{@spell hold person}"
+							]
+						},
+						"3": {
+							"slots": 2,
+							"spells": [
+								"{@spell sending}"
+							]
+						}
+					},
+					"ability": "int"
+				}
+			],
+			"tokenCredit": "Paizo",
+			"tokenCustom": true,
+			"spellcastingTags": [
+				"CW"
+			],
+			"hasToken": true
 		},
 		{
 			"name": "Yestabrod",
@@ -5442,7 +6011,7 @@
 				{
 					"name": "Petrifying Gaze",
 					"entries": [
-						"If a creature starts its turn within 15 feet of the basilisk and the two of them can see each other, the basilisk can force the creature to make a {@dc 12} Constitution saving throw if the basilisk isn't {@condition incapacitated}. On a failed save, the creature magically begins to turn to stone and is {@condition restrained}. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is {@condition petrified} until freed by the  {@spell greater restoration} spell or other magic.",
+						"If a creature starts its turn within 15 feet of the basilisk and the two of them can see each other, the basilisk can force the creature to make a {@dc 12} Constitution saving throw if the basilisk isn't {@condition incapacitated}. On a failed save, the creature magically begins to turn to stone and is {@condition restrained}. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is {@condition petrified} until freed by the {@spell greater restoration} spell or other magic.",
 						"A creature that isn't {@status surprised} can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the basilisk until the start of its next turn, when it can avert its eyes again. If it looks at the basilisk in the meantime, it must immediately make the save.",
 						"If the basilisk sees its reflection within 30 feet of it in bright light, it mistakes itself for a rival and targets itself with its gaze."
 					]
@@ -5523,6 +6092,15 @@
 						"replace": "the goblin",
 						"with": "Yuk Yuk",
 						"flags": "i"
+					},
+					"trait": {
+						"mode": "appendArr",
+						"items": {
+							"name": "Thrill-Seeker",
+							"entries": [
+								"Yuk Yuk has advantage on checks made to avoid being {@status surprised}."
+							]
+						}
 					}
 				}
 			},

--- a/json/bestiary/bestiary-oow.json
+++ b/json/bestiary/bestiary-oow.json
@@ -4,6 +4,11 @@
 			"monster": [
 				"MM"
 			]
+		},
+		"otherSources": {
+			"monster": {
+				"MM": "OoW"
+			}
 		}
 	},
 	"monster": [
@@ -113,6 +118,7 @@
 				"C",
 				"E"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"I",
@@ -123,8 +129,7 @@
 				"R"
 			],
 			"spellcastingTags": [
-				"CC",
-				"I"
+				"CC"
 			],
 			"hasToken": true
 		},
@@ -266,6 +271,7 @@
 			"languages": [
 				"Common"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C"
 			],
@@ -284,6 +290,7 @@
 				"poison",
 				"psychic"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -361,6 +368,7 @@
 				"Modron",
 				"can understand Common but speaks only preprogrammed responses"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"OTH"
@@ -397,6 +405,7 @@
 				"Modron",
 				"can understand Common but speaks only preprogrammed responses"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"OTH"
@@ -430,6 +439,7 @@
 				"Modron",
 				"can understand Common but speaks only preprogrammed responses"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"OTH"
@@ -466,6 +476,7 @@
 				"Modron",
 				"can understand Common but speaks only preprogrammed responses"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"OTH"
@@ -499,6 +510,7 @@
 				"Modron",
 				"can understand Common but speaks only preprogrammed responses"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"OTH"
@@ -532,6 +544,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"damageTags": [
 				"B"
 			],

--- a/json/bestiary/bestiary-pabtso.json
+++ b/json/bestiary/bestiary-pabtso.json
@@ -211,6 +211,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -267,6 +268,7 @@
 				"canHover": true
 			},
 			"cr": "12",
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -533,8 +535,12 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"battleaxe|phb"
+			],
+			"traitTags": [
+				"Sure-Footed"
 			],
 			"senseTags": [
 				"D"
@@ -1106,6 +1112,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1197,7 +1204,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The goblin takes the Disengage or Hide action."
+						"The goblin takes the {@action Disengage} or {@action Hide} action."
 					]
 				},
 				{
@@ -1354,7 +1361,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The goblin takes the Disengage or Hide action."
+						"The goblin takes the {@action Disengage} or {@action Hide} action."
 					]
 				}
 			],
@@ -2668,6 +2675,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -2878,6 +2886,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -3734,6 +3743,7 @@
 					"displayAs": "action"
 				}
 			],
+			"tokenCustom": true,
 			"spellcastingTags": [
 				"P"
 			],

--- a/json/bestiary/bestiary-phb.json
+++ b/json/bestiary/bestiary-phb.json
@@ -272,6 +272,9 @@
 			"name": "Animated Object (Tiny)",
 			"source": "PHB",
 			"page": 213,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Animated Object|XPHB"
 			],

--- a/json/bestiary/bestiary-pota.json
+++ b/json/bestiary/bestiary-pota.json
@@ -672,6 +672,7 @@
 				"formula": "1d8"
 			},
 			"action": null,
+			"tokenCustom": true,
 			"miscTags": [],
 			"hasToken": true
 		},
@@ -817,6 +818,7 @@
 					"human"
 				]
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1062,10 +1064,8 @@
 			"name": "Dark Tide Knight",
 			"source": "PotA",
 			"page": 205,
-			"otherSources": [
-				{
-					"source": "SLW"
-				}
+			"referenceSources": [
+				"SLW"
 			],
 			"size": [
 				"M"
@@ -1197,6 +1197,7 @@
 				]
 			},
 			"action": null,
+			"tokenCustom": true,
 			"miscTags": [],
 			"hasToken": true
 		},
@@ -1769,10 +1770,8 @@
 			"name": "Fathomer",
 			"source": "PotA",
 			"page": 207,
-			"otherSources": [
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS"
 			],
 			"size": [
 				"M"
@@ -2095,6 +2094,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"greatsword|phb"
 			],
@@ -3482,6 +3482,7 @@
 					"ability": "int"
 				}
 			],
+			"tokenCustom": true,
 			"damageTagsSpell": [
 				"F",
 				"O"
@@ -4700,6 +4701,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"maul|phb"
 			],
@@ -4922,6 +4924,7 @@
 					"ability": "int"
 				}
 			],
+			"tokenCustom": true,
 			"damageTagsLegendary": [],
 			"savingThrowForcedSpell": [
 				"charisma",
@@ -4961,6 +4964,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"warhammer|phb"
 			],
@@ -5534,6 +5538,7 @@
 				"CS"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"savingThrowForced": [

--- a/json/bestiary/bestiary-ps-i.json
+++ b/json/bestiary/bestiary-ps-i.json
@@ -230,6 +230,7 @@
 					]
 				}
 			},
+			"tokenCustom": true,
 			"damageTags": [
 				"F",
 				"P",
@@ -292,6 +293,7 @@
 				}
 			},
 			"cr": "11",
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -320,6 +322,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"damageTags": [
 				"B",
 				"N",
@@ -441,6 +444,7 @@
 				}
 			],
 			"traitTags": [
+				"Ethereal Sight",
 				"Incorporeal Movement"
 			],
 			"senseTags": [
@@ -562,6 +566,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -629,6 +634,7 @@
 					"ability": "wis"
 				}
 			],
+			"tokenCustom": true,
 			"damageTagsSpell": [
 				"F",
 				"T"
@@ -952,7 +958,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+						"The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point. If the vampire takes radiant damage or damage from {@item Holy Water (Flask)|PHB|holy water}, this trait doesn't function at the start of the vampire's next turn."
 					]
 				}
 			],

--- a/json/bestiary/bestiary-ps-x.json
+++ b/json/bestiary/bestiary-ps-x.json
@@ -119,6 +119,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -137,6 +138,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -178,6 +180,9 @@
 			],
 			"source": "PSX",
 			"page": 9,
+			"referenceSources": [
+				"XMtS"
+			],
 			"size": [
 				"M"
 			],
@@ -347,6 +352,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -997,6 +1003,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1007,6 +1014,9 @@
 			],
 			"source": "PSX",
 			"page": 30,
+			"referenceSources": [
+				"XMtS"
+			],
 			"size": [
 				"S"
 			],
@@ -1250,6 +1260,7 @@
 				"name": "Hadrosaurus",
 				"source": "VGM"
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1324,6 +1335,7 @@
 				"name": "Giant Frog",
 				"source": "MM"
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1342,6 +1354,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1360,6 +1373,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1378,6 +1392,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1418,6 +1433,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1653,6 +1669,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1671,6 +1688,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1752,6 +1770,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		}

--- a/json/bestiary/bestiary-ps-z.json
+++ b/json/bestiary/bestiary-ps-z.json
@@ -228,6 +228,7 @@
 				"name": "Stone Giant",
 				"source": "MM"
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -266,6 +267,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -509,6 +511,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -587,6 +590,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -606,6 +610,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -686,6 +691,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -713,6 +719,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"damageTagsLegendary": [],
 			"hasToken": true,
 			"hasFluffImages": true
@@ -822,7 +829,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kraken.mp3"
+				"path": "bestiary/kraken.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -846,6 +853,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH"
 			],
@@ -877,6 +885,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -896,6 +905,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -915,6 +925,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -952,6 +963,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -964,6 +976,7 @@
 				"name": "Boulderfoot Giant",
 				"source": "PSZ"
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -983,6 +996,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1007,6 +1021,7 @@
 				"name": "Gynosphinx",
 				"source": "MM"
 			},
+			"tokenCustom": true,
 			"damageTagsLegendary": [],
 			"hasToken": true,
 			"hasFluff": true,
@@ -1027,6 +1042,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -1084,6 +1100,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1102,6 +1119,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1120,6 +1138,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -1159,6 +1178,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluffImages": true
 		},
@@ -1177,6 +1197,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -1192,6 +1213,7 @@
 				"walk": 30,
 				"climb": 50
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -1204,6 +1226,7 @@
 				"name": "Wraith",
 				"source": "MM"
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -1223,6 +1246,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},

--- a/json/bestiary/bestiary-qftis.json
+++ b/json/bestiary/bestiary-qftis.json
@@ -920,19 +920,27 @@
 				{
 					"name": "Grenade Launcher {@recharge 5}",
 					"entries": [
-						"The robot fires a grenade at a point it can see within 120 feet of itself. The grenade explodes in a 20-foot-radius sphere centered on that point, creating one of the following effects (robot's choice):"
-					]
-				},
-				{
-					"name": "Concussion Grenade",
-					"entries": [
-						"Each creature in the sphere must make a {@dc 15} Dexterity saving throw, taking 21 ({@damage 6d6}) force damage on a failed save or half as much damage on a successful one."
-					]
-				},
-				{
-					"name": "Sleep Grenade",
-					"entries": [
-						"Each creature in the sphere must succeed on a {@dc 15} Constitution saving throw or have the {@condition unconscious} condition for 1 hour. The condition ends on a creature early if the creature takes damage or if another creature uses an action to shake it awake."
+						"The robot fires a grenade at a point it can see within 120 feet of itself. The grenade explodes in a 20-foot-radius sphere centered on that point, creating one of the following effects (robot's choice):",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Concussion Grenade",
+									"entries": [
+										"Each creature in the sphere must make a {@dc 15} Dexterity saving throw, taking 21 ({@damage 6d6}) force damage on a failed save or half as much damage on a successful one."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Sleep Grenade",
+									"entries": [
+										"Each creature in the sphere must succeed on a {@dc 15} Constitution saving throw or have the {@condition unconscious} condition for 1 hour. The condition ends on a creature early if the creature takes damage or if another creature uses an action to shake it awake."
+									]
+								}
+							]
+						}
 					]
 				}
 			],
@@ -940,7 +948,7 @@
 				{
 					"name": "Emergency Speed (2/Day)",
 					"entries": [
-						"The robot takes the Dash or Disengage action."
+						"The robot takes the {@action Dash} or {@action Disengage} action."
 					]
 				}
 			],
@@ -1503,7 +1511,6 @@
 			"damageTags": [
 				"N",
 				"P",
-				"R",
 				"S"
 			],
 			"miscTags": [
@@ -2258,7 +2265,7 @@
 				{
 					"name": "Cunning Trick",
 					"entries": [
-						"The leprechaun takes the Disengage or Hide action or makes a Dexterity ({@skill Sleight of Hand}) check."
+						"The leprechaun takes the {@action Disengage} or {@action Hide} action or makes a Dexterity ({@skill Sleight of Hand}) check."
 					]
 				}
 			],
@@ -3030,6 +3037,7 @@
 			],
 			"miscTags": [
 				"CUR",
+				"HPR",
 				"MW"
 			],
 			"conditionInflict": [
@@ -3147,7 +3155,7 @@
 					"name": "Communal Spellcasting (2/Day)",
 					"type": "spellcasting",
 					"headerEntries": [
-						"The pech works with three or more pechs to cast spells, requiring no spell components and using Wisdom as the spellcasting ability (save {@dc 12}). If at least three other pechs are within 30 feet of it, the pech can cast {@spell Wall of Stone} . If at least seven other pechs are within 30 feet of it, it can cast {@spell Greater Restoration} . Each other pech involved in casting the spell can't have the incapacitated condition and must have at least one use of Communal Spellcasting remaining, which it must immediately expend to participate (no action required)."
+						"The pech works with three or more pechs to cast spells, requiring no spell components and using Wisdom as the spellcasting ability (save {@dc 12}). If at least three other pechs are within 30 feet of it, the pech can cast {@spell Wall of Stone}. If at least seven other pechs are within 30 feet of it, it can cast {@spell Greater Restoration}. Each other pech involved in casting the spell can't have the incapacitated condition and must have at least one use of Communal Spellcasting remaining, which it must immediately expend to participate (no action required)."
 					],
 					"daily": {
 						"2": [
@@ -4356,7 +4364,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The vegepygmy takes the Disengage or Hide action."
+						"The vegepygmy takes the {@action Disengage} or {@action Hide} action."
 					]
 				}
 			],

--- a/json/bestiary/bestiary-rhw.json
+++ b/json/bestiary/bestiary-rhw.json
@@ -1,0 +1,10478 @@
+{
+	"_meta": {
+		"referenceSources": {
+			"monster": {
+				"XMM": "RHW"
+			}
+		}
+	},
+	"monster": [
+		{
+			"name": "Aberrant Death's Head",
+			"source": "RHW",
+			"page": 243,
+			"size": [
+				"T"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 24,
+				"formula": "7d4 + 7"
+			},
+			"speed": {
+				"walk": 5,
+				"fly": {
+					"number": 30,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 8,
+			"dex": 13,
+			"con": 12,
+			"int": 8,
+			"wis": 14,
+			"cha": 3,
+			"save": {
+				"int": "+1",
+				"wis": "+4"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 12,
+			"resist": [
+				"necrotic",
+				"psychic"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"poisoned"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Flyby",
+					"entries": [
+						"The death's head doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Brain-Rending Bite",
+					"entries": [
+						"{@atkr m} {@hit 3}, reach 5 ft. {@h}3 ({@damage 1d4 + 1}) Piercing damage plus 3 ({@damage 1d6}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the start of the death's head's next turn."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"swamp",
+				"urban"
+			],
+			"traitTags": [
+				"Flyby"
+			],
+			"senseTags": [
+				"D"
+			],
+			"damageTags": [
+				"P",
+				"Y"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Ankhtepot",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 88,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 202,
+				"formula": "27d8 + 81"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": {
+					"number": 30,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 18,
+			"dex": 10,
+			"con": 17,
+			"int": 15,
+			"wis": 20,
+			"cha": 16,
+			"save": {
+				"int": "+8",
+				"wis": "+11"
+			},
+			"skill": {
+				"history": "+8",
+				"perception": "+11",
+				"religion": "+8"
+			},
+			"senses": [
+				"Truesight 60 ft."
+			],
+			"passive": 21,
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"vulnerable": [
+				"fire"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"languages": [
+				"Celestial",
+				"Common",
+				"Draconic"
+			],
+			"cr": {
+				"cr": "17",
+				"xpLair": 20000
+			},
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Ankhtepot casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability (spell save {@dc 19}):"
+					],
+					"will": [
+						"{@spell Dispel Magic|XPHB}",
+						"{@spell Divination|XPHB}",
+						"{@spell Mage Hand|XPHB} (hand is {@condition Invisible|XPHB})",
+						"{@spell Power Word Stun|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Animate Dead|XPHB}",
+							"{@spell Sunburst|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Ankhtepot dies, he revives with all his {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Har'Akir."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Ankhtepot fails a saving throw, he can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Ankhtepot has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Ankhtepot makes four Negative Energy Burst attacks. He can replace one attack with a use of Spellcasting to cast {@spell Power Word Stun|XPHB}."
+					]
+				},
+				{
+					"name": "Negative Energy Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 11}, reach 5 ft. or range 60 ft. {@h}26 ({@damage 6d6 + 5}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Touch of Death {@recharge}",
+					"entries": [
+						"Ankhtepot touches one creature within 5 feet. If the creature has 80 {@variantrule Hit Points|XPHB} or fewer, it dies. Otherwise, it takes 52 ({@damage 8d12}) Necrotic damage."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Death Strike",
+					"entries": [
+						"Ankhtepot makes one Negative Energy Burst attack."
+					]
+				},
+				{
+					"name": "Hand of Fate",
+					"entries": [
+						"{@actSave str} {@dc 19}, one Large or smaller creature Ankhtepot can see within 60 feet. {@actSaveFail} 14 ({@damage 2d8 + 5}) Force damage, and the target is pushed or pulled up to 20 feet straight away or toward Ankhtepot. {@actSaveSuccess} Half damage only. {@actSaveSuccessOrFail} Ankhtepot can't take this action again until the start of his next turn."
+					]
+				},
+				{
+					"name": "Sands of Time",
+					"entries": [
+						"Ankhtepot teleports up to 60 feet to an unoccupied space he can see. {@actSave cha} {@dc 19}, each creature in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Ankhtepot at his destination space. {@actSaveFail} 11 ({@damage 2d10}) Necrotic damage, and the target magically ages 10 years. {@actSaveSuccess} Half damage only. {@actSaveSuccessOrFail} Ankhtepot can't take this action again until the start of his next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Ankhtepot",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CE",
+				"DR"
+			],
+			"damageTags": [
+				"N",
+				"O"
+			],
+			"damageTagsSpell": [
+				"R"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflictSpell": [
+				"blinded",
+				"stunned"
+			],
+			"savingThrowForced": [
+				"charisma",
+				"strength"
+			],
+			"savingThrowForcedSpell": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Azalin Rex",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 62,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "undead",
+				"tags": [
+					"wizard"
+				]
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				20
+			],
+			"hp": {
+				"average": 390,
+				"formula": "52d8 + 156"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 11,
+			"dex": 16,
+			"con": 16,
+			"int": 21,
+			"wis": 17,
+			"cha": 16,
+			"save": {
+				"dex": "+10",
+				"con": "+10",
+				"int": "+12",
+				"wis": "+10"
+			},
+			"skill": {
+				"arcana": "+19",
+				"history": "+12",
+				"insight": "+10",
+				"perception": "+10"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 20,
+			"resist": [
+				"cold",
+				"lightning"
+			],
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"languages": [
+				"all"
+			],
+			"cr": {
+				"cr": "23",
+				"xpLair": 62000
+			},
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Azalin casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 20}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Dispel Magic|XPHB}",
+						"{@spell Invisibility|XPHB}",
+						"{@spell Lightning Bolt|XPHB} (level 5 version)",
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Prestidigitation|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Animate Dead|XPHB}",
+							"{@spell Dimension Door|XPHB}",
+							"{@spell Modify Memory|XPHB}",
+							"{@spell Plane Shift|XPHB}",
+							"{@spell Scrying|XPHB}"
+						],
+						"1e": [
+							"{@spell Chain Lightning|XPHB}",
+							"{@spell Finger of Death|XPHB}",
+							"{@spell Power Word Kill|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				},
+				{
+					"name": "Siphon Spell",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Azalin casts {@spell Counterspell|XPHB} in response to the spell's trigger, using the same spellcasting ability as Spellcasting. If the target creature fails its saving throw against this {@spell Counterspell|XPHB}, Azalin steals knowledge of the triggering spell. For 1 hour or until Azalin takes this {@variantrule Reaction|XPHB} again, Azalin can cast that spell once, using the same spellcasting ability as Spellcasting."
+					],
+					"will": [
+						"{@spell Counterspell|XPHB}"
+					],
+					"ability": "int",
+					"displayAs": "reaction",
+					"hidden": [
+						"will"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Azalin dies and his spirit jar remains intact, he revives with all his {@variantrule Hit Points|XPHB} in {@dice 2d10} days in the unoccupied space nearest his spirit jar. If Azalin's spirit jar is destroyed, he instead revives in {@dice 4d10} days in Castle Avernus in Darkon."
+					]
+				},
+				{
+					"name": "Legendary Resistance (4/Day, or 5/Day in Domain)",
+					"entries": [
+						"If Azalin fails a saving throw, he can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Azalin makes three attacks, using Eldritch Burst or Paralyzing Touch in any combination."
+					]
+				},
+				{
+					"name": "Eldritch Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 12}, reach 5 ft. or range 120 ft. {@h}31 ({@damage 4d12 + 5}) Force damage."
+					]
+				},
+				{
+					"name": "Paralyzing Touch",
+					"entries": [
+						"{@atkr m} {@hit 12}, reach 5 ft. {@h}15 ({@damage 3d6 + 5}) Cold damage, and the target has the {@condition Paralyzed|XPHB} condition until the start of Azalin's next turn."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Eldritch Teleport",
+					"entries": [
+						"Azalin teleports up to 60 feet to an unoccupied space he can see and makes one Eldritch Burst or Paralyzing Touch attack."
+					]
+				},
+				{
+					"name": "Forbidden Knowledge",
+					"entries": [
+						"{@actSave int} {@dc 20}, up to three creatures Azalin can see within 60 feet. {@actSaveFail} 28 ({@damage 8d6}) Psychic damage, and the target has the {@condition Stunned|XPHB} condition until the end of Azalin's next turn. {@actSaveSuccess} Half damage only. {@actSaveSuccessOrFail} Azalin can't take this action again until the start of his next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Azalin Rex",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"XX"
+			],
+			"damageTags": [
+				"C",
+				"O",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"L",
+				"N",
+				"O",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"paralyzed",
+				"stunned"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"incapacitated",
+				"invisible"
+			],
+			"savingThrowForced": [
+				"intelligence"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"dexterity",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Bodytaker Plant",
+			"source": "RHW",
+			"page": 237,
+			"size": [
+				"H"
+			],
+			"type": "plant",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 138,
+				"formula": "12d12 + 60"
+			},
+			"speed": {
+				"walk": 10,
+				"climb": 10,
+				"swim": 10
+			},
+			"str": 18,
+			"dex": 8,
+			"con": 20,
+			"int": 14,
+			"wis": 14,
+			"cha": 18,
+			"senses": [
+				"Blindsight 120 ft."
+			],
+			"passive": 12,
+			"vulnerable": [
+				"poison"
+			],
+			"conditionImmune": [
+				"blinded",
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"prone"
+			],
+			"languages": [
+				"telepathy 120 ft."
+			],
+			"cr": "7",
+			"trait": [
+				{
+					"name": "Podling Link",
+					"entries": [
+						"The plant can see through and communicate telepathically with any of its podlings within 10 miles of it. When the plant dies, its podlings also die."
+					]
+				},
+				{
+					"name": "Rejuvenation",
+					"entries": [
+						"If the plant dies, it revives with all its {@variantrule Hit Points|XPHB} in {@dice 1d10} days. This trait doesn't function if the plant is reduced to 0 {@variantrule Hit Points|XPHB} by Poison damage or its remains are sprinkled with salt."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The plant makes three Vine attacks. It can replace one attack with a use of Entrapping Pod."
+					]
+				},
+				{
+					"name": "Vine",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 20 ft. {@h}17 ({@damage 3d8 + 4}) Slashing damage. If the target is a Large or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 14}) from one of four vines."
+					]
+				},
+				{
+					"name": "Entrapping Pod",
+					"entries": [
+						"{@actSave str} {@dc 15}, one Large or smaller creature the plant is grappling. {@actSaveFail} The target is pulled into the plant's space, is no longer {@condition Grappled|XPHB}, and is trapped in the plant's pod. While trapped, the target has the {@condition Blinded|XPHB} and {@condition Paralyzed|XPHB} conditions, and it has {@variantrule Cover|XPHB|Total Cover} against attacks and other effects outside the pod. After {@dice 2d4} hours, the trapped target dies, and if it was a Humanoid, a Bodytaker Podling resembling it emerges from the pod.",
+						"A creature outside the pod and within 5 feet of the plant can take an action to make a {@dc 14} Strength ({@skill Athletics|XPHB}) check. On a successful check, the target is removed from the pod, falls in a space within 5 feet of the plant, and has the {@condition Prone|XPHB} condition. If the plant dies, the trapped target is no longer {@condition Blinded|XPHB} or {@condition Paralyzed|XPHB} and can escape from the pod using 5 feet of movement, exiting {@condition Prone|XPHB}."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Transfer Harm",
+					"entries": [
+						"{@actTrigger} An attack roll hits the plant while a podling is within 5 feet of the plant. {@actResponse} The plant halves the damage it takes from that attack, and the podling takes the other half of the damage."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"grassland",
+				"hill",
+				"swamp"
+			],
+			"treasure": [
+				"any"
+			],
+			"traitTags": [
+				"Rejuvenation"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"TP"
+			],
+			"damageTags": [
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"blinded",
+				"grappled",
+				"paralyzed",
+				"prone"
+			],
+			"savingThrowForced": [
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Bodytaker Podling",
+			"source": "RHW",
+			"page": 236,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "plant",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 26,
+				"formula": "4d8 + 8"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 16,
+			"dex": 11,
+			"con": 14,
+			"int": 10,
+			"wis": 10,
+			"cha": 10,
+			"skill": {
+				"deception": "+4"
+			},
+			"senses": [
+				"Blindsight 30 ft."
+			],
+			"passive": 10,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Deep Speech plus one other language"
+			],
+			"cr": "1/2",
+			"trait": [
+				{
+					"name": "Semblance of Life",
+					"entries": [
+						"The podling is a physical copy of a creature digested by a Bodytaker Plant. The podling has {@variantrule Advantage|XPHB} on Charisma ({@skill Deception|XPHB}) checks made to pass as the digested creature. The podling melts into a slurry when it dies."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}6 ({@damage 1d6 + 3}) Bludgeoning damage."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"grassland",
+				"hill",
+				"swamp"
+			],
+			"treasure": [
+				"any"
+			],
+			"senseTags": [
+				"B"
+			],
+			"languageTags": [
+				"DS",
+				"X"
+			],
+			"damageTags": [
+				"B"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Boneless",
+			"source": "RHW",
+			"page": 238,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 22,
+				"formula": "4d8 + 4"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 15,
+			"dex": 14,
+			"con": 12,
+			"int": 1,
+			"wis": 10,
+			"cha": 1,
+			"skill": {
+				"stealth": "+4"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 10,
+			"resist": [
+				"bludgeoning"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common but can't speak"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Abduct",
+					"entries": [
+						"The boneless needn't spend extra movement to move a creature it is grappling."
+					]
+				},
+				{
+					"name": "Compression",
+					"entries": [
+						"The boneless can move through a space as narrow as 1 inch without expending extra movement to do so."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Smother",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}7 ({@damage 2d4 + 2}) Bludgeoning damage. If the target is a Medium or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 12}). Until the grapple ends, the target has the {@condition Blinded|XPHB} and {@condition Restrained|XPHB} conditions, is suffocating, and takes 7 ({@damage 2d4 + 2}) Bludgeoning damage at the start of each of the boneless's turns. The boneless can smother only one creature at a time. While grappling a target, the boneless can't take this action again."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Unraveling Flesh (1/Day)",
+					"entries": [
+						"{@actSave wis} {@dc 11}, each creature within 30 feet that can see the boneless. {@actSaveFail} The target has the {@condition Frightened|XPHB} condition. {@actSaveSuccessOrFail} The boneless moves up to its {@variantrule Speed|XPHB} without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks}."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"senseTags": [
+				"D"
+			],
+			"languageTags": [
+				"C",
+				"CS"
+			],
+			"damageTags": [
+				"B"
+			],
+			"miscTags": [
+				"AOE",
+				"MA"
+			],
+			"conditionInflict": [
+				"frightened",
+				"grappled"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Brain in a Jar",
+			"source": "RHW",
+			"page": 239,
+			"size": [
+				"S"
+			],
+			"type": "undead",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				11
+			],
+			"hp": {
+				"average": 55,
+				"formula": "10d6 + 20"
+			},
+			"speed": {
+				"walk": 5,
+				"fly": {
+					"number": 20,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 1,
+			"dex": 3,
+			"con": 15,
+			"int": 19,
+			"wis": 10,
+			"cha": 15,
+			"save": {
+				"int": "+6",
+				"cha": "+4"
+			},
+			"senses": [
+				"Blindsight 120 ft."
+			],
+			"passive": 10,
+			"conditionImmune": [
+				"exhaustion",
+				"paralyzed"
+			],
+			"languages": [
+				"telepathy 60 ft. understands Common plus three other languages but can't speak; telepathy 60 ft."
+			],
+			"cr": "3",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The brain casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 14}):"
+					],
+					"will": [
+						"{@spell Charm Person|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Mage Hand|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Compulsion|XPHB}",
+							"{@spell Hold Person|XPHB} (level 3 version)"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Detect Intelligence",
+					"entries": [
+						"The brain magically senses the location of any creature within 300 feet of itself that has an Intelligence score of 3 or higher, regardless of interposing barriers."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The brain has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The brain makes two Disrupting Burst attacks."
+					]
+				},
+				{
+					"name": "Disrupting Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 120 ft. {@h}11 ({@damage 2d6 + 4}) Psychic damage. The target can't take Reactions until the end of its next turn, and it has {@variantrule Disadvantage|XPHB} on saving throws to maintain {@status Concentration|XPHB} until the end of its next turn."
+					]
+				},
+				{
+					"name": "Mind Blast {@recharge 5}",
+					"entries": [
+						"{@actSave int} {@dc 14}, each creature in a 60-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 14 ({@damage 4d6}) Psychic damage, and the target has the {@condition Incapacitated|XPHB} condition until the end of the brain's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"TP"
+			],
+			"damageTags": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"incapacitated"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"paralyzed"
+			],
+			"savingThrowForced": [
+				"intelligence"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Carrion Stalker",
+			"source": "RHW",
+			"page": 240,
+			"size": [
+				"T"
+			],
+			"type": "aberration",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 55,
+				"formula": "10d4 + 30"
+			},
+			"speed": {
+				"walk": 30,
+				"burrow": 30
+			},
+			"str": 6,
+			"dex": 17,
+			"con": 16,
+			"int": 2,
+			"wis": 13,
+			"cha": 6,
+			"senses": [
+				"Tremorsense 60 ft."
+			],
+			"passive": 11,
+			"cr": "3",
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The carrion stalker makes two Tentacle attacks and one Stinger attack."
+					]
+				},
+				{
+					"name": "Tentacle",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}8 ({@damage 2d4 + 3}) Piercing damage, and the carrion stalker attaches to the target. While attached, the carrion stalker can't make Tentacle attacks against other targets.",
+						"The carrion stalker can detach itself by spending 5 feet of movement. The target or a creature within 5 feet of it can detach the carrion stalker as an action."
+					]
+				},
+				{
+					"name": "Stinger",
+					"entries": [
+						"{@atkr m} {@hit 5} (with {@variantrule Advantage|XPHB} if the carrion stalker is attached to the target), reach 5 ft. {@h}7 ({@damage 2d6}) Poison damage, and the target is subjected to the following effect. {@actSave con} {@dc 13}. {@actSaveFail} The target has the {@condition Poisoned|XPHB} condition. While {@condition Poisoned|XPHB} in this way, the target is infested with a carrion stalker larva. If the target is still {@condition Poisoned|XPHB} in this way after 24 hours, the effect ends as the larva becomes a fully grown Carrion Stalker, which bursts from the target's chest and kills it."
+					]
+				}
+			],
+			"environment": [
+				"swamp",
+				"underdark",
+				"urban"
+			],
+			"senseTags": [
+				"T"
+			],
+			"actionTags": [
+				"Multiattack",
+				"Tentacles"
+			],
+			"damageTags": [
+				"I",
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Carrionette",
+			"source": "RHW",
+			"page": 241,
+			"size": [
+				"T"
+			],
+			"type": "construct",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 17,
+				"formula": "5d4 + 5"
+			},
+			"speed": {
+				"walk": 25
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 8,
+			"dex": 15,
+			"con": 12,
+			"int": 8,
+			"wis": 14,
+			"cha": 14,
+			"skill": {
+				"stealth": "+6"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 12,
+			"resist": [
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"Common plus one other language"
+			],
+			"cr": "1",
+			"action": [
+				{
+					"name": "Silver Needle",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}1 Piercing damage plus 3 ({@damage 1d6}) Necrotic damage. If the target is a Humanoid not cursed by a carrionette, it is subjected to the following effect. {@actSave cha} {@dc 11}. {@actSaveFail} The target is cursed for 1 minute. Until the curse ends, the target has the {@condition Poisoned|XPHB} condition, and its {@variantrule Speed|XPHB} is reduced by 10 feet."
+					]
+				},
+				{
+					"name": "Soul Swap {@recharge 5}",
+					"entries": [
+						"{@actSave cha} {@dc 11}, one Humanoid the carrionette can see within 15 feet that is cursed by its Silver Needle. {@actSaveFail} The carrionette possesses the target's body, and the target possesses the carrionette's body and has the {@condition Unconscious|XPHB} condition for 1 hour. While possessing another body, the carrionette and target retain their alignments; personalities; Intelligence, Wisdom, and Charisma scores; and languages known. They otherwise adopt the other creature's game statistics, though the target can't use this Soul Swap action.",
+						"The possession is undone if the target (while in the carrionette's body) deals damage to the carrionette (in the target's original body) with its Silver Needle. If either body is destroyed, both the carrionette and the target die."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"treasure": [
+				"implements"
+			],
+			"senseTags": [
+				"D"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"N",
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"poisoned",
+				"unconscious"
+			],
+			"savingThrowForced": [
+				"charisma"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Chakuna",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 174,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "monstrosity",
+				"tags": [
+					"lycanthrope"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 210,
+				"formula": "28d8 + 84"
+			},
+			"speed": {
+				"walk": 30,
+				"alternate": {
+					"walk": [
+						{
+							"number": 50,
+							"condition": "(panther form only)"
+						}
+					]
+				},
+				"climb": {
+					"number": 40,
+					"condition": "(panther form only)"
+				}
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 17,
+			"dex": 18,
+			"con": 16,
+			"int": 10,
+			"wis": 15,
+			"cha": 11,
+			"save": {
+				"con": "+7",
+				"wis": "+6"
+			},
+			"skill": {
+				"perception": "+10",
+				"stealth": "+12"
+			},
+			"senses": [
+				"Darkvision 150 ft."
+			],
+			"passive": 20,
+			"languages": [
+				"Common (can't speak in panther form)"
+			],
+			"cr": {
+				"cr": "11",
+				"xpLair": 8400
+			},
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Chakuna dies and her heart remains intact, she revives with all her {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Valachan. Chakuna's heart is a Tiny object that has AC 17, HP 10, and {@variantrule Immunity|XPHB} to all damage except Fire."
+					]
+				},
+				{
+					"name": "Experienced Hunter",
+					"entries": [
+						"{@variantrule Difficult Terrain|XPHB} composed of undergrowth doesn't cost Chakuna extra movement."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Chakuna fails a saving throw, she can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Chakuna makes three attacks, using Scratch or Barbed Spear in any combination. She can replace one attack with a Bite attack."
+					]
+				},
+				{
+					"name": "Bite (Panther or Hybrid Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}20 ({@damage 3d10 + 4}) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. {@actSave con} {@dc 15}. {@actSaveFail} The target is cursed. If the cursed target drops to 0 {@variantrule Hit Points|XPHB}, it instead becomes a werepanther under the DM's control and has 10 {@variantrule Hit Points|XPHB} (use the Weretiger stat block). {@actSaveSuccess} The target is immune to Chakuna's curse for 24 hours."
+					]
+				},
+				{
+					"name": "Scratch",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}13 ({@damage 2d8 + 4}) Slashing damage."
+					]
+				},
+				{
+					"name": "Barbed Spear (Humanoid or Hybrid Form Only)",
+					"entries": [
+						"{@atkr m,r} {@hit 8}, reach 5 ft. or range 30/120 ft. {@h}8 ({@damage 1d8 + 4}) Piercing damage and the target receives a dire wound if it doesn't have one. While the target is wounded, its speed is reduced by 10 feet, and it loses 5 ({@dice 1d10}) {@variantrule Hit Points|XPHB} at the start of each of its turns. The wound closes after 1 minute, after a spell restores {@variantrule Hit Points|XPHB} to the target, or after the target or a creature within 5 feet of it takes an action to staunch the wound, doing so by succeeding on a {@dc 15} Wisdom ({@skill Medicine|XPHB}) check. {@hom}The spear magically returns to Chakuna's hand immediately after a ranged attack."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Prowl (Panther or Hybrid Form Only)",
+					"entries": [
+						"Chakuna moves up to her {@variantrule Speed|XPHB} without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks}. At the end of this movement, she can take the {@action Hide|XPHB} action."
+					]
+				},
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"Chakuna shape-shifts into a Large panther-humanoid hybrid or a Large panther, or she returns to her true humanoid form. Her game statistics, other than her size, are the same in each form. Any equipment she is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Pounce",
+					"entries": [
+						"Chakuna moves up to half her {@variantrule Speed|XPHB} and makes one Scratch attack."
+					]
+				},
+				{
+					"name": "Strike from Shadows",
+					"entries": [
+						"Chakuna makes one Barbed Spear attack. If Chakuna has the {@action Hide|XPHB} action's {@condition Invisible|XPHB} condition, this attack doesn't end that condition. Chakuna can't take this action again until the start of her next turn."
+					]
+				},
+				{
+					"name": "Sudden Bite",
+					"entries": [
+						"Chakuna uses Shape-Shift to turn into her hybrid form or panther form and then makes one Bite attack. Chakuna can't take this action again until the start of her next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Chakuna",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"CUR",
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Cthulhu",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 106,
+			"size": [
+				"G"
+			],
+			"type": "aberration",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				19
+			],
+			"hp": {
+				"average": 385,
+				"formula": "22d20 + 154"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": 30,
+				"swim": 60
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 29,
+			"dex": 12,
+			"con": 25,
+			"int": 28,
+			"wis": 18,
+			"cha": 24,
+			"save": {
+				"con": "+15",
+				"wis": "+12",
+				"cha": "+15"
+			},
+			"skill": {
+				"insight": "+12",
+				"perception": "+12",
+				"persuasion": "+15"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 22,
+			"resist": [
+				"acid",
+				"cold",
+				"lightning",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"languages": [
+				"all; telepathy 120 ft."
+			],
+			"cr": {
+				"cr": "25",
+				"xpLair": 90000
+			},
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Cthulhu casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 25}):"
+					],
+					"will": [
+						"{@spell Mind Spike|XPHB} (level 4 version)"
+					],
+					"daily": {
+						"3e": [
+							"{@spell Dream|XPHB}",
+							"{@spell Geas|XPHB} (can target creatures through dreams)"
+						],
+						"1e": [
+							"{@spell Befuddlement|XPHB}",
+							"{@spell Plane Shift|XPHB} (self only)"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"Cthulhu can breathe air and water."
+					]
+				},
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Cthulhu dies, it revives with all its {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks inside the Vault of Cthulhu."
+					]
+				},
+				{
+					"name": "Impossible Geometry",
+					"entries": [
+						"Ground, air, and water in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Cthulhu is {@variantrule Difficult Terrain|XPHB}. A creature that starts its turn in the {@variantrule Emanation [Area of Effect]|XPHB|Emanation} takes 7 ({@damage 2d6}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Legendary Resistance (4/Day, or 5/Day in Domain)",
+					"entries": [
+						"If Cthulhu fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Cthulhu has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Cthulhu makes three Eldritch Claw attacks and uses Spellcasting to cast {@spell Befuddlement|XPHB} if available or {@spell Mind Spike|XPHB} (level 4 version). It can replace one Eldritch Claw attack with a use of Tentacle."
+					]
+				},
+				{
+					"name": "Eldritch Claw",
+					"entries": [
+						"{@atkr m} {@hit 17}, reach 10 ft. {@h}18 ({@damage 2d8 + 9}) Slashing damage plus 9 ({@damage 2d8}) Acid damage. If the target is a Large or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 19}) from one of two limbs."
+					]
+				},
+				{
+					"name": "Tentacle",
+					"entries": [
+						"{@actSave con} {@dc 25}, one creature {@condition Grappled|XPHB} by Cthulhu. {@actSaveFail} 21 ({@damage 6d6}) Acid damage plus 13 ({@damage 3d8}) Psychic damage. {@actSaveSuccess} Half damage. {@actSaveSuccessOrFail} The target's {@variantrule Hit Points|XPHB|Hit Point} maximum decreases by an amount equal to the Psychic damage taken, and Cthulhu regains {@variantrule Hit Points|XPHB} equal to that amount."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Warp",
+					"entries": [
+						"Cthulhu teleports to an unoccupied space it can see within 120 feet, taking creatures it is grappling with it. Then each creature within 10 feet of the space it left is subjected to the following effect. {@actSave str} {@dc 25}. {@actSaveFail} 7 ({@damage 2d6}) Bludgeoning damage plus 7 ({@damage 2d6}) Thunder damage, and if the target is a Large or smaller creature, it has the {@condition Prone|XPHB} condition. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Clamp",
+					"entries": [
+						"Cthulhu makes an Eldritch Claw attack."
+					]
+				},
+				{
+					"name": "Fold Space",
+					"entries": [
+						"{@actSave cha} {@dc 25}, each creature and object that isn't being worn or carried in a 10-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point Cthulhu can see within 60 feet. {@actSaveFail} 36 ({@damage 8d8}) Force damage, and the target is teleported to an unoccupied space within 60 feet of Cthulhu that is horizontal to it. {@actSaveSuccess} Half damage only. {@actSaveSuccessOrFail} Cthulhu can't take this action again until the start of its next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Cthulhu",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Amphibious",
+				"Legendary Resistances",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack",
+				"Tentacles"
+			],
+			"languageTags": [
+				"TP",
+				"XX"
+			],
+			"damageTags": [
+				"A",
+				"B",
+				"O",
+				"S",
+				"T",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"HPR",
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"grappled",
+				"prone"
+			],
+			"conditionInflictSpell": [
+				"charmed"
+			],
+			"savingThrowForced": [
+				"charisma",
+				"constitution",
+				"strength"
+			],
+			"savingThrowForcedSpell": [
+				"intelligence",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Death's Head",
+			"source": "RHW",
+			"page": 242,
+			"size": [
+				"T"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 17,
+				"formula": "5d4 + 5"
+			},
+			"speed": {
+				"walk": 5,
+				"fly": {
+					"number": 30,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 8,
+			"dex": 13,
+			"con": 12,
+			"int": 5,
+			"wis": 14,
+			"cha": 3,
+			"passive": 12,
+			"resist": [
+				"necrotic"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"poisoned"
+			],
+			"cr": "1/2",
+			"trait": [
+				{
+					"name": "Flyby",
+					"entries": [
+						"The death's head doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 3}, reach 5 ft. {@h}3 ({@damage 1d4 + 1}) Piercing damage plus 7 ({@damage 2d6}) Necrotic damage."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"swamp",
+				"urban"
+			],
+			"traitTags": [
+				"Flyby"
+			],
+			"damageTags": [
+				"N",
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Death's Head Tree",
+			"source": "RHW",
+			"page": 243,
+			"size": [
+				"H"
+			],
+			"type": "plant",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 95,
+				"formula": "10d12 + 30"
+			},
+			"speed": {
+				"walk": 20
+			},
+			"str": 18,
+			"dex": 8,
+			"con": 16,
+			"int": 5,
+			"wis": 10,
+			"cha": 13,
+			"save": {
+				"str": "+6"
+			},
+			"senses": [
+				"Blindsight 120 ft."
+			],
+			"passive": 10,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"poisoned"
+			],
+			"cr": "4",
+			"trait": [
+				{
+					"name": "Overhanging Branches",
+					"entries": [
+						"The tree's allies can willingly end their moves in the tree's space. Allies in the tree's space have {@variantrule Cover|XPHB|Half Cover}."
+					]
+				},
+				{
+					"name": "Unholy Regrowth",
+					"entries": [
+						"If the tree dies, {@dice 2d6} Death's Head Trees regrow around the same place in 365 days unless the tree is killed by a creature under the effect of a {@spell Bless|XPHB} spell using a weapon that deals Slashing damage."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The tree makes two Slam attacks."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 10 ft. {@h}15 ({@damage 2d10 + 4}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Exploding Head",
+					"entries": [
+						"{@actSave dex} {@dc 14}, each creature in a 10-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point the tree can see within 120 feet. {@actSaveFail} 10 ({@damage 3d6}) Necrotic damage, and the creature has the {@condition Poisoned|XPHB} condition until the start of the tree's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Head Fruits",
+					"entries": [
+						"Each Undead ally in the tree's space can immediately take a {@variantrule Reaction|XPHB} to gain 5 {@variantrule Temporary Hit Points|XPHB}."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"swamp",
+				"urban"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"damageTags": [
+				"B",
+				"N"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Dullahan",
+			"source": "RHW",
+			"page": 244,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 127,
+				"formula": "17d8 + 51"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 18,
+			"dex": 14,
+			"con": 16,
+			"int": 11,
+			"wis": 15,
+			"cha": 16,
+			"save": {
+				"con": "+7"
+			},
+			"skill": {
+				"perception": "+6"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 16,
+			"resist": [
+				"cold",
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"blinded",
+				"charmed",
+				"deafened",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common plus one other language but can't speak"
+			],
+			"cr": "10",
+			"trait": [
+				{
+					"name": "Mounted Adept",
+					"entries": [
+						"While mounted and without the {@condition Incapacitated|XPHB} condition, the dullahan and its mount have {@variantrule Advantage|XPHB} on Dexterity saving throws, and the dullahan can force an attack targeted at its mount to target the dullahan instead."
+					]
+				},
+				{
+					"name": "Terrorizer",
+					"entries": [
+						"The dullahan has {@variantrule Advantage|XPHB} on attack rolls against targets that have the {@condition Frightened|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The dullahan makes two attacks, using Beheading Blade or Fiery Skull in any combination, and uses Headless Wail."
+					]
+				},
+				{
+					"name": "Beheading Blade",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}9 ({@damage 1d10 + 4}) Slashing damage plus 11 ({@damage 2d10}) Necrotic damage. If the target is reduced to 0 {@variantrule Hit Points|XPHB} by this attack, it dies and its head is lopped off. The head rises as a Death's Head in the space of the target's corpse or in the nearest unoccupied space. The head is under the dullahan's control. The dullahan can control no more than seven heads at a time."
+					]
+				},
+				{
+					"name": "Fiery Skull",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 120 ft. {@h}18 ({@damage 4d8}) Fire damage."
+					]
+				},
+				{
+					"name": "Headless Wail",
+					"entries": [
+						"{@actSave con} {@dc 15}, up to three creatures within 120 feet of the dullahan that aren't Constructs or Undead. {@actSaveFail} 13 ({@damage 2d12}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the start of the dullahan's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"environment": [
+				"grassland",
+				"hill",
+				"urban"
+			],
+			"treasure": [
+				"armaments"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"X"
+			],
+			"damageTags": [
+				"F",
+				"N",
+				"S",
+				"Y"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Ebonbane",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 150,
+			"size": [
+				"S"
+			],
+			"type": "construct",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 130,
+				"formula": "29d6 + 29"
+			},
+			"speed": {
+				"walk": 5,
+				"fly": {
+					"number": 50,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 18,
+			"dex": 18,
+			"con": 13,
+			"int": 17,
+			"wis": 14,
+			"cha": 19,
+			"save": {
+				"con": "+6",
+				"wis": "+7"
+			},
+			"skill": {
+				"arcana": "+8",
+				"history": "+8",
+				"perception": "+7"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 17,
+			"resist": [
+				"bludgeoning",
+				"fire",
+				"piercing",
+				"psychic",
+				"slashing"
+			],
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"deafened",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"Common; telepathy 10 ft."
+			],
+			"cr": {
+				"cr": "13",
+				"xpLair": 11500
+			},
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Ebonbane dies, it revives with all its {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks, teleporting somewhere in Shadowborn Manor. Until it revives, Ebonbane acts as a +3 Longsword when wielded by a creature."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Ebonbane fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Ebonbane has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Ebonbane makes three Darkflame Slash attacks. It can replace one of these attacks with a use of Possess {@variantrule Dead|XPHB} if available."
+					]
+				},
+				{
+					"name": "Darkflame Slash",
+					"entries": [
+						"{@atkr m,r} {@hit 9}, reach 5 ft. or range 90 ft. {@h}9 ({@damage 1d10 + 4}) Slashing damage plus 10 ({@damage 3d6}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Possess Dead {@recharge 5}",
+					"entries": [
+						"Ebonbane raises a Medium or Small Humanoid corpse within 5 feet of itself and possesses it. The corpse wields Ebonbane and is under its control. Ebonbane gains 50 {@variantrule Temporary Hit Points|XPHB}, and its statistics are the same, except its {@variantrule Speed|XPHB} increases to 30 feet, and it can speak through the corpse using any language the corpse knew in life.",
+						"The possession lasts until Ebonbane drops to 0 {@variantrule Hit Points|XPHB} or Ebonbane ends the possession as a {@variantrule Bonus Action|XPHB}. Once the possession ends, Ebonbane can't possess the corpse again. The corpse crumbles to dust 24 hours after the possession ends."
+					]
+				},
+				{
+					"name": "Worthy Wielder",
+					"entries": [
+						"{@actSave cha} {@dc 17}, one willing Humanoid within 5 feet. {@actSaveFail} 36 ({@damage 8d8}) Force damage. If this damage reduces the target to 0 {@variantrule Hit Points|XPHB}, Ebonbane devours its soul. A creature whose soul has been devoured by Ebonbane can be restored to life only by a {@spell Wish|XPHB} spell. {@actSaveSuccess} The target attunes to Ebonbane and can wield the sword."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Parry",
+					"entries": [
+						"{@actTrigger} Ebonbane is hit by a melee attack roll. {@actResponse} Ebonbane adds 5 to its AC against that attack, possibly causing it to miss."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Retaliate",
+					"entries": [
+						"Ebonbane moves up to half its {@variantrule Speed|XPHB} and makes one Darkflame Slash attack."
+					]
+				},
+				{
+					"name": "Runic Flare",
+					"entries": [
+						"{@actSave con} {@dc 17}, each creature of Ebonbane's choice in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Ebonbane. {@actSaveFail} The target has the {@condition Blinded|XPHB} condition and repeats the save at the end of each of its turns. The target succeeds automatically after 1 minute. {@actSaveSuccessOrFail} Ebonbane can't take this action again until the start of its next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Ebonbane",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack",
+				"Parry"
+			],
+			"languageTags": [
+				"C",
+				"TP"
+			],
+			"damageTags": [
+				"N",
+				"O",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"blinded"
+			],
+			"savingThrowForced": [
+				"charisma",
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Elder Thing",
+			"source": "RHW",
+			"page": 245,
+			"size": [
+				"L"
+			],
+			"type": "aberration",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 209,
+				"formula": "22d10 + 88"
+			},
+			"speed": {
+				"walk": 20,
+				"fly": {
+					"number": 90,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 21,
+			"dex": 11,
+			"con": 18,
+			"int": 20,
+			"wis": 17,
+			"cha": 16,
+			"save": {
+				"con": "+9",
+				"int": "+10"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 13,
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"psychic",
+				"slashing"
+			],
+			"immune": [
+				"lightning"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Deep Speech; telepathy 120 ft."
+			],
+			"cr": "14",
+			"spellcasting": [
+				{
+					"name": "Eldritch Magic (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The elder thing casts {@spell Command|XPHB}, {@spell Detect Thoughts|XPHB}, {@spell Gust of Wind|XPHB}, or {@spell Nondetection|XPHB}, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 18})."
+					],
+					"daily": {
+						"3": [
+							"{@spell Command|XPHB}",
+							"{@spell Detect Thoughts|XPHB}",
+							"{@spell Gust of Wind|XPHB}",
+							"{@spell Nondetection|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The elder thing has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The elder thing makes two Soothing Tentacle attacks and uses Psychic Skewer."
+					]
+				},
+				{
+					"name": "Soothing Tentacle",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 10 ft. {@h}14 ({@damage 2d8 + 5}) Psychic damage, and the target has the {@condition Charmed|XPHB} condition until the start of the elder thing's next turn."
+					]
+				},
+				{
+					"name": "Mind-Scouring Spores {@recharge}",
+					"entries": [
+						"{@actSave int} {@dc 18}, each creature in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the elder thing. {@actSaveFail} 55 ({@damage 10d10}) Psychic damage. For 1 minute, whenever the target takes the {@action Magic|XPHB} action, it takes 10 ({@damage 3d6}) Psychic damage. {@actSaveSuccess} Half damage only."
+					]
+				},
+				{
+					"name": "Psychic Skewer",
+					"entries": [
+						"{@actSave wis} {@dc 18}, one creature within 60 feet. {@actSaveFail} 22 ({@damage 4d10}) Psychic damage. If the target has the {@condition Charmed|XPHB} condition, it gains 1 {@condition Exhaustion|XPHB} level and has the {@condition Stunned|XPHB} condition while {@condition Charmed|XPHB}."
+					]
+				}
+			],
+			"environment": [
+				"mountain",
+				"underdark"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"DS",
+				"TP"
+			],
+			"damageTags": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"charmed",
+				"stunned"
+			],
+			"conditionInflictSpell": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"intelligence",
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"strength",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Ez d'Avenir",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 246,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"C",
+				"G"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 120,
+				"formula": "16d8 + 48"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 14,
+			"dex": 19,
+			"con": 16,
+			"int": 18,
+			"wis": 11,
+			"cha": 17,
+			"save": {
+				"dex": "+7",
+				"wis": "+3"
+			},
+			"skill": {
+				"acrobatics": "+7",
+				"deception": "+6",
+				"perception": "+3",
+				"stealth": "+7",
+				"survival": "+3"
+			},
+			"passive": 13,
+			"languages": [
+				"Common",
+				"Elvish"
+			],
+			"cr": "8",
+			"gear": [
+				"light crossbow|xphb",
+				"rapier|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Ez casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save {@dc 15}):"
+					],
+					"will": [
+						"{@spell Light|XPHB}",
+						"{@spell Mage Hand|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Dispel Evil and Good|XPHB}",
+							"{@spell Lightning Bolt|XPHB}",
+							"{@spell Magic Circle|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				},
+				{
+					"name": "Shield (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Ez casts {@spell Shield|XPHB} in response to that spell's trigger, using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"3": [
+							"{@spell Shield|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "reaction",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Ez makes three attacks, using Hunter's Blade or Fiery Bolt in any combination."
+					]
+				},
+				{
+					"name": "Hunter's Blade",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Piercing damage plus 11 ({@damage 2d10}) Radiant damage."
+					]
+				},
+				{
+					"name": "Fiery Bolt",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 120 ft. {@h}19 ({@damage 3d10 + 3}) Fire damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Bolster Allies",
+					"entries": [
+						"Ez chooses up to six allies within 60 feet. Each target that can hear her has Ez's choice of (A) {@variantrule Advantage|XPHB} on the next attack roll it makes before the end of its next turn or (B) {@variantrule Resistance|XPHB} to Acid, Necrotic, and Poison damage until the end of its next turn."
+					]
+				},
+				{
+					"name": "Curse of the All-Seeing Eye (1/Day)",
+					"entries": [
+						"Ez chooses a damage type. {@actSave wis} {@dc 15}, one target within 30 feet that Ez can see. {@actSaveFail} The target is cursed. Until the curse ends, the target has {@variantrule Vulnerability|XPHB} to the chosen damage type. The curse ends early if Ez uses this action again.",
+						"If the target drops to 0 {@variantrule Hit Points|XPHB} before the curse ends, Ez can take a {@variantrule Bonus Action|XPHB} on a later turn to curse a new creature."
+					]
+				},
+				{
+					"name": "Inspiring Rally",
+					"entries": [
+						"Ez chooses up to six allies within 60 feet. Each target that can hear her can take a {@variantrule Reaction|XPHB} to move up to its {@variantrule Speed|XPHB} without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks}."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"E"
+			],
+			"damageTags": [
+				"F",
+				"P",
+				"R"
+			],
+			"damageTagsSpell": [
+				"L"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"CUR",
+				"MA",
+				"RA"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"charisma",
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Gallows Speaker",
+			"source": "RHW",
+			"page": 248,
+			"size": [
+				"H"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 75,
+				"formula": "10d12 + 10"
+			},
+			"speed": {
+				"walk": 5,
+				"fly": {
+					"number": 40,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 9,
+			"dex": 16,
+			"con": 12,
+			"int": 10,
+			"wis": 12,
+			"cha": 19,
+			"senses": [
+				"Truesight 60 ft."
+			],
+			"passive": 11,
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"slashing",
+				"thunder"
+			],
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"poisoned",
+				"prone",
+				"restrained"
+			],
+			"languages": [
+				"Common plus two other languages"
+			],
+			"cr": "6",
+			"trait": [
+				{
+					"name": "Aura of Violence",
+					"entries": [
+						"At the end of each of the gallows speaker's turns, each creature of the gallows speaker's choice in a 15-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the gallows speaker suffers the following effect. {@actSave wis} {@dc 15}. {@actSaveFail} The target takes a {@variantrule Reaction|XPHB} to make a melee attack roll against a creature within reach. If no creature is within reach, the target takes 7 ({@damage 2d6}) Psychic damage."
+					]
+				},
+				{
+					"name": "Whirling Form",
+					"entries": [
+						"The gallows speaker can enter a creature's space and stop there."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The gallows speaker makes two Whirling Blades attacks."
+					]
+				},
+				{
+					"name": "Whirling Blades",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 60 ft. {@h}13 ({@damage 3d6 + 3}) Slashing damage plus 7 ({@damage 3d4}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Howling Wind {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 15}, each creature in a 30-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 18 ({@damage 4d8}) Thunder damage, and the target has the {@condition Frightened|XPHB} condition for 1 minute. While {@condition Frightened|XPHB} in this way, the creature has the {@condition Deafened|XPHB} condition, is compelled to shriek along with the gallows speaker, and can't cast spells with a Verbal component. The target repeats the save at the end of each of its turns, ending the effect on itself on a success. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"environment": [
+				"grassland",
+				"planar, shadowfell",
+				"swamp",
+				"urban"
+			],
+			"treasure": [
+				"armaments"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"N",
+				"S",
+				"T",
+				"Y"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"deafened",
+				"frightened"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Gennifer Weathermay-Foxgrove",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 278,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human",
+					"lycanthrope"
+				]
+			},
+			"alignment": [
+				"L",
+				"G"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 44,
+				"formula": "8d8 + 8"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 10,
+			"dex": 14,
+			"con": 13,
+			"int": 15,
+			"wis": 17,
+			"cha": 10,
+			"skill": {
+				"arcana": "+4",
+				"investigation": "+4",
+				"medicine": "+5",
+				"stealth": "+4"
+			},
+			"passive": 13,
+			"languages": [
+				"Common",
+				"Draconic",
+				"Infernal"
+			],
+			"cr": "3",
+			"gear": [
+				"component pouch|xphb",
+				"dagger|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Gennifer casts one of the following spells, using Wisdom as the spellcasting ability (spell save {@dc 13}):"
+					],
+					"will": [
+						"{@spell Light|XPHB}",
+						"{@spell Mending|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Locate Animals or Plants|XPHB}",
+							"{@spell Magic Circle|XPHB}",
+							"{@spell Protection from Poison|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				},
+				{
+					"name": "Occult Aid (2/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Gennifer casts {@spell Healing Word|XPHB}, using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"2": [
+							"{@spell Healing Word|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Suppressed Lycanthropy",
+					"entries": [
+						"If reduced to 0 {@variantrule Hit Points|XPHB}, Gennifer succumbs to lycanthropy. Her statistics are replaced by those of the Werewolf stat block, but she retains her alignment; personality; Intelligence, Wisdom, and Charisma scores; proficiencies; and languages known. She then immediately revives in her hybrid form with all her {@variantrule Hit Points|XPHB}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Gennifer makes two attacks, using Blessed Dagger or Radiant Wisp in any combination."
+					]
+				},
+				{
+					"name": "Blessed Dagger",
+					"entries": [
+						"{@atkr m,r} {@hit 4}, reach 5 ft. or range 20/60 ft. {@h}4 ({@damage 1d4 + 2}) Piercing damage plus 9 ({@damage 2d8}) Radiant damage."
+					]
+				},
+				{
+					"name": "Radiant Wisp",
+					"entries": [
+						"{@atkr r} {@hit 5}, range 60 ft. {@h}14 ({@damage 2d10 + 3}) Radiant damage."
+					]
+				},
+				{
+					"name": "Esoteric Ward {@recharge}",
+					"entries": [
+						"{@actSave con} {@dc 13}, each creature in a 15-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Gennifer. {@actSaveFail} 18 ({@damage 4d8}) Radiant damage. If the target is an Undead creature, it has the {@condition Stunned|XPHB} condition until the end of its next turn."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"DR",
+				"I"
+			],
+			"damageTags": [
+				"P",
+				"R"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW",
+				"RA",
+				"THW"
+			],
+			"conditionInflict": [
+				"stunned"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"savingThrowForcedSpell": [
+				"charisma"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Greater Star Spawn Emissary",
+			"source": "RHW",
+			"page": 268,
+			"size": [
+				"H"
+			],
+			"type": "aberration",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 304,
+				"formula": "21d12 + 168"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": {
+					"number": 40,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 24,
+			"dex": 13,
+			"con": 26,
+			"int": 27,
+			"wis": 22,
+			"cha": 25,
+			"save": {
+				"con": "+15",
+				"int": "+15",
+				"wis": "+13",
+				"cha": "+14"
+			},
+			"skill": {
+				"arcana": "+22",
+				"perception": "+13"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 23,
+			"resist": [
+				"acid",
+				"force",
+				"necrotic",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened"
+			],
+			"languages": [
+				"all; telepathy 120 ft."
+			],
+			"cr": {
+				"cr": "21",
+				"xpLair": 41000
+			},
+			"trait": [
+				{
+					"name": "Aberrant Restoration",
+					"entries": [
+						"If destroyed, the emissary revives with all its {@variantrule Hit Points|XPHB} in 1 day in the space of a Gibbering Mouther that was within 300 feet of the emissary when the emissary was destroyed; that mouther is destroyed."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+					"entries": [
+						"If the emissary fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The emissary makes two attacks, using Lashing Maw or Coagulated Nodule in any combination. It can replace one attack with Unearthly Bile if available."
+					]
+				},
+				{
+					"name": "Lashing Maw",
+					"entries": [
+						"{@atkr m} {@hit 14}, reach 15 ft. {@h}33 ({@damage 4d12 + 7}) Piercing damage plus 18 ({@damage 4d8}) Acid damage."
+					]
+				},
+				{
+					"name": "Coagulated Nodule",
+					"entries": [
+						"{@atkr r} {@hit 15}, range 120 ft. {@h}44 ({@damage 8d8 + 8}) Acid damage."
+					]
+				},
+				{
+					"name": "Unearthly Bile {@recharge 5}",
+					"entries": [
+						"{@actSave dex} {@dc 23}, each creature in a 30-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point the emissary can see within 120 feet. {@actSaveFail} 54 ({@damage 12d8}) Acid damage, and a Gibbering Mouther appears in an unoccupied space within 30 feet of the target. The mouthers take their turn immediately after the emissary on the same {@variantrule Initiative|XPHB} count. Each mouther fights until destroyed. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"legendaryActionsLair": 4,
+			"legendary": [
+				{
+					"name": "Forced Mutations",
+					"entries": [
+						"{@actSave cha} {@dc 23}, up to two creatures the emissary can see within 30 feet. {@actSaveFail} The target has the {@condition Paralyzed|XPHB} condition until the end of its next turn. {@actSaveSuccessOrFail} The emissary can't take this action again until the start of its next turn."
+					]
+				},
+				{
+					"name": "Teleporting Lash",
+					"entries": [
+						"The emissary can teleport up to 30 feet to an unoccupied space it can see, and it makes one Lashing Maw attack."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Star Spawn Emissary",
+				"source": "RHW"
+			},
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"any"
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"TP",
+				"XX"
+			],
+			"damageTags": [
+				"A",
+				"P"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"paralyzed"
+			],
+			"savingThrowForced": [
+				"charisma",
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Gremishka",
+			"source": "RHW",
+			"page": 249,
+			"size": [
+				"T"
+			],
+			"type": "monstrosity",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 31,
+				"formula": "7d4 + 14"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 12,
+			"dex": 14,
+			"con": 15,
+			"int": 11,
+			"wis": 14,
+			"cha": 4,
+			"senses": [
+				"Darkvision 30 ft."
+			],
+			"passive": 12,
+			"languages": [
+				"understands Common but can't speak"
+			],
+			"cr": "2",
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The gremishka has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite (Individual Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 1d6 + 2}) Piercing damage plus 7 ({@damage 2d6}) Force damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Magic Allergy (Individual Form Only; 1/Day)",
+					"entries": [
+						"{@actTrigger} A creature within 30 feet of the gremishka casts a spell. {@actResponse} The gremishka regains 15 {@variantrule Hit Points|XPHB}, then becomes a {@creature Swarm of Gremishkas|RHW|Medium swarm of Tiny creatures}."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"D"
+			],
+			"languageTags": [
+				"C",
+				"CS"
+			],
+			"damageTags": [
+				"O",
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Gug",
+			"source": "RHW",
+			"page": 250,
+			"size": [
+				"H"
+			],
+			"type": "aberration",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 250,
+				"formula": "20d12 + 120"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 22,
+			"dex": 15,
+			"con": 23,
+			"int": 7,
+			"wis": 16,
+			"cha": 11,
+			"save": {
+				"str": "+10",
+				"con": "+10"
+			},
+			"skill": {
+				"perception": "+7",
+				"stealth": "+10"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 17,
+			"languages": [
+				"understands Deep Speech but can't speak"
+			],
+			"cr": "12",
+			"trait": [
+				{
+					"name": "Pack Tactics",
+					"entries": [
+						"The gug has {@variantrule Advantage|XPHB} on an attack roll against a creature if at least one of the gug's allies is within 5 feet of the creature and the ally doesn't have the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The gug makes two Claw attacks and uses Chew."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 10 ft. {@h}22 ({@damage 3d10 + 6}) Slashing damage. If the target is a Medium or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 16}) from one of two claws."
+					]
+				},
+				{
+					"name": "Chew",
+					"entries": [
+						"{@actSave dex} {@dc 18}, up to two Medium or smaller creatures {@condition Grappled|XPHB} by the gug. {@actSaveFail} The gug places the target in its mouth and chews. A chewed creature is no longer {@condition Grappled|XPHB} but has the {@condition Restrained|XPHB} condition. While {@condition Restrained|XPHB} in this way, a target has {@variantrule Cover|XPHB|Half Cover} against attacks and other effects not originating from the gug and takes 10 ({@damage 3d6}) Piercing damage at the start of each of the gug's turns. A gug can have a maximum of four creatures in its mouth at a time.",
+						"A creature in the gug's mouth can take an action to make a {@dc 16} Strength ({@skill Athletics|XPHB}) check. On a successful check, the target is no longer {@condition Restrained|XPHB} and moves to an unoccupied space within 5 feet of the gug. If the gug dies, a target is no longer {@condition Restrained|XPHB} and can escape from the gug using 5 feet of movement, exiting with the {@condition Prone|XPHB} condition."
+					]
+				}
+			],
+			"environment": [
+				"underdark"
+			],
+			"treasure": [
+				"armaments"
+			],
+			"traitTags": [
+				"Pack Tactics"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"CS",
+				"DS"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"grappled",
+				"restrained"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Harkon Lukas",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 124,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "monstrosity",
+				"tags": [
+					"lycanthrope"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 187,
+				"formula": "22d8 + 88"
+			},
+			"speed": {
+				"walk": 30,
+				"alternate": {
+					"walk": [
+						{
+							"number": 40,
+							"condition": "(hybrid form only)"
+						},
+						{
+							"number": 50,
+							"condition": "(dire wolf form only)"
+						}
+					]
+				}
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 21,
+			"dex": 18,
+			"con": 19,
+			"int": 14,
+			"wis": 16,
+			"cha": 19,
+			"save": {
+				"con": "+9",
+				"wis": "+8"
+			},
+			"skill": {
+				"perception": "+8",
+				"performance": "+9",
+				"stealth": "+9"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 18,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Common (can't speak in dire wolf form)"
+			],
+			"cr": {
+				"cr": "14",
+				"xpLair": 13000
+			},
+			"gear": [
+				{
+					"item": "viol|xphb",
+					"displayName": "Violin"
+				}
+			],
+			"trait": [
+				{
+					"name": "Blood Frenzy",
+					"entries": [
+						"Harkon has {@variantrule Advantage|XPHB} on attack rolls against any creature that doesn't have all its {@variantrule Hit Points|XPHB}."
+					]
+				},
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Harkon dies, he revives with all his {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Kartakass."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Harkon fails a saving throw, he can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Regeneration",
+					"entries": [
+						"Harkon gains 10 {@variantrule Hit Points|XPHB} at the start of each of his turns if he has at least 1 {@variantrule Hit Points|XPHB|Hit Point}. If Harkon takes Radiant damage, this trait doesn't function at the start of his next turn."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Harkon makes two Swipe attacks. He can replace one attack with (A) Bite or (B) Enthralling Performance."
+					]
+				},
+				{
+					"name": "Bite (Dire Wolf or Hybrid Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 5 ft. {@h}14 ({@damage 2d8 + 5}) Piercing damage plus 14 ({@damage 4d6}) Necrotic damage. If the target is a Humanoid, it is subjected to the following effect: {@actSave con} {@dc 17}. {@actSaveFail} The target is cursed. If the cursed target drops to 0 {@variantrule Hit Points|XPHB}, it instead becomes a Werewolf under the DM's control and has 50 {@variantrule Hit Points|XPHB}. The curse can't be removed until Harkon dies. {@actSaveSuccess} The target is immune to Harkon's curse for 24 hours."
+					]
+				},
+				{
+					"name": "Swipe (Dire Wolf or Hybrid Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 5 ft. {@h}16 ({@damage 2d10 + 5}) Slashing damage. If the target is a Medium or smaller creature, it has the {@condition Prone|XPHB} condition."
+					]
+				},
+				{
+					"name": "Enthralling Performance (Humanoid Form Only)",
+					"entries": [
+						"{@actSave wis} {@dc 17}, each creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Harkon. {@actSaveFail} The target has the {@condition Charmed|XPHB} condition for 1 hour or until it takes damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"Harkon shape-shifts into a Large dire wolf-humanoid hybrid or a Large dire wolf, or he returns to his true humanoid form. His game statistics, other than his size, are the same in each form. Any equipment he is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Crushing Insult",
+					"entries": [
+						"Harkon uses Shape-Shift to return to his humanoid form, then uses the following effect. {@actSave wis} {@dc 17}, each creature of Harkon's choice that he can see within 30 feet of himself (creatures {@condition Charmed|XPHB} by Harkon automatically fail this save). {@actSaveFail} 16 ({@damage 3d10}) Psychic damage. {@actSaveSuccessOrFail} Harkon can't take this action again until the start of his next turn."
+					]
+				},
+				{
+					"name": "Pounce",
+					"entries": [
+						"Harkon moves up to half his {@variantrule Speed|XPHB} and makes one Swipe attack."
+					]
+				},
+				{
+					"name": "Surprise Bite",
+					"entries": [
+						"Harkon uses Shape-Shift to turn into his hybrid or dire wolf form and then makes one Bite attack. Harkon can't take this action again until the start of his next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Harkon Lukas",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances",
+				"Regeneration"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS"
+			],
+			"damageTags": [
+				"N",
+				"P",
+				"S",
+				"Y"
+			],
+			"miscTags": [
+				"CUR",
+				"MA"
+			],
+			"conditionInflict": [
+				"charmed",
+				"prone"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Hazlik",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 98,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human",
+					"wizard"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 154,
+				"formula": "28d8 + 28"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 10,
+			"dex": 16,
+			"con": 12,
+			"int": 20,
+			"wis": 15,
+			"cha": 16,
+			"save": {
+				"int": "+10",
+				"wis": "+7"
+			},
+			"skill": {
+				"arcana": "+10",
+				"history": "+10",
+				"perception": "+7"
+			},
+			"passive": 17,
+			"immune": [
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed"
+			],
+			"languages": [
+				"Abyssal",
+				"Common",
+				"Draconic",
+				"Giant",
+				"Infernal",
+				"Undercommon"
+			],
+			"cr": {
+				"cr": "14",
+				"xpLair": 13000
+			},
+			"gear": [
+				"quarterstaff|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Hazlik casts one of the following spells, using Intelligence as the spellcasting ability (spell save {@dc 18}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Disguise Self|XPHB}",
+						"{@spell Invisibility|XPHB}",
+						"{@spell Light|XPHB}",
+						"{@spell Mage Armor|XPHB} (included in AC)",
+						"{@spell Mage Hand|XPHB}",
+						"{@spell Prestidigitation|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Fly|XPHB}",
+							"{@spell Lightning Bolt|XPHB} (level 5 version)"
+						],
+						"1e": [
+							"{@spell Cone of Cold|XPHB}",
+							"{@spell Mind Blank|XPHB} (cast before combat)",
+							"{@spell Scrying|XPHB}",
+							"{@spell Teleport|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				},
+				{
+					"name": "Protective Magic (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Hazlik casts {@spell Counterspell|XPHB} or {@spell Shield|XPHB} in response to the spell's trigger, using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"3": [
+							"{@spell Counterspell|XPHB}",
+							"{@spell Shield|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "reaction",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Hazlik dies, he revives with all his {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Hazlan."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Hazlik fails a saving throw, he can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Hazlik has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Hazlik makes three Arcane Burst attacks."
+					]
+				},
+				{
+					"name": "Arcane Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 10}, reach 5 ft. or range 150 ft. {@h}21 ({@damage 3d10 + 5}) Force damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Wild Magic Surge",
+					"entries": [
+						"Hazlik manifests one of the following magic surges, targeting a creature he can see within 120 feet. While {@status Bloodied|XPHB}, Hazlik manifests two surges (roll {@dice 1d4}; reroll if Hazlik has already used that surge during this turn):",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "1: Misty Movement",
+									"entries": [
+										"Hazlik can teleport the target up to 30 feet to an unoccupied space he can see on a surface or liquid large enough to support the target."
+									]
+								},
+								{
+									"type": "item",
+									"name": "2: Eye Blight",
+									"entries": [
+										"{@actSave con} {@dc 18}. {@actSaveFail} The target has the {@condition Blinded|XPHB} condition until the end of its next turn."
+									]
+								},
+								{
+									"type": "item",
+									"name": "3: Mind Flare",
+									"entries": [
+										"{@actSave int} {@dc 18}. {@actSaveFail} 13 ({@damage 2d12}) Psychic damage, and the target can't take the {@action Magic|XPHB} action until the end of its next turn."
+									]
+								},
+								{
+									"type": "item",
+									"name": "4: Implode",
+									"entries": [
+										"{@actSave dex} {@dc 18}. {@actSaveFail} The target takes 10 ({@damage 3d6}) Force damage. {@actSaveSuccessOrFail} Each creature within 5 feet of the target takes 10 ({@damage 3d6}) Force damage."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Arcane Strike",
+					"entries": [
+						"Hazlik makes one Arcane Burst attack."
+					]
+				},
+				{
+					"name": "Arcane Teleport",
+					"entries": [
+						"Hazlik teleports up to 60 feet to an unoccupied space he can see, and each creature within 10 feet of the space he left takes 11 ({@damage 2d10}) Force damage. Hazlik can't take this action again until the start of his next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Hazlik",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances",
+				"Magic Resistance"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AB",
+				"C",
+				"DR",
+				"GI",
+				"I",
+				"U"
+			],
+			"damageTags": [
+				"O",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"C",
+				"L",
+				"O"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"blinded"
+			],
+			"conditionInflictSpell": [
+				"invisible"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"dexterity",
+				"intelligence"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"dexterity",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Inquisitor of the Mind Fire",
+			"source": "RHW",
+			"page": 272,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"L",
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 104,
+				"formula": "16d8 + 32"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 10,
+			"dex": 14,
+			"con": 15,
+			"int": 17,
+			"wis": 16,
+			"cha": 21,
+			"save": {
+				"int": "+6",
+				"wis": "+6",
+				"cha": "+8"
+			},
+			"skill": {
+				"insight": "+6",
+				"perception": "+6"
+			},
+			"senses": [
+				"Truesight 30 ft."
+			],
+			"passive": 16,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Common plus two other languages"
+			],
+			"cr": "8",
+			"gear": [
+				"breastplate|xphb",
+				"silvered longsword|xdmg"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The inquisitor casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save {@dc 16}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Dispel Magic|XPHB}",
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})",
+						"{@spell Sending|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Hold Monster|XPHB}",
+							"{@spell Modify Memory|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The inquisitor makes three Silvered Longsword attacks or uses Mind Fire three times. It can replace one attack or one use of Mind Fire with a use of Spellcasting to cast {@spell Hold Monster|XPHB} if available."
+					]
+				},
+				{
+					"name": "Silvered Longsword",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}14 ({@damage 2d8 + 5}) Slashing damage plus 4 ({@damage 1d8}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the start of the inquisitor's next turn. Critical {@h}If the target is a shape-shifted creature, it takes an additional 4 ({@damage 1d8}) Slashing damage."
+					]
+				},
+				{
+					"name": "Inquisitor's Command {@recharge 5}",
+					"entries": [
+						"{@actSave wis} {@dc 16}, each creature of the inquisitor's choice that it can see within 60 feet. {@actSaveFail} The target has the {@condition Charmed|XPHB} condition until the start of the inquisitor's next turn. On the {@condition Charmed|XPHB} target's turn, the inquisitor can telepathically control the target's move and make the target take the {@action Attack|XPHB} action (the inquisitor chooses the target), the {@action Dash|XPHB} action, or no action."
+					]
+				},
+				{
+					"name": "Mind Fire",
+					"entries": [
+						"{@actSave int} {@dc 16}, one creature the inquisitor can see within 120 feet. {@actSaveFail} 9 ({@damage 1d8 + 5}) Psychic damage, and the target has the {@condition Stunned|XPHB} condition until the start of the inquisitor's next turn."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"any"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"S",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW"
+			],
+			"conditionInflict": [
+				"charmed",
+				"frightened",
+				"stunned"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"incapacitated",
+				"paralyzed"
+			],
+			"savingThrowForced": [
+				"intelligence",
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Inquisitor of the Sword",
+			"source": "RHW",
+			"page": 273,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"L",
+				"N"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 120,
+				"formula": "16d8 + 48"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 12,
+			"dex": 14,
+			"con": 17,
+			"int": 15,
+			"wis": 18,
+			"cha": 16,
+			"save": {
+				"int": "+5",
+				"wis": "+7",
+				"cha": "+6"
+			},
+			"skill": {
+				"acrobatics": "+5",
+				"insight": "+7",
+				"perception": "+7"
+			},
+			"senses": [
+				"Truesight 30 ft."
+			],
+			"passive": 17,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Common plus two other languages"
+			],
+			"cr": "8",
+			"gear": [
+				"breastplate|xphb",
+				"silvered longsword|xdmg"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The inquisitor casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability (spell save {@dc 15}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Dispel Magic|XPHB}",
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})",
+						"{@spell Sending|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Dimension Door|XPHB}",
+							"{@spell Fly|XPHB}",
+							"{@spell Greater Invisibility|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Metabolic Control",
+					"entries": [
+						"At the start of each of its turns, if the inquisitor has at least 1 {@variantrule Hit Points|XPHB|Hit Point}, it regains 10 {@variantrule Hit Points|XPHB} and can end one condition on itself."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The inquisitor makes three Silvered Longsword attacks."
+					]
+				},
+				{
+					"name": "Silvered Longsword",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}13 ({@damage 2d8 + 4}) Slashing damage plus 4 ({@damage 1d8}) Psychic damage. Critical {@h}If the target is a shape-shifted creature, it takes an additional 4 ({@damage 1d8}) Slashing damage. {@hom}The inquisitor can teleport up to 60 feet to an unoccupied space it can see."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"any"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"S",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"O"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"MLW"
+			],
+			"conditionInflictSpell": [
+				"invisible"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Inquisitor of the Tome",
+			"source": "RHW",
+			"page": 273,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"L",
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 88,
+				"formula": "16d8 + 16"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 10,
+			"dex": 12,
+			"con": 12,
+			"int": 19,
+			"wis": 16,
+			"cha": 15,
+			"save": {
+				"int": "+7",
+				"wis": "+6",
+				"cha": "+5"
+			},
+			"skill": {
+				"arcana": "+10",
+				"history": "+7",
+				"nature": "+7",
+				"religion": "+10"
+			},
+			"senses": [
+				"Truesight 30 ft."
+			],
+			"passive": 13,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Common plus two other languages"
+			],
+			"cr": "8",
+			"gear": [
+				"longsword|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The inquisitor casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 15}):"
+					],
+					"will": [
+						"{@spell Detect Magic|XPHB}",
+						"{@spell Dispel Magic|XPHB}",
+						"{@spell Mage Armor|XPHB} (included in AC)",
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})",
+						"{@spell Sending|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Otiluke's Resilient Sphere|XPHB}",
+							"{@spell Telekinesis|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The inquisitor makes three Force Blade attacks. It can replace one attack with a use of Spellcasting to cast {@spell Otiluke's Resilient Sphere|XPHB} or {@spell Telekinesis|XPHB} if available."
+					]
+				},
+				{
+					"name": "Force Blade",
+					"entries": [
+						"{@atkr m,r} {@hit 7}, reach 5 ft. or range 120 ft. {@h}22 ({@damage 4d8 + 4}) Force damage. If the target is a Large or smaller creature, it is pushed up to 10 feet straight away from the inquisitor."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Implode {@recharge 4}",
+					"entries": [
+						"{@actSave dex} {@dc 15}, each creature in a 20-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point the inquisitor can see within 120 feet. {@actSaveFail} 27 ({@damage 6d8}) Force damage, and the target has the {@condition Prone|XPHB} condition and is pulled up to 20 feet straight toward the {@variantrule Sphere [Area of Effect]|XPHB|Sphere}'s center. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"any"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"O"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"conditionInflictSpell": [
+				"restrained"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"savingThrowForcedSpell": [
+				"dexterity",
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Ivan Dilisnya",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 54,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 90,
+				"formula": "12d8 + 36"
+			},
+			"speed": {
+				"walk": 40,
+				"climb": 40
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 18,
+			"dex": 14,
+			"con": 16,
+			"int": 19,
+			"wis": 12,
+			"cha": 15,
+			"save": {
+				"dex": "+5",
+				"wis": "+4"
+			},
+			"skill": {
+				"history": "+7",
+				"investigation": "+7",
+				"perception": "+7"
+			},
+			"passive": 17,
+			"languages": [
+				"Common"
+			],
+			"cr": {
+				"cr": "5",
+				"xpLair": 2300
+			},
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Ivan dies, he revives with all his {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Borca."
+					]
+				},
+				{
+					"name": "Legendary Resistance (2/Day, or 3/Day in Domain)",
+					"entries": [
+						"If Ivan fails a saving throw, he can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Ivan makes two Foreleg attacks. He can replace one attack with a use of Deadly Contraption."
+					]
+				},
+				{
+					"name": "Foreleg",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 10 ft. {@h}11 ({@damage 2d6 + 4}) Piercing damage."
+					]
+				},
+				{
+					"name": "Deadly Contraption",
+					"entries": [
+						"{@actSave dex} {@dc 15}, one creature Ivan can see within 30 feet. {@actSaveFail} 13 ({@damage 3d8}) Slashing damage. {@actSaveSuccessOrFail} A flailing clockwork contraption attaches to the target until the start of Ivan's next turn. If the target willingly moves 5 feet or more before then, the target takes 4 ({@damage 1d8}) Slashing damage.",
+						"At the start of Ivan's next turn, the device crumbles to dust and vanishes."
+					]
+				}
+			],
+			"legendaryActions": 2,
+			"legendary": [
+				{
+					"name": "Retaliate",
+					"entries": [
+						"Ivan makes one Foreleg attack."
+					]
+				},
+				{
+					"name": "Trapped Ground",
+					"entries": [
+						"Ivan spreads special caltrops to cover a 20-foot-square area within 5 feet of himself. The caltrops dissolve at the end of Ivan's next turn. Ivan can't take this action again until the start of his next turn.",
+						"When the caltrops appear, each creature in the area is subjected to the following effect; a creature that enters the caltrops for the first time on a turn or ends its turn there is also subjected to this effect. {@actSave dex} {@dc 15} (a creature makes this save only once per turn). {@actSaveFail} 9 ({@damage 2d8}) Piercing damage, and its {@variantrule Speed|XPHB} is reduced to 0 until the start of its next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Ivana Boritsi and Ivan Boritsi",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Ivana Boritsi",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 52,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 104,
+				"formula": "16d8 + 32"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 10,
+			"dex": 17,
+			"con": 14,
+			"int": 18,
+			"wis": 15,
+			"cha": 14,
+			"save": {
+				"dex": "+6",
+				"con": "+5"
+			},
+			"skill": {
+				"deception": "+8",
+				"nature": "+7",
+				"perception": "+5"
+			},
+			"passive": 15,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"poisoned"
+			],
+			"languages": [
+				"Common"
+			],
+			"cr": {
+				"cr": "5",
+				"xpLair": 2300
+			},
+			"spellcasting": [
+				{
+					"name": "Charm {@recharge 5}",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Ivana casts {@spell Charm Person|XPHB}, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 15}), and the duration is 24 hours."
+					],
+					"recharge": {
+						"5": [
+							"{@spell Charm Person|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "bonus",
+					"hidden": [
+						"recharge"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Ivana dies, she revives with all her {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Borca."
+					]
+				},
+				{
+					"name": "Legendary Resistance (2/Day, or 3/Day in Domain)",
+					"entries": [
+						"If Ivana fails a saving throw, she can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Ivana makes two Toxic Touch attacks."
+					]
+				},
+				{
+					"name": "Toxic Touch",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Poison damage. A Humanoid reduced to 0 {@variantrule Hit Points|XPHB} by this damage rises 24 hours later as a Vine Blight under Ivana's control unless the Humanoid is restored to life or its body is destroyed."
+					]
+				},
+				{
+					"name": "Stifling Perfume {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 15}, each creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Ivana. {@actSaveFail} 13 ({@damage 3d8}) Poison damage, and the target has the {@condition Prone|XPHB} condition. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Tree Stride",
+					"entries": [
+						"If within 5 feet of a Large or bigger inanimate plant, Ivana teleports to an unoccupied space within 5 feet of a second Large or bigger inanimate plant that is within 60 feet of the previous plant."
+					]
+				}
+			],
+			"legendaryActions": 2,
+			"legendary": [
+				{
+					"name": "Retaliate",
+					"entries": [
+						"Ivana makes one Toxic Touch attack."
+					]
+				},
+				{
+					"name": "Toxin Wave",
+					"entries": [
+						"{@actSave dex} {@dc 15}, each creature in a 15-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} The target has the {@condition Poisoned|XPHB} condition until the end of its next turn. While {@condition Poisoned|XPHB}, the target subtracts {@dice 1d6} from its damage rolls. {@actSaveSuccessOrFail} Ivana can't take this action again until the start of her next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Ivana Boritsi and Ivan Boritsi",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"I"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"poisoned",
+				"prone"
+			],
+			"conditionInflictSpell": [
+				"charmed"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"dexterity"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Jiangshi",
+			"source": "RHW",
+			"page": 251,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 119,
+				"formula": "14d8 + 56"
+			},
+			"speed": {
+				"walk": 20,
+				"fly": {
+					"number": 5,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 18,
+			"dex": 3,
+			"con": 18,
+			"int": 17,
+			"wis": 14,
+			"cha": 12,
+			"save": {
+				"con": "+8",
+				"int": "+7",
+				"wis": "+6",
+				"cha": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 16,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"languages": [
+				"Common plus three other languages"
+			],
+			"cr": "9",
+			"trait": [
+				{
+					"name": "Jiangshi Weaknesses",
+					"entries": [
+						"The jiangshi has these weaknesses:",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Fear of Its Own Reflection",
+									"entries": [
+										"If the jiangshi sees its reflection, it immediately takes its {@variantrule Reaction|XPHB}, if available, to move as far from the reflection as possible."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Susceptible to Holy Symbols",
+									"entries": [
+										"While the jiangshi is wearing or touching a {@item Holy Symbol|XPHB}, it loses its {@variantrule Immunity|XPHB} to the {@condition Frightened|XPHB} condition and automatically fails saving throws to avoid or end the {@condition Frightened|XPHB} condition."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The jiangshi makes three Slam attacks and uses Consume Energy."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}13 ({@damage 2d8 + 4}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Consume Energy",
+					"entries": [
+						"{@actSave con} {@dc 16}, one creature the jiangshi can see within 30 feet. {@actSaveFail} 18 ({@damage 4d8}) Necrotic damage. {@actSaveSuccess} Half damage. {@actSaveSuccessOrFail} The jiangshi regains {@variantrule Hit Points|XPHB} equal to the Necrotic damage taken, the jiangshi's {@variantrule Fly Speed|XPHB} increases to 20 feet until the end of its next turn, and it can take its Hungering Stride {@variantrule Bonus Action|XPHB}. A Humanoid reduced to 0 {@variantrule Hit Points|XPHB} by this damage rises at the end of the jiangshi's turn as a Wight under the jiangshi's control. If this wight kills a Humanoid with its Life Drain action, the wight transforms into an independent Jiangshi 5 days later."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Hungering Stride (Requires Consume Energy)",
+					"entries": [
+						"The jiangshi takes the {@action Dash|XPHB} action."
+					]
+				},
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The jiangshi shape-shifts into a Medium or Small Beast, Humanoid, or Undead creature, or it returns to its true form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"relics"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"B",
+				"N"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Laurie Weathermay-Foxgrove",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 279,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"L",
+				"G"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 65,
+				"formula": "10d8 + 20"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 17,
+			"dex": 13,
+			"con": 15,
+			"int": 10,
+			"wis": 14,
+			"cha": 10,
+			"skill": {
+				"athletics": "+5",
+				"investigation": "+2",
+				"perception": "+4"
+			},
+			"passive": 14,
+			"languages": [
+				"Common",
+				"Elvish"
+			],
+			"cr": "3",
+			"gear": [
+				"chain mail|xphb",
+				{
+					"item": "+1 longsword|xdmg",
+					"displayName": "Gossamer (+1 Longsword)"
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Laurie makes two attacks, using Gossamer or Light Crossbow in any combination."
+					]
+				},
+				{
+					"name": "Gossamer",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Slashing damage plus 3 ({@damage 1d6}) Radiant damage."
+					]
+				},
+				{
+					"name": "Light Crossbow",
+					"entries": [
+						"{@atkr r} {@hit 3}, range 80/320 ft. {@h}10 ({@damage 2d8 + 1}) Piercing damage plus 3 ({@damage 1d6}) Radiant damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Deflect Blow",
+					"entries": [
+						"{@actTrigger} An attack roll hits Laurie or a creature she can see within 5 feet. {@actResponse} The triggering attack's damage is reduced by 5 ({@dice 1d10})."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"E"
+			],
+			"damageTags": [
+				"P",
+				"R",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RNG"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Lesser Star Spawn Emissary",
+			"source": "RHW",
+			"page": 267,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "aberration",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				19
+			],
+			"hp": {
+				"average": 241,
+				"formula": "21d8 + 147"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": {
+					"number": 40,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 21,
+			"dex": 18,
+			"con": 24,
+			"int": 25,
+			"wis": 20,
+			"cha": 23,
+			"save": {
+				"int": "+13",
+				"wis": "+11",
+				"cha": "+12"
+			},
+			"skill": {
+				"arcana": "+19",
+				"deception": "+18",
+				"perception": "+11"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 21,
+			"resist": [
+				"acid",
+				"force",
+				"necrotic",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened"
+			],
+			"languages": [
+				"all; telepathy 120 ft."
+			],
+			"cr": {
+				"cr": "19",
+				"xpLair": 25000
+			},
+			"trait": [
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in lair)",
+					"entries": [
+						"If the emissary fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The emissary makes three attacks, using Lashing Maw or Invert Flesh in any combination."
+					]
+				},
+				{
+					"name": "Lashing Maw",
+					"entries": [
+						"{@atkr m} {@hit 11}, reach 15 ft. {@h}16 ({@damage 2d10 + 5}) Piercing damage plus 13 ({@damage 3d8}) Acid damage."
+					]
+				},
+				{
+					"name": "Invert Flesh",
+					"entries": [
+						"{@actSave con} {@dc 21}, one creature the emissary can see within 120 feet. {@actSaveFail} 29 ({@damage 4d10 + 7}) Force damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The emissary shape-shifts into a Small or Medium creature, or it returns to its true form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"legendaryActionsLair": 4,
+			"legendary": [
+				{
+					"name": "Teleporting Lash",
+					"entries": [
+						"The emissary teleports up to 30 feet to an unoccupied space it can see and makes one Lashing Maw attack."
+					]
+				},
+				{
+					"name": "Twist",
+					"entries": [
+						"The emissary uses Invert Flesh."
+					]
+				},
+				{
+					"name": "Warp Body",
+					"entries": [
+						"{@actSave con} {@dc 21}, one creature the emissary can see within 30 feet. {@actSaveFail} 27 ({@damage 6d8}) Force damage, and the target has the {@condition Stunned|XPHB} condition until the start of its next turn. {@actSaveSuccessOrFail} The emissary can't take this action again until the start of its next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Star Spawn Emissary",
+				"source": "RHW"
+			},
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"any"
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"TP",
+				"XX"
+			],
+			"damageTags": [
+				"A",
+				"O",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"stunned"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Lord Soth of Sithicus",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 158,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 228,
+				"formula": "24d8 + 120"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 22,
+			"dex": 11,
+			"con": 20,
+			"int": 12,
+			"wis": 16,
+			"cha": 20,
+			"save": {
+				"dex": "+6",
+				"wis": "+9",
+				"cha": "+11"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 13,
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Infernal"
+			],
+			"cr": {
+				"cr": "19",
+				"xpLair": 25000
+			},
+			"spellcasting": [
+				{
+					"name": "Commanding Magic (3/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Lord Soth casts {@spell Dispel Magic|XPHB}, {@spell Hold Person|XPHB}, or {@spell Banishment|XPHB} (level 5 version), using Charisma as the spellcasting ability (spell save {@dc 19})."
+					],
+					"daily": {
+						"3": [
+							"{@spell Dispel Magic|XPHB}",
+							"{@spell Hold Person|XPHB}",
+							"{@spell Banishment|XPHB} (level 5 version)"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Lord Soth dies, he revives with all his {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Sithicus."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Lord Soth fails a saving throw, he can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Lord Soth has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Marshal Undead",
+					"entries": [
+						"Undead creatures of Lord Soth's choice (excluding himself) in a 60-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from him have {@variantrule Advantage|XPHB} on attack rolls and saving throws. Lord Soth can't use this trait if he has the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Lord Soth makes three Forsaken Brand attacks."
+					]
+				},
+				{
+					"name": "Forsaken Brand",
+					"entries": [
+						"{@atkr m} {@hit 12}, reach 5 ft. {@h}10 ({@damage 1d8 + 6}) Slashing damage plus 13 ({@damage 3d8}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Cataclysmic Fire {@recharge 5}",
+					"entries": [
+						"{@actSave dex} {@dc 19}, each creature in a 20-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point Lord Soth can see within 120 feet. {@actSaveFail} 24 ({@damage 7d6}) Fire damage plus 24 ({@damage 7d6}) Necrotic damage. {@actSaveSuccess} Half damage."
+					]
+				},
+				{
+					"name": "Face of Death (1/Day)",
+					"entries": [
+						"{@actSave cha} {@dc 19}, each creature in a 60-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Lord Soth. {@actSaveFail} 22 ({@damage 4d10}) Psychic damage, and the creature has the {@condition Frightened|XPHB} condition. {@actSaveSuccess} Half damage only. {@actSaveSuccessOrFail} If this damage reduces the target to 0 {@variantrule Hit Points|XPHB}, the target dies."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Punish",
+					"entries": [
+						"Lord Soth moves up to half his {@variantrule Speed|XPHB}, and he makes one Forsaken Brand attack."
+					]
+				},
+				{
+					"name": "Soth's Command",
+					"entries": [
+						"Lord Soth casts {@spell Command|XPHB} (level 3 version), using the same spellcasting ability as Commanding Magic. Lord Soth can't take this action again until the start of his next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Lord Soth of Sithicus",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"I"
+			],
+			"damageTags": [
+				"F",
+				"N",
+				"S",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"conditionInflictSpell": [
+				"incapacitated",
+				"paralyzed"
+			],
+			"savingThrowForced": [
+				"charisma",
+				"dexterity"
+			],
+			"savingThrowForcedSpell": [
+				"charisma",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Loup Garou",
+			"source": "RHW",
+			"page": 252,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": {
+				"type": "monstrosity",
+				"tags": [
+					"lycanthrope"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 187,
+				"formula": "22d8 + 88"
+			},
+			"speed": {
+				"walk": 30,
+				"alternate": {
+					"walk": [
+						{
+							"number": 40,
+							"condition": "(hybrid form only)"
+						},
+						{
+							"number": 50,
+							"condition": "(dire wolf form only)"
+						}
+					]
+				}
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 24,
+			"dex": 18,
+			"con": 21,
+			"int": 14,
+			"wis": 16,
+			"cha": 16,
+			"save": {
+				"dex": "+9",
+				"con": "+10"
+			},
+			"skill": {
+				"perception": "+8",
+				"stealth": "+9"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 18,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Common (can't speak in dire wolf form)"
+			],
+			"cr": "13",
+			"gear": [
+				"longsword|xphb"
+			],
+			"trait": [
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the loup garou fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The loup garou makes two attacks, using Longsword or Rend in any combination. It can replace one attack with a Bite attack."
+					]
+				},
+				{
+					"name": "Bite (Dire Wolf or Hybrid Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 12}, reach 5 ft. {@h}16 ({@damage 2d8 + 7}) Piercing damage plus 14 ({@damage 4d6}) Necrotic damage. If the target is a Humanoid, it is subjected to the following effect. {@actSave con} {@dc 18}. {@actSaveFail} The target is cursed. If the cursed target drops to 0 {@variantrule Hit Points|XPHB}, it instead becomes a Werewolf under the DM's control and has 10 {@variantrule Hit Points|XPHB}. The curse can't be removed until this loup garou dies. {@actSaveSuccess} The target is immune to this loup garou's curse for 24 hours."
+					]
+				},
+				{
+					"name": "Longsword (Humanoid or Hybrid Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 12}, reach 5 ft. {@h}18 ({@damage 2d10 + 7}) Slashing damage plus 3 ({@damage 1d6}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Rend (Dire Wolf or Hybrid Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 12}, reach 5 ft. {@h}16 ({@damage 2d8 + 7}) Slashing damage. If the target is a Medium or smaller creature, it has the {@condition Prone|XPHB} condition."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The loup garou shape-shifts into a Large dire wolf-humanoid hybrid or a Large dire wolf, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Mauling Charge",
+					"entries": [
+						"The loup garou moves up to half its {@variantrule Speed|XPHB} without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks} and makes one Longsword or Rend attack."
+					]
+				},
+				{
+					"name": "Surprise Bite",
+					"entries": [
+						"The loup garou uses Shape-Shift, turning into its hybrid or dire wolf form, then makes one Bite attack. The loup garou can't take this action again until the start of its next turn."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"swamp",
+				"urban"
+			],
+			"treasure": [
+				"any"
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS"
+			],
+			"damageTags": [
+				"N",
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"CUR",
+				"MA",
+				"MLW"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Madam Eva",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 253,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"C",
+				"N"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 117,
+				"formula": "18d8 + 36"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 8,
+			"dex": 11,
+			"con": 14,
+			"int": 17,
+			"wis": 20,
+			"cha": 18,
+			"save": {
+				"wis": "+9",
+				"cha": "+8"
+			},
+			"skill": {
+				"arcana": "+7",
+				"insight": "+9",
+				"perception": "+9",
+				"religion": "+7"
+			},
+			"passive": 19,
+			"languages": [
+				"Abyssal",
+				"Common",
+				"Elvish",
+				"Infernal"
+			],
+			"cr": "10",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Madam Eva casts one of the following spells, using Wisdom as the spellcasting ability (spell save {@dc 17}):"
+					],
+					"will": [
+						"{@spell Light|XPHB}",
+						"{@spell Mending|XPHB}",
+						"{@spell Thaumaturgy|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Dispel Magic|XPHB}",
+							"{@spell Remove Curse|XPHB}"
+						],
+						"1e": [
+							"{@spell Greater Restoration|XPHB}",
+							"{@spell Raise Dead|XPHB}",
+							"{@spell Scrying|XPHB}",
+							"{@spell Spirit Guardians|XPHB} (level 8 version)"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				},
+				{
+					"name": "Evil Eye (2/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Madam Eva casts {@spell Hold Person|XPHB}, using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"2": [
+							"{@spell Hold Person|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Madam Eva has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Madam Eva makes three attacks, using Cursed Dagger or Radiant Flame in any combination."
+					]
+				},
+				{
+					"name": "Cursed Dagger",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 5 ft. {@h}10 ({@damage 2d4 + 5}) Piercing damage plus 21 ({@damage 6d6}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Radiant Flame",
+					"entries": [
+						"{@atkr r} {@hit 9}, range 60 ft. {@h}21 ({@damage 3d10 + 5}) Radiant damage, and the target has the {@condition Blinded|XPHB} condition until the start of Madam Eva's next turn."
+					]
+				},
+				{
+					"name": "Apocalyptic Visions {@recharge 5}",
+					"entries": [
+						"{@actSave wis} {@dc 17}, each creature in a 20-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point Madam Eva can see within 120 feet. {@actSaveFail} 24 ({@damage 7d6}) Necrotic damage plus 24 ({@damage 7d6}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the start of Madam Eva's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AB",
+				"C",
+				"E",
+				"I"
+			],
+			"damageTags": [
+				"N",
+				"P",
+				"R",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"N",
+				"R"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"MLW",
+				"RA"
+			],
+			"conditionInflict": [
+				"blinded",
+				"frightened"
+			],
+			"conditionInflictSpell": [
+				"paralyzed"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mi-Go",
+			"source": "RHW",
+			"page": 254,
+			"size": [
+				"M"
+			],
+			"type": "aberration",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 120,
+				"formula": "16d8 + 48"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 20,
+			"dex": 15,
+			"con": 16,
+			"int": 21,
+			"wis": 15,
+			"cha": 12,
+			"save": {
+				"dex": "+6",
+				"int": "+9",
+				"wis": "+6"
+			},
+			"skill": {
+				"arcana": "+9",
+				"perception": "+6",
+				"stealth": "+6"
+			},
+			"senses": [
+				"Truesight 120 ft."
+			],
+			"passive": 16,
+			"resist": [
+				"acid",
+				"lightning"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"all; telepathy 120 ft."
+			],
+			"cr": "9",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The mi-go casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 17}):"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Modify Memory|XPHB}",
+							"{@spell Plane Shift|XPHB} (self only)"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The mi-go has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Silver Canister",
+					"entries": [
+						"The mi-go has a silver canister. While holding or carrying the canister, the mi-go can use its Extract Brain action.",
+						"The canister has AC 15, HP 40, and {@variantrule Resistance|XPHB} to all damage. The canister breaks if reduced to 0 {@variantrule Hit Points|XPHB}. If the canister is broken, any brains inside it are destroyed. The mi-go can create a new canister after 7 days."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The mi-go makes two Pincer attacks. It can replace one attack with a use of Dazing Ray if available."
+					]
+				},
+				{
+					"name": "Pincer",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 5 ft. {@h}23 ({@damage 4d8 + 5}) Slashing damage plus 16 ({@damage 3d10}) Acid damage. If the target is a Medium or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 15}) from one of two pincers."
+					]
+				},
+				{
+					"name": "Dazing Ray {@recharge 4}",
+					"entries": [
+						"{@actSave dex} {@dc 17}, one creature the mi-go can see within 60 feet. {@actSaveFail} 22 ({@damage 4d10}) Lightning damage plus 10 ({@damage 3d6}) Force damage, and the target has the {@condition Stunned|XPHB} condition until the end of the mi-go's next turn."
+					]
+				},
+				{
+					"name": "Extract Brain (Requires Silver Canister)",
+					"entries": [
+						"{@actSave con} {@dc 17}, one creature that is {@condition Grappled|XPHB} by the mi-go or that has the {@condition Stunned|XPHB} condition. {@actSaveFail} 77 ({@damage 14d10}) Piercing damage. {@actSaveSuccess} Half damage. {@actSaveSuccessOrFail} If this damage reduces the target to 0 {@variantrule Hit Points|XPHB}, the mi-go kills it, removes its brain, and places the brain in its silver canister."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"hill",
+				"mountain",
+				"underdark"
+			],
+			"treasure": [
+				"implements"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"TP",
+				"XX"
+			],
+			"damageTags": [
+				"A",
+				"L",
+				"O",
+				"P",
+				"S"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"grappled",
+				"stunned"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"incapacitated"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"dexterity"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mist Horror",
+			"source": "RHW",
+			"page": 255,
+			"size": [
+				"L"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 45,
+				"formula": "7d10 + 7"
+			},
+			"speed": {
+				"walk": 25,
+				"fly": {
+					"number": 25,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 1,
+			"dex": 15,
+			"con": 12,
+			"int": 6,
+			"wis": 13,
+			"cha": 16,
+			"senses": [
+				"Blindsight 120 ft."
+			],
+			"passive": 11,
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"slashing"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"poisoned",
+				"prone",
+				"restrained",
+				"unconscious"
+			],
+			"cr": "3",
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The mist horror casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save {@dc 13}):"
+					],
+					"will": [
+						"{@spell Fog Cloud|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Command|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				}
+			],
+			"trait": [
+				{
+					"name": "Air Form",
+					"entries": [
+						"The mist horror can enter an enemy's space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so."
+					]
+				},
+				{
+					"name": "One with the Mists",
+					"entries": [
+						"While the mist horror is in fog or mist, it has the {@condition Invisible|XPHB} condition. The mist horror has the {@condition Incapacitated|XPHB} condition while it is outside an area of fog or mist."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The mist horror makes two Mind Rend attacks. It can replace one attack with a use of Spellcasting to cast {@spell Command|XPHB} if available."
+					]
+				},
+				{
+					"name": "Mind Rend",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}8 ({@damage 1d10 + 3}) Psychic damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Instill Dread {@recharge 4}",
+					"entries": [
+						"{@actSave wis} {@dc 13}, each creature in the mist horror's space. {@actSaveFail} The target has the {@condition Frightened|XPHB} condition until the start of the mist horror's next turn."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"damageTags": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"frightened",
+				"incapacitated",
+				"invisible"
+			],
+			"conditionInflictSpell": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mist Wanderer",
+			"source": "RHW",
+			"page": 256,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 52,
+				"formula": "8d8 + 16"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 10,
+			"dex": 14,
+			"con": 14,
+			"int": 12,
+			"wis": 16,
+			"cha": 13,
+			"skill": {
+				"arcana": "+3",
+				"insight": "+5",
+				"medicine": "+5"
+			},
+			"passive": 13,
+			"languages": [
+				"Common plus one other language"
+			],
+			"cr": "3",
+			"gear": [
+				"orb|xphb",
+				"leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The wanderer casts one of the following spells, using Wisdom as the spellcasting ability (spell save {@dc 13}):"
+					],
+					"will": [
+						"{@spell Light|XPHB}",
+						"{@spell Mage Hand|XPHB}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Augury|XPHB}",
+							"{@spell Detect Magic|XPHB}",
+							"{@spell Mind Spike|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				},
+				{
+					"name": "Evil Eye (1/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The wanderer casts {@spell Hold Person|XPHB}, using the same spellcasting ability as Spellcasting."
+					],
+					"daily": {
+						"1": [
+							"{@spell Hold Person|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Death Curse",
+					"entries": [
+						"{@actSave cha} {@dc 13}, each creature in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the wanderer when it dies. {@actSaveFail} The target is cursed. While cursed, the target has the {@condition Blinded|XPHB} and {@condition Deafened|XPHB} conditions."
+					]
+				},
+				{
+					"name": "Mist Walker",
+					"entries": [
+						"The wanderer can travel safely through the Mists to reach a specific domain it knows by name. The wanderer still can't bypass domain borders closed by a Darklord's will."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The wanderer makes two Radiant Burst attacks. It can replace one attack with a use of Spellcasting to cast {@spell Mind Spike|XPHB} if available."
+					]
+				},
+				{
+					"name": "Radiant Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 5}, reach 5 ft. or range 60 ft. {@h}14 ({@damage 2d10 + 3}) Radiant damage."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"arcana",
+				"individual"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"R"
+			],
+			"damageTagsSpell": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"CUR",
+				"MA",
+				"RA"
+			],
+			"conditionInflictSpell": [
+				"paralyzed"
+			],
+			"savingThrowForced": [
+				"charisma"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mordenheim's Monster",
+			"source": "RHW",
+			"page": 257,
+			"size": [
+				"M"
+			],
+			"type": "construct",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 161,
+				"formula": "19d8 + 76"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 22,
+			"dex": 16,
+			"con": 19,
+			"int": 14,
+			"wis": 10,
+			"cha": 5,
+			"save": {
+				"str": "+10",
+				"dex": "+7"
+			},
+			"skill": {
+				"acrobatics": "+7",
+				"athletics": "+14"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 10,
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"slashing"
+			],
+			"immune": [
+				"lightning",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"petrified",
+				"poisoned"
+			],
+			"languages": [
+				"Common plus one other language"
+			],
+			"cr": "12",
+			"trait": [
+				{
+					"name": "Greater Lightning Absorption",
+					"entries": [
+						"Whenever the monster is subjected to Lightning damage, it regains a number of {@variantrule Hit Points|XPHB} equal to the Lightning damage dealt, and its {@variantrule Speed|XPHB} increases by 40 feet until the end of its next turn."
+					]
+				},
+				{
+					"name": "Immutable Form",
+					"entries": [
+						"The monster can't shape-shift."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The monster has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The monster makes two Slam attacks and uses Crush or Throw."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 5 ft. {@h}13 ({@damage 2d6 + 6}) Bludgeoning damage plus 7 ({@damage 2d6}) Lightning damage. If the target is a Medium or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 18}) from one of two hands."
+					]
+				},
+				{
+					"name": "Crush",
+					"entries": [
+						"{@actSave str} {@dc 18}, one creature {@condition Grappled|XPHB} by the monster. {@actSaveFail} 13 ({@damage 2d6 + 6}) Bludgeoning damage plus 7 ({@damage 2d6}) Lightning damage, and the target has the {@condition Restrained|XPHB} condition. While {@condition Restrained|XPHB}, the target is suffocating."
+					]
+				},
+				{
+					"name": "Throw",
+					"entries": [
+						"The monster throws a creature {@condition Grappled|XPHB} by it to a space it can see within 30 feet of itself that isn't in the air. {@actSave dex} {@dc 18}, the creature thrown and each creature in the destination space. {@actSaveFail} 13 ({@damage 2d6 + 6}) Bludgeoning damage, and the target has the {@condition Prone|XPHB} condition. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Violent Leap",
+					"entries": [
+						"The monster spends 10 feet of movement to jump to a space within 40 feet that contains one or more Medium or smaller creatures. {@actSave dex} {@dc 18}, each creature in the monster's destination space. {@actSaveFail} 14 ({@damage 4d6}) Bludgeoning damage, and the target has the {@condition Prone|XPHB} condition. {@actSaveSuccessOrFail} The target moves to the nearest unoccupied space."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"treasure": [
+				"individual"
+			],
+			"traitTags": [
+				"Damage Absorption",
+				"Immutable Form",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"B",
+				"L"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"grappled",
+				"prone",
+				"restrained"
+			],
+			"savingThrowForced": [
+				"dexterity",
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mother Lorinda",
+			"source": "RHW",
+			"page": 166,
+			"size": [
+				"M"
+			],
+			"type": "fey",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 105,
+				"formula": "14d8 + 42"
+			},
+			"speed": {
+				"walk": 30,
+				"swim": 30
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 18,
+			"dex": 13,
+			"con": 16,
+			"int": 13,
+			"wis": 17,
+			"cha": 15,
+			"save": {
+				"str": "+7",
+				"dex": "+4",
+				"con": "+6",
+				"wis": "+6"
+			},
+			"skill": {
+				"arcana": "+7",
+				"deception": "+5",
+				"perception": "+6",
+				"stealth": "+4"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 16,
+			"languages": [
+				"Common",
+				"Elvish",
+				"Sylvan"
+			],
+			"cr": {
+				"cr": "8",
+				"xpLair": 5000
+			},
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Lorinda casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save {@dc 14}, {@hit 6} to hit with spell attacks):"
+					],
+					"will": [
+						"{@spell Charm Person|XPHB}",
+						"{@spell Dancing Lights|XPHB}",
+						"{@spell Disguise Self|XPHB} (24-hour duration)",
+						"{@spell Invisibility|XPHB} (self only, and Lorinda leaves no tracks while {@condition Invisible|XPHB})",
+						"{@spell Minor Illusion|XPHB}",
+						"{@spell Ray of Sickness|XPHB} (level 3 version)"
+					],
+					"daily": {
+						"1e": [
+							"{@spell Augury|XPHB}",
+							"{@spell Blight|XPHB}",
+							"{@spell Plant Growth|XPHB}",
+							"{@spell Scrying|XPHB}",
+							"{@spell Unseen Servant|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "action"
+				},
+				{
+					"name": "Overwhelming Presence",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Lorinda casts {@spell Slow|XPHB}, using the same spellcasting ability as Spellcasting. Lorinda can't take this action again until the start of her next turn."
+					],
+					"legendary": {
+						"1": [
+							"{@spell Slow|XPHB}"
+						]
+					},
+					"ability": "wis",
+					"displayAs": "legendary",
+					"hidden": [
+						"legendary"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"Lorinda can breathe air and water."
+					]
+				},
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Lorinda dies, she revives with all her {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Tepest."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Lorinda fails a saving throw, she can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Mimicry",
+					"entries": [
+						"Lorinda can mimic noises and animal sounds. A creature that hears the mimicry can tell it is an imitation only with a successful {@dc 15} Wisdom ({@skill Insight|XPHB}) check."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Lorinda makes two Mother's Brand attacks."
+					]
+				},
+				{
+					"name": "Mother's Brand",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Bludgeoning damage plus 5 ({@damage 1d10}) Fire damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Mother's Visage (1/Day)",
+					"entries": [
+						"Lorinda shape-shifts into Mother, a deity revered by the people of Tepest, for 8 hours. Her game statistics are the same in each form. Any equipment she is wearing or carrying isn't transformed.",
+						"While in the form of Mother, Lorinda can use Spellcasting to cast {@spell Charm Person|XPHB} as a {@variantrule Bonus Action|XPHB}.",
+						"Lorinda reverts to her true form if she drops to 50 {@variantrule Hit Points|XPHB} or fewer.",
+						"When Lorinda reverts to her true form, each creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Lorinda is subjected to the following effect. {@actSave wis} {@dc 14} (the target succeeds automatically if it is a Construct or an Undead). {@actSaveFail} The target has the {@condition Frightened|XPHB} condition for 1 minute. While {@condition Frightened|XPHB}, the target has {@variantrule Disadvantage|XPHB} on saving throws."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Brand",
+					"entries": [
+						"Lorinda teleports to an unoccupied space she can see within 30 feet and can make one Mother's Brand attack."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Mother Lorinda",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Amphibious",
+				"Legendary Resistances",
+				"Mimicry"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"E",
+				"S"
+			],
+			"damageTags": [
+				"B",
+				"F"
+			],
+			"damageTagsSpell": [
+				"I",
+				"N"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"invisible",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"savingThrowForcedSpell": [
+				"constitution",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Necrichor",
+			"source": "RHW",
+			"page": 258,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 85,
+				"formula": "10d8 + 40"
+			},
+			"speed": {
+				"walk": 20,
+				"climb": 20
+			},
+			"str": 8,
+			"dex": 16,
+			"con": 18,
+			"int": 17,
+			"wis": 13,
+			"cha": 10,
+			"save": {
+				"con": "+7",
+				"int": "+6",
+				"wis": "+4"
+			},
+			"senses": [
+				"Blindsight 120 ft."
+			],
+			"passive": 11,
+			"resist": [
+				"acid",
+				"necrotic"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"blinded",
+				"charmed",
+				"deafened",
+				"exhaustion",
+				"frightened",
+				"grappled",
+				"paralyzed",
+				"poisoned",
+				"prone",
+				"restrained"
+			],
+			"languages": [
+				"telepathy 120 ft. Common plus two other languages"
+			],
+			"cr": "7",
+			"trait": [
+				{
+					"name": "Amorphous",
+					"entries": [
+						"The necrichor can move through a space as narrow as 1 inch without expending extra movement to do so."
+					]
+				},
+				{
+					"name": "Legendary Resistance (2/Day)",
+					"entries": [
+						"If the necrichor fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Reborn by Blood",
+					"entries": [
+						"If destroyed, the necrichor revives with all its {@variantrule Hit Points|XPHB} in {@dice 1d10} days in the nearest unoccupied space next to a creature of its choice that it has previously possessed with its Blood Puppeteering action. This trait doesn't function if the destroyed necrichor's remains are in a vessel affected by the {@spell Hallow|XPHB} spell or if all the necrichor's previous Blood Puppeteering targets are dead."
+					]
+				},
+				{
+					"name": "Spider Climb",
+					"entries": [
+						"The necrichor can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The necrichor makes two Necrotic Burst attacks."
+					]
+				},
+				{
+					"name": "Necrotic Burst",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 120 ft. {@h}12 ({@damage 2d8 + 3}) Force damage plus 11 ({@damage 2d10}) Necrotic damage, and the target has the {@condition Poisoned|XPHB} condition until the start of the necrichor's next turn. While {@condition Poisoned|XPHB}, the target can't regain {@variantrule Hit Points|XPHB}."
+					]
+				},
+				{
+					"name": "Blood Puppeteering {@recharge}",
+					"entries": [
+						"{@actSave con} {@dc 15}, one {@status Bloodied|XPHB} creature within 5 feet. Constructs and Undead automatically succeed on this save. {@actSaveFail} The target is possessed by the necrichor; the necrichor disappears, and the target has the {@condition Incapacitated|XPHB} condition and loses control of its body. The necrichor now controls the target's body, but the target retains awareness. The necrichor can't be targeted by any attack, spell, or other effect except ones that specifically target Undead. The necrichor's game statistics are the same, except it uses the possessed target's {@variantrule Speed|XPHB} and Strength, Dexterity, and Constitution scores.",
+						"The possession lasts until the target drops to 0 {@variantrule Hit Points|XPHB} or the necrichor leaves it as a {@variantrule Bonus Action|XPHB}. When the possession ends, the necrichor appears in an unoccupied space within 5 feet of the target, and the target is immune to this necrichor's Blood Puppeteering for 24 hours. {@actSaveSuccess} The target is immune to this necrichor's Blood Puppeteering for 24 hours."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"traitTags": [
+				"Amorphous",
+				"Legendary Resistances",
+				"Spider Climb"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"TP",
+				"X"
+			],
+			"damageTags": [
+				"N",
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"incapacitated",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Nightgaunt",
+			"source": "RHW",
+			"page": 259,
+			"size": [
+				"L"
+			],
+			"type": "aberration",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 136,
+				"formula": "16d10 + 48"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 17,
+			"dex": 20,
+			"con": 16,
+			"int": 13,
+			"wis": 16,
+			"cha": 10,
+			"save": {
+				"dex": "+8",
+				"wis": "+6"
+			},
+			"senses": [
+				"Blindsight 60 ft."
+			],
+			"passive": 13,
+			"resist": [
+				"lightning",
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"blinded",
+				"deafened",
+				"exhaustion"
+			],
+			"languages": [
+				"understands Deep Speech but can't speak"
+			],
+			"cr": "8",
+			"trait": [
+				{
+					"name": "Flyby",
+					"entries": [
+						"The nightgaunt doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The nightgaunt makes two attacks, using Claw or Barb in any combination. It can replace one attack with a use of Ascend."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}14 ({@damage 2d8 + 5}) Slashing damage plus 10 ({@damage 3d6}) Poison damage. If the target is a Medium or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 13})."
+					]
+				},
+				{
+					"name": "Barb",
+					"entries": [
+						"{@atkr r} {@hit 8}, range 60 ft. {@h}21 ({@damage 6d6}) Piercing damage, and the target has the {@condition Poisoned|XPHB} condition until the end of its next turn."
+					]
+				},
+				{
+					"name": "Ascend",
+					"entries": [
+						"The nightgaunt flies upward in a straight line, moving up to its {@variantrule Fly Speed|XPHB}. If the nightgaunt is grappling a creature, it ignores the extra movement cost to carry the creature with it."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Tickle",
+					"entries": [
+						"{@actSave wis} {@dc 16}, one creature {@condition Grappled|XPHB} by the nightgaunt. {@actSaveFail} The target has the {@condition Incapacitated|XPHB} condition until the start of the nightgaunt's next turn."
+					]
+				}
+			],
+			"environment": [
+				"mountain",
+				"underdark"
+			],
+			"treasure": [
+				"implements",
+				"individual"
+			],
+			"traitTags": [
+				"Flyby"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"CS",
+				"DS"
+			],
+			"damageTags": [
+				"I",
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"grappled",
+				"incapacitated",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Petrifying Death's Head",
+			"source": "RHW",
+			"page": 243,
+			"size": [
+				"T"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 21,
+				"formula": "6d4 + 6"
+			},
+			"speed": {
+				"walk": 5,
+				"fly": {
+					"number": 30,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 8,
+			"dex": 12,
+			"con": 13,
+			"int": 5,
+			"wis": 14,
+			"cha": 3,
+			"save": {
+				"con": "+3"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 12,
+			"resist": [
+				"necrotic"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"poisoned"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Flyby",
+					"entries": [
+						"The death's head doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Petrifying Bite",
+					"entries": [
+						"{@atkr m} {@hit 3}, reach 5 ft. {@h}3 ({@damage 1d4 + 1}) Piercing damage plus 3 ({@damage 1d6}) Necrotic damage. If the target is a creature, it is subjected to the following effect. {@actSave con} {@dc 11}. {@actSaveFail 1} The target has the {@condition Restrained|XPHB} condition and repeats the save at the end of its next turn if it is still {@condition Restrained|XPHB}, ending the effect on itself on a success. {@actSaveFail 2} The target has the {@condition Petrified|XPHB} condition instead of the {@condition Restrained|XPHB} condition for 10 minutes, after which the effect ends on the target."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"swamp",
+				"urban"
+			],
+			"traitTags": [
+				"Flyby"
+			],
+			"senseTags": [
+				"D"
+			],
+			"damageTags": [
+				"N",
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"petrified",
+				"restrained"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Priest of Osybus",
+			"source": "RHW",
+			"page": 261,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 60,
+				"formula": "8d8 + 24"
+			},
+			"speed": {
+				"walk": 20,
+				"climb": 20
+			},
+			"str": 10,
+			"dex": 14,
+			"con": 16,
+			"int": 18,
+			"wis": 17,
+			"cha": 11,
+			"save": {
+				"int": "+7",
+				"wis": "+6",
+				"cha": "+3"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 13,
+			"languages": [
+				"Common plus two other languages"
+			],
+			"cr": "6",
+			"trait": [
+				{
+					"name": "Tattoo of Osybus",
+					"entries": [
+						"If damage reduces the priest to 0 {@variantrule Hit Points|XPHB}, it receives a random boon. Roll {@dice 1d6} to determine the boon the priest receives. The priest revives at the start of its next turn with half its {@variantrule Hit Points|XPHB}, and its creature type is now Undead."
+					]
+				},
+				{
+					"name": "1: Dread Boon",
+					"entries": [
+						"An aura of dread fills a 15-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the priest. {@actSave wis} {@dc 15}, each non-Undead creature that starts its turn in the {@variantrule Emanation [Area of Effect]|XPHB|Emanation}. {@actSaveFail} The target has the {@condition Frightened|XPHB} condition until the start of its next turn"
+					]
+				},
+				{
+					"name": "2: Ectoplasmic Boon",
+					"entries": [
+						"Sticky ectoplasm slows creatures in a 15-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the priest. {@actSave str} {@dc 15}, each creature that starts its turn in the {@variantrule Emanation [Area of Effect]|XPHB|Emanation}. {@actSaveFail} The target's {@variantrule Speed|XPHB} is reduced by 10 feet until the start of its next turn."
+					]
+				},
+				{
+					"name": "3: Vampiric Boon",
+					"entries": [
+						"When the priest deals Necrotic damage to a creature, the priest gains {@variantrule Temporary Hit Points|XPHB} equal to the damage dealt."
+					]
+				},
+				{
+					"name": "4: Blazing Boon",
+					"entries": [
+						"The priest has a {@variantrule Fly Speed|XPHB} of 30 feet and {@variantrule Immunity|XPHB} to Fire damage."
+					]
+				},
+				{
+					"name": "5: Spectral Boon",
+					"entries": [
+						"The priest has {@variantrule Resistance|XPHB} to Bludgeoning, Piercing, and Slashing damage, and it has {@variantrule Vulnerability|XPHB} to Radiant damage. Additionally, the priest can move through other creatures and objects as if they were {@variantrule Difficult Terrain|XPHB}. It takes 5 ({@damage 1d10}) Force damage if it ends its turn inside an object."
+					]
+				},
+				{
+					"name": "6: Deathly Boon",
+					"entries": [
+						"When the priest revives with this boon, all corpses of Small or Medium Humanoids in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the priest rise as Skeletons under the priest's control. Additionally, at the end of each of the priest's turns, each non-Undead creature in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the priest takes 5 ({@damage 1d10}) Necrotic damage.",
+						"The priest dies and this trait doesn't function if the priest receives a boon it already has or the priest's tattoo of Osybus is destroyed. The tattoo is destroyed only if the priest takes 15 damage or more on a single turn while the priest has 0 {@variantrule Hit Points|XPHB}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The priest makes two attacks, using Soul Blade or Necrotic Bolt in any combination."
+					]
+				},
+				{
+					"name": "Soul Blade",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}9 ({@damage 2d4 + 4}) Piercing damage. If the target is a creature, it has the {@condition Paralyzed|XPHB} condition until the start of the priest's next turn. If this damage reduces a Medium or smaller creature to 0 {@variantrule Hit Points|XPHB}, the creature dies, and its soul becomes trapped in a soul tattoo on the priest's body. The soul is freed if the priest dies."
+					]
+				},
+				{
+					"name": "Necrotic Bolt",
+					"entries": [
+						"{@atkr r} {@hit 7}, range 120 ft. {@h}30 ({@damage 4d12 + 4}) Necrotic damage, and the target can't regain {@variantrule Hit Points|XPHB} until the start of the priest's next turn."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Soul Tattoo {@recharge 5}",
+					"entries": [
+						"The priest magically animates a soul tattoo on its body that becomes a Shadow in an unoccupied space within 5 feet of the priest. The shadow takes its turn immediately after the priest on the same {@variantrule Initiative|XPHB} count, and it obeys the priest. The shadow remains animate until it is destroyed, it is more than 120 feet from the priest, the priest dies, or the priest uses this {@variantrule Bonus Action|XPHB} again."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"any"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"N",
+				"O",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"frightened",
+				"paralyzed"
+			],
+			"savingThrowForced": [
+				"strength",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Ramya Vasavadan",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 116,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 190,
+				"formula": "20d8 + 100"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 14,
+			"dex": 20,
+			"con": 20,
+			"int": 12,
+			"wis": 16,
+			"cha": 18,
+			"save": {
+				"str": "+7",
+				"wis": "+8"
+			},
+			"skill": {
+				"perception": "+8",
+				"persuasion": "+9"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 18,
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"Abyssal",
+				"Common"
+			],
+			"cr": {
+				"cr": "15",
+				"xpLair": 15000
+			},
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Ramya casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 17}):"
+					],
+					"will": [
+						"{@spell Phantom Steed|XPHB}"
+					],
+					"daily": {
+						"1": [
+							"{@spell Create Undead|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action"
+				},
+				{
+					"name": "Illusory Disguise",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Ramya casts {@spell Disguise Self|XPHB} using the same spellcasting ability as Spellcasting. The spell lasts until Ramya drops to 80 {@variantrule Hit Points|XPHB} or fewer or uses her Vengeful Fire action. Intelligence ({@skill Investigation|XPHB}) checks to discern her true appearance are made with {@variantrule Disadvantage|XPHB}.",
+						"When the disguise ends, each creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Ramya is subjected to the following effect. Wisdom {@variantrule Saving Throw|XPHB}: {@dc 17} (the target succeeds automatically if it is a Construct or an Undead). Failure: The target has the {@condition Frightened|XPHB} condition for 1 minute. While {@condition Frightened|XPHB}, the target has {@variantrule Disadvantage|XPHB} on saving throws."
+					],
+					"will": [
+						"{@spell Disguise Self|XPHB}"
+					],
+					"ability": "cha",
+					"displayAs": "bonus",
+					"hidden": [
+						"will"
+					]
+				},
+				{
+					"name": "Dread Authority",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Ramya casts {@spell Command|XPHB}, using the same spellcasting ability as Spellcasting. Ramya can't take this action again until the start of her next turn."
+					],
+					"legendary": {
+						"1": [
+							"{@spell Command|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "legendary",
+					"hidden": [
+						"legendary"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Ramya dies, her body dissolves into mist, and she gains a new body in {@dice 1d10} weeks, reviving with all her {@variantrule Hit Points|XPHB} somewhere in Kalakeri."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Ramya fails a saving throw, she can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Ramya has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Marshal Undead",
+					"entries": [
+						"Undead creatures of Ramya's choice (excluding herself) in a 60-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from her have {@variantrule Advantage|XPHB} on attack rolls and saving throws. She can't use this trait if she has the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Ramya makes three Dread Blade attacks."
+					]
+				},
+				{
+					"name": "Dread Blade",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 5 ft. {@h}12 ({@damage 2d6 + 5}) Slashing damage plus 9 ({@damage 2d8}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Vengeful Fire {@recharge 5}",
+					"entries": [
+						"{@actSave dex} {@dc 17}, each creature in a 20-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point Ramya can see within 120 feet. {@actSaveFail} 28 ({@damage 8d6}) Fire damage plus 28 ({@damage 8d6}) Necrotic damage. {@actSaveSuccess} Half damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Parry",
+					"entries": [
+						"{@actTrigger} Ramya is hit by a melee attack roll while holding a weapon. {@actResponse} Ramya adds 5 to her AC against that attack, possibly causing it to miss."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Lunge",
+					"entries": [
+						"Ramya moves up to half her {@variantrule Speed|XPHB} and makes one Dread Blade attack."
+					]
+				},
+				{
+					"name": "Words of Silence",
+					"entries": [
+						"{@actSave con} {@dc 17}, one creature Ramya can see within 120 feet. {@actSaveFail} 21 ({@damage 6d6}) Psychic damage, and the target is cursed until the end of its next turn. Until the curse ends, the target can't speak or cast spells with a Verbal component. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"traitTags": [
+				"Legendary Resistances",
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack",
+				"Parry"
+			],
+			"languageTags": [
+				"AB",
+				"C"
+			],
+			"damageTags": [
+				"F",
+				"N",
+				"S",
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA"
+			],
+			"conditionInflictSpell": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"dexterity"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Reanimated Companion",
+			"source": "RHW",
+			"summonedByClass": "Artificer|EFA",
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				{
+					"special": "10 plus your Intelligence modifier"
+				}
+			],
+			"hp": {
+				"special": "5 plus five times your Artificer level (the companion has a number of Hit Dice [d8s] equal to your Artificer level)"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 11,
+			"dex": 10,
+			"con": 16,
+			"int": 4,
+			"wis": 10,
+			"cha": 6,
+			"senses": [
+				"blindsight 60 ft."
+			],
+			"passive": 10,
+			"resist": [
+				"necrotic",
+				"poison"
+			],
+			"immune": [
+				"lightning"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"poisoned"
+			],
+			"languages": [
+				"understands the languages you know"
+			],
+			"pbNote": "equals your Proficiency Bonus",
+			"trait": [
+				{
+					"name": "Death Burst",
+					"entries": [
+						"The companion explodes when it dies. {@actSave dex} DC equals {@dcYourSpellSave}, each creature in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the companion. {@actSaveFail} {@damage 2d4} Necrotic damage. {@actSaveSuccess} Half damage."
+					]
+				},
+				{
+					"name": "Lightning Absorption",
+					"entries": [
+						"Whenever the companion is subjected to Lightning damage, it regains a number of {@variantrule Hit Points|XPHB} equal to the Lightning damage dealt."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Dreadful Swipe",
+					"entries": [
+						"{@atkr m} {@hitYourSpellAttack Bonus equals your spell attack modifier}, reach 5 ft. {@h}{@dice 1d4} plus your Intelligence modifier Necrotic damage, and the target can't take {@action Opportunity Attack|XPHB|Opportunity Attacks} until the start of its next turn."
+					]
+				}
+			],
+			"traitTags": [
+				"Damage Absorption",
+				"Death Burst"
+			],
+			"senseTags": [
+				"B"
+			],
+			"damageTags": [
+				"N"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"hasToken": true
+		},
+		{
+			"name": "Relentless Juggernaut",
+			"source": "RHW",
+			"page": 263,
+			"size": [
+				"L"
+			],
+			"type": "fiend",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 168,
+				"formula": "16d10 + 80"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 22,
+			"dex": 12,
+			"con": 20,
+			"int": 8,
+			"wis": 15,
+			"cha": 16,
+			"save": {
+				"dex": "+5",
+				"wis": "+6",
+				"cha": "+7"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 12,
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened"
+			],
+			"languages": [
+				"understands all but can't speak"
+			],
+			"cr": "12",
+			"trait": [
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the juggernaut fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Regeneration",
+					"entries": [
+						"The juggernaut regains 10 {@variantrule Hit Points|XPHB} at the start of each of its turns. If the juggernaut takes Radiant damage or damage from a {@variantrule Critical Hit|XPHB}, this trait doesn't function on the juggernaut's next turn. The juggernaut dies only if it starts its turn with 0 {@variantrule Hit Points|XPHB} and doesn't regenerate."
+					]
+				},
+				{
+					"name": "Siege Monster",
+					"entries": [
+						"The juggernaut deals double damage to objects and structures."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The juggernaut makes two attacks, using Executioner's Blade or Crushing Stone in any combination."
+					]
+				},
+				{
+					"name": "Executioner's Blade",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 10 ft. {@h}19 ({@damage 3d8 + 6}) Slashing damage, and the target's {@variantrule Speed|XPHB} is reduced by 10 feet until the end of the juggernaut's next turn."
+					]
+				},
+				{
+					"name": "Crushing Stone",
+					"entries": [
+						"{@atkr r} {@hit 10}, range 60 ft. {@h}13 ({@damage 2d6 + 6}) Bludgeoning damage, and the target has the {@condition Incapacitated|XPHB} condition until the start of the juggernaut's next turn."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Implacable Advance",
+					"entries": [
+						"The juggernaut moves up to half its {@variantrule Speed|XPHB}, ignoring {@variantrule Difficult Terrain|XPHB}. Each creature in its path is subjected to the following effect. {@actSave str} {@dc 18}. {@actSaveFail} 7 ({@damage 2d6}) Bludgeoning damage, and the target has the {@condition Prone|XPHB} condition. {@actSaveSuccessOrFail} The juggernaut can't take this action again until the start of its next turn."
+					]
+				},
+				{
+					"name": "Sweeping Blade",
+					"entries": [
+						"{@actSave dex} {@dc 18}, each creature in a 15-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 11 ({@damage 1d10 + 6}) Slashing damage, and the target is pulled up to 10 feet straight toward the juggernaut."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"armaments"
+			],
+			"traitTags": [
+				"Legendary Resistances",
+				"Regeneration",
+				"Siege Monster"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"CS",
+				"XX"
+			],
+			"damageTags": [
+				"B",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"incapacitated",
+				"prone"
+			],
+			"savingThrowForced": [
+				"dexterity",
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Relentless Nightmare",
+			"source": "RHW",
+			"page": 263,
+			"size": [
+				"M"
+			],
+			"type": "fiend",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				17
+			],
+			"hp": {
+				"average": 144,
+				"formula": "17d8 + 68"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 20,
+			"dex": 18,
+			"con": 19,
+			"int": 13,
+			"wis": 16,
+			"cha": 18,
+			"save": {
+				"dex": "+8",
+				"con": "+8",
+				"cha": "+8"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 13,
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened"
+			],
+			"languages": [
+				"understands all but can't speak"
+			],
+			"cr": "11",
+			"trait": [
+				{
+					"name": "Legendary Resistance (2/Day)",
+					"entries": [
+						"If the nightmare fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Nightmarish Restoration",
+					"entries": [
+						"If the nightmare dies, its body disappears into mist, and it gains a new body in {@dice 1d10} days, reviving with all its {@variantrule Hit Points|XPHB} in the nearest unoccupied space next to an {@condition Unconscious|XPHB} creature cursed by its Haunter's Spear. This trait doesn't function if there are no remaining targets cursed in this way."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The nightmare makes two Haunter's Spear attacks. It can replace one attack with a use of Exhausting Gaze."
+					]
+				},
+				{
+					"name": "Haunter's Spear",
+					"entries": [
+						"{@atk m,r} +9, reach 10 ft. or range 60 ft. {@h}14 ({@damage 2d8 + 5}) Piercing damage plus 10 ({@damage 3d6}) Psychic damage. Additionally, the target is cursed by the nightmare if it isn't already. Until this curse ends, finishing a {@variantrule Long Rest|XPHB} doesn't reduce the target's {@condition Exhaustion|XPHB} level."
+					]
+				},
+				{
+					"name": "Exhausting Gaze",
+					"entries": [
+						"{@actSave wis} {@dc 16}, one creature the nightmare can see within 60 feet. {@actSaveFail} 14 ({@damage 4d6}) Psychic damage, and the target gains 1 {@condition Exhaustion|XPHB} level."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Dreamwalk",
+					"entries": [
+						"The nightmare teleports to an unoccupied space within 5 feet of a creature it can see, then makes a Haunter's Spear attack."
+					]
+				},
+				{
+					"name": "Narcotize",
+					"entries": [
+						"The nightmare targets one creature it can see within 120 feet that's cursed by its Haunter's Spear. The target takes 7 ({@damage 2d6}) Psychic damage and has the {@condition Unconscious|XPHB} condition for 1 hour, until it takes damage, or until a creature within 5 feet of it takes an action to wake it."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"armaments"
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"CS",
+				"XX"
+			],
+			"damageTags": [
+				"P",
+				"Y"
+			],
+			"miscTags": [
+				"CUR",
+				"MA",
+				"MLW",
+				"RA",
+				"RCH",
+				"THW"
+			],
+			"conditionInflict": [
+				"unconscious"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Relentless Slasher",
+			"source": "RHW",
+			"page": 262,
+			"size": [
+				"M"
+			],
+			"type": "fiend",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 91,
+				"formula": "14d8 + 28"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 12,
+			"dex": 18,
+			"con": 14,
+			"int": 14,
+			"wis": 15,
+			"cha": 16,
+			"save": {
+				"str": "+4",
+				"dex": "+7",
+				"con": "+5",
+				"wis": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 12,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"understands all but can't speak"
+			],
+			"cr": "8",
+			"trait": [
+				{
+					"name": "Legendary Resistance (1/Day)",
+					"entries": [
+						"If the slasher fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The slasher makes two Slasher's Knife attacks."
+					]
+				},
+				{
+					"name": "Slasher's Knife",
+					"entries": [
+						"{@atkr m,r} {@hit 7}, reach 5 ft. or range 30/60 ft. {@h}9 ({@damage 2d4 + 4}) Slashing damage plus 21 ({@damage 6d6}) Necrotic damage."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Homing Knife",
+					"entries": [
+						"{@actSave dex} {@dc 15}, one creature within 120 feet that the slasher has hit with its Slasher's Knife attack within the last 24 hours. {@actSaveFail} 11 ({@damage 2d6 + 4}) Slashing damage."
+					]
+				},
+				{
+					"name": "Vanishing Strike",
+					"entries": [
+						"The slasher makes one Slasher's Knife attack, then teleports up to 30 feet to an unoccupied space it can see. The slasher can't take this action again until the start of its next turn."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"treasure": [
+				"armaments"
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"CS",
+				"XX"
+			],
+			"damageTags": [
+				"N",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Rudolph van Richten",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 264,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"L",
+				"G"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 105,
+				"formula": "14d8 + 42"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 9,
+			"dex": 14,
+			"con": 16,
+			"int": 17,
+			"wis": 18,
+			"cha": 15,
+			"save": {
+				"con": "+6",
+				"wis": "+7"
+			},
+			"skill": {
+				"arcana": "+6",
+				"medicine": "+7",
+				"perception": "+7",
+				"religion": "+6",
+				"sleight of hand": "+5"
+			},
+			"passive": 17,
+			"languages": [
+				"Abyssal",
+				"Common",
+				"Elvish",
+				"Infernal"
+			],
+			"cr": "5",
+			"gear": [
+				"hand crossbow|xphb",
+				"leather armor|xphb"
+			],
+			"trait": [
+				{
+					"name": "Shield of Erasmus",
+					"entries": [
+						"While {@status Bloodied|XPHB}, Rudolph has {@variantrule Resistance|XPHB} to Force, Poison, and Psychic damage."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Rudolph makes three attacks, using Silver Sword Cane or Hand Crossbow in any combination."
+					]
+				},
+				{
+					"name": "Silver Sword Cane",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}5 ({@damage 1d6 + 2}) Slashing damage plus 5 ({@damage 2d4}) Radiant damage. Critical {@h}The target has the {@condition Poisoned|XPHB} condition until it finishes a {@variantrule Long Rest|XPHB}. It makes a {@dc 15} Constitution saving throw at end of each hour, ending the effect on a success."
+					]
+				},
+				{
+					"name": "Hand Crossbow",
+					"entries": [
+						"{@atkr r} {@hit 5}, range 30/120 ft. {@h}5 ({@damage 1d6 + 2}) Piercing damage plus 5 ({@damage 2d4}) Radiant damage."
+					]
+				},
+				{
+					"name": "Repel Evil {@recharge 5}",
+					"entries": [
+						"{@actSave cha} {@dc 15}, each creature of Rudolph's choice in a 30-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 18 ({@damage 4d8}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the end of Rudolph's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Occult Aid (2/Day)",
+					"entries": [
+						"Rudolph casts {@spell Cure Wounds|XPHB}, {@spell Dispel Evil and Good|XPHB}, or {@spell Sanctuary|XPHB}, using Wisdom as the spellcasting modifier (spell save {@dc 15})."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AB",
+				"C",
+				"E",
+				"I"
+			],
+			"damageTags": [
+				"P",
+				"R",
+				"S",
+				"Y"
+			],
+			"miscTags": [
+				"MA",
+				"RA",
+				"RNG"
+			],
+			"conditionInflict": [
+				"frightened",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"charisma",
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Saidra d'Honaire",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 72,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 90,
+				"formula": "12d8 + 36"
+			},
+			"speed": {
+				"walk": 5,
+				"fly": {
+					"number": 60,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"initiative": {
+				"proficiency": 2
+			},
+			"str": 6,
+			"dex": 17,
+			"con": 16,
+			"int": 12,
+			"wis": 14,
+			"cha": 17,
+			"save": {
+				"dex": "+7",
+				"wis": "+6"
+			},
+			"skill": {
+				"insight": "+10",
+				"perception": "+6",
+				"performance": "+7",
+				"stealth": "+7"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 16,
+			"resist": [
+				"acid",
+				"bludgeoning",
+				"cold",
+				"fire",
+				"piercing",
+				"slashing"
+			],
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"poisoned",
+				"prone",
+				"restrained",
+				"unconscious"
+			],
+			"languages": [
+				"Common"
+			],
+			"cr": {
+				"cr": "9",
+				"xpLair": 5900
+			},
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Saidra casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save {@dc 15}):"
+					],
+					"ability": "cha",
+					"displayAs": "action"
+				},
+				{
+					"name": "Truth or Die (1/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Saidra asks a creature she can see within 60 feet to identify itself and casts {@spell Disintegrate|XPHB} targeting the creature, requiring no Material components and using Charisma as the spellcasting ability ({@dc 15}, with {@variantrule Disadvantage|XPHB} if the target lies)."
+					],
+					"daily": {
+						"1": [
+							"{@spell Disintegrate|XPHB}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "action",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Saidra dies, she revives with all her {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Dementlieu."
+					]
+				},
+				{
+					"name": "Incorporeal Movement",
+					"entries": [
+						"Saidra can move through other creatures and objects as if they were {@variantrule Difficult Terrain|XPHB}. She takes 5 ({@damage 1d10}) Force damage if she ends her turn inside an object."
+					]
+				},
+				{
+					"name": "Lie Detector",
+					"entries": [
+						"Saidra knows whether she hears a lie."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Saidra fails a saving throw, she can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Sunlight Sensitivity",
+					"entries": [
+						"While in sunlight, Saidra has {@variantrule Disadvantage|XPHB} on ability checks and attack rolls"
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Saidra makes three Necrotic Burst attacks. She can replace one of these attacks with a use of Spellcasting."
+					]
+				},
+				{
+					"name": "Necrotic Burst",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. or range 30 ft. {@h}14 ({@damage 2d10 + 3}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Life Drain",
+					"entries": [
+						"{@actSave con} {@dc 15}, one creature Saidra can see within 30 feet. {@actSaveFail} 28 ({@damage 8d6}) Necrotic damage, and its {@variantrule Hit Points|XPHB|Hit Point} maximum decreases by an amount equal to the damage taken. {@actSaveSuccess} Half damage only."
+					]
+				},
+				{
+					"name": "At Will:",
+					"entries": [
+						"{@spell Charm Person|XPHB} (duchess form only), {@spell Fear|XPHB} (Red Death form only)."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"Saidra shape-shifts into the Red Death, or she returns to her true form as the duchess. Her game statistics are the same in each form. Any equipment she is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Lash Out",
+					"entries": [
+						"Saidra makes one Necrotic Burst attack."
+					]
+				},
+				{
+					"name": "Shadow Veil",
+					"entries": [
+						"Saidra gives herself the {@condition Invisible|XPHB} condition until the start of her next turn and can fly up to half her {@variantrule Fly Speed|XPHB}. The condition ends early immediately after Saidra deals damage. Saidra can't take this action again until the start of her next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Saidra d'Honaire",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Incorporeal Movement",
+				"Legendary Resistances",
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"N",
+				"O"
+			],
+			"damageTagsSpell": [
+				"O"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"HPR",
+				"MA"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"savingThrowForcedSpell": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Shoggoth",
+			"source": "RHW",
+			"page": 266,
+			"size": [
+				"H"
+			],
+			"type": "aberration",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 172,
+				"formula": "15d12 + 75"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": 30,
+				"swim": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 22,
+			"dex": 16,
+			"con": 21,
+			"int": 20,
+			"wis": 17,
+			"cha": 8,
+			"save": {
+				"dex": "+7",
+				"con": "+9"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 13,
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"slashing"
+			],
+			"immune": [
+				"cold"
+			],
+			"conditionImmune": [
+				"grappled",
+				"prone",
+				"restrained"
+			],
+			"languages": [
+				"Deep Speech; telepathy 60 ft."
+			],
+			"cr": "11",
+			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"The shoggoth can breathe air and water."
+					]
+				},
+				{
+					"name": "Mimicry",
+					"entries": [
+						"The shoggoth can mimic voices and animal sounds. A creature that hears this mimicry can tell it is an imitation only with a successful {@dc 13} Wisdom ({@skill Insight|XPHB}) check."
+					]
+				},
+				{
+					"name": "Susceptible to Charm",
+					"entries": [
+						"The shoggoth has {@variantrule Disadvantage|XPHB} on saving throws to avoid or end the {@condition Charmed|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The shoggoth makes three Pseudopod attacks. It can replace one attack with a use of Suction Burst if available."
+					]
+				},
+				{
+					"name": "Pseudopod",
+					"entries": [
+						"{@atkr m} {@hit 10}, reach 15 ft. {@h}15 ({@damage 2d8 + 6}) Bludgeoning damage plus 11 ({@damage 2d10}) Thunder damage, and the creature has the {@condition Grappled|XPHB} condition (escape {@dc 16}) from one of four pseudopods."
+					]
+				},
+				{
+					"name": "Suction Burst {@recharge 4}",
+					"entries": [
+						"{@actSave str} {@dc 18}, one creature {@condition Grappled|XPHB} by the shoggoth. {@actSaveFail} 22 ({@damage 4d10}) Thunder damage, and the target is repelled from the shoggoth. The target no longer has the {@condition Grappled|XPHB} condition, is pushed up to 30 feet straight away from the shoggoth, and has the {@condition Deafened|XPHB} and {@condition Stunned|XPHB} conditions until the end of its next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Cold Sprint",
+					"entries": [
+						"{@actTrigger} The shoggoth is subjected to Cold damage. {@actResponse} The shoggoth moves up to its {@variantrule Speed|XPHB} and can make one Pseudopod attack with {@variantrule Advantage|XPHB}."
+					]
+				}
+			],
+			"environment": [
+				"arctic",
+				"coastal",
+				"swamp",
+				"underdark"
+			],
+			"traitTags": [
+				"Amphibious",
+				"Mimicry"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"DS",
+				"TP"
+			],
+			"damageTags": [
+				"B",
+				"T"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"grappled"
+			],
+			"savingThrowForced": [
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Strahd Skeleton",
+			"source": "RHW",
+			"page": 269,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 65,
+				"formula": "10d8 + 20"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 17,
+			"dex": 13,
+			"con": 15,
+			"int": 12,
+			"wis": 15,
+			"cha": 16,
+			"save": {
+				"str": "+5"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 12,
+			"immune": [
+				"poison"
+			],
+			"vulnerable": [
+				"bludgeoning"
+			],
+			"conditionImmune": [
+				"exhaustion",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common but can't speak"
+			],
+			"cr": "4",
+			"gear": [
+				"longsword|xphb",
+				"shield|xphb"
+			],
+			"trait": [
+				{
+					"name": "Undead Fortitude",
+					"entries": [
+						"If damage reduces the skeleton to 0 {@variantrule Hit Points|XPHB}, it makes a Constitution saving throw ({@dc 5} plus the damage taken) unless the damage is Radiant or from a {@variantrule Critical Hit|XPHB}. On a successful save, the skeleton drops to 1 {@variantrule Hit Points|XPHB|Hit Point} instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The skeleton makes two Vampiric Longsword attacks. It can replace one attack with a use of Shield Bash."
+					]
+				},
+				{
+					"name": "Vampiric Longsword",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}7 ({@damage 1d8 + 3}) Slashing damage plus 7 ({@damage 2d6}) Necrotic damage. The target's {@variantrule Hit Points|XPHB|Hit Point} maximum decreases by an amount equal to the Necrotic damage taken."
+					]
+				},
+				{
+					"name": "Shield Bash",
+					"entries": [
+						"{@actSave str} {@dc 13}, one creature within 5 feet that the skeleton can see. {@actSaveFail} 10 ({@damage 2d6 + 3}) Bludgeoning damage. If the target is a Medium or smaller creature, it has the {@condition Prone|XPHB} condition."
+					]
+				}
+			],
+			"environment": [
+				"planar, shadowfell",
+				"underdark",
+				"urban"
+			],
+			"traitTags": [
+				"Undead Fortitude"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS"
+			],
+			"damageTags": [
+				"B",
+				"N",
+				"S"
+			],
+			"miscTags": [
+				"HPR",
+				"MA",
+				"MLW"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"savingThrowForced": [
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Strahd von Zarovich",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 42,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "undead",
+				"tags": [
+					"vampire"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 204,
+				"formula": "24d8 + 96"
+			},
+			"speed": {
+				"walk": 40,
+				"climb": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 18,
+			"dex": 18,
+			"con": 18,
+			"int": 20,
+			"wis": 15,
+			"cha": 18,
+			"save": {
+				"dex": "+9",
+				"wis": "+7",
+				"cha": "+9"
+			},
+			"skill": {
+				"arcana": "+15",
+				"perception": "+12",
+				"religion": "+10",
+				"stealth": "+14"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 22,
+			"resist": [
+				"necrotic"
+			],
+			"languages": [
+				"Abyssal",
+				"Common",
+				"Draconic",
+				"Elvish",
+				"Giant",
+				"Infernal"
+			],
+			"cr": {
+				"cr": "15",
+				"xpLair": 15000
+			},
+			"spellcasting": [
+				{
+					"name": "Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Strahd casts one of the following spells, using Intelligence as the spellcasting ability (spell save {@dc 18}):"
+					],
+					"will": [
+						"{@spell Detect Thoughts|XPHB}",
+						"{@spell Fog Cloud|XPHB}",
+						"{@spell Mage Hand|XPHB}"
+					],
+					"daily": {
+						"2e": [
+							"{@spell Animate Dead|XPHB}",
+							"{@spell Fireball|XPHB}",
+							"{@spell Gust of Wind|XPHB}",
+							"{@spell Mirror Image|XPHB}",
+							"{@spell Nondetection|XPHB}"
+						],
+						"1e": [
+							"{@spell Greater Invisibility|XPHB}",
+							"{@spell Polymorph|XPHB}",
+							"{@spell Scrying|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "action"
+				},
+				{
+					"name": "Charm",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Strahd casts {@spell Charm Person|XPHB}, requiring no spell components and using the same spellcasting ability as Spellcasting. When the spell is cast this way, its duration is 24 hours, and the {@condition Charmed|XPHB} target is a willing recipient of Strahd's Bite, the damage of which doesn't end the spell. When the spell ends, the target is unaware it was {@condition Charmed|XPHB} by Strahd."
+					],
+					"will": [
+						"{@spell Charm Person|XPHB}"
+					],
+					"ability": "int",
+					"displayAs": "bonus",
+					"hidden": [
+						"will"
+					]
+				},
+				{
+					"name": "Count's Command",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Strahd casts {@spell Command|XPHB} (level 2 version), requiring no spell components and using the same spellcasting ability as Spellcasting."
+					],
+					"legendary": {
+						"1": [
+							"{@spell Command|XPHB} (level 2 version)"
+						]
+					},
+					"ability": "int",
+					"displayAs": "legendary",
+					"hidden": [
+						"legendary"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Strahd dies, he revives with all his {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Barovia."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Strahd fails a saving throw, he can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Misty Escape",
+					"entries": [
+						"If Strahd drops to 0 {@variantrule Hit Points|XPHB} outside his resting place, he uses Shape-Shift to become mist (no action required). If he can't use Shape-Shift, he is destroyed. While Strahd has 0 {@variantrule Hit Points|XPHB} in mist form, he can't return to his vampire form, and he must reach his resting place within 2 hours or be destroyed. Once in his resting place, Strahd returns to his vampire form and has the {@condition Paralyzed|XPHB} condition until he regains any {@variantrule Hit Points|XPHB}, and he regains 1 {@variantrule Hit Points|XPHB|Hit Point} after spending 1 hour there."
+					]
+				},
+				{
+					"name": "Spider Climb",
+					"entries": [
+						"Strahd can climb difficult surfaces, including ceilings, without making an ability check."
+					]
+				},
+				{
+					"name": "Vampire Weakness",
+					"entries": [
+						"Strahd has these weaknesses:",
+						{
+							"type": "list",
+							"style": "list-hang-subtrait",
+							"items": [
+								{
+									"type": "itemSub",
+									"name": "Forbiddance",
+									"entries": [
+										"Strahd can't enter a residence without an invitation from an occupant."
+									]
+								},
+								{
+									"type": "itemSub",
+									"name": "Running Water",
+									"entries": [
+										"Strahd takes 20 Acid damage if he ends his turn in running water."
+									]
+								},
+								{
+									"type": "itemSub",
+									"name": "Stake to the Heart",
+									"entries": [
+										"If a weapon that deals Piercing damage is driven into Strahd's heart while Strahd has the {@condition Incapacitated|XPHB} condition in his resting place, Strahd has the {@condition Paralyzed|XPHB} condition until the weapon is removed."
+									]
+								},
+								{
+									"type": "itemSub",
+									"name": "Sunlight",
+									"entries": [
+										"Strahd takes 20 Radiant damage if he starts his turn in sunlight. While in sunlight, he has {@variantrule Disadvantage|XPHB} on attack rolls and ability checks."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Strahd makes two Death Strike attacks. He can replace one of these attacks with a use of (A) Bite or (B) Spellcasting to cast {@spell Fireball|XPHB} if available."
+					]
+				},
+				{
+					"name": "Death Strike",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Slashing damage plus 14 ({@damage 4d6}) Necrotic damage. If the target is a Large or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 14}) from one of two hands."
+					]
+				},
+				{
+					"name": "Bite (Bat or Vampire Form Only)",
+					"entries": [
+						"{@actSave con} {@dc 17}, one creature within 5 feet that is willing or that has the {@condition Grappled|XPHB}, {@condition Incapacitated|XPHB}, or {@condition Restrained|XPHB} condition. {@actSaveFail} 7 ({@damage 1d6 + 4}) Piercing damage plus 10 ({@damage 3d6}) Necrotic damage. The target's {@variantrule Hit Points|XPHB|Hit Point} maximum decreases by an amount equal to the Necrotic damage taken, and Strahd regains {@variantrule Hit Points|XPHB} equal to that amount. A Humanoid reduced to 0 {@variantrule Hit Points|XPHB} by this damage rises the following night as a Vampire Spawn under Strahd's control, unless the Humanoid is restored to life or its body is destroyed."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"If Strahd isn't in sunlight or running water, he shape-shifts into a Tiny bat ({@variantrule Speed|XPHB} 5 ft., {@variantrule Fly Speed|XPHB} 30 ft.), a Medium wolf ({@variantrule Speed|XPHB} 40 ft.), or a Medium cloud of mist ({@variantrule Speed|XPHB} 5 ft., {@variantrule Fly Speed|XPHB} 20 ft. [hover]), or he returns to his vampire form. Anything he is wearing transforms with him.",
+						"While in bat or wolf form, Strahd can't speak. His game statistics, other than his size and {@variantrule Speed|XPHB}, are unchanged.",
+						"While in mist form, Strahd can't take any actions, speak, or manipulate objects. He is weightless and can enter an enemy's space and stop there. If air can pass through a space, Strahd can do so, but he can't pass through liquid. Strahd has {@variantrule Resistance|XPHB} to all damage, except the damage he takes from sunlight."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Striding Strike",
+					"entries": [
+						"Strahd moves up to half his {@variantrule Speed|XPHB}, and he makes one Death Strike attack."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Strahd von Zarovich",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances",
+				"Spider Climb"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AB",
+				"C",
+				"DR",
+				"E",
+				"GI",
+				"I"
+			],
+			"damageTags": [
+				"A",
+				"N",
+				"P",
+				"R",
+				"S"
+			],
+			"damageTagsSpell": [
+				"F"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"HPR",
+				"MA"
+			],
+			"conditionInflict": [
+				"grappled",
+				"paralyzed"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"invisible",
+				"prone"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"savingThrowForcedSpell": [
+				"dexterity",
+				"strength",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Strigoi",
+			"source": "RHW",
+			"page": 270,
+			"size": [
+				"M"
+			],
+			"type": "monstrosity",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 52,
+				"formula": "7d8 + 21"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": 40
+			},
+			"str": 17,
+			"dex": 14,
+			"con": 16,
+			"int": 11,
+			"wis": 17,
+			"cha": 10,
+			"save": {
+				"str": "+5",
+				"dex": "+4"
+			},
+			"skill": {
+				"perception": "+5",
+				"stealth": "+4"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 15,
+			"resist": [
+				"necrotic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Common"
+			],
+			"cr": "4",
+			"trait": [
+				{
+					"name": "Stirge Telepathy",
+					"entries": [
+						"The strigoi can magically control stirges within 120 feet of itself using a special telepathy."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The strigoi makes two Claw attacks and one Proboscis attack."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}10 ({@damage 2d6 + 3}) Slashing damage."
+					]
+				},
+				{
+					"name": "Proboscis",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}5 ({@damage 1d4 + 3}) Piercing damage plus 7 ({@damage 2d6}) Necrotic damage. The target's {@variantrule Hit Points|XPHB|Hit Point} maximum decreases by an amount equal to the Necrotic damage taken, and the strigoi regains {@variantrule Hit Points|XPHB} equal to that amount. A creature reduced to 0 {@variantrule Hit Points|XPHB} by this attack dies, leaving behind nothing except its skin and equipment."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Protective Swarm {@recharge}",
+					"entries": [
+						"The strigoi summons a swarm of bloodthirsty mosquitoes in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from itself, which lasts for 1 minute or until the strigoi's {@status Concentration|XPHB} on it ends. Whenever the swarm enters a creature's space or a creature enters the swarm or ends its turn there, that creature is subjected to the following effect (a creature makes this save only once per turn, and strigoi and stirges are unaffected). {@actSave con} {@dc 13}. {@actSaveFail} 3 ({@damage 1d6}) Necrotic damage, and the target has the {@condition Poisoned|XPHB} condition until the end of its next turn."
+					]
+				}
+			],
+			"environment": [
+				"desert",
+				"forest",
+				"grassland",
+				"hill",
+				"mountain",
+				"swamp",
+				"underdark",
+				"urban"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"N",
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"HPR",
+				"MA"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Swarm of Gremishkas",
+			"source": "RHW",
+			"page": 249,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "monstrosity",
+				"swarmSize": "T"
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 31,
+				"formula": "7d4 + 14"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 12,
+			"dex": 14,
+			"con": 15,
+			"int": 11,
+			"wis": 14,
+			"cha": 4,
+			"senses": [
+				"Darkvision 30 ft."
+			],
+			"passive": 12,
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"slashing"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"prone",
+				"restrained",
+				"stunned"
+			],
+			"languages": [
+				"understands Common but can't speak"
+			],
+			"cr": "2",
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The gremishka has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Swarm (Swarm Form Only)",
+					"entries": [
+						"The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny creature. The swarm can't regain {@variantrule Hit Points|XPHB} or gain {@variantrule Temporary Hit Points|XPHB}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Swarming Bites (Swarm Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}12 ({@damage 3d6 + 2}) Piercing damage, or 9 ({@damage 3d4 + 2}) Piercing damage if the swarm is {@status Bloodied|XPHB}, plus 7 ({@damage 2d6}) Force damage. If the target is attuned to any magic items, its {@variantrule Attunement|XPHB} to one item (DM's choice) ends."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"D"
+			],
+			"languageTags": [
+				"C",
+				"CS"
+			],
+			"damageTags": [
+				"O",
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Swarm of Infesting Insects",
+			"source": "RHW",
+			"page": 271,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "beast",
+				"swarmSize": "T"
+			},
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 33,
+				"formula": "6d8 + 6"
+			},
+			"speed": {
+				"walk": 20,
+				"climb": 20,
+				"swim": 20
+			},
+			"str": 3,
+			"dex": 14,
+			"con": 12,
+			"int": 1,
+			"wis": 7,
+			"cha": 1,
+			"senses": [
+				"Blindsight 30 ft."
+			],
+			"passive": 8,
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"slashing"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"prone",
+				"restrained",
+				"stunned"
+			],
+			"cr": "2",
+			"trait": [
+				{
+					"name": "Swarm",
+					"entries": [
+						"The swarm can occupy another creature's space and vice versa, and it can move through any opening large enough for a Tiny creature. The swarm can't regain {@variantrule Hit Points|XPHB} or gain {@variantrule Temporary Hit Points|XPHB}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Infestation",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}12 ({@damage 4d4 + 2}) Poison damage, or 7 ({@damage 2d4 + 2}) Poison damage if the swarm is {@status Bloodied|XPHB}, and the target has the {@condition Poisoned|XPHB} condition. If the target remains {@condition Poisoned|XPHB} in this way after 1 hour, it is subjected to the following effect. {@actSave con} {@dc 11}. {@actSaveFail} Roll {@dice 1d6}: on a 1-2, the target has the {@condition Blinded|XPHB} condition; on a 3-4, the target's {@variantrule Hit Points|XPHB|Hit Point} maximum decreases by 5 ({@dice 1d10}); on a 5-6, the target gains 1 {@condition Exhaustion|XPHB} level. The effect lasts until the {@condition Poisoned|XPHB} condition ends. {@actSaveSuccess} The {@condition Poisoned|XPHB} condition ends."
+					]
+				}
+			],
+			"environment": [
+				"coastal",
+				"forest",
+				"grassland",
+				"swamp",
+				"urban"
+			],
+			"senseTags": [
+				"B"
+			],
+			"damageTags": [
+				"I"
+			],
+			"miscTags": [
+				"HPR",
+				"MA"
+			],
+			"conditionInflict": [
+				"blinded",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Swarm of Ravenous Insects",
+			"source": "RHW",
+			"page": 271,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "beast",
+				"swarmSize": "T"
+			},
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 39,
+				"formula": "6d8 + 12"
+			},
+			"speed": {
+				"walk": 30,
+				"burrow": 30,
+				"climb": 30
+			},
+			"str": 3,
+			"dex": 15,
+			"con": 14,
+			"int": 1,
+			"wis": 12,
+			"cha": 1,
+			"senses": [
+				"Tremorsense 60 ft."
+			],
+			"passive": 11,
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"slashing"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"prone",
+				"restrained",
+				"stunned"
+			],
+			"cr": "3",
+			"trait": [
+				{
+					"name": "Skeletonize",
+					"entries": [
+						"If the swarm starts its turn in the same space as a Large or smaller corpse, the corpse is destroyed, leaving behind only what it was wearing or carrying."
+					]
+				},
+				{
+					"name": "Swarm",
+					"entries": [
+						"The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny creature. The swarm can't regain {@variantrule Hit Points|XPHB} or gain {@variantrule Temporary Hit Points|XPHB}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Ravenous Bites",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}20 ({@damage 4d8 + 2}) Piercing damage, or 11 ({@damage 2d8 + 2}) Piercing damage if the swarm is {@status Bloodied|XPHB}, and the target has the {@condition Poisoned|XPHB} condition for 1 minute as insects burrow inside it. The condition ends early if a spell or effect restores {@variantrule Hit Points|XPHB} to the target. While {@condition Poisoned|XPHB}, the target takes 4 ({@damage 1d8}) Piercing damage at the start of each of its turns. A creature reduced to 0 {@variantrule Hit Points|XPHB} by this damage dies."
+					]
+				}
+			],
+			"environment": [
+				"coastal",
+				"forest",
+				"grassland",
+				"swamp",
+				"urban"
+			],
+			"senseTags": [
+				"T"
+			],
+			"damageTags": [
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Swarm of Zombie Limbs",
+			"source": "RHW",
+			"page": 282,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "undead",
+				"swarmSize": "T"
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 26,
+				"formula": "4d8 + 8"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 12,
+			"dex": 14,
+			"con": 14,
+			"int": 1,
+			"wis": 5,
+			"cha": 3,
+			"senses": [
+				"Blindsight 30 ft."
+			],
+			"passive": 7,
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"poisoned",
+				"prone",
+				"restrained",
+				"stunned"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Swarm",
+					"entries": [
+						"The swarm can occupy another creature's space and vice versa, and it can move through any opening large enough for a Tiny chunk of flesh. The swarm can't regain {@variantrule Hit Points|XPHB} or gain {@variantrule Temporary Hit Points|XPHB}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Rotten Flesh",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}9 ({@damage 2d6 + 2}) Necrotic damage, or 5 ({@damage 1d6 + 2}) Necrotic damage if the swarm is {@status Bloodied|XPHB}, and the target has the {@condition Poisoned|XPHB} condition until the end of its next turn."
+					]
+				}
+			],
+			"environment": [
+				"planar, shadowfell",
+				"underdark",
+				"urban"
+			],
+			"senseTags": [
+				"B"
+			],
+			"damageTags": [
+				"N"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Unspeakable Horror",
+			"source": "RHW",
+			"page": 274,
+			"size": [
+				"H"
+			],
+			"type": "monstrosity",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 126,
+				"formula": "12d12 + 48"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 21,
+			"dex": 13,
+			"con": 19,
+			"int": 3,
+			"wis": 14,
+			"cha": 17,
+			"save": {
+				"con": "+7",
+				"wis": "+5"
+			},
+			"senses": [
+				"Truesight 60 ft."
+			],
+			"passive": 12,
+			"resist": [
+				"acid",
+				"cold",
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"frightened",
+				"grappled",
+				"prone",
+				"restrained"
+			],
+			"cr": "8",
+			"trait": [
+				{
+					"name": "Incomprehensible Form",
+					"entries": [
+						"Attack rolls against the horror have {@variantrule Disadvantage|XPHB}. This trait is suppressed while the horror has the {@condition Incapacitated|XPHB} condition."
+					]
+				},
+				{
+					"name": "Regeneration",
+					"entries": [
+						"The horror regains 10 {@variantrule Hit Points|XPHB} at the start of each of its turns if it has at least 1 {@variantrule Hit Points|XPHB|Hit Point}."
+					]
+				},
+				{
+					"name": "Terrifying Aura",
+					"entries": [
+						"The horror radiates an aura in a 15-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} while it doesn't have the {@condition Incapacitated|XPHB} condition. {@actSave wis} {@dc 15}, any enemy that starts its turn in the aura. {@actSaveFail} The target has the {@condition Frightened|XPHB} condition until the start of its next turn. While {@condition Frightened|XPHB} in this way, the target has the {@condition Paralyzed|XPHB} condition. {@actSaveSuccess} The target is immune to this horror's aura for 24 hours."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The horror makes three Phantasmic Assault attacks."
+					]
+				},
+				{
+					"name": "Phantasmic Assault",
+					"entries": [
+						"{@atkr m,r} {@hit 8}, reach 5 ft. or range 60 ft. {@h}14 ({@damage 4d6}) Cold, Necrotic, Poison, or Psychic damage (horror's choice)."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Warp Mind",
+					"entries": [
+						"{@actTrigger} A creature the horror can see within 120 feet of itself takes the {@action Study|XPHB} action or makes a Constitution saving throw to maintain {@status Concentration|XPHB}. {@actResponse d}{@actSave wis} {@dc 15}, the triggering creature. {@actSaveFail} 7 ({@damage 2d6}) Psychic damage, and the target has the {@condition Stunned|XPHB} condition until the end of its next turn."
+					]
+				}
+			],
+			"environment": [
+				"any"
+			],
+			"traitTags": [
+				"Regeneration"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"damageTags": [
+				"Y"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"frightened",
+				"paralyzed",
+				"stunned"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Vampire Mind Flayer",
+			"source": "RHW",
+			"page": 276,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 85,
+				"formula": "10d8 + 40"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": 30
+			},
+			"str": 18,
+			"dex": 18,
+			"con": 18,
+			"int": 5,
+			"wis": 15,
+			"cha": 18,
+			"save": {
+				"dex": "+7",
+				"wis": "+5",
+				"cha": "+7"
+			},
+			"skill": {
+				"perception": "+5",
+				"stealth": "+7"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 15,
+			"resist": [
+				"necrotic",
+				"psychic"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"understands Deep Speech but can't speak"
+			],
+			"cr": "5",
+			"trait": [
+				{
+					"name": "Spider Climb",
+					"entries": [
+						"The mind flayer can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+					]
+				},
+				{
+					"name": "Sunlight Hypersensitivity",
+					"entries": [
+						"The mind flayer takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has {@variantrule Disadvantage|XPHB} on attack rolls and ability checks."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The mind flayer makes two Claw attacks, or one Claw attack and one Tentacles attack, and uses Mind Burst if available."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Slashing damage plus 10 ({@damage 3d6}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Tentacles",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}11 ({@damage 2d6 + 4}) Piercing damage. If the target is a Medium or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 14})."
+					]
+				},
+				{
+					"name": "Drink Sapience",
+					"entries": [
+						"{@actSave wis} {@dc 15}, one creature the mind flayer has {@condition Grappled|XPHB}. {@actSaveFail} 21 ({@damage 6d6}) Psychic damage, and the creature gains 1 {@condition Exhaustion|XPHB} level. The target's {@variantrule Hit Points|XPHB|Hit Point} maximum decreases by an amount equal to the Psychic damage taken, and the mind flayer regains {@variantrule Hit Points|XPHB} equal to that amount."
+					]
+				},
+				{
+					"name": "Mind Burst {@recharge 5}",
+					"entries": [
+						"{@actSave int} {@dc 15}, each creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the mind flayer. {@actSaveFail} The target has the {@condition Incapacitated|XPHB} condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"any"
+			],
+			"traitTags": [
+				"Spider Climb",
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack",
+				"Tentacles"
+			],
+			"languageTags": [
+				"CS",
+				"DS"
+			],
+			"damageTags": [
+				"N",
+				"P",
+				"S",
+				"Y"
+			],
+			"miscTags": [
+				"HPR",
+				"MA"
+			],
+			"conditionInflict": [
+				"grappled",
+				"incapacitated"
+			],
+			"savingThrowForced": [
+				"intelligence",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Vampire Nosferatu",
+			"source": "RHW",
+			"page": 275,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 85,
+				"formula": "9d8 + 45"
+			},
+			"speed": {
+				"walk": 40,
+				"climb": 40
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 20,
+			"dex": 18,
+			"con": 21,
+			"int": 6,
+			"wis": 17,
+			"cha": 14,
+			"save": {
+				"dex": "+7",
+				"con": "+8",
+				"wis": "+6"
+			},
+			"skill": {
+				"perception": "+6",
+				"stealth": "+10"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 16,
+			"resist": [
+				"necrotic"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"Common plus one other language"
+			],
+			"cr": "8",
+			"trait": [
+				{
+					"name": "Blood Frenzy",
+					"entries": [
+						"The nosferatu has {@variantrule Advantage|XPHB} on attack rolls against any creature that doesn't have all its {@variantrule Hit Points|XPHB}."
+					]
+				},
+				{
+					"name": "Regeneration",
+					"entries": [
+						"The nosferatu regains 10 {@variantrule Hit Points|XPHB} at the start of each of its turns if it has at least 1 {@variantrule Hit Points|XPHB|Hit Point}. If the nosferatu takes Radiant damage, this trait doesn't function on the nosferatu's next turn."
+					]
+				},
+				{
+					"name": "Spider Climb",
+					"entries": [
+						"The nosferatu can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+					]
+				},
+				{
+					"name": "Sunlight Hypersensitivity",
+					"entries": [
+						"The nosferatu takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has {@variantrule Disadvantage|XPHB} on attack rolls and ability checks."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The nosferatu makes one Bite attack and two Claw attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}9 ({@damage 1d8 + 5}) Piercing damage plus 11 ({@damage 2d10}) Necrotic damage. The target's {@variantrule Hit Points|XPHB|Hit Point} maximum decreases by an amount equal to the Necrotic damage taken, and the nosferatu regains {@variantrule Hit Points|XPHB} equal to that amount."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 5 ft. {@h}9 ({@damage 1d8 + 5}) Slashing damage."
+					]
+				},
+				{
+					"name": "Blood Spew {@recharge 5}",
+					"entries": [
+						"{@actSave con} {@dc 16}, each creature in a 15-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} 27 ({@damage 6d8}) Necrotic damage, and the creature can't regain {@variantrule Hit Points|XPHB} for 1 minute. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Bloodthirsty Slash",
+					"entries": [
+						"{@actTrigger} A {@status Bloodied|XPHB} creature the nosferatu can see within 40 feet takes damage. {@actResponse} The nosferatu moves up to its {@variantrule Speed|XPHB} without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks} and makes a Claw attack against the triggering creature."
+					]
+				}
+			],
+			"environment": [
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"any"
+			],
+			"traitTags": [
+				"Regeneration",
+				"Spider Climb",
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"N",
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"HPR",
+				"MA"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Viktra Mordenheim",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 132,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 123,
+				"formula": "19d8 + 38"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 11,
+			"dex": 16,
+			"con": 15,
+			"int": 21,
+			"wis": 10,
+			"cha": 10,
+			"save": {
+				"con": "+5",
+				"cha": "+3"
+			},
+			"skill": {
+				"arcana": "+8",
+				"investigation": "+8",
+				"medicine": "+6"
+			},
+			"passive": 10,
+			"languages": [
+				"Common",
+				"Draconic",
+				"Dwarvish",
+				"Elvish",
+				"Goblin",
+				"Halfling"
+			],
+			"cr": {
+				"cr": "7",
+				"xpLair": 3900
+			},
+			"gear": [
+				"studded leather armor|xphb"
+			],
+			"spellcasting": [
+				{
+					"name": "Activate Constructs (1/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"Viktra casts {@spell Animate Objects|XPHB}, using Intelligence as the spellcasting ability."
+					],
+					"daily": {
+						"1": [
+							"{@spell Animate Objects|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Bolster Inventions",
+					"entries": [
+						"At the end of each of Viktra's turns, each of her Construct allies in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from Viktra gains 5 {@variantrule Temporary Hit Points|XPHB}. This trait doesn't function if Viktra has the {@condition Incapacitated|XPHB} condition."
+					]
+				},
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Viktra dies, she revives with all her {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Lamordia."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Viktra fails a saving throw, she can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Viktra makes two Lightning Rod attacks. She can replace one attack with a use of Syringe."
+					]
+				},
+				{
+					"name": "Lightning Rod",
+					"entries": [
+						"{@atkr m,r} {@hit 6}, reach 5 ft. or range 90 ft. {@h}12 ({@damage 2d8 + 3}) Lightning damage, and the target can't take Reactions until the start of its next turn."
+					]
+				},
+				{
+					"name": "Syringe",
+					"entries": [
+						"{@actSave con} {@dc 16}, one creature Viktra can see within 5 feet. {@actSaveFail} The target has the {@condition Poisoned|XPHB} condition for 1 minute. While {@condition Poisoned|XPHB} in this way, the target suffers one of the following effects (Viktra's choice). The target repeats the save at the end of each of its turns, ending the effect on itself on a success. The target succeeds automatically after 1 minute:",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Corrosive Serum",
+									"entries": [
+										"The target takes 10 ({@damage 4d4}) Acid damage at the start of each of its turns, and its {@variantrule Speed|XPHB} decreases by 10 feet."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Deadly Serum",
+									"entries": [
+										"The target takes 11 ({@damage 2d10}) Necrotic damage at the start of each of its turns, and it can't regain {@variantrule Hit Points|XPHB}."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Mind-Altering Serum",
+									"entries": [
+										"The target takes 10 ({@damage 3d6}) Psychic damage at the start of each of its turns, and it has {@variantrule Disadvantage|XPHB} on saving throws to maintain {@status Concentration|XPHB}."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Redirect Attack",
+					"entries": [
+						"{@actTrigger} A creature Viktra can see makes an attack roll against her. {@actResponse} Viktra chooses a Small or Medium ally within 5 feet of herself. Viktra and that ally swap places, and the ally becomes the target of the attack instead."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Shocking Prod",
+					"entries": [
+						"Viktra moves up to half her {@variantrule Speed|XPHB} and makes one Lightning Rod attack. Viktra can't take this action again until the start of her next turn."
+					]
+				},
+				{
+					"name": "Static Explosion",
+					"entries": [
+						"{@actSave dex} {@dc 16}, each creature in a 10-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point Viktra can see within 90 feet. {@actSaveFail} 5 ({@damage 2d4}) Lightning damage. {@actSaveSuccess} Half damage."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Viktra Mordenheim",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"D",
+				"DR",
+				"E",
+				"GO",
+				"H"
+			],
+			"damageTags": [
+				"A",
+				"L",
+				"N",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"B",
+				"P",
+				"S"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"incapacitated",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Vladeska Drakov",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 80,
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				18
+			],
+			"hp": {
+				"average": 170,
+				"formula": "20d8 + 80"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 19,
+			"dex": 15,
+			"con": 18,
+			"int": 14,
+			"wis": 13,
+			"cha": 16,
+			"save": {
+				"con": "+8",
+				"cha": "+7"
+			},
+			"skill": {
+				"athletics": "+8",
+				"perception": "+5"
+			},
+			"passive": 15,
+			"conditionImmune": [
+				"frightened"
+			],
+			"languages": [
+				"Common",
+				"Giant",
+				"Orc"
+			],
+			"cr": {
+				"cr": "12",
+				"xpLair": 10000
+			},
+			"gear": [
+				"pike|xphb",
+				{
+					"item": "spear|xphb",
+					"quantity": 6
+				},
+				"studded leather armor|xphb"
+			],
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Vladeska dies, she revives with all her {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Falkovnia."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Vladeska fails a saving throw, she can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Vladeska makes two Pike attacks. She can replace one attack with an Impaling Spear attack."
+					]
+				},
+				{
+					"name": "Impaling Spear",
+					"entries": [
+						"{@atkr m,r} {@hit 8}, reach 5 ft. or range 20/60 ft. {@h}13 ({@damage 2d8 + 4}) Piercing damage, and the target is impaled on Vladeska's spear. While impaled, the creature has the {@condition Restrained|XPHB} condition and takes 3 ({@damage 1d6}) Piercing damage at the start of each of its turns. The target or a creature within 5 feet of it can take an action to remove it from the spear."
+					]
+				},
+				{
+					"name": "Pike",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 10 ft. {@h}15 ({@damage 2d10 + 4}) Piercing damage."
+					]
+				},
+				{
+					"name": "Artillery Fire (1/Day)",
+					"entries": [
+						"{@actSave dex} {@dc 15}, each creature in a 20-foot-radius, 60-foot-high {@variantrule Cylinder [Area of Effect]|XPHB|Cylinder} centered on a point Vladeska can see within 300 feet. {@actSaveFail} 13 ({@damage 3d8}) Bludgeoning damage plus 13 ({@damage 3d8}) Fire damage, and the target has the {@condition Prone|XPHB} condition. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Redirect Attack",
+					"entries": [
+						"{@actTrigger} A creature Vladeska can see makes an attack roll against her. {@actResponse} Vladeska chooses a Small or Medium ally within 5 feet of herself. She and that ally swap places, and the ally becomes the target of the attack instead."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Advance",
+					"entries": [
+						"Vladeska moves up to half her {@variantrule Speed|XPHB} and makes one Pike attack."
+					]
+				},
+				{
+					"name": "Dreadful Impaling",
+					"entries": [
+						"Vladeska makes an Impaling Spear attack. If the attack hits and the target is a creature, each ally of the target within 30 feet is subjected to the following effect. {@actSave wis} {@dc 15}. {@actSaveFail} The target has the {@condition Frightened|XPHB} condition until the end of its next turn. {@actSaveSuccessOrFail} Vladeska can't take this action again until the start of her next turn."
+					]
+				},
+				{
+					"name": "Order Ballista",
+					"entries": [
+						"{@actSave dex} {@dc 15}, one creature Vladeska can see within 120 feet. {@actSaveFail} 14 ({@damage 4d6 + 3}) Piercing damage, and the target's {@variantrule Speed|XPHB} is halved until the end of its next turn."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Vladeska Drakov",
+				"source": "RHW"
+			},
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"GI",
+				"O"
+			],
+			"damageTags": [
+				"B",
+				"F",
+				"P"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"MLW",
+				"RA",
+				"RCH",
+				"THW"
+			],
+			"conditionInflict": [
+				"frightened",
+				"prone",
+				"restrained"
+			],
+			"savingThrowForced": [
+				"dexterity",
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Waxwork",
+			"source": "RHW",
+			"page": 277,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "construct",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 52,
+				"formula": "7d8 + 21"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 17,
+			"dex": 13,
+			"con": 16,
+			"int": 1,
+			"wis": 10,
+			"cha": 1,
+			"senses": [
+				"Blindsight 30 ft."
+			],
+			"passive": 10,
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"slashing"
+			],
+			"immune": [
+				"poison",
+				"psychic"
+			],
+			"vulnerable": [
+				"fire"
+			],
+			"conditionImmune": [
+				"blinded",
+				"charmed",
+				"deafened",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"petrified",
+				"poisoned",
+				"stunned",
+				"unconscious"
+			],
+			"languages": [
+				"understands Common but can't speak"
+			],
+			"cr": "3",
+			"trait": [
+				{
+					"name": "Meltable",
+					"entries": [
+						"If the waxwork takes Fire damage, until the end of its next turn, its {@variantrule Speed|XPHB} decreases by 20 feet and it has {@variantrule Disadvantage|XPHB} on saving throws."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The waxwork makes two Sculpting Knife attacks."
+					]
+				},
+				{
+					"name": "Sculpting Knife",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}10 ({@damage 2d6 + 3}) Slashing damage."
+					]
+				},
+				{
+					"name": "Wax Lob",
+					"entries": [
+						"{@atkr r} {@hit 5}, range 20/60 ft. {@h}8 ({@damage 2d4 + 3}) Bludgeoning damage, and the target's {@variantrule Speed|XPHB} decreases by 10 feet until the end of its next turn."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The waxwork shape-shifts into a humanoid of its size, or it returns to its true form. Its game statistics are the same in each form. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"environment": [
+				"urban"
+			],
+			"treasure": [
+				"implements"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS"
+			],
+			"damageTags": [
+				"B",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Wereraven",
+			"source": "RHW",
+			"page": 280,
+			"size": [
+				"S",
+				"M"
+			],
+			"type": {
+				"type": "monstrosity",
+				"tags": [
+					"lycanthrope"
+				]
+			},
+			"alignment": [
+				"N",
+				"G"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 54,
+				"formula": "12d8"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": {
+					"number": 50,
+					"condition": "(raven or hybrid form only)"
+				}
+			},
+			"str": 10,
+			"dex": 15,
+			"con": 11,
+			"int": 13,
+			"wis": 15,
+			"cha": 14,
+			"skill": {
+				"insight": "+4",
+				"perception": "+6"
+			},
+			"passive": 16,
+			"languages": [
+				"Common plus one other language"
+			],
+			"cr": "2",
+			"gear": [
+				"shortbow|xphb"
+			],
+			"trait": [
+				{
+					"name": "Mimicry",
+					"entries": [
+						"The wereraven can mimic voices and animal sounds. A creature that hears this mimicry can tell it is an imitation only with a successful {@dc 12} Wisdom ({@skill Insight|XPHB}) check."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The wereraven makes two attacks, using Scratch or Shortbow in any combination. It can replace one attack with a Beak attack."
+					]
+				},
+				{
+					"name": "Beak (Raven or Hybrid Form Only)",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}11 ({@damage 2d8 + 2}) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. {@actSave con} {@dc 10}. {@actSaveFail} The target is cursed. If the cursed target drops to 0 {@variantrule Hit Points|XPHB}, it instead becomes a Wereraven under the DM's control and has 10 {@variantrule Hit Points|XPHB}. {@actSaveSuccess} The target is immune to this wereraven's curse for 24 hours."
+					]
+				},
+				{
+					"name": "Scratch",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}7 ({@damage 2d4 + 2}) Slashing damage."
+					]
+				},
+				{
+					"name": "Shortbow (Humanoid or Hybrid Form Only)",
+					"entries": [
+						"{@atkr r} {@hit 4}, range 80/320 ft. {@h}9 ({@damage 2d6 + 2}) Piercing damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The wereraven shape-shifts into a Medium raven-humanoid hybrid or a Small raven, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"environment": [
+				"forest",
+				"urban"
+			],
+			"treasure": [
+				"individual"
+			],
+			"traitTags": [
+				"Mimicry"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"X"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"CUR",
+				"MA",
+				"RA",
+				"RNG"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Wilfred Godefroy",
+			"isNamedCreature": true,
+			"source": "RHW",
+			"page": 142,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 72,
+				"formula": "16d8"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": 30
+			},
+			"str": 8,
+			"dex": 14,
+			"con": 10,
+			"int": 13,
+			"wis": 14,
+			"cha": 17,
+			"skill": {
+				"intimidation": "+6",
+				"perception": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 15,
+			"resist": [
+				"acid",
+				"bludgeoning",
+				"cold",
+				"fire",
+				"lightning",
+				"piercing",
+				"slashing",
+				"thunder"
+			],
+			"immune": [
+				"necrotic",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"poisoned",
+				"prone",
+				"restrained",
+				"unconscious"
+			],
+			"languages": [
+				"Common"
+			],
+			"cr": {
+				"cr": "6",
+				"xpLair": 2900
+			},
+			"trait": [
+				{
+					"name": "Darklord Restoration",
+					"entries": [
+						"If Wilfred dies, he revives with all his {@variantrule Hit Points|XPHB} in {@dice 1d10} weeks somewhere in Mordent."
+					]
+				},
+				{
+					"name": "Incorporeal Movement",
+					"entries": [
+						"Wilfred can move through other creatures and objects as if they were {@variantrule Difficult Terrain|XPHB}. He takes 5 ({@damage 1d10}) Force damage if he ends his turn inside an object."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day, or 4/Day in Domain)",
+					"entries": [
+						"If Wilfred fails a saving throw, he can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Possessive Aura",
+					"entries": [
+						"Grasping, ghostly servants surround Wilfred in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from him. A creature that ends its turn in this area is subjected to the following effect. {@actSave cha} {@dc 14}. {@actSaveFail} The target has the {@condition Charmed|XPHB} condition. While the creature is {@condition Charmed|XPHB} in this way, its {@variantrule Speed|XPHB} is reduced to 0. The target repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Wilfred makes two attacks, using {@variantrule Object|XPHB} Slam or Hunting Rifle in any combination."
+					]
+				},
+				{
+					"name": "Object Slam",
+					"entries": [
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}10 ({@damage 2d6 + 3}) Force damage."
+					]
+				},
+				{
+					"name": "Hunting Rifle",
+					"entries": [
+						"{@atkr r} {@hit 6}, range 40/120 ft. {@h}9 ({@damage 1d12 + 3}) Necrotic damage."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Redirect Attack",
+					"entries": [
+						"{@actTrigger} A creature Wilfred can see makes an attack roll against him. {@actResponse} Wilfred chooses a Small or Medium creature within 5 feet of himself that has the {@condition Charmed|XPHB} condition. Wilfred and that creature swap places, and the creature becomes the target of the attack instead."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Bone-Chilling Step",
+					"entries": [
+						"Wilfred teleports up to 60 feet to an unoccupied space he can see, and each creature within 10 feet of the space he left takes 4 ({@damage 1d8}) Necrotic damage. Wilfred can't take this action again until the start of his next turn."
+					]
+				},
+				{
+					"name": "Fated Bullet",
+					"entries": [
+						"{@actSave dex} {@dc 14}, one creature Wilfred can see within 120 feet. {@actSaveFail} 16 ({@damage 2d12 + 3}) Necrotic damage, and the target can't regain {@variantrule Hit Points|XPHB} until the start of its next turn. {@actSaveSuccessOrFail} Wilfred can't take this action again until the start of his next turn."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"Wilfred makes one {@variantrule Object|XPHB} Slam attack."
+					]
+				}
+			],
+			"legendaryGroup": {
+				"name": "Wilfred Godefroy",
+				"source": "RHW"
+			},
+			"attachedItems": [
+				"hunting rifle|xdmg"
+			],
+			"traitTags": [
+				"Incorporeal Movement",
+				"Legendary Resistances"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"N",
+				"O"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RA",
+				"RNG"
+			],
+			"conditionInflict": [
+				"charmed"
+			],
+			"savingThrowForced": [
+				"charisma",
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Yithian",
+			"source": "RHW",
+			"page": 281,
+			"size": [
+				"L"
+			],
+			"type": "aberration",
+			"alignment": [
+				"C",
+				"N"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 180,
+				"formula": "19d10 + 76"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 18,
+			"dex": 10,
+			"con": 18,
+			"int": 21,
+			"wis": 18,
+			"cha": 19,
+			"save": {
+				"con": "+9",
+				"int": "+10"
+			},
+			"senses": [
+				"Truesight 60 ft."
+			],
+			"passive": 14,
+			"immune": [
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"languages": [
+				"Deep Speech; telepathy 120 ft."
+			],
+			"cr": "15",
+			"spellcasting": [
+				{
+					"name": "Eldritch Magic (2/Day)",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The yithian casts {@spell Clairvoyance|XPHB}, {@spell Modify Memory|XPHB}, {@spell Phantasmal Killer|XPHB}, or Transport via Plants, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 18})."
+					],
+					"daily": {
+						"2": [
+							"{@spell Clairvoyance|XPHB}",
+							"{@spell Modify Memory|XPHB}",
+							"{@spell Phantasmal Killer|XPHB}"
+						]
+					},
+					"ability": "int",
+					"displayAs": "bonus",
+					"hidden": [
+						"daily"
+					]
+				}
+			],
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The yithian has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Shielded Mind",
+					"entries": [
+						"The yithian's thoughts can't be read by any means, and other creatures can communicate with it telepathically only if it allows them."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The yithian makes three Pincer attacks. It can replace one attack with a use of Sup."
+					]
+				},
+				{
+					"name": "Pincer",
+					"entries": [
+						"{@atkr m} {@hit 9}, reach 10 ft. {@h}18 ({@damage 4d6 + 4}) Piercing damage and the creature has the {@condition Grappled|XPHB} condition (escape {@dc 14})."
+					]
+				},
+				{
+					"name": "Sup",
+					"entries": [
+						"{@actSave int} {@dc 18}, one creature within 10 feet that has the {@condition Grappled|XPHB}, {@condition Incapacitated|XPHB}, or {@condition Restrained|XPHB} condition. {@actSaveFail} 15 ({@damage 3d6 + 5}) Psychic damage. The target's {@variantrule Hit Points|XPHB} maximum decreases by an amount equal to the damage taken, and the yithian regains {@variantrule Hit Points|XPHB} equal to that amount."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Mind Swap {@recharge}",
+					"entries": [
+						"{@actSave int} {@dc 18}, one Humanoid the yithian can see within 5 feet. {@actSaveFail} The target is possessed by the yithian; the yithian disappears, and the target has the {@condition Incapacitated|XPHB} condition and loses control of its body. The yithian now controls the body; the target has no awareness of the yithian's actions. The yithian can't be targeted by any attack, spell, or other effect. The yithian's game statistics are the same, except it uses the possessed target's {@variantrule Speed|XPHB} and Strength, Dexterity, and Constitution modifiers. It knows everything the target knew.",
+						"The possession lasts until the body drops to 0 {@variantrule Hit Points|XPHB} or the yithian leaves as a {@variantrule Bonus Action|XPHB}. When the possession ends, the yithian returns to its body, which appears within 5 feet of the target. The target is {@condition Stunned|XPHB} for 1 minute by alien memories, and it is immune to this yithian's Mind Swap for 24 hours. {@actSaveSuccess} The target is immune to Mind Swap for 24 hours."
+					]
+				}
+			],
+			"environment": [
+				"desert",
+				"underdark",
+				"urban"
+			],
+			"treasure": [
+				"arcana"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"DS",
+				"TP"
+			],
+			"damageTags": [
+				"P",
+				"Y"
+			],
+			"damageTagsSpell": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"O"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"grappled",
+				"incapacitated",
+				"stunned"
+			],
+			"conditionInflictSpell": [
+				"charmed",
+				"incapacitated"
+			],
+			"savingThrowForced": [
+				"intelligence"
+			],
+			"savingThrowForcedSpell": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Zombie Clot",
+			"source": "RHW",
+			"page": 283,
+			"size": [
+				"H"
+			],
+			"type": "undead",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 104,
+				"formula": "11d12 + 33"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 20,
+			"dex": 10,
+			"con": 16,
+			"int": 3,
+			"wis": 8,
+			"cha": 10,
+			"save": {
+				"con": "+6"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 9,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"paralyzed",
+				"petrified",
+				"poisoned",
+				"prone",
+				"stunned"
+			],
+			"languages": [
+				"understands Common plus one other language but can't speak"
+			],
+			"cr": "6",
+			"trait": [
+				{
+					"name": "Deathly Stench",
+					"entries": [
+						"{@actSave con} {@dc 14}, any creature that starts its turn in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the zombie. {@actSaveFail} 9 ({@damage 2d8}) Poison damage, and the target has the {@condition Poisoned|XPHB} condition until the start of its next turn."
+					]
+				},
+				{
+					"name": "Undead Fortitude",
+					"entries": [
+						"If damage reduces the zombie to 0 {@variantrule Hit Points|XPHB}, it makes a Constitution saving throw ({@dc 5} plus the damage taken) unless the damage is Radiant or from a {@variantrule Critical Hit|XPHB}. On a successful save, the zombie drops to 1 {@variantrule Hit Points|XPHB|Hit Point} instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The zombie makes two Slam attacks."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atkr m} {@hit 8}, reach 10 ft. {@h}15 ({@damage 3d6 + 5}) Bludgeoning damage."
+					]
+				},
+				{
+					"name": "Flesh Entomb {@recharge 5}",
+					"entries": [
+						"{@actSave str} {@dc 16}, one creature the zombie can see within 30 feet. {@actSaveFail} 16 ({@damage 3d10}) Bludgeoning damage. If the target is a Large or smaller creature, it is entombed in a pile of dead flesh. While entombed, the target has the {@condition Restrained|XPHB} condition, has {@variantrule Cover|XPHB|Total Cover} against attacks and other effects outside the dead flesh, and takes 10 ({@damage 3d6}) Necrotic damage at the start of each of its turns.",
+						"The target can be freed if the dead flesh is destroyed (AC 10; HP 25; {@variantrule Immunity|XPHB} to Necrotic, Poison, and Psychic damage)."
+					]
+				}
+			],
+			"environment": [
+				"planar, shadowfell",
+				"underdark",
+				"urban"
+			],
+			"traitTags": [
+				"Undead Fortitude"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"X"
+			],
+			"damageTags": [
+				"B",
+				"I",
+				"N"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"poisoned",
+				"restrained"
+			],
+			"savingThrowForced": [
+				"constitution",
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Zombie Plague Spreader",
+			"source": "RHW",
+			"page": 283,
+			"size": [
+				"M"
+			],
+			"type": "undead",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				10
+			],
+			"hp": {
+				"average": 78,
+				"formula": "12d8 + 24"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 16,
+			"dex": 10,
+			"con": 15,
+			"int": 3,
+			"wis": 5,
+			"cha": 5,
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 7,
+			"resist": [
+				"necrotic"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"poisoned"
+			],
+			"languages": [
+				"understands Common plus one other language but can't speak"
+			],
+			"cr": "4",
+			"trait": [
+				{
+					"name": "Undead Fortitude",
+					"entries": [
+						"If damage reduces the zombie to 0 {@variantrule Hit Points|XPHB}, it makes a Constitution saving throw ({@dc 5} plus the damage taken) unless the damage is Radiant or from a {@variantrule Critical Hit|XPHB}. On a successful save, the zombie drops to 1 {@variantrule Hit Points|XPHB|Hit Point} instead."
+					]
+				},
+				{
+					"name": "Viral Aura",
+					"entries": [
+						"{@actSave con} {@dc 12}, any creature that starts its turn in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the zombie. {@actSaveFail} The target has the {@condition Poisoned|XPHB} condition until the start of its next turn. While {@condition Poisoned|XPHB}, the target can't regain {@variantrule Hit Points|XPHB}. {@actSaveSuccess} The creature is immune to this zombie's Viral Aura for 24 hours."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The zombie makes two Slam attacks."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}6 ({@damage 1d6 + 3}) Bludgeoning damage plus 9 ({@damage 2d8}) Necrotic damage."
+					]
+				},
+				{
+					"name": "Virulent Miasma (1/Day)",
+					"entries": [
+						"{@actSave con} {@dc 12}, each creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the zombie. {@actSaveFail} 14 ({@damage 4d6}) Poison damage. {@actSaveSuccess} Half damage. {@actSaveSuccessOrFail} If this damage reduces the target to 0 {@variantrule Hit Points|XPHB}, it dies and rises 1 minute later as a Zombie."
+					]
+				}
+			],
+			"environment": [
+				"planar, shadowfell",
+				"underdark",
+				"urban"
+			],
+			"traitTags": [
+				"Undead Fortitude"
+			],
+			"senseTags": [
+				"D"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"CS",
+				"X"
+			],
+			"damageTags": [
+				"B",
+				"I",
+				"N"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		}
+	]
+}

--- a/json/bestiary/bestiary-rmbre.json
+++ b/json/bestiary/bestiary-rmbre.json
@@ -88,6 +88,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Keen Senses"
 			],
@@ -184,6 +185,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -430,6 +432,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Aggressive"
 			],
@@ -513,6 +516,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],

--- a/json/bestiary/bestiary-rot.json
+++ b/json/bestiary/bestiary-rot.json
@@ -64,6 +64,7 @@
 				"petrified",
 				"poisoned"
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Rejuvenation"
 			],
@@ -161,6 +162,9 @@
 						"with": "Diderius",
 						"flags": "i"
 					}
+				},
+				"_preserve": {
+					"legendaryGroup": true
 				}
 			},
 			"int": 18,
@@ -220,6 +224,7 @@
 					"ability": "int"
 				}
 			],
+			"tokenCustom": true,
 			"savingThrowForcedSpell": [
 				"constitution",
 				"dexterity",
@@ -547,7 +552,7 @@
 							{
 								"name": "Draconic Majesty",
 								"entries": [
-									"While wearing no armor and wearing the Blue Dragon Mask, Galvan adds his Charisma bonus to her AC (included)."
+									"While wearing no armor and wearing the Blue Dragon Mask, Galvan adds his Charisma bonus to his AC (included)."
 								]
 							},
 							{
@@ -600,12 +605,12 @@
 			"page": 55,
 			"otherSources": [
 				{
-					"source": "DC"
-				},
-				{
 					"source": "ToD",
 					"page": 141
 				}
+			],
+			"referenceSources": [
+				"DC"
 			],
 			"_copy": {
 				"name": "Gladiator",
@@ -624,6 +629,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"senseTags": [
 				"B",
 				"D"
@@ -678,6 +684,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"senseTags": [
 				"B",
 				"D"
@@ -911,7 +918,8 @@
 				"N",
 				"E"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Maccath the Crimson",
@@ -954,10 +962,10 @@
 				"X"
 			],
 			"spellcastingTags": [
-				"CW",
-				"I"
+				"CW"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Marfulb",
@@ -976,6 +984,7 @@
 				"source": "RoT"
 			},
 			"int": 13,
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1000,6 +1009,7 @@
 					"human"
 				]
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1512,6 +1522,9 @@
 			"damageTags": [
 				"F"
 			],
+			"miscTags": [
+				"AOE"
+			],
 			"conditionInflict": [
 				"restrained"
 			],
@@ -1520,6 +1533,7 @@
 				"strength"
 			],
 			"hasToken": true,
+			"hasFluff": true,
 			"hasFluffImages": true
 		},
 		{
@@ -1577,6 +1591,7 @@
 				}
 			},
 			"tokenCredit": "FromSoftware",
+			"tokenCustom": true,
 			"damageTags": [
 				"I",
 				"S"
@@ -1591,12 +1606,12 @@
 			"page": 92,
 			"otherSources": [
 				{
-					"source": "BGDIA"
-				},
-				{
 					"source": "ToD",
 					"page": 190
 				}
+			],
+			"referenceSources": [
+				"BGDIA"
 			],
 			"size": [
 				"G"
@@ -1897,7 +1912,8 @@
 				"DR",
 				"I"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		}
 	]
 }

--- a/json/bestiary/bestiary-rtg.json
+++ b/json/bestiary/bestiary-rtg.json
@@ -1,4 +1,11 @@
 {
+	"_meta": {
+		"otherSources": {
+			"monster": {
+				"MM": "RtG"
+			}
+		}
+	},
 	"monster": [
 		{
 			"name": "Dirt-Under-Nails",
@@ -169,6 +176,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"mace|phb"
 			],
@@ -327,6 +335,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"club|phb"
 			],

--- a/json/bestiary/bestiary-scc.json
+++ b/json/bestiary/bestiary-scc.json
@@ -207,6 +207,9 @@
 			"name": "Art Elemental Mascot",
 			"source": "SCC",
 			"page": 185,
+			"referenceSources": [
+				"SCC-HfMT"
+			],
 			"size": [
 				"S"
 			],
@@ -508,6 +511,10 @@
 			"name": "Brackish Trudge",
 			"source": "SCC",
 			"page": 187,
+			"referenceSources": [
+				"SCC-ARiR",
+				"SCC-HfMT"
+			],
 			"size": [
 				"L"
 			],
@@ -589,6 +596,10 @@
 			"name": "Cogwork Archivist",
 			"source": "SCC",
 			"page": 188,
+			"referenceSources": [
+				"SCC-CK",
+				"SCC-TMM"
+			],
 			"size": [
 				"L"
 			],
@@ -722,6 +733,9 @@
 			"name": "Daemogoth",
 			"source": "SCC",
 			"page": 189,
+			"referenceSources": [
+				"SCC-ARiR"
+			],
 			"size": [
 				"H"
 			],
@@ -993,6 +1007,9 @@
 			"name": "First-Year Student",
 			"source": "SCC",
 			"page": 191,
+			"referenceSources": [
+				"SCC-CK"
+			],
 			"size": [
 				"S",
 				"M"
@@ -1092,6 +1109,9 @@
 			"name": "Fractal Mascot",
 			"source": "SCC",
 			"page": 192,
+			"referenceSources": [
+				"SCC-HfMT"
+			],
 			"size": [
 				"S"
 			],
@@ -1463,6 +1483,10 @@
 			"name": "Inkling Mascot",
 			"source": "SCC",
 			"page": 195,
+			"referenceSources": [
+				"SCC-HfMT",
+				"SCC-TMM"
+			],
 			"size": [
 				"T"
 			],
@@ -1539,7 +1563,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the inkling takes the Hide action."
+						"While in dim light or darkness, the inkling takes the {@action Hide} action."
 					]
 				}
 			],
@@ -1573,6 +1597,11 @@
 			"name": "Lorehold Apprentice",
 			"source": "SCC",
 			"page": 197,
+			"referenceSources": [
+				"SCC-CK",
+				"SCC-HfMT",
+				"SCC-TMM"
+			],
 			"size": [
 				"S",
 				"M"
@@ -1688,6 +1717,10 @@
 			"name": "Lorehold Pledgemage",
 			"source": "SCC",
 			"page": 197,
+			"referenceSources": [
+				"SCC-ARiR",
+				"SCC-TMM"
+			],
 			"size": [
 				"S",
 				"M"
@@ -1828,6 +1861,9 @@
 			"name": "Lorehold Professor of Chaos",
 			"source": "SCC",
 			"page": 198,
+			"referenceSources": [
+				"SCC-TMM"
+			],
 			"size": [
 				"S",
 				"M"
@@ -1955,6 +1991,9 @@
 			"name": "Lorehold Professor of Order",
 			"source": "SCC",
 			"page": 198,
+			"referenceSources": [
+				"SCC-TMM"
+			],
 			"size": [
 				"S",
 				"M"
@@ -2099,6 +2138,9 @@
 			"name": "Mage Hunter",
 			"source": "SCC",
 			"page": 199,
+			"referenceSources": [
+				"SCC-HfMT"
+			],
 			"size": [
 				"L"
 			],
@@ -2255,9 +2297,16 @@
 		},
 		{
 			"name": "Murgaxor",
+			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "SCC",
 			"page": 180,
+			"referenceSources": [
+				"SCC-ARiR",
+				"SCC-CK",
+				"SCC-HfMT",
+				"SCC-TMM"
+			],
 			"size": [
 				"M"
 			],
@@ -2332,7 +2381,7 @@
 				{
 					"name": "Sanguine Sense",
 					"entries": [
-						"While Murgaxor isn't {@condition blinded}, he can see any creature that isn't an Undead or a Construct within 60 feet of himself, even through {@quickref Cover||3||total cover}, heavily obscured areas, invisibility, or any other phenomena that would prevent sight."
+						"While Murgaxor isn't {@condition blinded}, he can see any creature that isn't an Undead or a Construct within 60 feet of himself, even through {@quickref Cover||3||total cover}, {@quickref Vision and Light||2||heavily obscured} areas, invisibility, or any other phenomena that would prevent sight."
 					]
 				}
 			],
@@ -2572,6 +2621,9 @@
 			"name": "Oriq Blood Mage",
 			"source": "SCC",
 			"page": 201,
+			"referenceSources": [
+				"SCC-ARiR"
+			],
 			"size": [
 				"M"
 			],
@@ -2645,7 +2697,7 @@
 				{
 					"name": "Sanguine Sense",
 					"entries": [
-						"While the blood mage isn't {@condition blinded}, it can see any creature that isn't an Undead or a Construct within 60 feet of itself, even through {@quickref Cover||3||total cover}, heavily obscured areas, invisibility, or any other phenomena that would prevent sight."
+						"While the blood mage isn't {@condition blinded}, it can see any creature that isn't an Undead or a Construct within 60 feet of itself, even through {@quickref Cover||3||total cover}, {@quickref Vision and Light||2||heavily obscured} areas, invisibility, or any other phenomena that would prevent sight."
 					]
 				}
 			],
@@ -2833,6 +2885,11 @@
 			"name": "Pest Mascot",
 			"source": "SCC",
 			"page": 203,
+			"referenceSources": [
+				"SCC-ARiR",
+				"SCC-HfMT",
+				"SCC-TMM"
+			],
 			"size": [
 				"T"
 			],
@@ -3021,6 +3078,10 @@
 			"name": "Prismari Pledgemage",
 			"source": "SCC",
 			"page": 205,
+			"referenceSources": [
+				"SCC-ARiR",
+				"SCC-CK"
+			],
 			"size": [
 				"S",
 				"M"
@@ -3157,6 +3218,9 @@
 			"name": "Prismari Professor of Expression",
 			"source": "SCC",
 			"page": 206,
+			"referenceSources": [
+				"SCC-ARiR"
+			],
 			"size": [
 				"S",
 				"M"
@@ -3530,6 +3594,9 @@
 			"name": "Quandrix Pledgemage",
 			"source": "SCC",
 			"page": 208,
+			"referenceSources": [
+				"SCC-ARiR"
+			],
 			"size": [
 				"S",
 				"M"
@@ -3650,6 +3717,9 @@
 			"name": "Quandrix Professor of Substance",
 			"source": "SCC",
 			"page": 209,
+			"referenceSources": [
+				"SCC-CK"
+			],
 			"size": [
 				"S",
 				"M"
@@ -3992,6 +4062,9 @@
 			"name": "Ruin Grinder",
 			"source": "SCC",
 			"page": 211,
+			"referenceSources": [
+				"SCC-ARiR"
+			],
 			"size": [
 				"L"
 			],
@@ -4108,6 +4181,9 @@
 			"name": "Scufflecup Teacup",
 			"source": "SCC",
 			"page": 159,
+			"referenceSources": [
+				"SCC-ARiR"
+			],
 			"size": [
 				"T"
 			],
@@ -4152,6 +4228,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"B"
 			],
@@ -4455,6 +4532,9 @@
 			"name": "Silverquill Pledgemage",
 			"source": "SCC",
 			"page": 214,
+			"referenceSources": [
+				"SCC-ARiR"
+			],
 			"size": [
 				"S",
 				"M"
@@ -4577,6 +4657,10 @@
 			"name": "Silverquill Professor of Radiance",
 			"source": "SCC",
 			"page": 215,
+			"referenceSources": [
+				"SCC-CK",
+				"SCC-HfMT"
+			],
 			"size": [
 				"S",
 				"M"
@@ -4702,6 +4786,10 @@
 			"name": "Silverquill Professor of Shadow",
 			"source": "SCC",
 			"page": 215,
+			"referenceSources": [
+				"SCC-CK",
+				"SCC-HfMT"
+			],
 			"size": [
 				"S",
 				"M"
@@ -4841,6 +4929,10 @@
 			"name": "Spirit Statue Mascot",
 			"source": "SCC",
 			"page": 216,
+			"referenceSources": [
+				"SCC-HfMT",
+				"SCC-TMM"
+			],
 			"size": [
 				"M"
 			],
@@ -4927,6 +5019,9 @@
 			"name": "Strixhaven Campus Guide",
 			"source": "SCC",
 			"page": 217,
+			"referenceSources": [
+				"SCC-CK"
+			],
 			"size": [
 				"S"
 			],
@@ -5440,6 +5535,10 @@
 			"name": "Witherbloom Apprentice",
 			"source": "SCC",
 			"page": 221,
+			"referenceSources": [
+				"SCC-CK",
+				"SCC-HfMT"
+			],
 			"size": [
 				"S",
 				"M"
@@ -5569,6 +5668,10 @@
 			"name": "Witherbloom Pledgemage",
 			"source": "SCC",
 			"page": 222,
+			"referenceSources": [
+				"SCC-ARiR",
+				"SCC-CK"
+			],
 			"size": [
 				"S",
 				"M"
@@ -5980,9 +6083,13 @@
 		},
 		{
 			"name": "Y'demi",
+			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "SCC",
 			"page": 172,
+			"referenceSources": [
+				"SCC-ARiR"
+			],
 			"size": [
 				"M"
 			],
@@ -6056,7 +6163,7 @@
 				{
 					"name": "Sanguine Sense",
 					"entries": [
-						"While Y'demi isn't {@condition blinded}, she can see any creature that isn't an Undead or a Construct within 60 feet of itself, even through {@quickref Cover||3||total cover}, heavily obscured areas, invisibility, or any other phenomena that would prevent sight."
+						"While Y'demi isn't {@condition blinded}, she can see any creature that isn't an Undead or a Construct within 60 feet of itself, even through {@quickref Cover||3||total cover}, {@quickref Vision and Light||2||heavily obscured} areas, invisibility, or any other phenomena that would prevent sight."
 					]
 				}
 			],
@@ -6088,6 +6195,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"actionTags": [
 				"Multiattack"
 			],

--- a/json/bestiary/bestiary-sdw.json
+++ b/json/bestiary/bestiary-sdw.json
@@ -194,6 +194,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"B"
 			],

--- a/json/bestiary/bestiary-skt.json
+++ b/json/bestiary/bestiary-skt.json
@@ -662,16 +662,11 @@
 			"isNamedCreature": true,
 			"source": "SKT",
 			"page": 96,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"DC",
+				"OoW",
+				"SDW",
+				"SLW"
 			],
 			"_copy": {
 				"name": "Ancient Green Dragon",
@@ -899,159 +894,89 @@
 			"isNamedCreature": true,
 			"source": "SKT",
 			"page": 192,
-			"size": [
-				"H"
-			],
-			"type": "giant",
+			"_copy": {
+				"name": "Cloud Giant",
+				"source": "MM",
+				"_mod": {
+					"spellcasting": {
+						"mode": "appendArr",
+						"items": [
+							{
+								"name": "Spellcasting",
+								"type": "spellcasting",
+								"headerEntries": [
+									"Sansuri casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save {@dc 15}; {@hit 7} to hit with spell attacks):"
+								],
+								"will": [
+									"{@spell mage hand}",
+									"{@spell message}",
+									"{@spell prestidigitation}",
+									"{@spell ray of frost}"
+								],
+								"daily": {
+									"2e": [
+										"{@spell arcane lock}",
+										"{@spell gust of wind}",
+										"{@spell invisibility}",
+										"{@spell magic missile}",
+										"{@spell unseen servant}"
+									],
+									"1e": [
+										"{@spell globe of invulnerability}",
+										"{@spell haste}",
+										"{@spell hypnotic pattern}",
+										"{@spell ice storm}",
+										"{@spell lightning bolt}",
+										"{@spell Mordenkainen's sword}",
+										"{@spell wall of force}"
+									]
+								},
+								"ability": "int",
+								"displayAs": "action"
+							}
+						]
+					},
+					"action": [
+						{
+							"mode": "replaceArr",
+							"replace": "Morningstar",
+							"items": [
+								{
+									"name": "Spear",
+									"entries": [
+										"{@atk mw} {@hit 12} to hit, reach 10 ft., one target. {@h}21 ({@damage 3d8 + 8}) piercing damage."
+									]
+								}
+							]
+						},
+						{
+							"mode": "replaceArr",
+							"replace": "Multiattack",
+							"items": [
+								{
+									"name": "Multiattack",
+									"entries": [
+										"Sansuri makes two spear attacks."
+									]
+								}
+							]
+						}
+					]
+				}
+			},
 			"alignment": [
 				"N",
 				"E"
 			],
-			"ac": [
-				{
-					"ac": 14,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 200,
-				"formula": "16d12 + 96"
-			},
-			"speed": {
-				"walk": 40
-			},
-			"str": 27,
-			"dex": 10,
-			"con": 22,
 			"int": 16,
-			"wis": 16,
-			"cha": 16,
-			"save": {
-				"con": "+10",
-				"wis": "+7",
-				"cha": "+7"
-			},
-			"skill": {
-				"insight": "+7",
-				"perception": "+7"
-			},
-			"passive": 17,
 			"languages": [
 				"Auran",
 				"Common",
 				"Giant"
 			],
 			"cr": "11",
-			"spellcasting": [
-				{
-					"name": "Innate Spellcasting",
-					"type": "spellcasting",
-					"headerEntries": [
-						"Sansuri's innate spellcasting ability is Charisma. She can innately cast the following spells, requiring no material components:"
-					],
-					"will": [
-						"{@spell detect magic}",
-						"{@spell fog cloud}",
-						"{@spell light}"
-					],
-					"daily": {
-						"3e": [
-							"{@spell feather fall}",
-							"{@spell fly}",
-							"{@spell misty step}",
-							"{@spell telekinesis}"
-						],
-						"1e": [
-							"{@spell control weather}",
-							"{@spell gaseous form}"
-						]
-					},
-					"ability": "cha"
-				},
-				{
-					"name": "Spellcasting",
-					"type": "spellcasting",
-					"headerEntries": [
-						"Sansuri casts one of the following spells, requiring no material components and using Intelligence as the spellcasting ability (spell save {@dc 15}; {@hit 7} to hit with spell attacks):"
-					],
-					"will": [
-						"{@spell mage hand}",
-						"{@spell message}",
-						"{@spell prestidigitation}",
-						"{@spell ray of frost}"
-					],
-					"daily": {
-						"2e": [
-							"{@spell arcane lock}",
-							"{@spell gust of wind}",
-							"{@spell invisibility}",
-							"{@spell magic missile}",
-							"{@spell unseen servant}"
-						],
-						"1e": [
-							"{@spell globe of invulnerability}",
-							"{@spell haste}",
-							"{@spell hypnotic pattern}",
-							"{@spell ice storm}",
-							"{@spell lightning bolt}",
-							"{@spell Mordenkainen's sword}",
-							"{@spell wall of force}"
-						]
-					},
-					"ability": "int",
-					"displayAs": "action"
-				}
-			],
-			"trait": [
-				{
-					"name": "Keen Smell",
-					"entries": [
-						"Sansuri has advantage on Wisdom ({@skill Perception}) checks that rely on smell."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Fling",
-					"entries": [
-						"Sansuri tries to throw a Small or Medium creature within 10 feet of her. The target must succeed on a {@dc 20} Dexterity saving throw or be hurled up to 60 feet horizontally in a direction of Sansuri's choice and land {@condition prone}, taking {@damage 1d8} bludgeoning damage for every 10 feet it was thrown."
-					]
-				},
-				{
-					"name": "Wind Aura",
-					"entries": [
-						"A magical aura of wind surrounds Sansuri. The aura is a 10-foot-radius sphere that lasts as long as Sansuri maintains {@status concentration} on it (as if {@status concentration||concentrating} on a spell). While the aura is in effect, Sansuri gains a +2 bonus to its AC against ranged weapon attacks, and all open flames within the aura are extinguished unless they are magical."
-					]
-				},
-				{
-					"name": "Multiattack",
-					"entries": [
-						"Sansuri makes two spear attacks."
-					]
-				},
-				{
-					"name": "Morningstar",
-					"entries": [
-						"{@atk mw} {@hit 12} to hit, reach 10 ft., one target. {@h}21 ({@damage 3d8 + 8}) piercing damage."
-					]
-				},
-				{
-					"name": "Rock",
-					"entries": [
-						"{@atk rw} {@hit 12} to hit, range 60/240 ft., one target. {@h}30 ({@damage 4d10 + 8}) bludgeoning damage."
-					]
-				}
-			],
 			"attachedItems": [
-				"morningstar|phb"
-			],
-			"traitTags": [
-				"Keen Senses"
-			],
-			"actionTags": [
-				"Multiattack"
+				"spear|phb"
 			],
 			"languageTags": [
 				"AU",
@@ -1079,16 +1004,10 @@
 				"RCH",
 				"RW"
 			],
-			"conditionInflict": [
-				"prone"
-			],
 			"conditionInflictSpell": [
 				"charmed",
 				"incapacitated",
 				"invisible"
-			],
-			"savingThrowForced": [
-				"dexterity"
 			],
 			"savingThrowForcedSpell": [
 				"dexterity",
@@ -1103,10 +1022,8 @@
 			"name": "Crag Cat",
 			"source": "SKT",
 			"page": 240,
-			"otherSources": [
-				{
-					"source": "IDRotF"
-				}
+			"referenceSources": [
+				"IDRotF"
 			],
 			"size": [
 				"L"
@@ -1314,7 +1231,7 @@
 				{
 					"name": "Greatsword",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) slashing damage"
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) slashing damage."
 					]
 				},
 				{
@@ -3280,6 +3197,7 @@
 				"I"
 			],
 			"miscTags": [
+				"AOE",
 				"MW",
 				"RCH",
 				"RW"
@@ -3727,7 +3645,7 @@
 			"type": "elemental",
 			"alignment": [
 				"C",
-				"E"
+				"N"
 			],
 			"ac": [
 				16
@@ -3785,7 +3703,7 @@
 			"cr": "23",
 			"spellcasting": [
 				{
-					"name": "Spellcasting",
+					"name": "Innate Spellcasting",
 					"type": "spellcasting",
 					"headerEntries": [
 						"Maegera casts {@spell fireball} (spell save {@dc 19}), requiring no material components and using Charisma as the spellcasting ability."
@@ -3836,7 +3754,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"{@atk mw} {@hit 12} to hit, reach 15 ft., one target. {@h}15 ({@damage 3d6 + 5}) bludgeoning damage plus 35 ({@damage 10d6}) fire damage"
+						"{@atk mw} {@hit 12} to hit, reach 15 ft., one target. {@h}15 ({@damage 3d6 + 5}) bludgeoning damage plus 35 ({@damage 10d6}) fire damage,"
 					]
 				}
 			],
@@ -3881,7 +3799,7 @@
 				"F"
 			],
 			"spellcastingTags": [
-				"O"
+				"I"
 			],
 			"miscTags": [
 				"AOE",
@@ -4067,7 +3985,7 @@
 				{
 					"name": "Club",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}5 ({@damage 1d4 + 1}) bludgeoning damage"
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}5 ({@damage 1d4 + 1}) bludgeoning damage."
 					]
 				},
 				{
@@ -4268,7 +4186,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of his turns, Narth can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of his turns, Narth can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -4995,7 +4913,10 @@
 			"speed": {
 				"walk": 30
 			},
-			"cr": "0",
+			"cr": {
+				"cr": "0",
+				"xp": 0
+			},
 			"trait": null,
 			"action": null,
 			"traitTags": [],
@@ -5574,7 +5495,8 @@
 				"tags": [
 					{
 						"tag": "human",
-						"prefix": "Illuskan"
+						"prefix": "Illuskan",
+						"prefixHidden": true
 					}
 				]
 			},
@@ -5610,6 +5532,15 @@
 			"name": "Sheep",
 			"source": "SKT",
 			"page": 142,
+			"otherSources": [
+				{
+					"source": "IDRotF",
+					"page": 76
+				}
+			],
+			"referenceSources": [
+				"IDRotF"
+			],
 			"_copy": {
 				"name": "Goat",
 				"source": "MM",
@@ -6135,7 +6066,7 @@
 				{
 					"name": "Ink Cloud (Costs 3 Actions)",
 					"entries": [
-						"While underwater, Slarkrethel expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than Slarkrethel. Each creature other than Slarkrethel that ends its turn there must succeed on a {@dc 23} Constitution saving throw, taking 16 ({@damage 3d10}) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of Slarkrethel's next turn."
+						"While underwater, Slarkrethel expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is {@quickref Vision and Light||2||heavily obscured} to creatures other than Slarkrethel. Each creature other than Slarkrethel that ends its turn there must succeed on a {@dc 23} Constitution saving throw, taking 16 ({@damage 3d10}) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of Slarkrethel's next turn."
 					]
 				}
 			],
@@ -6305,7 +6236,8 @@
 				"tags": [
 					{
 						"tag": "human",
-						"prefix": "Shou"
+						"prefix": "Shou",
+						"prefixHidden": true
 					}
 				]
 			},
@@ -6687,10 +6619,8 @@
 			"name": "Tressym",
 			"source": "SKT",
 			"page": 242,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"size": [
 				"T"
@@ -6878,6 +6808,9 @@
 			"isNamedCreature": true,
 			"source": "SKT",
 			"page": 254,
+			"referenceSources": [
+				"WDMM"
+			],
 			"size": [
 				"M"
 			],

--- a/json/bestiary/bestiary-slw.json
+++ b/json/bestiary/bestiary-slw.json
@@ -177,6 +177,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -564,6 +565,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"False Appearance"
 			],
@@ -661,6 +663,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Keen Senses",
 				"Pack Tactics"

--- a/json/bestiary/bestiary-tce.json
+++ b/json/bestiary/bestiary-tce.json
@@ -102,6 +102,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Regeneration"
 			],
@@ -119,6 +120,7 @@
 				"Y"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"hasToken": true,
@@ -271,6 +273,7 @@
 					}
 				]
 			},
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Magic Resistance"
@@ -499,7 +502,7 @@
 				{
 					"name": "Shred",
 					"entries": [
-						"{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target. {@h}{@damage 1d4 + 3 + PB} slashing damage"
+						"{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target. {@h}{@damage 1d4 + 3 + PB} slashing damage."
 					]
 				}
 			],
@@ -603,6 +606,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Flyby",
 				"Pack Tactics",
@@ -960,6 +964,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -1248,6 +1253,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Amorphous"
 			],
@@ -1505,6 +1511,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"shortsword|phb"
 			],
@@ -1674,6 +1681,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Death Burst",
 				"Devil's Sight",
@@ -1696,6 +1704,7 @@
 				"S"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"hasToken": true,
@@ -1852,6 +1861,9 @@
 					"source": "ERLW",
 					"page": 62
 				}
+			],
+			"reprintedAs": [
+				"Homunculus Servant|EFA"
 			],
 			"summonedByClass": "Artificer|TCE",
 			"size": [
@@ -2307,7 +2319,7 @@
 				{
 					"name": "Shadow Stealth (Fear Only)",
 					"entries": [
-						"While in dim light or darkness, the spirit takes the Hide action."
+						"While in dim light or darkness, the spirit takes the {@action Hide} action."
 					]
 				}
 			],
@@ -2324,6 +2336,7 @@
 				"C"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -2399,6 +2412,9 @@
 					"source": "ERLW",
 					"page": 61
 				}
+			],
+			"reprintedAs": [
+				"Steel Defender|EFA"
 			],
 			"summonedByClass": "Artificer|TCE",
 			"size": [
@@ -2587,6 +2603,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Incorporeal Movement"
 			],

--- a/json/bestiary/bestiary-tftyp.json
+++ b/json/bestiary/bestiary-tftyp.json
@@ -48,6 +48,15 @@
 			"name": "Animated Table",
 			"source": "TftYP",
 			"page": 230,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"L"
 			],
@@ -153,6 +162,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 158,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Commoner",
 				"source": "MM",
@@ -190,6 +202,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 159,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Orc",
 				"source": "MM"
@@ -202,6 +217,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 9,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"size": [
 				"M"
 			],
@@ -387,6 +405,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 23,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"size": [
 				"M"
 			],
@@ -484,6 +505,15 @@
 			"name": "Centaur Mummy",
 			"source": "TftYP",
 			"page": 231,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"L"
 			],
@@ -606,6 +636,7 @@
 			],
 			"miscTags": [
 				"CUR",
+				"HPR",
 				"MLW",
 				"MW",
 				"RCH"
@@ -628,6 +659,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 170,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Frost Giant",
 				"source": "MM",
@@ -676,6 +710,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 158,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Commoner",
 				"source": "MM",
@@ -699,6 +736,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 16,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"_copy": {
 				"name": "Troll",
 				"source": "MM",
@@ -744,6 +784,15 @@
 			"name": "Dread Warrior",
 			"source": "TftYP",
 			"page": 233,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"M"
 			],
@@ -859,6 +908,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 126,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Spy",
 				"source": "MM",
@@ -943,6 +995,15 @@
 			"name": "Duergar Spy",
 			"source": "TftYP",
 			"page": 234,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"M"
 			],
@@ -1002,7 +1063,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of its turns, the spy can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of its turns, the spy can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -1095,6 +1156,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 25,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"size": [
 				"M"
 			],
@@ -1191,6 +1255,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 159,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Druid",
 				"source": "MM",
@@ -1218,6 +1285,9 @@
 			"name": "Elder Black Pudding",
 			"source": "TftYP",
 			"page": 143,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Black Pudding",
 				"source": "MM"
@@ -1265,6 +1335,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 22,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"size": [
 				"M"
 			],
@@ -1346,7 +1419,7 @@
 					"name": "Channel Divinity: Turn Undead (1/Short Rest)",
 					"entries": [
 						"Erky presents his holy Symbol and speaks a prayer censuring the Undead. Each Undead that can see or hear Erky within 30 feet of him must make a {@dc 12} Wisdom saving throw. If the creature fails its saving throw, it is turned for 1 minute or until it takes any damage.",
-						"A turned creature must spend its turns trying to move as far away from Erky as it can, and it can't willingly move to a space within 30 feet of him. It also can't take reactions. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If there's nowhere to move, the creature can use the Dodge action."
+						"A turned creature must spend its turns trying to move as far away from Erky as it can, and it can't willingly move to a space within 30 feet of him. It also can't take reactions. For its action, it can use only the {@action Dash} action or try to escape from an effect that prevents it from moving. If there's nowhere to move, the creature can use the {@action Dodge} action."
 					]
 				}
 			],
@@ -1392,6 +1465,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 189,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Cloud Giant",
 				"source": "MM",
@@ -1466,6 +1542,9 @@
 			"name": "Fire Giant Servant",
 			"source": "TftYP",
 			"page": 171,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Hill Giant",
 				"source": "MM",
@@ -1527,6 +1606,10 @@
 			"name": "Four-Armed Gargoyle",
 			"source": "TftYP",
 			"page": 129,
+			"referenceSources": [
+				"TftYP-DiT",
+				"TftYP-ToH"
+			],
 			"size": [
 				"M"
 			],
@@ -1637,6 +1720,9 @@
 			"name": "Frost Giant Servant",
 			"source": "TftYP",
 			"page": 187,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Hill Giant",
 				"source": "MM"
@@ -1667,6 +1753,15 @@
 			"name": "Giant Crayfish",
 			"source": "TftYP",
 			"page": 235,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"L"
 			],
@@ -1750,6 +1845,15 @@
 			"name": "Giant Ice Toad",
 			"source": "TftYP",
 			"page": 235,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"L"
 			],
@@ -1856,6 +1960,15 @@
 			"name": "Giant Lightning Eel",
 			"source": "TftYP",
 			"page": 236,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"L"
 			],
@@ -1930,6 +2043,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -1944,16 +2058,17 @@
 			"name": "Giant Skeleton",
 			"source": "TftYP",
 			"page": 236,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"DC",
+				"IMR",
+				"SDW",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"size": [
 				"H"
@@ -2068,6 +2183,15 @@
 			"name": "Giant Subterranean Lizard",
 			"source": "TftYP",
 			"page": 236,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"H"
 			],
@@ -2157,6 +2281,9 @@
 			"name": "Goblin Commoner",
 			"source": "TftYP",
 			"page": 24,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"_copy": {
 				"name": "Commoner",
 				"source": "MM",
@@ -2202,6 +2329,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 151,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Priest",
 				"source": "MM",
@@ -2228,6 +2358,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 42,
+			"referenceSources": [
+				"TftYP-TFoF"
+			],
 			"_copy": {
 				"name": "Ogre",
 				"source": "MM",
@@ -2261,16 +2394,17 @@
 			"name": "Greater Zombie",
 			"source": "TftYP",
 			"page": 237,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"DC",
+				"IMR",
+				"SDW",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"size": [
 				"M"
@@ -2384,6 +2518,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 25,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"size": [
 				"S"
 			],
@@ -2460,7 +2597,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+						"The goblin can take the {@action Disengage} or {@action Hide} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -2518,6 +2655,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 170,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Hill Giant",
 				"source": "MM",
@@ -2538,6 +2678,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 21,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"size": [
 				"M"
 			],
@@ -2582,6 +2725,7 @@
 			],
 			"miscTags": [
 				"DIS",
+				"HPR",
 				"MW"
 			],
 			"savingThrowForced": [
@@ -2596,6 +2740,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 160,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Deathlock Wight",
 				"source": "MTF",
@@ -2614,6 +2761,9 @@
 			"name": "Hill Giant Sergeant",
 			"source": "TftYP",
 			"page": 170,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Hill Giant",
 				"source": "MM"
@@ -2653,6 +2803,9 @@
 			"name": "Hill Giant Subchief",
 			"source": "TftYP",
 			"page": 170,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Stone Giant",
 				"source": "MM"
@@ -2664,10 +2817,9 @@
 			"name": "Huge Giant Crab",
 			"source": "TftYP",
 			"page": 103,
-			"otherSources": [
-				{
-					"source": "SLW"
-				}
+			"referenceSources": [
+				"SLW",
+				"TftYP-WPM"
 			],
 			"size": [
 				"H"
@@ -2772,6 +2924,9 @@
 			"name": "Huge Polar Bear",
 			"source": "TftYP",
 			"page": 187,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Polar Bear",
 				"source": "MM"
@@ -2791,6 +2946,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 157,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Commoner",
 				"source": "MM",
@@ -2820,6 +2978,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 189,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Cloud Giant",
 				"source": "MM",
@@ -2891,6 +3052,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 15,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"_copy": {
 				"name": "Quasit",
 				"source": "MM",
@@ -2911,6 +3075,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 45,
+			"referenceSources": [
+				"TftYP-TFoF"
+			],
 			"size": [
 				"M"
 			],
@@ -3084,6 +3251,15 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 238,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"L"
 			],
@@ -3189,6 +3365,15 @@
 			"name": "Kelpie",
 			"source": "TftYP",
 			"page": 238,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"M"
 			],
@@ -3321,6 +3506,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 132,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Commoner",
 				"source": "MM",
@@ -3351,6 +3539,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 157,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Commoner",
 				"source": "MM"
@@ -3369,6 +3560,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 193,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Fire Giant",
 				"source": "MM",
@@ -3419,6 +3613,9 @@
 			"name": "Kobold Commoner",
 			"source": "TftYP",
 			"page": 18,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"_copy": {
 				"name": "Commoner",
 				"source": "MM",
@@ -3479,10 +3676,10 @@
 			"name": "Lacedon",
 			"source": "TftYP",
 			"page": 147,
-			"otherSources": [
-				{
-					"source": "EGW"
-				}
+			"referenceSources": [
+				"EGW",
+				"TftYP-DiT",
+				"US"
 			],
 			"_copy": {
 				"name": "Ghoul",
@@ -3508,6 +3705,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 131,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Evoker",
 				"source": "VGM",
@@ -3517,8 +3717,38 @@
 						"replace": "the evoker",
 						"with": "Lahnis",
 						"flags": "i"
+					},
+					"trait": {
+						"mode": "appendArr",
+						"items": {
+							"name": "Special Equipment",
+							"entries": [
+								"Lahnis wears a {@item ring of protection}."
+							]
+						}
 					}
 				}
+			},
+			"ac": [
+				{
+					"ac": 13,
+					"from": [
+						"{@item ring of protection}"
+					]
+				},
+				{
+					"ac": 16,
+					"condition": "with {@spell mage armor}",
+					"braces": true
+				}
+			],
+			"save": {
+				"str": "+0",
+				"dex": "+3",
+				"con": "+2",
+				"int": "+8",
+				"wis": "+6",
+				"cha": "+1"
 			},
 			"hasToken": true,
 			"hasFluffImages": true
@@ -3562,6 +3792,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 153,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Deva",
 				"source": "MM",
@@ -3581,6 +3814,15 @@
 			"name": "Malformed Kraken",
 			"source": "TftYP",
 			"page": 239,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"H"
 			],
@@ -3733,6 +3975,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 157,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Enchanter",
 				"source": "VGM",
@@ -3760,6 +4005,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 91,
+			"referenceSources": [
+				"TftYP-THSoT"
+			],
 			"size": [
 				"M"
 			],
@@ -3871,6 +4119,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 209,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Drow Priestess of Lolth",
 				"source": "MM",
@@ -3908,6 +4159,15 @@
 			"name": "Nereid",
 			"source": "TftYP",
 			"page": 240,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"M"
 			],
@@ -4040,6 +4300,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 54,
+			"referenceSources": [
+				"TftYP-TFoF"
+			],
 			"_copy": {
 				"name": "Duergar",
 				"source": "MM",
@@ -4098,6 +4361,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 196,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Assassin",
 				"source": "MM",
@@ -4135,6 +4401,9 @@
 			"name": "Ogre Skeleton",
 			"source": "TftYP",
 			"page": 54,
+			"referenceSources": [
+				"TftYP-TFoF"
+			],
 			"_copy": {
 				"name": "Ogre",
 				"source": "MM",
@@ -4157,6 +4426,15 @@
 			"name": "Ooze Master",
 			"source": "TftYP",
 			"page": 241,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"H"
 			],
@@ -4405,6 +4683,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 157,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Yuan-ti Malison (Type 3)",
 				"source": "MM",
@@ -4425,6 +4706,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 132,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Necromancer",
 				"source": "VGM",
@@ -4450,6 +4734,9 @@
 			"name": "Reduced-Threat Aboleth",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Aboleth",
 				"source": "MM",
@@ -4467,6 +4754,9 @@
 			"name": "Reduced-Threat Basilisk",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Basilisk",
 				"source": "MM",
@@ -4483,6 +4773,9 @@
 			"name": "Reduced-Threat Behir",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Behir",
 				"source": "MM",
@@ -4516,6 +4809,9 @@
 			"name": "Reduced-Threat Beholder",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Beholder",
 				"source": "MM",
@@ -4532,6 +4828,9 @@
 			"name": "Reduced-Threat Black Pudding",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Black Pudding",
 				"source": "MM",
@@ -4548,6 +4847,9 @@
 			"name": "Reduced-Threat Carrion Crawler",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Carrion Crawler",
 				"source": "MM",
@@ -4564,6 +4866,9 @@
 			"name": "Reduced-Threat Clay Golem",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Clay Golem",
 				"source": "MM",
@@ -4580,6 +4885,9 @@
 			"name": "Reduced-Threat Darkmantle",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Darkmantle",
 				"source": "MM",
@@ -4596,6 +4904,9 @@
 			"name": "Reduced-Threat Displacer Beast",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Displacer Beast",
 				"source": "MM",
@@ -4612,6 +4923,9 @@
 			"name": "Reduced-Threat Dragon Turtle",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Dragon Turtle",
 				"source": "MM",
@@ -4653,6 +4967,9 @@
 			"name": "Reduced-Threat Ettercap",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Ettercap",
 				"source": "MM",
@@ -4674,6 +4991,9 @@
 			"name": "Reduced-Threat Flesh Golem",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Flesh Golem",
 				"source": "MM",
@@ -4690,6 +5010,9 @@
 			"name": "Reduced-Threat Glabrezu",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Glabrezu",
 				"source": "MM",
@@ -4706,6 +5029,9 @@
 			"name": "Reduced-Threat Gray Ooze",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Gray Ooze",
 				"source": "MM",
@@ -4726,6 +5052,9 @@
 			"name": "Reduced-Threat Helmed Horror",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Helmed Horror",
 				"source": "MM",
@@ -4742,6 +5071,9 @@
 			"name": "Reduced-Threat Hezrou",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Hezrou",
 				"source": "MM",
@@ -4758,6 +5090,9 @@
 			"name": "Reduced-Threat Hook Horror",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Hook Horror",
 				"source": "MM",
@@ -4774,6 +5109,9 @@
 			"name": "Reduced-Threat Ochre Jelly",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Ochre Jelly",
 				"source": "MM",
@@ -4790,6 +5128,9 @@
 			"name": "Reduced-Threat Otyugh",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Otyugh",
 				"source": "MM",
@@ -4829,6 +5170,9 @@
 			"name": "Reduced-Threat Owlbear",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Owlbear",
 				"source": "MM",
@@ -4845,6 +5189,9 @@
 			"name": "Reduced-Threat Peryton",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Peryton",
 				"source": "MM",
@@ -4861,6 +5208,9 @@
 			"name": "Reduced-Threat Remorhaz",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Remorhaz",
 				"source": "MM",
@@ -4877,6 +5227,9 @@
 			"name": "Reduced-Threat Stone Golem",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Stone Golem",
 				"source": "MM",
@@ -4893,6 +5246,9 @@
 			"name": "Reduced-Threat Vrock",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Vrock",
 				"source": "MM",
@@ -4909,6 +5265,9 @@
 			"name": "Reduced-Threat Wight",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Wight",
 				"source": "MM",
@@ -4925,6 +5284,9 @@
 			"name": "Reduced-Threat Wyvern",
 			"source": "TftYP",
 			"page": 113,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Wyvern",
 				"source": "MM",
@@ -4941,6 +5303,10 @@
 			"name": "Scrag",
 			"source": "TftYP",
 			"page": 147,
+			"referenceSources": [
+				"RoT",
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Troll",
 				"source": "MM"
@@ -4957,12 +5323,20 @@
 			"page": 242,
 			"otherSources": [
 				{
-					"source": "LR"
-				},
-				{
 					"source": "GoS",
 					"page": 252
 				}
+			],
+			"referenceSources": [
+				"GoS",
+				"LR",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"size": [
 				"L"
@@ -5073,6 +5447,9 @@
 			"name": "Sentient Gray Ooze",
 			"source": "TftYP",
 			"page": 158,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Gray Ooze",
 				"source": "MM",
@@ -5100,6 +5477,9 @@
 			"name": "Sentient Ochre Jelly",
 			"source": "TftYP",
 			"page": 158,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Ochre Jelly",
 				"source": "MM",
@@ -5125,6 +5505,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 119,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Knight",
 				"source": "MM",
@@ -5146,6 +5529,15 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 242,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"M"
 			],
@@ -5281,6 +5673,15 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 243,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"M"
 			],
@@ -5383,10 +5784,15 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 243,
-			"otherSources": [
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"MOT",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"size": [
 				"M"
@@ -5526,6 +5932,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 102,
+			"referenceSources": [
+				"TftYP-WPM"
+			],
 			"size": [
 				"M"
 			],
@@ -5593,7 +6002,7 @@
 					"name": "Spellcasting",
 					"type": "spellcasting",
 					"headerEntries": [
-						"Snarla is a 6th-level spellcaster. Her spellcasting ability is Intelligence (spell save {@dc 14}, +6 to hit with spell attacks). She has the following wizard spells prepared:"
+						"Snarla is a 6th-level spellcaster. Her spellcasting ability is Intelligence (spell save {@dc 14}, {@hit 6} to hit with spell attacks). She has the following wizard spells prepared:"
 					],
 					"spells": {
 						"0": {
@@ -5656,7 +6065,7 @@
 				{
 					"name": "Bite (Wolf or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 12} Constitution saving throw or be cursed with werewolf lycanthropy."
+						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 12} Constitution saving throw or be cursed with werewolf {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				},
 				{
@@ -5741,6 +6150,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 53,
+			"referenceSources": [
+				"TftYP-TFoF"
+			],
 			"size": [
 				"M"
 			],
@@ -5951,6 +6363,15 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 244,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"M"
 			],
@@ -6210,6 +6631,15 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 245,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"L"
 			],
@@ -6343,6 +6773,15 @@
 			"name": "Thayan Apprentice",
 			"source": "TftYP",
 			"page": 245,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"M"
 			],
@@ -6474,6 +6913,15 @@
 			"name": "Thayan Warrior",
 			"source": "TftYP",
 			"page": 246,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"M"
 			],
@@ -6587,6 +7035,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 173,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Stone Giant",
 				"source": "MM",
@@ -6643,6 +7094,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 158,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Commoner",
 				"source": "MM",
@@ -6674,6 +7128,15 @@
 			"name": "Thorn Slinger",
 			"source": "TftYP",
 			"page": 246,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"L"
 			],
@@ -6755,6 +7218,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 68,
+			"referenceSources": [
+				"TftYP-THSoT"
+			],
 			"size": [
 				"M"
 			],
@@ -6831,7 +7297,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+						"The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from {@item Holy Water (Flask)|PHB|holy water}, this trait doesn't function at the start of the vampire's next turn."
 					]
 				},
 				{
@@ -6945,6 +7411,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 159,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"_copy": {
 				"name": "Wight",
 				"source": "MM",
@@ -6963,6 +7432,9 @@
 			"name": "Werejaguar",
 			"source": "TftYP",
 			"page": 79,
+			"referenceSources": [
+				"TftYP-THSoT"
+			],
 			"_copy": {
 				"name": "Weretiger",
 				"source": "MM",
@@ -7002,6 +7474,15 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 248,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"G"
 			],
@@ -7112,6 +7593,9 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 83,
+			"referenceSources": [
+				"TftYP-THSoT"
+			],
 			"_copy": {
 				"name": "Roper",
 				"source": "MM",
@@ -7132,6 +7616,9 @@
 			"name": "Yeti Leader",
 			"source": "TftYP",
 			"page": 183,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"_copy": {
 				"name": "Yeti",
 				"source": "MM",
@@ -7282,6 +7769,15 @@
 			"isNamedCreature": true,
 			"source": "TftYP",
 			"page": 248,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"size": [
 				"S"
 			],

--- a/json/bestiary/bestiary-toa.json
+++ b/json/bestiary/bestiary-toa.json
@@ -304,6 +304,7 @@
 				"CW"
 			],
 			"miscTags": [
+				"AOE",
 				"CUR",
 				"MLW",
 				"MW"
@@ -636,6 +637,9 @@
 			"name": "Almiraj",
 			"source": "ToA",
 			"page": 211,
+			"referenceSources": [
+				"TTP"
+			],
 			"size": [
 				"S"
 			],
@@ -1098,13 +1102,9 @@
 			"name": "Assassin Vine",
 			"source": "ToA",
 			"page": 213,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"GoS",
+				"SDW"
 			],
 			"size": [
 				"L"
@@ -1386,7 +1386,8 @@
 				"N",
 				"G"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Bag of Nails",
@@ -1608,12 +1609,16 @@
 				"N",
 				"E"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
 			"name": "Chwinga",
 			"source": "ToA",
 			"page": 216,
+			"referenceSources": [
+				"TTP"
+			],
 			"size": [
 				"T"
 			],
@@ -1970,12 +1975,16 @@
 				"N",
 				"E"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
 			"name": "Eblis",
 			"source": "ToA",
 			"page": 219,
+			"referenceSources": [
+				"TTP"
+			],
 			"size": [
 				"L"
 			],
@@ -2113,7 +2122,8 @@
 					}
 				}
 			},
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Elok Jaharwon",
@@ -2168,7 +2178,8 @@
 				"N",
 				"G"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Fenthaza",
@@ -2401,6 +2412,9 @@
 			"name": "Giant Snapping Turtle",
 			"source": "ToA",
 			"page": 222,
+			"referenceSources": [
+				"TTP"
+			],
 			"size": [
 				"L"
 			],
@@ -2616,7 +2630,8 @@
 				"H",
 				"X"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Grabstab",
@@ -2667,6 +2682,7 @@
 				"L",
 				"G"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2804,6 +2820,9 @@
 			"name": "Jaculi",
 			"source": "ToA",
 			"page": 225,
+			"referenceSources": [
+				"TTP"
+			],
 			"size": [
 				"L"
 			],
@@ -2956,6 +2975,9 @@
 			"name": "Kamadan",
 			"source": "ToA",
 			"page": 225,
+			"referenceSources": [
+				"TLK"
+			],
 			"size": [
 				"L"
 			],
@@ -3200,7 +3222,8 @@
 					}
 				}
 			},
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Kwayothé",
@@ -3279,10 +3302,9 @@
 			"isNamedCreature": true,
 			"source": "ToA",
 			"page": 227,
-			"otherSources": [
-				{
-					"source": "BGDIA"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"TTP"
 			],
 			"size": [
 				"M"
@@ -3521,7 +3543,8 @@
 				"L",
 				"G"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Mwaxanaré",
@@ -3757,6 +3780,7 @@
 				"L",
 				"G"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -3965,7 +3989,8 @@
 				"N",
 				"G"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ras Nsi",
@@ -3973,6 +3998,9 @@
 			"isNamedCreature": true,
 			"source": "ToA",
 			"page": 230,
+			"referenceSources": [
+				"TTP"
+			],
 			"size": [
 				"M"
 			],
@@ -4240,7 +4268,8 @@
 					}
 				}
 			},
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Salida",
@@ -4309,6 +4338,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Magic Resistance"
 			],
@@ -4361,7 +4391,8 @@
 				"intimidation": "+5",
 				"survival": "+7"
 			},
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Skeleton Key",
@@ -4788,7 +4819,8 @@
 				]
 			},
 			"alignment": [
-				"L"
+				"L",
+				"N"
 			],
 			"languages": [
 				"Common",
@@ -4796,6 +4828,7 @@
 				"Elvish",
 				"Halfling"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"D",
@@ -5072,6 +5105,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"damageTags": [
 				"P"
 			],
@@ -5542,6 +5576,9 @@
 			"isNamedCreature": true,
 			"source": "ToA",
 			"page": 58,
+			"reprintedAs": [
+				"Valindra Shadowmantle|FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -5833,10 +5870,9 @@
 			"isNamedCreature": true,
 			"source": "ToA",
 			"page": 235,
-			"otherSources": [
-				{
-					"source": "WDH"
-				}
+			"referenceSources": [
+				"TTP",
+				"WDH"
 			],
 			"size": [
 				"M"
@@ -6635,6 +6671,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{

--- a/json/bestiary/bestiary-tofw.json
+++ b/json/bestiary/bestiary-tofw.json
@@ -98,6 +98,7 @@
 				}
 			},
 			"tokenCredit": "@hamosart",
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -309,10 +310,8 @@
 			"isNamedCreature": true,
 			"source": "ToFW",
 			"page": 10,
-			"otherSources": [
-				{
-					"source": "MPP"
-				}
+			"referenceSources": [
+				"MPP"
 			],
 			"size": [
 				"T"

--- a/json/bestiary/bestiary-ttp.json
+++ b/json/bestiary/bestiary-ttp.json
@@ -7,7 +7,8 @@
 		},
 		"otherSources": {
 			"monster": {
-				"MTF": "TTP"
+				"MTF": "TTP",
+				"MM": "TTP"
 			}
 		}
 	},

--- a/json/bestiary/bestiary-veor.json
+++ b/json/bestiary/bestiary-veor.json
@@ -204,6 +204,7 @@
 				"O"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -225,6 +226,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 116,
 			"_copy": {
 				"name": "Werewolf",
 				"source": "MM",
@@ -298,7 +300,7 @@
 				{
 					"name": "Berserk",
 					"entries": [
-						"Whenever the bearer takes damage or makes a Strength or Dexterity saving throw, roll a {@dice d6}. On a 5 or 6, the bearer goes berserk. On each of its turns while berserk, the bearer has advantage on melee attack rolls, it can Dash as a bonus action, and it must attack the nearest creature it can see. If no creature is near enough to move to and attack, the bearer attacks an object, with preference for an object smaller than itself. Once the bearer goes berserk, it remains berserk until it is destroyed or its creator gives it a pristine black rose."
+						"Whenever the bearer takes damage or makes a Strength or Dexterity saving throw, roll a {@dice d6}. On a 5 or 6, the bearer goes berserk. On each of its turns while berserk, the bearer has advantage on melee attack rolls, it can {@action Dash} as a bonus action, and it must attack the nearest creature it can see. If no creature is near enough to move to and attack, the bearer attacks an object, with preference for an object smaller than itself. Once the bearer goes berserk, it remains berserk until it is destroyed or its creator gives it a pristine black rose."
 					]
 				},
 				{
@@ -666,7 +668,7 @@
 				{
 					"name": "Mist Sight",
 					"entries": [
-						"The blazebear can see normally through heavily obscured areas created by mist or fog, including areas created by spells such as Fog Cloud."
+						"The blazebear can see normally through {@quickref Vision and Light||2||heavily obscured} areas created by mist or fog, including areas created by spells such as Fog Cloud."
 					]
 				}
 			],
@@ -1245,6 +1247,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 80,
 			"_copy": {
 				"name": "Blade Scout",
 				"source": "VEoR",
@@ -1730,6 +1733,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 29,
 			"_copy": {
 				"name": "Priest",
 				"source": "MM",
@@ -1961,6 +1965,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 53,
 			"_copy": {
 				"name": "Erinyes",
 				"source": "MM",
@@ -1980,6 +1985,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 64,
 			"_copy": {
 				"name": "Mage",
 				"source": "MM",
@@ -2271,6 +2277,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 49,
 			"_copy": {
 				"name": "Mage",
 				"source": "MM",
@@ -2582,10 +2589,11 @@
 			"hasFluffImages": true
 		},
 		{
-			"name": "Inda",
+			"name": "Inda Malayuri",
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 68,
 			"_copy": {
 				"name": "Deva",
 				"source": "MM",
@@ -2608,6 +2616,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 18,
 			"_copy": {
 				"name": "Noble",
 				"source": "MM",
@@ -2641,6 +2650,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 28,
 			"_copy": {
 				"name": "Necromancer Wizard",
 				"source": "MPMM",
@@ -3018,7 +3028,6 @@
 			"damageTags": [
 				"N",
 				"P",
-				"R",
 				"S"
 			],
 			"miscTags": [
@@ -3040,6 +3049,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 156,
 			"_copy": {
 				"name": "Vampire",
 				"source": "MM",
@@ -3059,6 +3069,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 54,
 			"_copy": {
 				"name": "Spiderdragon",
 				"source": "VEoR",
@@ -3078,6 +3089,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 34,
 			"_copy": {
 				"name": "Lonely Sorrowsworn",
 				"source": "MPMM",
@@ -3097,6 +3109,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 157,
 			"_copy": {
 				"name": "Red Abishai",
 				"source": "MPMM",
@@ -3116,6 +3129,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 132,
 			"_copy": {
 				"name": "Assassin",
 				"source": "MM",
@@ -3145,6 +3159,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 60,
 			"_copy": {
 				"name": "Githyanki Knight",
 				"source": "MM",
@@ -3168,6 +3183,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 41,
 			"_copy": {
 				"name": "Assassin",
 				"source": "MM",
@@ -3302,7 +3318,7 @@
 				{
 					"name": "Mirror Stealth",
 					"entries": [
-						"While within 5 feet of a reflective surface, such as a mirror, the mirror shade takes the Hide action."
+						"While within 5 feet of a reflective surface, such as a mirror, the mirror shade takes the {@action Hide} action."
 					]
 				}
 			],
@@ -3717,6 +3733,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 175,
 			"_copy": {
 				"name": "Drow Mage",
 				"source": "MM",
@@ -3736,6 +3753,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 157,
 			"_copy": {
 				"name": "Blue Abishai",
 				"source": "MPMM",
@@ -3755,6 +3773,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 129,
 			"_copy": {
 				"name": "Adult Lunar Dragon",
 				"source": "BAM",
@@ -4106,6 +4125,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 80,
 			"_copy": {
 				"name": "Blade Scout",
 				"source": "VEoR",
@@ -4326,6 +4346,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 66,
 			"_copy": {
 				"name": "Treant",
 				"source": "MM",
@@ -4492,6 +4513,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 146,
 			"_copy": {
 				"name": "False Lich",
 				"source": "VEoR",
@@ -4511,6 +4533,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 158,
 			"_copy": {
 				"name": "Green Abishai",
 				"source": "MPMM",
@@ -4530,6 +4553,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 113,
 			"_copy": {
 				"name": "Werewolf",
 				"source": "MM",
@@ -4556,6 +4580,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 31,
 			"_copy": {
 				"name": "Vampire",
 				"source": "MM",
@@ -4575,6 +4600,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 20,
 			"_copy": {
 				"name": "Mage",
 				"source": "MM",
@@ -4601,6 +4627,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 95,
 			"_copy": {
 				"name": "Inquisitor of the Tome",
 				"source": "VRGR",
@@ -4644,6 +4671,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 22,
 			"_copy": {
 				"name": "Marid",
 				"source": "MM",
@@ -4895,6 +4923,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -5154,7 +5183,6 @@
 				"F",
 				"N",
 				"P",
-				"R",
 				"S"
 			],
 			"spellcastingTags": [
@@ -5388,6 +5416,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 115,
 			"_copy": {
 				"name": "Archmage",
 				"source": "MM",
@@ -5417,6 +5446,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 23,
 			"_copy": {
 				"name": "Mage",
 				"source": "MM",
@@ -5447,6 +5477,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 158,
 			"_copy": {
 				"name": "Rakshasa",
 				"source": "MM",
@@ -5467,6 +5498,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 175,
 			"_copy": {
 				"name": "Drow Mage",
 				"source": "MM",
@@ -5486,6 +5518,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 120,
 			"_copy": {
 				"name": "Werewolf",
 				"source": "MM",
@@ -6352,6 +6385,7 @@
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VEoR",
+			"page": 60,
 			"_copy": {
 				"name": "Githyanki Knight",
 				"source": "MM",

--- a/json/bestiary/bestiary-vgm.json
+++ b/json/bestiary/bestiary-vgm.json
@@ -160,7 +160,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/abjurer.mp3"
+				"path": "bestiary/abjurer.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -198,6 +198,9 @@
 			"name": "Alhoon",
 			"source": "VGM",
 			"page": 172,
+			"referenceSources": [
+				"TLK"
+			],
 			"reprintedAs": [
 				"Alhoon|MPMM"
 			],
@@ -399,7 +402,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/alhoon.mp3"
+				"path": "bestiary/alhoon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -460,10 +463,8 @@
 			"name": "Annis Hag",
 			"source": "VGM",
 			"page": 159,
-			"otherSources": [
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"MOT"
 			],
 			"reprintedAs": [
 				"Annis Hag|MPMM"
@@ -824,7 +825,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/annis-hag.mp3"
+				"path": "bestiary/annis-hag.opus"
 			},
 			"senseTags": [
 				"D"
@@ -1139,22 +1140,13 @@
 			"name": "Apprentice Wizard",
 			"source": "VGM",
 			"page": 209,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "ERLW"
-				}
+			"referenceSources": [
+				"AZfyT",
+				"DIP",
+				"ERLW",
+				"SLW",
+				"TLK",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Apprentice Wizard|MPMM"
@@ -1236,7 +1228,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/apprentice-wizard.mp3"
+				"path": "bestiary/apprentice-wizard.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -1273,14 +1265,14 @@
 			"page": 210,
 			"otherSources": [
 				{
-					"source": "WDMM"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "MOT"
+					"source": "WDMM",
+					"page": 311
 				}
+			],
+			"referenceSources": [
+				"GoS",
+				"MOT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Archdruid|MPMM"
@@ -1444,7 +1436,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/archdruid.mp3"
+				"path": "bestiary/archdruid.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -1492,16 +1484,10 @@
 			"name": "Archer",
 			"source": "VGM",
 			"page": 210,
-			"otherSources": [
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"DIP",
+				"MOT",
+				"SLW"
 			],
 			"reprintedAs": [
 				"Archer|MPMM"
@@ -1582,7 +1568,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/archer.mp3"
+				"path": "bestiary/archer.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -1668,7 +1654,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/aurochs.mp3"
+				"path": "bestiary/aurochs.opus"
 			},
 			"traitTags": [
 				"Charge"
@@ -1811,7 +1797,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/babau.mp3"
+				"path": "bestiary/babau.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -1914,7 +1900,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the banderhobb can take the Hide action as a bonus action."
+						"While in dim light or darkness, the banderhobb can take the {@action Hide} action as a bonus action."
 					]
 				}
 			],
@@ -1950,7 +1936,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/banderhobb.mp3"
+				"path": "bestiary/banderhobb.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -1985,16 +1971,10 @@
 			"name": "Bard",
 			"source": "VGM",
 			"page": 211,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"GoS",
+				"SDW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Bard|MPMM"
@@ -2115,7 +2095,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bard.mp3"
+				"path": "bestiary/bard.opus"
 			},
 			"attachedItems": [
 				"shortbow|phb",
@@ -2155,10 +2135,15 @@
 			"name": "Barghest",
 			"source": "VGM",
 			"page": 123,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				}
+			"referenceSources": [
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Barghest|MPMM"
@@ -2312,7 +2297,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/barghest.mp3"
+				"path": "bestiary/barghest.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -2718,7 +2703,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bheur-hag.mp3"
+				"path": "bestiary/bheur-hag.opus"
 			},
 			"senseTags": [
 				"D"
@@ -3119,7 +3104,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guard-drake.mp3"
+				"path": "bestiary/guard-drake.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -3149,19 +3134,11 @@
 			"name": "Blackguard",
 			"source": "VGM",
 			"page": 211,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"DC",
+				"DIP",
+				"MOT",
+				"SDW"
 			],
 			"reprintedAs": [
 				"Blackguard|MPMM"
@@ -3283,7 +3260,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blackguard.mp3"
+				"path": "bestiary/blackguard.opus"
 			},
 			"attachedItems": [
 				"glaive|phb",
@@ -3408,7 +3385,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guard-drake.mp3"
+				"path": "bestiary/guard-drake.opus"
 			},
 			"senseTags": [
 				"D"
@@ -3435,13 +3412,9 @@
 			"name": "Bodak",
 			"source": "VGM",
 			"page": 127,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Bodak|MPMM"
@@ -3553,7 +3526,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bodak.mp3"
+				"path": "bestiary/bodak.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity"
@@ -3568,7 +3541,6 @@
 			"damageTags": [
 				"B",
 				"N",
-				"R",
 				"Y"
 			],
 			"miscTags": [
@@ -3588,13 +3560,9 @@
 			"name": "Boggle",
 			"source": "VGM",
 			"page": 128,
-			"otherSources": [
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"IMR",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Boggle|MPMM"
@@ -3687,7 +3655,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/boggle.mp3"
+				"path": "bestiary/boggle.opus"
 			},
 			"senseTags": [
 				"D"
@@ -3744,6 +3712,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -3765,6 +3734,7 @@
 					"ability": "int"
 				}
 			],
+			"tokenCustom": true,
 			"spellcastingTags": [
 				"CW"
 			],
@@ -3800,6 +3770,7 @@
 					]
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -3832,6 +3803,7 @@
 					]
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -3864,6 +3836,7 @@
 					]
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -3886,6 +3859,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -3908,6 +3882,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -3918,10 +3893,8 @@
 			],
 			"source": "VGM",
 			"page": 139,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Brontosaurus|MPMM"
@@ -3979,7 +3952,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brontosaurus.mp3"
+				"path": "bestiary/brontosaurus.opus"
 			},
 			"damageTags": [
 				"B"
@@ -4002,10 +3975,8 @@
 			"name": "Catoblepas",
 			"source": "VGM",
 			"page": 129,
-			"otherSources": [
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"MOT"
 			],
 			"reprintedAs": [
 				"Catoblepas|MPMM"
@@ -4076,7 +4047,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/catoblepas.mp3"
+				"path": "bestiary/catoblepas.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -4193,7 +4164,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cave-fisher.mp3"
+				"path": "bestiary/cave-fisher.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -4226,14 +4197,22 @@
 			"page": 212,
 			"otherSources": [
 				{
-					"source": "WDMM"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
+					"source": "WDMM",
+					"page": 312
 				}
+			],
+			"referenceSources": [
+				"GoS",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Champion|MPMM"
@@ -4325,7 +4304,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/champion.mp3"
+				"path": "bestiary/champion.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb",
@@ -4446,7 +4425,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/chitine.mp3"
+				"path": "bestiary/chitine.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -4616,7 +4595,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/choldrith.mp3"
+				"path": "bestiary/choldrith.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -4828,7 +4807,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cloud-giant-smiling-one.mp3"
+				"path": "bestiary/cloud-giant-smiling-one.opus"
 			},
 			"attachedItems": [
 				"morningstar|phb"
@@ -4872,10 +4851,15 @@
 			"name": "Conjurer",
 			"source": "VGM",
 			"page": 212,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				}
+			"referenceSources": [
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Conjurer Wizard|MPMM"
@@ -5007,7 +4991,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/conjurer.mp3"
+				"path": "bestiary/conjurer.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -5046,10 +5030,8 @@
 			"name": "Cow",
 			"source": "VGM",
 			"page": 207,
-			"otherSources": [
-				{
-					"source": "DIP"
-				}
+			"referenceSources": [
+				"DIP"
 			],
 			"size": [
 				"L"
@@ -5097,7 +5079,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cow.mp3"
+				"path": "bestiary/cow.opus"
 			},
 			"traitTags": [
 				"Charge"
@@ -5179,7 +5161,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cranium-rat.mp3"
+				"path": "bestiary/cranium-rat.opus"
 			},
 			"traitTags": [
 				"Illumination"
@@ -5205,10 +5187,8 @@
 			"name": "Darkling",
 			"source": "VGM",
 			"page": 134,
-			"otherSources": [
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Darkling|MPMM"
@@ -5288,7 +5268,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/darkling.mp3"
+				"path": "bestiary/darkling.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -5328,10 +5308,8 @@
 			"name": "Darkling Elder",
 			"source": "VGM",
 			"page": 134,
-			"otherSources": [
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Darkling Elder|MPMM"
@@ -5417,7 +5395,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/darkling-elder.mp3"
+				"path": "bestiary/darkling-elder.opus"
 			},
 			"attachedItems": [
 				"shortsword|phb"
@@ -5551,7 +5529,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/death-kiss.mp3"
+				"path": "bestiary/death-kiss.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -5655,7 +5633,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rothe.mp3"
+				"path": "bestiary/rothe.opus"
 			},
 			"traitTags": [
 				"Charge"
@@ -5679,10 +5657,8 @@
 			"name": "Deep Scion",
 			"source": "VGM",
 			"page": 135,
-			"otherSources": [
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS"
 			],
 			"reprintedAs": [
 				"Deep Scion|MPMM"
@@ -5791,7 +5767,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deep-scion.mp3"
+				"path": "bestiary/deep-scion.opus"
 			},
 			"attachedItems": [
 				"battleaxe|phb"
@@ -5836,14 +5812,10 @@
 			],
 			"source": "VGM",
 			"page": 139,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "PSX",
-					"page": 30
-				}
+			"referenceSources": [
+				"PSX",
+				"ToA",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Deinonychus|MPMM"
@@ -5916,7 +5888,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deinonychus.mp3"
+				"path": "bestiary/deinonychus.opus"
 			},
 			"traitTags": [
 				"Pounce"
@@ -6027,7 +5999,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/devourer.mp3"
+				"path": "bestiary/devourer.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -6061,10 +6033,9 @@
 			],
 			"source": "VGM",
 			"page": 139,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Dimetrodon|MPMM"
@@ -6117,7 +6088,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dimetrodon.mp3"
+				"path": "bestiary/dimetrodon.opus"
 			},
 			"damageTags": [
 				"P"
@@ -6285,7 +6256,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/diviner.mp3"
+				"path": "bestiary/diviner.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -6320,10 +6291,9 @@
 			"name": "Dolphin",
 			"source": "VGM",
 			"page": 208,
-			"otherSources": [
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Dolphin|MPMM"
@@ -6393,7 +6363,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dolphin.mp3"
+				"path": "bestiary/dolphin.opus"
 			},
 			"traitTags": [
 				"Charge",
@@ -6530,7 +6500,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/draegloth.mp3"
+				"path": "bestiary/draegloth.opus"
 			},
 			"traitTags": [
 				"Fey Ancestry"
@@ -6727,7 +6697,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/elder-brain.mp3"
+				"path": "bestiary/elder-brain.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -6785,10 +6755,15 @@
 			"name": "Enchanter",
 			"source": "VGM",
 			"page": 213,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				}
+			"referenceSources": [
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Enchanter Wizard|MPMM"
@@ -6921,7 +6896,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/enchanter.mp3"
+				"path": "bestiary/enchanter.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -6957,19 +6932,19 @@
 			"name": "Evoker",
 			"source": "VGM",
 			"page": 214,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "ERLW"
-				}
+			"referenceSources": [
+				"DIP",
+				"ERLW",
+				"LLK",
+				"SLW",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Evoker Wizard|MPMM"
@@ -7109,7 +7084,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/evoker.mp3"
+				"path": "bestiary/evoker.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -7241,7 +7216,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fire-giant-dreadnought.mp3"
+				"path": "bestiary/fire-giant-dreadnought.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -7272,10 +7247,8 @@
 			"name": "Firenewt Warlock of Imix",
 			"source": "VGM",
 			"page": 143,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Firenewt Warlock of Imix|MPMM"
@@ -7437,10 +7410,8 @@
 			"name": "Firenewt Warrior",
 			"source": "VGM",
 			"page": 142,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Firenewt Warrior|MPMM"
@@ -7525,7 +7496,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/firenewt-warrior.mp3"
+				"path": "bestiary/firenewt-warrior.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -7559,16 +7530,11 @@
 			"name": "Flail Snail",
 			"source": "VGM",
 			"page": 144,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				}
+			"referenceSources": [
+				"DIP",
+				"SLW",
+				"ToA",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Flail Snail|MPMM"
@@ -7624,21 +7590,18 @@
 							"style": "list-hang-notitle",
 							"items": [
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "1\u20132",
-									"style": "italic",
 									"entry": "If the spell affects an area or has multiple targets, it fails and has no effect. If the spell targets only the snail, it has no effect on the snail and is reflected back at the caster, using the spell slot level, spell save DC, attack bonus, and spellcasting ability of the caster."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "3\u20134",
-									"style": "italic",
 									"entry": "No additional effect."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "5\u20136",
-									"style": "italic",
 									"entry": "The snail's shell converts some of the spell's energy into a burst of destructive force. Each creature within 30 feet of the snail must make a {@dc 15} Constitution saving throw, taking {@damage 1d6} force damage per level of the spell on a failed save, or half as much damage on a successful one."
 								}
 							]
@@ -7685,7 +7648,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flail-snail.mp3"
+				"path": "bestiary/flail-snail.opus"
 			},
 			"senseTags": [
 				"D",
@@ -7820,7 +7783,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flind.mp3"
+				"path": "bestiary/flind.opus"
 			},
 			"attachedItems": [
 				"longbow|phb"
@@ -7861,10 +7824,9 @@
 			"name": "Froghemoth",
 			"source": "VGM",
 			"page": 145,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"LLK",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Froghemoth|MPMM"
@@ -7962,7 +7924,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/froghemoth.mp3"
+				"path": "bestiary/froghemoth.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -8107,7 +8069,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/frost-giant-everlasting-one.mp3"
+				"path": "bestiary/frost-giant-everlasting-one.opus"
 			},
 			"attachedItems": [
 				"greataxe|phb"
@@ -8232,39 +8194,33 @@
 							"style": "list-hang-notitle",
 							"items": [
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "1. Devour Magic Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 14} Dexterity saving throw or have one of its magic items lose all magical properties until the start of the gauth's next turn. If the object is a charged item, it also loses {@dice 1d4} charges. Determine the affected item randomly, ignoring single-use items such as potions and scrolls."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "2. Enervation Ray",
-									"style": "italic",
 									"entry": "The targeted creature must make a {@dc 14} Constitution saving throw, taking 18 ({@damage 4d8}) necrotic damage on a failed save, or half as much damage on a successful one."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "3. Pushing Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 14} Strength saving throw or be pushed up to 15 feet directly away from the gauth and have its speed halved until the start of the gauth's next turn."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "4. Fire Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 14} Dexterity saving throw or take 22 ({@damage 4d10}) fire damage."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "5. Paralyzing Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 14} Constitution saving throw or be {@condition paralyzed} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "6. Sleep Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 14} Wisdom saving throw or fall asleep and remain {@condition unconscious} for 1 minute. The target awakens if it takes damage or another creature takes an action to wake it. This ray has no effect on constructs and undead."
 								}
 							]
@@ -8277,7 +8233,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gauth.mp3"
+				"path": "bestiary/gauth.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -8296,6 +8252,7 @@
 				"P"
 			],
 			"miscTags": [
+				"AOE",
 				"MW"
 			],
 			"conditionInflict": [
@@ -8320,10 +8277,8 @@
 			],
 			"source": "VGM",
 			"page": 126,
-			"otherSources": [
-				{
-					"source": "WDH"
-				}
+			"referenceSources": [
+				"WDH"
 			],
 			"reprintedAs": [
 				"Gazer|MPMM"
@@ -8402,27 +8357,23 @@
 							"style": "list-hang-notitle",
 							"items": [
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "1. Dazing Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 12} Wisdom saving throw or be {@condition charmed} until the start of the gazer's next turn. While the target is {@condition charmed} in this way, its speed is halved, and it has disadvantage on attack rolls."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "2. Fear Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 12} Wisdom saving throw or be {@condition frightened} until the start of the gazer's next turn."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "3. Frost Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 12} Dexterity saving throw or take 10 ({@damage 3d6}) cold damage."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "4. Telekinetic Ray",
-									"style": "italic",
 									"entries": [
 										"If the target is a creature that is Medium or smaller, it must succeed on a {@dc 12} Strength saving throw or be moved up to 30 feet directly away from the gazer.",
 										"If the target is an object weighing 10 pounds or less that isn't being worn or carried, the gazer moves it up to 30 feet in any direction. The gazer can also exert fine control on objects with this ray, such as manipulating a simple tool or opening a container."
@@ -8458,7 +8409,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gazer.mp3"
+				"path": "bestiary/gazer.opus"
 			},
 			"traitTags": [
 				"Aggressive",
@@ -8491,10 +8442,8 @@
 			"name": "Giant Strider",
 			"source": "VGM",
 			"page": 143,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Giant Strider|MPMM"
@@ -8562,7 +8511,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-strider.mp3"
+				"path": "bestiary/giant-strider.opus"
 			},
 			"traitTags": [
 				"Damage Absorption"
@@ -8586,13 +8535,9 @@
 			"name": "Girallon",
 			"source": "VGM",
 			"page": 152,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Girallon|MPMM"
@@ -8669,7 +8614,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/girallon.mp3"
+				"path": "bestiary/girallon.opus"
 			},
 			"traitTags": [
 				"Aggressive",
@@ -8787,7 +8732,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll-flesh-gnawer.mp3"
+				"path": "bestiary/gnoll-flesh-gnawer.opus"
 			},
 			"attachedItems": [
 				"shortsword|phb"
@@ -8910,7 +8855,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll-hunter.mp3"
+				"path": "bestiary/gnoll-hunter.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -9036,7 +8981,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll-witherling.mp3"
+				"path": "bestiary/gnoll-witherling.opus"
 			},
 			"attachedItems": [
 				"club|phb"
@@ -9150,7 +9095,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guard-drake.mp3"
+				"path": "bestiary/guard-drake.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -9180,10 +9125,8 @@
 			"name": "Grung",
 			"source": "VGM",
 			"page": 156,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Grung|MPMM"
@@ -9322,7 +9265,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grung.mp3"
+				"path": "bestiary/grung.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -9463,10 +9406,8 @@
 			"name": "Grung Elite Warrior",
 			"source": "VGM",
 			"page": 157,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Grung Elite Warrior|MPMM"
@@ -9617,7 +9558,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grung-elite-warrior.mp3"
+				"path": "bestiary/grung-elite-warrior.opus"
 			},
 			"attachedItems": [
 				"dagger|phb",
@@ -9762,10 +9703,8 @@
 			"name": "Grung Wildling",
 			"source": "VGM",
 			"page": 157,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Grung Wildling|MPMM"
@@ -9947,7 +9886,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grung-wildling.mp3"
+				"path": "bestiary/grung-wildling.opus"
 			},
 			"attachedItems": [
 				"dagger|phb",
@@ -10099,14 +10038,9 @@
 			],
 			"source": "VGM",
 			"page": 140,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "PSX",
-					"page": 29
-				}
+			"referenceSources": [
+				"PSX",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Hadrosaurus|MPMM"
@@ -10158,7 +10092,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hadrosaurus.mp3"
+				"path": "bestiary/hadrosaurus.opus"
 			},
 			"damageTags": [
 				"B"
@@ -10301,7 +10235,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hobgoblin-devastator.mp3"
+				"path": "bestiary/hobgoblin-devastator.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -10460,7 +10394,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hobgoblin-iron-shadow.mp3"
+				"path": "bestiary/hobgoblin-iron-shadow.opus"
 			},
 			"attachedItems": [
 				"dart|phb"
@@ -10769,7 +10703,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mind-flayer-lich-illithilich.mp3"
+				"path": "bestiary/mind-flayer-lich-illithilich.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -10845,10 +10779,15 @@
 			"name": "Illusionist",
 			"source": "VGM",
 			"page": 214,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				}
+			"referenceSources": [
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Illusionist Wizard|MPMM"
@@ -10973,7 +10912,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/illusionist.mp3"
+				"path": "bestiary/illusionist.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -11251,7 +11190,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ki-rin.mp3"
+				"path": "bestiary/ki-rin.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -11298,13 +11237,9 @@
 			"name": "Kobold Dragonshield",
 			"source": "VGM",
 			"page": 165,
-			"otherSources": [
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				}
+			"referenceSources": [
+				"DIP",
+				"SLW"
 			],
 			"reprintedAs": [
 				"Kobold Dragonshield|MPMM"
@@ -11404,7 +11339,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kobold-dragonshield.mp3"
+				"path": "bestiary/kobold-dragonshield.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -11440,10 +11375,9 @@
 			"name": "Kobold Inventor",
 			"source": "VGM",
 			"page": 166,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"LLK",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Kobold Inventor|MPMM"
@@ -11525,51 +11459,43 @@
 							"style": "list-hang-notitle",
 							"items": [
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "1. Acid",
-									"style": "italic",
 									"entry": "The kobold hurls a flask of {@item Acid (vial)|phb|acid}. {@atk rw} {@hit 4} to hit, range 5/20 ft., one target. {@h}7 ({@damage 2d6}) acid damage."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "2. Alchemist's fire",
-									"style": "italic",
 									"entry": "The kobold throws a flask of {@item Alchemist's Fire (flask)|phb|alchemist's fire}. {@atk rw} {@hit 4} to hit, range 5/20 ft., one target. {@h}2 ({@damage 1d4}) fire damage at the start of each of the target's turns. A creature can end this damage by using its action to make a {@dc 10} Dexterity check to extinguish the flames."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "3. Basket of Centipedes",
-									"style": "italic",
 									"entry": "The kobold throws a small basket into a 5-foot-square space within 20 feet of it. A {@creature swarm of centipedes||swarm of insects (centipedes)} with 11 hit points emerges from the basket and rolls initiative. At the end of each of the swarm's turns, there's a {@chance 50} chance that the swarm disperses."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "4. Green Slime Pot",
-									"style": "italic",
 									"entry": "The kobold throws a clay pot full of green slime at the target, and it breaks open on impact. {@atk rw} {@hit 4} to hit, range 5/20 ft., one target. {@h}The target is covered in a patch of {@hazard green slime} (see chapter 5 of the Dungeon Master's Guide). Miss: A patch of green slime covers a randomly determined 5-foot-square section of wall or floor within 5 feet of the target."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "5. Rot Grub Pot",
-									"style": "italic",
 									"entry": "The kobold throws a clay pot into a 5-foot-square space within 20 feet of it, and it breaks open on impact. A {@creature swarm of rot grubs|vgm} (see appendix A) emerges from the shattered pot and remains a hazard in that square."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "6. Scorpion on a Stick",
-									"style": "italic",
 									"entry": "The kobold makes a melee attack with a scorpion tied to the end of a 5-foot-long pole. {@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}1 piercing damage, and the target must make a {@dc 9} Constitution saving throw, taking 4 ({@damage 1d8}) poison damage on a failed save, or half as much damage on a successful one."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "7. Skunk in a Cage",
-									"style": "italic",
 									"entry": "The kobold releases a skunk into an unoccupied space within 5 feet of it. The skunk has a walking speed of 20 feet, AC 10, 1 hit point, and no effective attacks. It rolls initiative and, on its turn, uses its action to spray musk at a random creature within 5 feet of it. The target must make a {@dc 9} Constitution saving throw. On a failed save, the target retches and can't take actions for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. A creature that doesn't need to breathe or is immune to poison automatically succeeds on the saving throw. Once the skunk has sprayed its musk, it can't do so again until it finishes a short or long rest."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "8. Wasp Nest in a Bag",
-									"style": "italic",
 									"entry": "The kobold throws a small bag into a 5-foot-square space within 20 feet of it. A {@creature swarm of wasps||swarm of insects (wasps)} with 11 hit points emerges from the bag and rolls initiative. At the end of each of the swarm's turns, there's a {@chance 50} chance that the swarm disperses."
 								}
 							]
@@ -11586,7 +11512,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kobold-inventor.mp3"
+				"path": "bestiary/kobold-inventor.opus"
 			},
 			"attachedItems": [
 				"dagger|phb",
@@ -11628,10 +11554,8 @@
 			"name": "Kobold Scale Sorcerer",
 			"source": "VGM",
 			"page": 167,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Kobold Scale Sorcerer|MPMM"
@@ -11756,7 +11680,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kobold-scale-sorcerer.mp3"
+				"path": "bestiary/kobold-scale-sorcerer.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -11807,10 +11731,8 @@
 			"name": "Korred",
 			"source": "VGM",
 			"page": 168,
-			"otherSources": [
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Korred|MPMM"
@@ -11941,7 +11863,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/korred.mp3"
+				"path": "bestiary/korred.opus"
 			},
 			"attachedItems": [
 				"greatclub|phb"
@@ -11998,19 +11920,11 @@
 			"name": "Kraken Priest",
 			"source": "VGM",
 			"page": 215,
-			"otherSources": [
-				{
-					"source": "GoS"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "LR"
-				}
+			"referenceSources": [
+				"DIP",
+				"GoS",
+				"LR",
+				"SLW"
 			],
 			"reprintedAs": [
 				"Kraken Priest|MPMM"
@@ -12120,7 +12034,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kraken-priest.mp3"
+				"path": "bestiary/kraken-priest.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -12161,13 +12075,16 @@
 			"name": "Leucrotta",
 			"source": "VGM",
 			"page": 169,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"MOT",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Leucrotta|MPMM"
@@ -12224,7 +12141,7 @@
 				{
 					"name": "Kicking Retreat",
 					"entries": [
-						"If the leucrotta attacks with its hooves, it can take the Disengage action as a bonus action."
+						"If the leucrotta attacks with its hooves, it can take the {@action Disengage} action as a bonus action."
 					]
 				},
 				{
@@ -12266,7 +12183,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/leucrotta.mp3"
+				"path": "bestiary/leucrotta.opus"
 			},
 			"traitTags": [
 				"Keen Senses",
@@ -12298,16 +12215,17 @@
 			"name": "Martial Arts Adept",
 			"source": "VGM",
 			"page": 216,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"LLK",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Martial Arts Adept|MPMM"
@@ -12399,7 +12317,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/martial-arts-adept.mp3"
+				"path": "bestiary/martial-arts-adept.opus"
 			},
 			"attachedItems": [
 				"dart|phb"
@@ -12438,21 +12356,17 @@
 			"page": 216,
 			"otherSources": [
 				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				},
-				{
 					"source": "IMR",
-					"page": 216
-				},
-				{
-					"source": "MOT"
+					"page": 54
 				}
+			],
+			"referenceSources": [
+				"DIP",
+				"IMR",
+				"MOT",
+				"SDW",
+				"SLW",
+				"TLK"
 			],
 			"reprintedAs": [
 				"Master Thief|MPMM"
@@ -12510,7 +12424,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of its turns, the thief can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of its turns, the thief can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -12559,7 +12473,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/master-thief.mp3"
+				"path": "bestiary/master-thief.opus"
 			},
 			"attachedItems": [
 				"light crossbow|phb",
@@ -12593,10 +12507,8 @@
 			"name": "Maw Demon",
 			"source": "VGM",
 			"page": 137,
-			"otherSources": [
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS"
 			],
 			"reprintedAs": [
 				"Maw Demon|MPMM"
@@ -12677,7 +12589,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/maw-demon.mp3"
+				"path": "bestiary/maw-demon.opus"
 			},
 			"traitTags": [
 				"Rampage"
@@ -12703,10 +12615,8 @@
 			"name": "Meenlock",
 			"source": "VGM",
 			"page": 170,
-			"otherSources": [
-				{
-					"source": "CM"
-				}
+			"referenceSources": [
+				"CM"
 			],
 			"reprintedAs": [
 				"Meenlock|MPMM"
@@ -12791,7 +12701,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/meenlock.mp3"
+				"path": "bestiary/meenlock.opus"
 			},
 			"traitTags": [
 				"Light Sensitivity"
@@ -13125,39 +13035,33 @@
 							"style": "list-hang-notitle",
 							"items": [
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "1. Aversion Ray",
-									"style": "italic",
 									"entry": "The targeted creature must make a {@dc 13} Charisma saving throw. On a failed save, the target has disadvantage on attack rolls for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "2. Fear Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 13} Wisdom saving throw or be {@condition frightened} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "3. Psychic Ray",
-									"style": "italic",
 									"entry": "The target must succeed on a {@dc 13} Intelligence saving throw or take 27 ({@damage 6d8}) psychic damage."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "4. Slowing Ray",
-									"style": "italic",
 									"entry": "The targeted creature must make a {@dc 13} Dexterity saving throw. On a failed save, the target's speed is halved for 1 minute. In addition, the creature can't take reactions, and it can take either an action or a bonus action on its turn but not both. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "5. Stunning Ray",
-									"style": "italic",
 									"entry": "The targeted creature must succeed on a {@dc 13} Constitution saving throw or be {@condition stunned} for 1 minute. The target can repeat the saving throw at the start of each of its turns, ending the effect on itself on a success."
 								},
 								{
-									"type": "item",
+									"type": "itemSub",
 									"name": "6. Telekinetic Ray",
-									"style": "italic",
 									"entries": [
 										"If the target is a creature, it must make a {@dc 13} Strength saving throw. On a failed save, the mindwitness moves it up to 30 feet in any direction, and it is {@condition restrained} by the ray's telekinetic grip until the start of the mindwitness's next turn or until the mindwitness is {@condition incapacitated}.",
 										"If the target is an object weighing 300 pounds or less that isn't being worn or carried, it is telekinetically moved up to 30 feet in any direction. The mindwitness can also exert fine control on objects with this ray, such as manipulating a simple tool or opening a door or a container."
@@ -13173,7 +13077,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mindwitness.mp3"
+				"path": "bestiary/mindwitness.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -13379,7 +13283,7 @@
 				{
 					"name": "Hypnosis",
 					"entries": [
-						"The morkoth projects a 30-foot cone of magical energy. Each creature in that area must make a {@dc 17} Wisdom saving throw. On a failed save, the creature is {@condition charmed} by the morkoth for 1 minute. While {@condition charmed} in this way, the target tries to get as close to the morkoth as possible, using its actions to Dash until it is within 5 feet of the morkoth. A {@condition charmed} target can repeat the saving throw at the end of each of its turns and whenever it takes damage, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature has advantage on saving throws against the morkoth's Hypnosis for 24 hours."
+						"The morkoth projects a 30-foot cone of magical energy. Each creature in that area must make a {@dc 17} Wisdom saving throw. On a failed save, the creature is {@condition charmed} by the morkoth for 1 minute. While {@condition charmed} in this way, the target tries to get as close to the morkoth as possible, using its actions to {@action Dash} until it is within 5 feet of the morkoth. A {@condition charmed} target can repeat the saving throw at the end of each of its turns and whenever it takes damage, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature has advantage on saving throws against the morkoth's Hypnosis for 24 hours."
 					]
 				}
 			],
@@ -13401,7 +13305,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/morkoth.mp3"
+				"path": "bestiary/morkoth.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -13547,7 +13451,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mouth-of-grolantor.mp3"
+				"path": "bestiary/mouth-of-grolantor.opus"
 			},
 			"languageTags": [
 				"GI"
@@ -13568,16 +13472,17 @@
 			"name": "Necromancer",
 			"source": "VGM",
 			"page": 217,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				},
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				}
+			"referenceSources": [
+				"DC",
+				"DIP",
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Necromancer Wizard|MPMM"
@@ -13721,7 +13626,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/necromancer.mp3"
+				"path": "bestiary/necromancer.opus"
 			},
 			"languageTags": [
 				"X"
@@ -13844,7 +13749,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/neogi.mp3"
+				"path": "bestiary/neogi.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -13945,7 +13850,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/neogi-hatchling.mp3"
+				"path": "bestiary/neogi-hatchling.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -14110,7 +14015,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/neogi-master.mp3"
+				"path": "bestiary/neogi-master.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -14174,8 +14079,12 @@
 			"page": 181,
 			"otherSources": [
 				{
-					"source": "WDMM"
+					"source": "WDMM",
+					"page": 315
 				}
+			],
+			"referenceSources": [
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Neothelid|MPMM"
@@ -14273,7 +14182,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/neothelid.mp3"
+				"path": "bestiary/neothelid.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -14407,7 +14316,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The nilbog can take the Disengage or Hide action as a bonus action on each of its turns."
+						"The nilbog can take the {@action Disengage} or {@action Hide} action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -14440,7 +14349,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nilbog.mp3"
+				"path": "bestiary/nilbog.opus"
 			},
 			"attachedItems": [
 				"shortbow|phb"
@@ -14589,7 +14498,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orc-blade-of-ilneval.mp3"
+				"path": "bestiary/orc-blade-of-ilneval.opus"
 			},
 			"attachedItems": [
 				"javelin|phb",
@@ -14743,7 +14652,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orc-claw-of-luthic.mp3"
+				"path": "bestiary/orc-claw-of-luthic.opus"
 			},
 			"traitTags": [
 				"Aggressive"
@@ -14892,7 +14801,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orc-hand-of-yurtrus.mp3"
+				"path": "bestiary/orc-hand-of-yurtrus.opus"
 			},
 			"traitTags": [
 				"Aggressive"
@@ -15009,7 +14918,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orc-nurtured-one-of-yurtrus.mp3"
+				"path": "bestiary/orc-nurtured-one-of-yurtrus.opus"
 			},
 			"traitTags": [
 				"Aggressive"
@@ -15095,7 +15004,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of its turns, the orc can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of its turns, the orc can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -15152,7 +15061,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/orc-red-fang.mp3"
+				"path": "bestiary/orc-red-fang.opus"
 			},
 			"attachedItems": [
 				"dart|phb",
@@ -15186,10 +15095,8 @@
 			"name": "Ox",
 			"source": "VGM",
 			"page": 208,
-			"otherSources": [
-				{
-					"source": "PotA"
-				}
+			"referenceSources": [
+				"PotA"
 			],
 			"reprintedAs": [
 				"Ox|MPMM"
@@ -15246,7 +15153,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ox.mp3"
+				"path": "bestiary/ox.opus"
 			},
 			"traitTags": [
 				"Beast of Burden",
@@ -15268,10 +15175,9 @@
 			],
 			"source": "VGM",
 			"page": 140,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Quetzalcoatlus|MPMM"
@@ -15339,7 +15245,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quetzalcoatlus.mp3"
+				"path": "bestiary/quetzalcoatlus.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -15358,10 +15264,9 @@
 			"name": "Quickling",
 			"source": "VGM",
 			"page": 187,
-			"otherSources": [
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"LLK",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Quickling|MPMM"
@@ -15438,7 +15343,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quickling.mp3"
+				"path": "bestiary/quickling.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -15543,7 +15448,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guard-drake.mp3"
+				"path": "bestiary/guard-drake.opus"
 			},
 			"senseTags": [
 				"D"
@@ -15570,19 +15475,10 @@
 			"name": "Redcap",
 			"source": "VGM",
 			"page": 188,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "BGDIA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "WBtW"
-				}
+			"referenceSources": [
+				"BGDIA",
+				"IMR",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Redcap|MPMM"
@@ -15686,7 +15582,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/redcap.mp3"
+				"path": "bestiary/redcap.opus"
 			},
 			"altArt": [
 				{
@@ -15781,7 +15677,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rothe.mp3"
+				"path": "bestiary/rothe.opus"
 			},
 			"traitTags": [
 				"Charge"
@@ -15898,7 +15794,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sea-spawn.mp3"
+				"path": "bestiary/sea-spawn.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -16047,7 +15943,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shadow-mastiff.mp3"
+				"path": "bestiary/shadow-mastiff.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -16210,7 +16106,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shoosuva.mp3"
+				"path": "bestiary/shoosuva.opus"
 			},
 			"traitTags": [
 				"Rampage"
@@ -16248,16 +16144,9 @@
 			"name": "Slithering Tracker",
 			"source": "VGM",
 			"page": 191,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "IMR"
-				},
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"IMR",
+				"MOT"
 			],
 			"reprintedAs": [
 				"Slithering Tracker|MPMM"
@@ -16365,7 +16254,7 @@
 				{
 					"name": "Watery Stealth",
 					"entries": [
-						"While underwater, the slithering tracker has advantage on Dexterity ({@skill Stealth}) checks made to hide, and it can take the Hide action as a bonus action."
+						"While underwater, the slithering tracker has advantage on Dexterity ({@skill Stealth}) checks made to hide, and it can take the {@action Hide} action as a bonus action."
 					]
 				}
 			],
@@ -16389,7 +16278,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/slithering-tracker.mp3"
+				"path": "bestiary/slithering-tracker.opus"
 			},
 			"traitTags": [
 				"Ambusher",
@@ -16510,7 +16399,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spawn-of-kyuss.mp3"
+				"path": "bestiary/spawn-of-kyuss.opus"
 			},
 			"traitTags": [
 				"Regeneration"
@@ -16548,10 +16437,8 @@
 			],
 			"source": "VGM",
 			"page": 140,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Stegosaurus|MPMM"
@@ -16600,7 +16487,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stegosaurus.mp3"
+				"path": "bestiary/stegosaurus.opus"
 			},
 			"damageTags": [
 				"P"
@@ -16677,7 +16564,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stench-cow.mp3"
+				"path": "bestiary/stench-cow.opus"
 			},
 			"traitTags": [
 				"Charge"
@@ -16804,7 +16691,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stone-giant-dreamwalker.mp3"
+				"path": "bestiary/stone-giant-dreamwalker.opus"
 			},
 			"attachedItems": [
 				"greatclub|phb"
@@ -16846,10 +16733,8 @@
 			"name": "Storm Giant Quintessent",
 			"source": "VGM",
 			"page": 151,
-			"otherSources": [
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS"
 			],
 			"reprintedAs": [
 				"Storm Giant Quintessent|MPMM"
@@ -16985,7 +16870,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/storm-giant-quintessent.mp3"
+				"path": "bestiary/storm-giant-quintessent.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -17133,7 +17018,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-cranium-rats.mp3"
+				"path": "bestiary/swarm-of-cranium-rats.opus"
 			},
 			"traitTags": [
 				"Illumination"
@@ -17166,10 +17051,8 @@
 			"name": "Swarm of Rot Grubs",
 			"source": "VGM",
 			"page": 208,
-			"otherSources": [
-				{
-					"source": "GoS"
-				}
+			"referenceSources": [
+				"GoS"
 			],
 			"reprintedAs": [
 				"Swarm of Rot Grubs|MPMM"
@@ -17241,7 +17124,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-rot-grubs.mp3"
+				"path": "bestiary/swarm-of-rot-grubs.opus"
 			},
 			"senseTags": [
 				"B"
@@ -17261,22 +17144,11 @@
 			"name": "Swashbuckler",
 			"source": "VGM",
 			"page": 217,
-			"otherSources": [
-				{
-					"source": "WDH"
-				},
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SLW"
-				},
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"DIP",
+				"SDW",
+				"SLW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Swashbuckler|MPMM"
@@ -17332,7 +17204,7 @@
 				{
 					"name": "Lightfooted",
 					"entries": [
-						"The swashbuckler can take the Dash or Disengage action as a bonus action on each of its turns."
+						"The swashbuckler can take the {@action Dash} or {@action Disengage} action as a bonus action on each of its turns."
 					]
 				},
 				{
@@ -17368,7 +17240,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swashbuckler.mp3"
+				"path": "bestiary/swashbuckler.opus"
 			},
 			"attachedItems": [
 				"dagger|phb",
@@ -17503,7 +17375,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tanarukk.mp3"
+				"path": "bestiary/tanarukk.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb"
@@ -17539,10 +17411,8 @@
 			"name": "Thorny",
 			"source": "VGM",
 			"page": 197,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Thorny Vegepygmy|MPMM"
@@ -17622,7 +17492,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/thorny.mp3"
+				"path": "bestiary/thorny.opus"
 			},
 			"traitTags": [
 				"Camouflage",
@@ -17721,7 +17591,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tlincalli.mp3"
+				"path": "bestiary/tlincalli.opus"
 			},
 			"attachedItems": [
 				"longsword|phb"
@@ -17762,10 +17632,15 @@
 			"name": "Transmuter",
 			"source": "VGM",
 			"page": 218,
-			"otherSources": [
-				{
-					"source": "TftYP"
-				}
+			"referenceSources": [
+				"TftYP",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Transmuter Wizard|MPMM"
@@ -17902,7 +17777,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/transmuter.mp3"
+				"path": "bestiary/transmuter.opus"
 			},
 			"attachedItems": [
 				"quarterstaff|phb"
@@ -17942,10 +17817,8 @@
 			"name": "Trapper",
 			"source": "VGM",
 			"page": 194,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"reprintedAs": [
 				"Trapper|MPMM"
@@ -18015,7 +17888,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/trapper.mp3"
+				"path": "bestiary/trapper.opus"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -18047,8 +17920,12 @@
 			"page": 175,
 			"otherSources": [
 				{
-					"source": "WDMM"
+					"source": "WDMM",
+					"page": 316
 				}
+			],
+			"referenceSources": [
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ulitharid|MPMM"
@@ -18175,7 +18052,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ulitharid.mp3"
+				"path": "bestiary/ulitharid.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -18312,7 +18189,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vargouille.mp3"
+				"path": "bestiary/vargouille.opus"
 			},
 			"senseTags": [
 				"D"
@@ -18346,10 +18223,8 @@
 			"name": "Vegepygmy",
 			"source": "VGM",
 			"page": 196,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Vegepygmy|MPMM"
@@ -18432,7 +18307,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vegepygmy.mp3"
+				"path": "bestiary/vegepygmy.opus"
 			},
 			"attachedItems": [
 				"sling|phb"
@@ -18464,10 +18339,8 @@
 			"name": "Vegepygmy Chief",
 			"source": "VGM",
 			"page": 197,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Vegepygmy Chief|MPMM"
@@ -18562,7 +18435,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vegepygmy-chief.mp3"
+				"path": "bestiary/vegepygmy-chief.opus"
 			},
 			"attachedItems": [
 				"spear|phb"
@@ -18609,14 +18482,10 @@
 			],
 			"source": "VGM",
 			"page": 140,
-			"otherSources": [
-				{
-					"source": "ToA"
-				},
-				{
-					"source": "PSX",
-					"page": 30
-				}
+			"referenceSources": [
+				"PSX",
+				"ToA",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Velociraptor|MPMM"
@@ -18688,7 +18557,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/velociraptor.mp3"
+				"path": "bestiary/velociraptor.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -18710,19 +18579,11 @@
 			"name": "War Priest",
 			"source": "VGM",
 			"page": 218,
-			"otherSources": [
-				{
-					"source": "DC"
-				},
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				},
-				{
-					"source": "MOT"
-				}
+			"referenceSources": [
+				"DC",
+				"DIP",
+				"MOT",
+				"SDW"
 			],
 			"reprintedAs": [
 				"War Priest|MPMM"
@@ -18868,7 +18729,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/war-priest.mp3"
+				"path": "bestiary/war-priest.opus"
 			},
 			"attachedItems": [
 				"maul|phb"
@@ -19045,7 +18906,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/warlock-of-the-archfey.mp3"
+				"path": "bestiary/warlock-of-the-archfey.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -19090,10 +18951,8 @@
 			"name": "Warlock of the Fiend",
 			"source": "VGM",
 			"page": 219,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"reprintedAs": [
 				"Warlock of the Fiend|MPMM"
@@ -19243,7 +19102,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/warlock-of-the-fiend.mp3"
+				"path": "bestiary/warlock-of-the-fiend.opus"
 			},
 			"attachedItems": [
 				"mace|phb"
@@ -19294,10 +19153,8 @@
 			"name": "Warlock of the Great Old One",
 			"source": "VGM",
 			"page": 220,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"reprintedAs": [
 				"Warlock of the Great Old One|MPMM"
@@ -19441,7 +19298,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/warlock-of-the-great-old-one.mp3"
+				"path": "bestiary/warlock-of-the-great-old-one.opus"
 			},
 			"attachedItems": [
 				"dagger|phb"
@@ -19494,10 +19351,8 @@
 			"name": "Warlord",
 			"source": "VGM",
 			"page": 220,
-			"otherSources": [
-				{
-					"source": "IMR"
-				}
+			"referenceSources": [
+				"IMR"
 			],
 			"reprintedAs": [
 				"Warlord|MPMM"
@@ -19610,7 +19465,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/warlord.mp3"
+				"path": "bestiary/warlord.opus"
 			},
 			"attachedItems": [
 				"greatsword|phb",
@@ -19718,7 +19573,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guard-drake.mp3"
+				"path": "bestiary/guard-drake.opus"
 			},
 			"senseTags": [
 				"D"
@@ -19745,13 +19600,9 @@
 			"name": "Wood Woad",
 			"source": "VGM",
 			"page": 198,
-			"otherSources": [
-				{
-					"source": "DIP"
-				},
-				{
-					"source": "SDW"
-				}
+			"referenceSources": [
+				"DIP",
+				"SDW"
 			],
 			"reprintedAs": [
 				"Wood Woad|MPMM"
@@ -19856,7 +19707,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wood-woad.mp3"
+				"path": "bestiary/wood-woad.opus"
 			},
 			"attachedItems": [
 				"club|phb"
@@ -19942,7 +19793,7 @@
 				{
 					"name": "Low Cunning",
 					"entries": [
-						"The xvart can take the Disengage action as a bonus action on each of its turns."
+						"The xvart can take the {@action Disengage} action as a bonus action on each of its turns."
 					]
 				},
 				{
@@ -19978,7 +19829,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/xvart.mp3"
+				"path": "bestiary/xvart.opus"
 			},
 			"attachedItems": [
 				"shortsword|phb",
@@ -20057,7 +19908,7 @@
 				{
 					"name": "Low Cunning",
 					"entries": [
-						"The xvart can take the Disengage action as a bonus action on each of its turns."
+						"The xvart can take the {@action Disengage} action as a bonus action on each of its turns."
 					]
 				},
 				{
@@ -20093,7 +19944,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/xvart-speaker.mp3"
+				"path": "bestiary/xvart-speaker.opus"
 			},
 			"attachedItems": [
 				"shortsword|phb",
@@ -20221,7 +20072,7 @@
 				{
 					"name": "Low Cunning",
 					"entries": [
-						"The xvart can take the Disengage action as a bonus action on each of its turns."
+						"The xvart can take the {@action Disengage} action as a bonus action on each of its turns."
 					]
 				},
 				{
@@ -20251,7 +20102,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/xvart-warlock-of-raxivort.mp3"
+				"path": "bestiary/xvart-warlock-of-raxivort.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -20396,7 +20247,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yeth-hound.mp3"
+				"path": "bestiary/yeth-hound.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -20617,7 +20468,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-anathema.mp3"
+				"path": "bestiary/yuan-ti-anathema.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -20679,10 +20530,8 @@
 			"name": "Yuan-ti Broodguard",
 			"source": "VGM",
 			"page": 203,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Yuan-ti Broodguard|MPMM"
@@ -20810,7 +20659,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-broodguard.mp3"
+				"path": "bestiary/yuan-ti-broodguard.opus"
 			},
 			"traitTags": [
 				"Reckless"
@@ -20841,11 +20690,6 @@
 			"name": "Yuan-ti Malison (Type 4)",
 			"source": "VGM",
 			"page": 96,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
-			],
 			"size": [
 				"M"
 			],
@@ -20983,7 +20827,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-malison.mp3"
+				"path": "bestiary/yuan-ti-malison.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -21030,11 +20874,6 @@
 			"name": "Yuan-ti Malison (Type 5)",
 			"source": "VGM",
 			"page": 96,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
-			],
 			"size": [
 				"M"
 			],
@@ -21172,7 +21011,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-malison.mp3"
+				"path": "bestiary/yuan-ti-malison.opus"
 			},
 			"attachedItems": [
 				"longbow|phb",
@@ -21409,7 +21248,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-mind-whisperer.mp3"
+				"path": "bestiary/yuan-ti-mind-whisperer.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -21460,10 +21299,8 @@
 			"name": "Yuan-ti Nightmare Speaker",
 			"source": "VGM",
 			"page": 205,
-			"otherSources": [
-				{
-					"source": "ToA"
-				}
+			"referenceSources": [
+				"ToA"
 			],
 			"reprintedAs": [
 				"Yuan-ti Nightmare Speaker|MPMM"
@@ -21655,7 +21492,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-nightmare-speaker.mp3"
+				"path": "bestiary/yuan-ti-nightmare-speaker.opus"
 			},
 			"attachedItems": [
 				"scimitar|phb"
@@ -21911,7 +21748,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-pit-master.mp3"
+				"path": "bestiary/yuan-ti-pit-master.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",

--- a/json/bestiary/bestiary-vrgr.json
+++ b/json/bestiary/bestiary-vrgr.json
@@ -11,6 +11,9 @@
 			"name": "Bodytaker Plant",
 			"source": "VRGR",
 			"page": 226,
+			"reprintedAs": [
+				"Bodytaker Plant|RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -135,6 +138,12 @@
 			"name": "Boneless",
 			"source": "VRGR",
 			"page": 228,
+			"referenceSources": [
+				"HoL"
+			],
+			"reprintedAs": [
+				"Boneless|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -242,12 +251,18 @@
 		{
 			"name": "Brain in a Jar",
 			"source": "VRGR",
-			"page": 278,
+			"page": 229,
 			"otherSources": [
 				{
 					"source": "IDRotF",
-					"page": 278
+					"page": 279
 				}
+			],
+			"referenceSources": [
+				"IDRotF"
+			],
+			"reprintedAs": [
+				"Brain in a Jar|RHW"
 			],
 			"size": [
 				"S"
@@ -361,7 +376,7 @@
 				{
 					"name": "Mind Blast {@recharge 5}",
 					"entries": [
-						"The brain magically emits psychic energy in a 60-foot cone. Each creature in that area must succeed on a {@dc 14} Intelligence saving throw or take 17 ({@damage 3d8 + 4}) psychic damage and be {@condition stunned} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"The brain magically emits psychic energy in a 60-foot cone. Each creature in that area must succeed on a {@dc 14} Intelligence saving throw or take 17 ({@damage 3d8 + 4}) psychic damage and be {@condition stunned} for 1 minute. A {@condition stunned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				}
 			],
@@ -414,6 +429,9 @@
 			"name": "Carrion Stalker",
 			"source": "VRGR",
 			"page": 230,
+			"reprintedAs": [
+				"Carrion Stalker|RHW"
+			],
 			"size": [
 				"T"
 			],
@@ -503,6 +521,12 @@
 			"name": "Carrionette",
 			"source": "VRGR",
 			"page": 231,
+			"referenceSources": [
+				"HoL"
+			],
+			"reprintedAs": [
+				"Carrionette|RHW"
+			],
 			"size": [
 				"S"
 			],
@@ -596,6 +620,12 @@
 			"name": "Death's Head",
 			"source": "VRGR",
 			"page": 232,
+			"referenceSources": [
+				"HoL"
+			],
+			"reprintedAs": [
+				"Death's Head|RHW"
+			],
 			"size": [
 				"T"
 			],
@@ -691,6 +721,9 @@
 			"name": "Dullahan",
 			"source": "VRGR",
 			"page": 233,
+			"reprintedAs": [
+				"Dullahan|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -857,6 +890,7 @@
 		},
 		{
 			"name": "Elise",
+			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VRGR",
 			"page": 143,
@@ -982,6 +1016,9 @@
 			"name": "Gallows Speaker",
 			"source": "VRGR",
 			"page": 234,
+			"reprintedAs": [
+				"Gallows Speaker|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -1106,6 +1143,9 @@
 			"name": "Greater Star Spawn Emissary",
 			"source": "VRGR",
 			"page": 245,
+			"reprintedAs": [
+				"Greater Star Spawn Emissary|RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -1261,6 +1301,12 @@
 			"name": "Gremishka",
 			"source": "VRGR",
 			"page": 235,
+			"referenceSources": [
+				"HoL"
+			],
+			"reprintedAs": [
+				"Gremishka|RHW"
+			],
 			"size": [
 				"T"
 			],
@@ -1352,6 +1398,9 @@
 			"name": "Inquisitor of the Mind Fire",
 			"source": "VRGR",
 			"page": 248,
+			"reprintedAs": [
+				"Inquisitor of the Mind Fire|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -1447,7 +1496,7 @@
 				{
 					"name": "Inquisitor's Command {@recharge 5}",
 					"entries": [
-						"Each creature of the inquisitor's choice that it can see within 60 feet of it must succeed on a {@dc 15} Wisdom saving throw or be {@condition charmed} until the start of the inquisitor's next turn. On the {@condition charmed} target's turn, the inquisitor can telepathically control the target's move, action, or both. When controlled in this way, the target can take only the Attack (inquisitor chooses the target) or Dash action."
+						"Each creature of the inquisitor's choice that it can see within 60 feet of it must succeed on a {@dc 15} Wisdom saving throw or be {@condition charmed} until the start of the inquisitor's next turn. On the {@condition charmed} target's turn, the inquisitor can telepathically control the target's move, action, or both. When controlled in this way, the target can take only the Attack (inquisitor chooses the target) or {@action Dash} action."
 					]
 				}
 			],
@@ -1498,6 +1547,9 @@
 			"name": "Inquisitor of the Sword",
 			"source": "VRGR",
 			"page": 249,
+			"reprintedAs": [
+				"Inquisitor of the Sword|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -1640,10 +1692,11 @@
 			"name": "Inquisitor of the Tome",
 			"source": "VRGR",
 			"page": 249,
-			"otherSources": [
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"VEoR"
+			],
+			"reprintedAs": [
+				"Inquisitor of the Tome|RHW"
 			],
 			"size": [
 				"M"
@@ -1790,6 +1843,7 @@
 		},
 		{
 			"name": "Isolde",
+			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "VRGR",
 			"page": 86,
@@ -1979,6 +2033,9 @@
 			"name": "Jiangshi",
 			"source": "VRGR",
 			"page": 236,
+			"reprintedAs": [
+				"Jiangshi|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -2099,6 +2156,9 @@
 			"name": "Lesser Star Spawn Emissary",
 			"source": "VRGR",
 			"page": 245,
+			"reprintedAs": [
+				"Lesser Star Spawn Emissary|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -2224,6 +2284,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances",
 				"Unusual Nature"
@@ -2264,6 +2325,9 @@
 			],
 			"source": "VRGR",
 			"page": 237,
+			"reprintedAs": [
+				"Loup Garou|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -2348,7 +2412,7 @@
 				{
 					"name": "Bite (Dire Wolf or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}13 ({@damage 2d8 + 4}) piercing damage plus 14 ({@damage 4d6}) necrotic damage. If the target is a Humanoid, it must succeed on a {@dc 17} Constitution saving throw or be cursed with loup garou lycanthropy."
+						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}13 ({@damage 2d8 + 4}) piercing damage plus 14 ({@damage 4d6}) necrotic damage. If the target is a Humanoid, it must succeed on a {@dc 17} Constitution saving throw or be cursed with loup garou {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				},
 				{
@@ -2435,10 +2499,11 @@
 			"name": "Necrichor",
 			"source": "VRGR",
 			"page": 238,
-			"otherSources": [
-				{
-					"source": "AATM"
-				}
+			"referenceSources": [
+				"AATM"
+			],
+			"reprintedAs": [
+				"Necrichor|RHW"
 			],
 			"size": [
 				"M"
@@ -2504,7 +2569,7 @@
 				{
 					"name": "Rejuvenation",
 					"entries": [
-						"Unless its lifeless remains are splashed with holy water or placed in a vessel under the effects of the {@spell hallow} spell, the destroyed necrichor re-forms in {@dice 1d10} days, regaining all its hits points and appearing in the place it died or in the nearest unoccupied space."
+						"Unless its lifeless remains are splashed with {@item Holy Water (Flask)|PHB|holy water} or placed in a vessel under the effects of the {@spell hallow} spell, the destroyed necrichor re-forms in {@dice 1d10} days, regaining all its hits points and appearing in the place it died or in the nearest unoccupied space."
 					]
 				},
 				{
@@ -2543,7 +2608,7 @@
 					"name": "Blood Puppeteering {@recharge}",
 					"entries": [
 						"The necrichor targets a creature it can see within 5 feet of it that is missing any of its hit points. If the target isn't a Construct or an Undead, it must succeed on a {@dc 14} Constitution saving throw or the necrichor enters the target's space and attaches itself to the target for 1 minute. While attached, the necrichor takes only half damage dealt to it (round down), and the target takes the remaining damage. The necrichor can attach to only one creature at a time.",
-						"The attached necrichor can telepathically control the target's move, action, or both. When controlled this way, the target can take only the Attack action (necrichor chooses the target) or the Dash action. The attached target can repeat the saving throw at the end of each of its turns, detaching from the necrichor and forcing it to move into the nearest unoccupied space on a success."
+						"The attached necrichor can telepathically control the target's move, action, or both. When controlled this way, the target can take only the Attack action (necrichor chooses the target) or the {@action Dash} action. The attached target can repeat the saving throw at the end of each of its turns, detaching from the necrichor and forcing it to move into the nearest unoccupied space on a success."
 					]
 				}
 			],
@@ -2584,6 +2649,9 @@
 			"name": "Nosferatu",
 			"source": "VRGR",
 			"page": 239,
+			"reprintedAs": [
+				"Vampire Nosferatu|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -2704,7 +2772,6 @@
 			"damageTags": [
 				"N",
 				"P",
-				"R",
 				"S"
 			],
 			"miscTags": [
@@ -2723,6 +2790,9 @@
 			"name": "Podling",
 			"source": "VRGR",
 			"page": 227,
+			"reprintedAs": [
+				"Bodytaker Podling|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -2778,6 +2848,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Unusual Nature"
 			],
@@ -2801,10 +2872,12 @@
 			"name": "Priest of Osybus",
 			"source": "VRGR",
 			"page": 241,
-			"otherSources": [
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"HoL",
+				"VEoR"
+			],
+			"reprintedAs": [
+				"Priest of Osybus|RHW"
 			],
 			"size": [
 				"M"
@@ -3134,6 +3207,9 @@
 			"name": "Relentless Juggernaut",
 			"source": "VRGR",
 			"page": 243,
+			"reprintedAs": [
+				"Relentless Juggernaut|RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -3293,6 +3369,9 @@
 			"name": "Relentless Slasher",
 			"source": "VRGR",
 			"page": 242,
+			"reprintedAs": [
+				"Relentless Slasher|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -3383,6 +3462,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Legendary Resistances"
 			],
@@ -3411,6 +3491,9 @@
 			"name": "Strigoi",
 			"source": "VRGR",
 			"page": 246,
+			"reprintedAs": [
+				"Strigoi|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -3521,6 +3604,9 @@
 			"name": "Swarm of Gremishkas",
 			"source": "VRGR",
 			"page": 235,
+			"reprintedAs": [
+				"Swarm of Gremishkas|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -3600,6 +3686,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -3622,6 +3709,9 @@
 			"name": "Swarm of Maggots",
 			"source": "VRGR",
 			"page": 247,
+			"referenceSources": [
+				"HoL"
+			],
 			"size": [
 				"M"
 			],
@@ -3719,6 +3809,7 @@
 			],
 			"miscTags": [
 				"DIS",
+				"HPR",
 				"MW"
 			],
 			"conditionInflict": [
@@ -3813,6 +3904,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Spider Climb"
 			],
@@ -3832,6 +3924,9 @@
 			"name": "Swarm of Zombie Limbs",
 			"source": "VRGR",
 			"page": 254,
+			"reprintedAs": [
+				"Swarm of Zombie Limbs|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -3915,6 +4010,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Unusual Nature"
 			],
@@ -3994,6 +4090,9 @@
 			"name": "Unspeakable Horror",
 			"source": "VRGR",
 			"page": 250,
+			"reprintedAs": [
+				"Unspeakable Horror|RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -4302,6 +4401,9 @@
 			"name": "Vampiric Mind Flayer",
 			"source": "VRGR",
 			"page": 252,
+			"reprintedAs": [
+				"Vampire Mind Flayer|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -4456,12 +4558,17 @@
 			"page": 253,
 			"otherSources": [
 				{
-					"source": "CM"
-				},
-				{
 					"source": "CoS",
 					"page": 242
 				}
+			],
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"HoL"
+			],
+			"reprintedAs": [
+				"Wereraven|RHW"
 			],
 			"size": [
 				"M"
@@ -4531,7 +4638,7 @@
 				{
 					"name": "Beak (Raven or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}1 piercing damage in raven form, or 4 ({@damage 1d4 + 2}) piercing damage in hybrid form. If the target is humanoid, it must succeed on a {@dc 10} Constitution saving throw or be cursed with wereraven lycanthropy."
+						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}1 piercing damage in raven form, or 4 ({@damage 1d4 + 2}) piercing damage in hybrid form. If the target is humanoid, it must succeed on a {@dc 10} Constitution saving throw or be cursed with wereraven {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				},
 				{
@@ -4584,6 +4691,9 @@
 			"name": "Zombie Clot",
 			"source": "VRGR",
 			"page": 255,
+			"reprintedAs": [
+				"Zombie Clot|RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -4710,6 +4820,12 @@
 			"name": "Zombie Plague Spreader",
 			"source": "VRGR",
 			"page": 255,
+			"referenceSources": [
+				"HoL"
+			],
+			"reprintedAs": [
+				"Zombie Plague Spreader|RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -4789,6 +4905,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Undead Fortitude",
 				"Unusual Nature"

--- a/json/bestiary/bestiary-wbtw.json
+++ b/json/bestiary/bestiary-wbtw.json
@@ -1034,10 +1034,8 @@
 			"name": "Displacer Beast Kitten",
 			"source": "WBtW",
 			"page": 108,
-			"otherSources": [
-				{
-					"source": "BMT"
-				}
+			"referenceSources": [
+				"BMT"
 			],
 			"size": [
 				"S"
@@ -1189,7 +1187,7 @@
 				{
 					"name": "+1 Longsword",
 					"entries": [
-						"{@atk mw}  {@hit 2} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d8}) slashing damage, or 5 ({@damage 1d10}) slashing damage when used with two hands. If the target is a creature that is Large or bigger, it takes an extra 5 ({@damage 1d10}) slashing damage."
+						"{@atk mw} {@hit 2} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d8}) slashing damage, or 5 ({@damage 1d10}) slashing damage when used with two hands. If the target is a creature that is Large or bigger, it takes an extra 5 ({@damage 1d10}) slashing damage."
 					]
 				}
 			],
@@ -1791,6 +1789,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Keen Senses"
 			],
@@ -2254,7 +2253,7 @@
 				{
 					"name": "Light Crossbow",
 					"entries": [
-						"{@atk rw} {@hit 5} to hit (the target gains no benefit from less than {@quickref Cover||3||total cover}), range 320 ft., one target. {@h}7 ({@damage 1d8 + 3}) piercing damage. {@hom}Immediately after making this attack, the harengon can use the Hide action."
+						"{@atk rw} {@hit 5} to hit (the target gains no benefit from less than {@quickref Cover||3||total cover}), range 320 ft., one target. {@h}7 ({@damage 1d8 + 3}) piercing damage. {@hom}Immediately after making this attack, the harengon can use the {@action Hide} action."
 					]
 				}
 			],
@@ -2285,10 +2284,8 @@
 			"isNamedCreature": true,
 			"source": "WBtW",
 			"page": 205,
-			"otherSources": [
-				{
-					"source": "VEoR"
-				}
+			"referenceSources": [
+				"VEoR"
 			],
 			"size": [
 				"M"
@@ -2776,7 +2773,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"Jingle Jangle can take the Disengage or Hide action as a bonus action on each of her turns."
+						"Jingle Jangle can take the {@action Disengage} or {@action Hide} action as a bonus action on each of her turns."
 					]
 				}
 			],
@@ -3870,6 +3867,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Keen Senses"
 			],
@@ -3999,7 +3997,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of her turns, Raezil can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of her turns, Raezil can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -5672,6 +5670,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"attachedItems": [
 				"dagger|phb"
 			],
@@ -5713,6 +5712,7 @@
 				"average": 7,
 				"formula": "2d6"
 			},
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -5807,7 +5807,7 @@
 				{
 					"name": "Assassin's Whim",
 					"entries": [
-						"Zarak takes the Dash, Disengage, or Hide action."
+						"Zarak takes the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				}
 			],

--- a/json/bestiary/bestiary-wdh.json
+++ b/json/bestiary/bestiary-wdh.json
@@ -115,7 +115,7 @@
 				{
 					"name": "Greataxe",
 					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}11 ({@damage 1d12 + 5}) slashing damage"
+						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}11 ({@damage 1d12 + 5}) slashing damage."
 					]
 				},
 				{
@@ -451,7 +451,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rat.mp3"
+				"path": "bestiary/rat.opus"
 			},
 			"traitTags": [
 				"Keen Senses"
@@ -630,58 +630,38 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 112,
+			"_copy": {
+				"name": "Commoner",
+				"source": "MM",
+				"_templates": [
+					{
+						"name": "Strongheart Halfling",
+						"source": "PHB"
+					}
+				],
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the commoner",
+						"with": "Bepis",
+						"flags": "i"
+					}
+				}
+			},
 			"size": [
 				"S"
 			],
-			"type": {
-				"type": "humanoid",
-				"tags": [
-					{
-						"tag": "halfling",
-						"prefix": "Strongheart"
-					}
-				]
-			},
 			"alignment": [
 				"L",
 				"G"
 			],
-			"ac": [
-				10
-			],
 			"hp": {
-				"average": 4,
-				"formula": "1d8"
+				"average": 3,
+				"formula": "1d6"
 			},
 			"speed": {
 				"walk": 25
 			},
-			"str": 10,
-			"dex": 10,
-			"con": 10,
-			"int": 10,
-			"wis": 10,
-			"cha": 10,
-			"passive": 10,
-			"languages": [
-				"Common",
-				"Halfling"
-			],
-			"cr": "0",
-			"trait": [
-				{
-					"name": "Halfling Nimbleness",
-					"entries": [
-						"Bepis can move through a space occupied by a creature of a size larger than him"
-					]
-				},
-				{
-					"name": "Brave",
-					"entries": [
-						"Bepis has advantage on saving throws against being {@condition frightened}."
-					]
-				}
-			],
 			"languageTags": [
 				"C",
 				"H"
@@ -750,7 +730,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"On each of her turns, the Black Viper can use a bonus action to take the Dash, Disengage, or Hide action."
+						"On each of her turns, the Black Viper can use a bonus action to take the {@action Dash}, {@action Disengage}, or {@action Hide} action."
 					]
 				},
 				{
@@ -1213,7 +1193,11 @@
 			"type": {
 				"type": "humanoid",
 				"tags": [
-					"elf"
+					{
+						"tag": "elf",
+						"prefix": "Drow",
+						"prefixHidden": true
+					}
 				]
 			},
 			"alignment": [
@@ -1573,102 +1557,41 @@
 				"N",
 				"E"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
 			"name": "Engineer",
 			"source": "WDH",
 			"page": 141,
-			"size": [
-				"S"
-			],
-			"type": {
-				"type": "humanoid",
-				"tags": [
+			"_copy": {
+				"name": "Apprentice Wizard",
+				"source": "VGM",
+				"_templates": [
 					{
-						"tag": "gnome",
-						"prefix": "Rock"
+						"name": "Rock Gnome",
+						"source": "PHB"
 					}
-				]
+				],
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "apprentice",
+						"with": "engineer"
+					}
+				}
 			},
 			"alignment": [
 				"N",
 				"G"
 			],
-			"ac": [
-				10
-			],
 			"hp": {
 				"average": 7,
 				"formula": "2d6"
 			},
-			"speed": {
-				"walk": 25
-			},
-			"str": 10,
-			"dex": 10,
-			"con": 10,
-			"int": 14,
-			"wis": 10,
-			"cha": 11,
-			"skill": {
-				"arcana": "+4",
-				"history": "+4"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 10,
 			"languages": [
 				"Common",
 				"Gnomish"
-			],
-			"cr": "1/4",
-			"spellcasting": [
-				{
-					"name": "Spellcasting",
-					"type": "spellcasting",
-					"headerEntries": [
-						"The gnome is a 1st-level spellcaster. Its spellcasting ability is Intelligence. It has the following wizard spells prepared:"
-					],
-					"spells": {
-						"0": {
-							"spells": [
-								"{@spell fire bolt}",
-								"{@spell mending}",
-								"{@spell prestidigitation}"
-							]
-						},
-						"1": {
-							"slots": 2,
-							"spells": [
-								"{@spell burning hands}",
-								"{@spell disguise self}",
-								"{@spell shield}"
-							]
-						}
-					},
-					"ability": "int"
-				}
-			],
-			"trait": [
-				{
-					"name": "Gnome Cunning",
-					"entries": [
-						"The gnome has advantage on all Intelligence, Wisdom and Charisma saving throws against magic."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Dagger",
-					"entries": [
-						"{@atk mw} {@hit 2} to hit, reach 5 ft., one target. {@h}2 ({@damage 1d4}) piercing damage. Or Ranged Weapon Attack: {@hit 2} to hit, range 20/60 ft., one target. {@h}2 ({@damage 1d4}) piercing damage."
-					]
-				}
-			],
-			"attachedItems": [
-				"dagger|phb"
 			],
 			"senseTags": [
 				"D"
@@ -1676,22 +1599,6 @@
 			"languageTags": [
 				"C",
 				"G"
-			],
-			"damageTags": [
-				"P"
-			],
-			"damageTagsSpell": [
-				"F"
-			],
-			"spellcastingTags": [
-				"CW"
-			],
-			"miscTags": [
-				"MLW",
-				"MW"
-			],
-			"savingThrowForcedSpell": [
-				"dexterity"
 			],
 			"hasToken": true,
 			"hasFluff": true
@@ -1702,111 +1609,35 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 32,
+			"_copy": {
+				"name": "Druid",
+				"source": "MM",
+				"_templates": [
+					{
+						"name": "Wood Elf",
+						"source": "PHB"
+					}
+				],
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the druid",
+						"with": "Fala",
+						"flags": "i"
+					}
+				}
+			},
 			"size": [
 				"M"
 			],
-			"type": {
-				"type": "humanoid",
-				"tags": [
-					{
-						"tag": "elf",
-						"prefix": "Wood"
-					}
-				]
-			},
 			"alignment": [
 				"C",
 				"G"
 			],
-			"ac": [
-				11,
-				{
-					"ac": 16,
-					"condition": "with {@spell barkskin}",
-					"braces": true
-				}
-			],
-			"hp": {
-				"average": 27,
-				"formula": "5d8 + 5"
-			},
-			"speed": {
-				"walk": 35
-			},
-			"str": 10,
-			"dex": 12,
-			"con": 13,
-			"int": 12,
-			"wis": 15,
-			"cha": 11,
-			"skill": {
-				"medicine": "+4",
-				"nature": "+3",
-				"perception": "+4"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 14,
 			"languages": [
 				"Druidic",
 				"Common",
 				"Elvish"
-			],
-			"cr": "2",
-			"spellcasting": [
-				{
-					"name": "Spellcasting",
-					"type": "spellcasting",
-					"headerEntries": [
-						"Fala is a 4th-level spellcaster. Their spellcasting ability is Wisdom. They have the following druid spells prepared:"
-					],
-					"spells": {
-						"0": {
-							"spells": [
-								"{@spell druidcraft}",
-								"{@spell produce flame}",
-								"{@spell shillelagh}"
-							]
-						},
-						"1": {
-							"slots": 4,
-							"spells": [
-								"{@spell entangle}",
-								"{@spell longstrider}",
-								"{@spell speak with animals}",
-								"{@spell thunderwave}"
-							]
-						},
-						"2": {
-							"slots": 3,
-							"spells": [
-								"{@spell animal messenger}",
-								"{@spell barkskin}"
-							]
-						}
-					},
-					"ability": "wis"
-				}
-			],
-			"trait": [
-				{
-					"name": "Fey Ancestry",
-					"entries": [
-						"Fala has advantage on saving throws against being {@condition charmed}, and magic can't put them to sleep."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Quarterstaff",
-					"entries": [
-						"{@atk mw} {@hit 2} to hit or Melee Weapon Attack {@hit 4} to hit with shillelagh, reach 5 ft., one target. {@h}3 ({@damage 1d6}) bludgeoning damage, or 6 ({@damage 1d8 + 2}) bludgeoning damage with shillelagh or if wielded with two hands."
-					]
-				}
-			],
-			"attachedItems": [
-				"quarterstaff|phb"
 			],
 			"traitTags": [
 				"Fey Ancestry"
@@ -1818,27 +1649,6 @@
 				"C",
 				"DU",
 				"E"
-			],
-			"damageTags": [
-				"B"
-			],
-			"damageTagsSpell": [
-				"F",
-				"T"
-			],
-			"spellcastingTags": [
-				"CD"
-			],
-			"miscTags": [
-				"MLW",
-				"MW"
-			],
-			"conditionInflictSpell": [
-				"restrained"
-			],
-			"savingThrowForcedSpell": [
-				"constitution",
-				"strength"
 			],
 			"hasToken": true,
 			"hasFluff": true
@@ -1907,6 +1717,7 @@
 			],
 			"int": 7,
 			"cha": 13,
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -2290,6 +2101,7 @@
 				"religion": "+2",
 				"insight": "+4"
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -3363,15 +3175,45 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 158,
-			"size": [
-				"M"
-			],
+			"_copy": {
+				"name": "Mage",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the mage",
+						"with": "Kaevja",
+						"flags": "i"
+					},
+					"_": {
+						"mode": "replaceSpells",
+						"spells": {
+							"3": [
+								{
+									"replace": "{@spell fly}",
+									"with": "{@spell sending}"
+								}
+							]
+						}
+					},
+					"trait": {
+						"mode": "appendArr",
+						"items": {
+							"name": "Special Equipment",
+							"entries": [
+								"Kaevja carries a yellow {@item elemental gem}. As an action she can break the gem releasing an earth elemental under her command."
+							]
+						}
+					}
+				}
+			},
 			"type": {
 				"type": "humanoid",
 				"tags": [
 					{
 						"tag": "human",
-						"prefix": "Mulan"
+						"prefix": "Mulan",
+						"prefixHidden": true
 					}
 				]
 			},
@@ -3379,145 +3221,11 @@
 				"L",
 				"E"
 			],
-			"ac": [
-				12,
-				{
-					"ac": 15,
-					"condition": "with {@spell mage armor}",
-					"braces": true
-				}
-			],
-			"hp": {
-				"average": 40,
-				"formula": "9d8"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 9,
-			"dex": 14,
-			"con": 11,
-			"int": 17,
-			"wis": 12,
-			"cha": 11,
-			"save": {
-				"int": "+6",
-				"wis": "+4"
-			},
-			"skill": {
-				"arcana": "+6",
-				"history": "+6"
-			},
-			"passive": 11,
 			"languages": [
 				"Common",
 				"Draconic",
 				"Dwarvish",
 				"Elvish"
-			],
-			"cr": "6",
-			"spellcasting": [
-				{
-					"name": "Spellcasting",
-					"type": "spellcasting",
-					"headerEntries": [
-						"Kaevja is a 9th-level spellcaster. Her spellcasting ability is Intelligence. Kaevja has the following wizard spells prepared:"
-					],
-					"spells": {
-						"0": {
-							"spells": [
-								"{@spell fire bolt}",
-								"{@spell light}",
-								"{@spell mage hand}",
-								"{@spell prestidigitation}"
-							]
-						},
-						"1": {
-							"slots": 4,
-							"spells": [
-								"{@spell detect magic}",
-								"{@spell mage armor}",
-								"{@spell magic missile}",
-								"{@spell shield}"
-							]
-						},
-						"2": {
-							"slots": 3,
-							"spells": [
-								"{@spell misty step}",
-								"{@spell suggestion}"
-							]
-						},
-						"3": {
-							"slots": 3,
-							"spells": [
-								"{@spell counterspell}",
-								"{@spell fireball}",
-								"{@spell sending}"
-							]
-						},
-						"4": {
-							"slots": 3,
-							"spells": [
-								"{@spell greater invisibility}",
-								"{@spell ice storm}"
-							]
-						},
-						"5": {
-							"slots": 1,
-							"spells": [
-								"{@spell cone of cold}"
-							]
-						}
-					},
-					"ability": "int"
-				}
-			],
-			"trait": [
-				{
-					"name": "Special Equipment",
-					"entries": [
-						"Kaevja carries a yellow {@item elemental gem}. As an action she can break the gem releasing an earth elemental under her command."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Dagger",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage. Or Ranged Weapon Attack: {@hit 5} to hit, range 20/60 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage."
-					]
-				}
-			],
-			"attachedItems": [
-				"dagger|phb"
-			],
-			"languageTags": [
-				"C",
-				"D",
-				"DR",
-				"E"
-			],
-			"damageTags": [
-				"P"
-			],
-			"damageTagsSpell": [
-				"B",
-				"C",
-				"F",
-				"O"
-			],
-			"spellcastingTags": [
-				"CW"
-			],
-			"miscTags": [
-				"MLW",
-				"MW"
-			],
-			"savingThrowForcedSpell": [
-				"constitution",
-				"dexterity",
-				"wisdom"
 			],
 			"hasToken": true,
 			"hasFluff": true
@@ -4286,164 +3994,52 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 85,
-			"size": [
-				"S"
-			],
-			"type": {
-				"type": "humanoid",
-				"tags": [
+			"_copy": {
+				"name": "Mage",
+				"source": "MM",
+				"_templates": [
 					{
-						"tag": "halfling",
-						"prefix": "Lightfoot"
+						"name": "Lightfoot Halfling",
+						"source": "PHB"
 					}
-				]
+				],
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the mage",
+						"with": "Losser",
+						"flags": "i"
+					},
+					"_": {
+						"mode": "replaceSpells",
+						"spells": {
+							"3": [
+								{
+									"replace": "{@spell counterspell}",
+									"with": "{@spell animate dead}"
+								}
+							],
+							"4": [
+								{
+									"replace": "{@spell greater invisibility}",
+									"with": "{@spell blight}"
+								}
+							]
+						}
+					}
+				}
 			},
 			"alignment": [
 				"C",
 				"E"
 			],
-			"ac": [
-				12,
-				{
-					"ac": 15,
-					"condition": "with {@spell mage armor}",
-					"braces": true
-				}
-			],
 			"hp": {
 				"average": 31,
 				"formula": "9d6"
 			},
-			"speed": {
-				"walk": 25
-			},
-			"str": 9,
-			"dex": 14,
-			"con": 11,
-			"int": 17,
-			"wis": 12,
-			"cha": 11,
-			"save": {
-				"int": "+6",
-				"wis": "+4"
-			},
-			"skill": {
-				"arcana": "+6",
-				"history": "+6"
-			},
-			"passive": 11,
-			"languages": [
-				"Common",
-				"Halfling"
-			],
-			"cr": "6",
-			"spellcasting": [
-				{
-					"name": "Spellcasting",
-					"type": "spellcasting",
-					"headerEntries": [
-						"The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence. The mage has the following wizard spells prepared:"
-					],
-					"spells": {
-						"0": {
-							"spells": [
-								"{@spell fire bolt}",
-								"{@spell light}",
-								"{@spell mage hand}",
-								"{@spell prestidigitation}"
-							]
-						},
-						"1": {
-							"slots": 4,
-							"spells": [
-								"{@spell detect magic}",
-								"{@spell mage armor}",
-								"{@spell magic missile}",
-								"{@spell shield}"
-							]
-						},
-						"2": {
-							"slots": 3,
-							"spells": [
-								"{@spell misty step}",
-								"{@spell suggestion}"
-							]
-						},
-						"3": {
-							"slots": 3,
-							"spells": [
-								"{@spell animate dead}",
-								"{@spell fireball}",
-								"{@spell fly}"
-							]
-						},
-						"4": {
-							"slots": 3,
-							"spells": [
-								"{@spell blight}",
-								"{@spell ice storm}"
-							]
-						},
-						"5": {
-							"slots": 1,
-							"spells": [
-								"{@spell cone of cold}"
-							]
-						}
-					},
-					"ability": "int"
-				}
-			],
-			"trait": [
-				{
-					"name": "Halfling Nimbleness",
-					"entries": [
-						"Losser can move through the space of a creature that is a size bigger than him."
-					]
-				},
-				{
-					"name": "Brave",
-					"entries": [
-						"Losser has advantage on saving throws against being {@condition frightened}."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Dagger",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage. Or Ranged Weapon Attack: {@hit 5} to hit, range 20/60 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage."
-					]
-				}
-			],
-			"attachedItems": [
-				"dagger|phb"
-			],
 			"languageTags": [
 				"C",
 				"H"
-			],
-			"damageTags": [
-				"P"
-			],
-			"damageTagsSpell": [
-				"B",
-				"C",
-				"F",
-				"N",
-				"O"
-			],
-			"spellcastingTags": [
-				"CW"
-			],
-			"miscTags": [
-				"MLW",
-				"MW"
-			],
-			"savingThrowForcedSpell": [
-				"constitution",
-				"dexterity",
-				"wisdom"
 			],
 			"hasToken": true,
 			"hasFluff": true
@@ -4553,166 +4149,48 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 149,
-			"size": [
-				"S"
-			],
-			"type": {
-				"type": "humanoid",
-				"tags": [
+			"_copy": {
+				"name": "Mage",
+				"source": "MM",
+				"_templates": [
 					{
-						"tag": "halfling",
-						"prefix": "Lightfoot"
+						"name": "Lightfoot Halfling",
+						"source": "PHB"
 					}
-				]
+				],
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the mage",
+						"with": "Manafret",
+						"flags": "i"
+					},
+					"trait": {
+						"mode": "appendArr",
+						"items": {
+							"name": "Special Equipment",
+							"entries": [
+								"Manafret wears a {@item teleporter ring|WDH}."
+							]
+						}
+					}
+				}
 			},
 			"alignment": [
 				"L",
 				"E"
 			],
-			"ac": [
-				12,
-				{
-					"ac": 15,
-					"condition": "with {@spell mage armor}",
-					"braces": true
-				}
-			],
 			"hp": {
 				"average": 31,
 				"formula": "9d6"
 			},
-			"speed": {
-				"walk": 25
-			},
-			"str": 9,
-			"dex": 14,
-			"con": 11,
-			"int": 17,
-			"wis": 12,
-			"cha": 11,
-			"save": {
-				"int": "+6",
-				"wis": "+4"
-			},
-			"skill": {
-				"arcana": "+6",
-				"history": "+6"
-			},
-			"passive": 11,
 			"languages": [
 				"Common",
 				"Halfling"
 			],
-			"cr": "6",
-			"spellcasting": [
-				{
-					"name": "Spellcasting",
-					"type": "spellcasting",
-					"headerEntries": [
-						"The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence. The mage has the following wizard spells prepared:"
-					],
-					"spells": {
-						"0": {
-							"spells": [
-								"{@spell fire bolt}",
-								"{@spell light}",
-								"{@spell mage hand}",
-								"{@spell prestidigitation}"
-							]
-						},
-						"1": {
-							"slots": 4,
-							"spells": [
-								"{@spell detect magic}",
-								"{@spell mage armor}",
-								"{@spell magic missile}",
-								"{@spell shield}"
-							]
-						},
-						"2": {
-							"slots": 3,
-							"spells": [
-								"{@spell misty step}",
-								"{@spell suggestion}"
-							]
-						},
-						"3": {
-							"slots": 3,
-							"spells": [
-								"{@spell counterspell}",
-								"{@spell fireball}",
-								"{@spell fly}"
-							]
-						},
-						"4": {
-							"slots": 3,
-							"spells": [
-								"{@spell greater invisibility}",
-								"{@spell ice storm}"
-							]
-						},
-						"5": {
-							"slots": 1,
-							"spells": [
-								"{@spell cone of cold}"
-							]
-						}
-					},
-					"ability": "int"
-				}
-			],
-			"trait": [
-				{
-					"name": "Halfling Nimbleness",
-					"entries": [
-						"Manafret can move through a space of a Medium or larger creature."
-					]
-				},
-				{
-					"name": "Brave",
-					"entries": [
-						"Manafret has advantage on saving throws against being {@condition frightened}."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Dagger",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage. Or Ranged Weapon Attack: {@hit 5} to hit, range 20/60 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage."
-					]
-				}
-			],
-			"attachedItems": [
-				"dagger|phb"
-			],
 			"languageTags": [
 				"C",
 				"H"
-			],
-			"damageTags": [
-				"P"
-			],
-			"damageTagsSpell": [
-				"B",
-				"C",
-				"F",
-				"O"
-			],
-			"spellcastingTags": [
-				"CW"
-			],
-			"miscTags": [
-				"MLW",
-				"MW"
-			],
-			"conditionInflictSpell": [
-				"invisible"
-			],
-			"savingThrowForcedSpell": [
-				"constitution",
-				"dexterity",
-				"wisdom"
 			],
 			"hasToken": true,
 			"hasFluff": true
@@ -4723,6 +4201,9 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 209,
+			"reprintedAs": [
+				"Manshoon|FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -5828,7 +5309,8 @@
 			],
 			"traitTags": [
 				"Magic Resistance",
-				"Magic Weapons"
+				"Magic Weapons",
+				"Sure-Footed"
 			],
 			"senseTags": [
 				"D"
@@ -6102,84 +5584,38 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 213,
-			"size": [
-				"M"
-			],
+			"_copy": {
+				"name": "Noble",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the noble",
+						"with": "Orond",
+						"flags": "i"
+					}
+				}
+			},
 			"type": {
 				"type": "humanoid",
 				"tags": [
 					{
 						"tag": "human",
-						"prefix": "Tethyrian"
+						"prefix": "Tethyrian",
+						"prefixHidden": true
 					}
 				]
 			},
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"{@item breastplate|phb}"
-					]
-				}
-			],
-			"hp": {
-				"average": 9,
-				"formula": "2d8"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 11,
-			"dex": 12,
-			"con": 11,
 			"int": 9,
-			"wis": 14,
-			"cha": 16,
-			"skill": {
-				"deception": "+5",
-				"insight": "+4",
-				"persuasion": "+5"
-			},
-			"passive": 12,
 			"languages": [
 				"Common"
 			],
-			"cr": "1/8",
-			"action": [
-				{
-					"name": "Rapier",
-					"entries": [
-						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}5 ({@damage 1d8 + 1}) piercing damage."
-					]
-				}
-			],
-			"reaction": [
-				{
-					"name": "Parry",
-					"entries": [
-						"Orond adds 2 to its AC against one melee attack that would hit it. To do so, Orond must see the attacker and be wielding a melee weapon."
-					]
-				}
-			],
-			"attachedItems": [
-				"rapier|phb"
-			],
-			"actionTags": [
-				"Parry"
-			],
 			"languageTags": [
 				"C"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"MLW",
-				"MW"
 			],
 			"hasToken": true,
 			"hasFluff": true,
@@ -6639,15 +6075,25 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 215,
-			"size": [
-				"M"
-			],
+			"_copy": {
+				"name": "Swashbuckler",
+				"source": "VGM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the swashbuckler",
+						"with": "Renaer",
+						"flags": "i"
+					}
+				}
+			},
 			"type": {
 				"type": "humanoid",
 				"tags": [
 					{
 						"tag": "human",
-						"prefix": "Illuskan"
+						"prefix": "Illuskan",
+						"prefixHidden": true
 					}
 				]
 			},
@@ -6655,87 +6101,11 @@
 				"C",
 				"G"
 			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"{@item leather armor|phb}"
-					]
-				}
-			],
-			"hp": {
-				"average": 66,
-				"formula": "12d8 + 12"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 12,
-			"dex": 18,
-			"con": 12,
-			"int": 14,
-			"wis": 11,
-			"cha": 15,
-			"skill": {
-				"acrobatics": "+8",
-				"athletics": "+5",
-				"persuasion": "+6"
-			},
-			"passive": 10,
 			"languages": [
 				"Common"
 			],
-			"cr": "3",
-			"trait": [
-				{
-					"name": "Lightfooted",
-					"entries": [
-						"The swashbuckler can take the Dash or Disengage action as a bonus action on each of its turns."
-					]
-				},
-				{
-					"name": "Suave Defense",
-					"entries": [
-						"While the swashbuckler is wearing light or no armor and wielding no shield, its AC includes its Charisma modifier."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The swashbuckler makes three attacks: one with a dagger and two with its rapier."
-					]
-				},
-				{
-					"name": "Dagger",
-					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d4 + 4}) piercing damage. Or Ranged Weapon Attack: {@hit 6} to hit, range 20/60 ft., one target. {@h}6 ({@damage 1d4 + 4}) piercing damage."
-					]
-				},
-				{
-					"name": "Rapier",
-					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}8 ({@damage 1d8 + 4}) piercing damage."
-					]
-				}
-			],
-			"attachedItems": [
-				"dagger|phb",
-				"rapier|phb"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
 			"languageTags": [
 				"C"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"MLW",
-				"MW"
 			],
 			"hasToken": true,
 			"hasFluff": true,
@@ -6916,15 +6286,33 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 216,
-			"size": [
-				"M"
-			],
+			"_copy": {
+				"name": "Veteran",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the veteran",
+						"with": "Saeth",
+						"flags": "i"
+					},
+					"_": [
+						{
+							"mode": "addSkills",
+							"skills": {
+								"intimidation": 1
+							}
+						}
+					]
+				}
+			},
 			"type": {
 				"type": "humanoid",
 				"tags": [
 					{
 						"tag": "human",
-						"prefix": "Illuskan"
+						"prefix": "Illuskan",
+						"prefixHidden": true
 					}
 				]
 			},
@@ -6932,83 +6320,12 @@
 				"L",
 				"G"
 			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"{@item splint armor|phb}"
-					]
-				}
-			],
-			"hp": {
-				"average": 58,
-				"formula": "9d8 + 18"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 16,
-			"dex": 13,
-			"con": 14,
-			"int": 10,
-			"wis": 11,
 			"cha": 14,
-			"skill": {
-				"athletics": "+5",
-				"perception": "+2",
-				"intimidation": "+4"
-			},
-			"passive": 12,
 			"languages": [
 				"Common"
 			],
-			"cr": "3",
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"Saeth makes two longsword attacks. If he has a shortsword drawn, he can also make a shortsword attack."
-					]
-				},
-				{
-					"name": "Longsword",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}7 ({@damage 1d8 + 3}) slashing damage, or 8 ({@damage 1d10 + 3}) slashing damage if used with two hands."
-					]
-				},
-				{
-					"name": "Shortsword",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage."
-					]
-				},
-				{
-					"name": "Heavy Crossbow",
-					"entries": [
-						"{@atk rw} {@hit 3} to hit, range 100/400 ft., one target. {@h}6 ({@damage 1d10 + 1}) piercing damage."
-					]
-				}
-			],
-			"attachedItems": [
-				"heavy crossbow|phb",
-				"longsword|phb",
-				"shortsword|phb"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
 			"languageTags": [
 				"C"
-			],
-			"damageTags": [
-				"P",
-				"S"
-			],
-			"miscTags": [
-				"MLW",
-				"MW",
-				"RNG",
-				"RW"
 			],
 			"hasToken": true,
 			"hasFluff": true,
@@ -7038,6 +6355,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"languageTags": [
 				"H",
 				"X"
@@ -7149,7 +6467,7 @@
 				{
 					"name": "Bite (Rat or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 11} Constitution saving throw or be cursed with wererat lycanthropy."
+						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage. If the target is a humanoid, it must succeed on a {@dc 11} Constitution saving throw or be cursed with wererat {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				},
 				{
@@ -8047,6 +7365,9 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 216,
+			"referenceSources": [
+				"WDMM"
+			],
 			"size": [
 				"M"
 			],
@@ -8394,15 +7715,25 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 216,
-			"size": [
-				"M"
-			],
+			"_copy": {
+				"name": "Assassin",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the assassin",
+						"with": "Urstul",
+						"flags": "i"
+					}
+				}
+			},
 			"type": {
 				"type": "humanoid",
 				"tags": [
 					{
 						"tag": "human",
-						"prefix": "Illuskan"
+						"prefix": "Illuskan",
+						"prefixHidden": true
 					}
 				]
 			},
@@ -8410,114 +7741,15 @@
 				"L",
 				"E"
 			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"{@item studded leather armor|phb|studded leather}"
-					]
-				}
-			],
-			"hp": {
-				"average": 78,
-				"formula": "12d8 + 24"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 11,
-			"dex": 16,
-			"con": 14,
-			"int": 13,
-			"wis": 11,
-			"cha": 10,
-			"save": {
-				"dex": "+6",
-				"int": "+4"
-			},
-			"skill": {
-				"acrobatics": "+6",
-				"deception": "+3",
-				"perception": "+3",
-				"stealth": "+9"
-			},
-			"passive": 13,
-			"resist": [
-				"poison"
-			],
 			"languages": [
 				"Common",
 				"Orc",
 				"Thieves' cant"
 			],
-			"cr": "8",
-			"trait": [
-				{
-					"name": "Assassinate",
-					"entries": [
-						"During its first turn, Urstul has advantage on attack rolls against any creature that hasn't taken a turn. Any hit Urstul scores against a {@status surprised} creature is a critical hit."
-					]
-				},
-				{
-					"name": "Evasion",
-					"entries": [
-						"If Urstul is subjected to an effect that allows him to make a Dexterity saving throw to take only half damage, Urstul instead takes no damage if he succeeds on the saving throw, and only half damage if it fails."
-					]
-				},
-				{
-					"name": "Sneak Attack (1/Turn)",
-					"entries": [
-						"Urstul deals an extra 14 ({@damage 4d6}) damage when he hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 feet of an ally of Urstul that isn't {@condition incapacitated} and Urstul doesn't have disadvantage on the attack roll."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"Urstul makes two shortsword attacks."
-					]
-				},
-				{
-					"name": "Shortsword",
-					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage, and the target must make a {@dc 15} Constitution saving throw, taking 24 ({@damage 7d6}) poison damage on a failed save, or half as much damage on a successful one."
-					]
-				},
-				{
-					"name": "Light Crossbow",
-					"entries": [
-						"{@atk rw} {@hit 6} to hit, range 80/320 ft., one target. {@h}7 ({@damage 1d8 + 3}) piercing damage, and the target must make a {@dc 15} Constitution saving throw, taking 24 ({@damage 7d6}) poison damage on a failed save, or half as much damage on a successful one."
-					]
-				}
-			],
-			"attachedItems": [
-				"light crossbow|phb",
-				"shortsword|phb"
-			],
-			"traitTags": [
-				"Sneak Attack"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
 			"languageTags": [
 				"C",
 				"O",
 				"TC"
-			],
-			"damageTags": [
-				"I",
-				"P"
-			],
-			"miscTags": [
-				"MLW",
-				"MW",
-				"RNG",
-				"RW"
-			],
-			"savingThrowForced": [
-				"constitution"
 			],
 			"hasToken": true,
 			"hasFluff": true,
@@ -9328,6 +8560,7 @@
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -9492,86 +8725,40 @@
 			"isNamedCreature": true,
 			"source": "WDH",
 			"page": 220,
-			"size": [
-				"M"
-			],
+			"_copy": {
+				"name": "Noble",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the noble",
+						"with": "Yalah",
+						"flags": "i"
+					}
+				}
+			},
 			"type": {
 				"type": "humanoid",
 				"tags": [
 					{
 						"tag": "human",
-						"prefix": "Tethyrian"
+						"prefix": "Tethyrian",
+						"prefixHidden": true
 					}
 				]
 			},
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"{@item breastplate|phb}"
-					]
-				}
-			],
-			"hp": {
-				"average": 9,
-				"formula": "2d8"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 11,
-			"dex": 12,
-			"con": 11,
-			"int": 12,
-			"wis": 16,
-			"cha": 16,
-			"skill": {
-				"deception": "+5",
-				"insight": "+5",
-				"persuasion": "+5"
-			},
-			"passive": 13,
+			"int": 16,
 			"languages": [
 				"Common",
 				"Infernal"
 			],
-			"cr": "1/8",
-			"action": [
-				{
-					"name": "Rapier",
-					"entries": [
-						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}5 ({@damage 1d8 + 1}) piercing damage."
-					]
-				}
-			],
-			"reaction": [
-				{
-					"name": "Parry",
-					"entries": [
-						"Yalah adds 2 to its AC against one melee attack that would hit it. To do so, Yalah must see the attacker and be wielding a melee weapon."
-					]
-				}
-			],
-			"attachedItems": [
-				"rapier|phb"
-			],
-			"actionTags": [
-				"Parry"
-			],
 			"languageTags": [
 				"C",
 				"I"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"MLW",
-				"MW"
 			],
 			"hasToken": true,
 			"hasFluff": true,
@@ -9695,134 +8882,49 @@
 		},
 		{
 			"name": "Zhent Martial Arts Adept",
+			"shortName": "Adept",
+			"alias": [
+				"Havia Quickknife",
+				"Mookie Plush"
+			],
 			"source": "WDH",
 			"page": 160,
-			"size": [
-				"S"
-			],
-			"type": {
-				"type": "humanoid",
-				"tags": [
+			"_copy": {
+				"name": "Martial Arts Adept",
+				"source": "VGM",
+				"_templates": [
 					{
-						"tag": "halfling",
-						"prefix": "Lightfoot"
+						"name": "Lightfoot Halfling",
+						"source": "PHB"
 					}
-				]
+				],
+				"_mod": {
+					"trait": {
+						"mode": "appendArr",
+						"items": {
+							"name": "Special Equipment",
+							"entries": [
+								"The adept wears a {@item teleporter ring|WDH}."
+							]
+						}
+					}
+				}
 			},
 			"alignment": [
 				"L",
 				"E"
 			],
-			"ac": [
-				16
-			],
 			"hp": {
 				"average": 49,
 				"formula": "11d6 + 11"
 			},
-			"speed": {
-				"walk": 25
-			},
-			"str": 11,
-			"dex": 17,
-			"con": 13,
-			"int": 11,
-			"wis": 16,
-			"cha": 10,
-			"skill": {
-				"acrobatics": "+5",
-				"insight": "+5",
-				"stealth": "+5"
-			},
-			"passive": 13,
 			"languages": [
 				"Common",
 				"Halfling"
 			],
-			"cr": "3",
-			"trait": [
-				{
-					"name": "Halfling Nimbleness",
-					"entries": [
-						"The adept can move through the space of a medium of larger creature."
-					]
-				},
-				{
-					"name": "Brave",
-					"entries": [
-						"The adept has advantage on any saving throws against being {@condition frightened}."
-					]
-				},
-				{
-					"name": "Unarmored Defense",
-					"entries": [
-						"While the adept is wearing no armor and wielding no shield, their AC includes their Wisdom modifier."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The adept makes three unarmed strikes or three dart attacks."
-					]
-				},
-				{
-					"name": "Unarmed Strike",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}7 ({@damage 1d8 + 3}) bludgeoning damage. If the target is a creature, the adept can choose one of the following additional effects:",
-						{
-							"type": "list",
-							"items": [
-								"The target must succeed on a {@dc 13} Strength saving throw or drop one item it is holding (adept's choice).",
-								"The target must succeed on a {@dc 13} Dexterity saving throw or be knocked {@condition prone}.",
-								"The target must succeed on a {@dc 13} Constitution saving throw or be {@condition stunned} until the end of the adept's next turn."
-							]
-						}
-					]
-				},
-				{
-					"name": "Dart",
-					"entries": [
-						"{@atk rw} {@hit 5} to hit, range 20/60 ft., one target. {@h}5 ({@damage 1d4 + 3}) piercing damage."
-					]
-				}
-			],
-			"reaction": [
-				{
-					"name": "Deflect Missile",
-					"entries": [
-						"In response to being hit by a ranged weapon attack, the adept deflects the missile. The damage it takes from the attack is reduced by {@dice 1d10 + 3}. If the damage is reduced to 0, the adept catches the missile if it's small enough to hold in one hand and the adept has a hand free."
-					]
-				}
-			],
-			"attachedItems": [
-				"dart|phb"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
 			"languageTags": [
 				"C",
 				"H"
-			],
-			"damageTags": [
-				"B",
-				"P"
-			],
-			"miscTags": [
-				"MW",
-				"RW",
-				"THW"
-			],
-			"conditionInflict": [
-				"prone",
-				"stunned"
-			],
-			"savingThrowForced": [
-				"constitution",
-				"dexterity",
-				"strength"
 			],
 			"hasToken": true,
 			"hasFluff": true

--- a/json/bestiary/bestiary-wdmm.json
+++ b/json/bestiary/bestiary-wdmm.json
@@ -38,6 +38,10 @@
 					}
 				}
 			},
+			"hp": {
+				"average": 140,
+				"formula": "14d8 + 28"
+			},
 			"hasToken": true
 		},
 		{
@@ -88,7 +92,7 @@
 				{
 					"name": "Magic Bolt",
 					"entries": [
-						"{@atk rw} {@hit 6} to hit, range 120 ft., one target. {@h}16 ({@damage 3d10}) fire damage"
+						"{@atk rw} {@hit 6} to hit, range 120 ft., one target. {@h}16 ({@damage 3d10}) fire damage."
 					]
 				}
 			],
@@ -173,7 +177,7 @@
 			],
 			"trait": [
 				{
-					"name": "Wielder Domination",
+					"name": "Charm",
 					"entries": [
 						"A creature can grab the staff out of the air with a successful grapple check against the staff, and grappling the staff does not reduce the creature's speed. Any creature that successfully grapples the staff must succeed on a {@dc 12} Charisma saving throw or be {@condition charmed} by the staff until the staff is no longer in its grasp. While the creature is {@condition charmed}, the staff can issue commands to it, which the creature does its best to obey. The creature can repeat the saving throw each time it takes damage, ending the effect on itself on a success. A creature that successfully resists the staff's control can't be {@condition charmed} by it for 24 hours.",
 						"A creature holding the staff that isn't {@condition charmed} by it can use an action to attempt to break the staff over a knee or against a solid surface, doing so with a successful {@dc 17} Strength ({@skill Athletics}) check. Breaking the staff in this manner destroys it."
@@ -188,7 +192,7 @@
 					]
 				},
 				{
-					"name": "Staff",
+					"name": "Melee Attack",
 					"entries": [
 						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}7 ({@damage 2d6}) bludgeoning damage plus 1 cold damage."
 					]
@@ -213,6 +217,47 @@
 			"savingThrowForced": [
 				"charisma"
 			],
+			"hasToken": true
+		},
+		{
+			"name": "Animated Statue",
+			"source": "WDMM",
+			"page": 125,
+			"_copy": {
+				"name": "Archmage",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "archmage",
+						"with": "statue",
+						"flags": "i"
+					},
+					"_": {
+						"mode": "replaceSpells",
+						"spells": {
+							"4": [
+								{
+									"replace": "{@spell banishment}",
+									"with": "{@spell ice storm}"
+								}
+							],
+							"7": [
+								{
+									"replace": "{@spell teleport}",
+									"with": "{@spell finger of death}"
+								}
+							]
+						}
+					}
+				}
+			},
+			"type": "construct",
+			"alignment": [
+				"U"
+			],
+			"tokenCredit": "Onefold, Ltd.",
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -250,6 +295,7 @@
 				"understands Abyssal but can't speak"
 			],
 			"cr": "11",
+			"tokenCustom": true,
 			"traitTags": [
 				"Immutable Form",
 				"Magic Resistance",
@@ -495,6 +541,55 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Armored Troglodyte",
+			"source": "WDMM",
+			"page": 150,
+			"_copy": {
+				"name": "Troglodyte",
+				"source": "MM",
+				"_mod": {
+					"action": [
+						{
+							"mode": "replaceArr",
+							"replace": "Multiattack",
+							"items": {
+								"name": "Multiattack",
+								"entries": [
+									"The troglodyte either makes two attacks with its longsword, or it makes three attacks: one with its bite and two with its claws."
+								]
+							}
+						},
+						{
+							"mode": "replaceArr",
+							"replace": "Claw",
+							"items": {
+								"name": "Longsword",
+								"entries": [
+									"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) slashing damage, or 7 ({@damage 1d10 + 2}) slashing damage if used with two hands."
+								]
+							}
+						}
+					]
+				}
+			},
+			"ac": [
+				{
+					"ac": 14,
+					"from": [
+						"{@item breastplate|phb}"
+					]
+				}
+			],
+			"languages": [
+				"understands Undercommon but can't speak"
+			],
+			"languageTags": [
+				"CS",
+				"U"
+			],
+			"hasToken": true
+		},
+		{
 			"name": "Ashtyrranthor",
 			"isNpc": true,
 			"isNamedCreature": true,
@@ -587,6 +682,27 @@
 			"hasToken": true
 		},
 		{
+			"name": "Azal",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WDMM",
+			"page": 202,
+			"_copy": {
+				"name": "Githzerai Zerth",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the githzerai",
+						"with": "Azal",
+						"flags": "i"
+					}
+				}
+			},
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
 			"name": "Berlain Shadowdusk",
 			"isNpc": true,
 			"isNamedCreature": true,
@@ -602,10 +718,10 @@
 						"with": "Berlain",
 						"flags": "i"
 					},
-					"trait": {
+					"bonus": {
 						"mode": "appendArr",
 						"items": {
-							"name": "Extra Parts",
+							"name": "Fused Form",
 							"entries": [
 								"As a bonus action, Berlain can use her extra mouth and arms to cast any cantrip she has prepared."
 							]
@@ -713,6 +829,7 @@
 					"ability": "int"
 				}
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"DS",
@@ -768,6 +885,30 @@
 				"MW",
 				"RCH"
 			],
+			"hasToken": true
+		},
+		{
+			"name": "Blacktongue Bullywug",
+			"source": "WDMM",
+			"page": 110,
+			"_copy": {
+				"name": "Bullywug",
+				"source": "MM",
+				"_mod": {
+					"action": {
+						"mode": "replaceArr",
+						"replace": "Spear",
+						"items": [
+							{
+								"name": "Spear",
+								"entries": [
+									"{@atk mw,rw} {@hit 3} to hit, reach 5 ft. or range 20/60 ft., one target. {@h}4 ({@damage 1d6 + 1}) piercing damage, or 5 ({@damage 1d8 + 1}) piercing damage if used with two hands to make a melee attack. A creature hit by a bullywug's Spear attack must succeed on a {@dc 13} Constitution saving throw or be {@condition poisoned} for 1 minute. A creature {@condition poisoned} in this way is also {@condition paralyzed}. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+								]
+							}
+						]
+					}
+				}
+			},
 			"hasToken": true
 		},
 		{
@@ -867,7 +1008,7 @@
 				{
 					"name": "Tail Stinger",
 					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 10 ft., one creature. {@h}19 ({@damage 3d6 + 9}) piercing damage, and the target must make a {@dc 19} Constitution saving throw, taking 42 ({@damage 12d6}) poison damage on a failed save, or half as much damage on a successful one."
+						"{@atk mw} {@hit 14} to hit, reach 10 ft., one creature. {@h}19 ({@damage 3d6 + 9}) piercing damage, and the target must make a {@dc 19} Constitution saving throw, taking 42 ({@damage 12d6}) poison damage on a failed save, or half as much damage on a successful one."
 					]
 				}
 			],
@@ -937,19 +1078,7 @@
 			"page": 189,
 			"_copy": {
 				"name": "Ogre",
-				"source": "MM",
-				"_mod": {
-					"trait": {
-						"mode": "appendArr",
-						"items": {
-							"type": "entries",
-							"name": "Tied Down",
-							"entries": [
-								"While lashed to the floor, the creature is {@condition prone} and {@condition restrained}. It also suffers from two levels of {@condition exhaustion}."
-							]
-						}
-					}
-				}
+				"source": "MM"
 			},
 			"int": 1,
 			"languages": null,
@@ -973,6 +1102,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"actionTags": [
 				"Multiattack",
 				"Tentacles"
@@ -1140,6 +1270,7 @@
 					"ability": "int"
 				}
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"DS",
@@ -1190,6 +1321,7 @@
 				"N",
 				"E"
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -1293,6 +1425,19 @@
 			"hasFluff": true
 		},
 		{
+			"name": "Crystal Helm Nothic",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WDMM",
+			"page": 130,
+			"_copy": {
+				"name": "Nothic",
+				"source": "MM"
+			},
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
 			"name": "Deformed Duergar",
 			"isNpc": true,
 			"source": "WDMM",
@@ -1311,7 +1456,7 @@
 								]
 							},
 							{
-								"name": "Merged Heads",
+								"name": "Two Heads",
 								"entries": [
 									"The duergar has advantage on Wisdom ({@skill Perception}) checks and on saving throws against being {@condition charmed}, {@condition frightened}, {@condition stunned}, and knocked {@condition unconscious}."
 								]
@@ -1349,8 +1494,8 @@
 						"with": "Dezmyr",
 						"flags": "i"
 					},
-					"trait": {
-						"mode": "prependArr",
+					"bonus": {
+						"mode": "appendArr",
 						"items": [
 							{
 								"name": "Warp Reality",
@@ -1362,6 +1507,11 @@
 					}
 				}
 			},
+			"languages": [
+				"Abyssal",
+				"Common",
+				"Deep Speech"
+			],
 			"spellcasting": [
 				{
 					"name": "Spellcasting",
@@ -1409,6 +1559,11 @@
 					"ability": "cha"
 				}
 			],
+			"languageTags": [
+				"AB",
+				"C",
+				"DS"
+			],
 			"savingThrowForcedSpell": [
 				"constitution",
 				"wisdom"
@@ -1427,7 +1582,7 @@
 				"source": "MM",
 				"_templates": [
 					{
-						"name": "Drow",
+						"name": "Drow (Levitate)",
 						"source": "PHB"
 					}
 				],
@@ -1449,6 +1604,10 @@
 					}
 				}
 			},
+			"alignment": [
+				"N",
+				"E"
+			],
 			"languages": [
 				"Abyssal",
 				"Common",
@@ -1457,6 +1616,7 @@
 				"Goblin",
 				"Undercommon"
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Fey Ancestry",
 				"Magic Resistance",
@@ -1507,6 +1667,12 @@
 					}
 				}
 			},
+			"hp": {
+				"average": 221,
+				"formula": "13d12 + 78"
+			},
+			"tokenCredit": "Paizo",
+			"tokenCustom": true,
 			"damageTags": [
 				"F",
 				"S"
@@ -1539,6 +1705,9 @@
 							]
 						}
 					}
+				},
+				"_preserve": {
+					"legendaryGroup": true
 				}
 			},
 			"languages": [
@@ -1651,7 +1820,8 @@
 				"dexterity",
 				"wisdom"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Fazrian",
@@ -1691,7 +1861,8 @@
 				"constitution"
 			],
 			"hasToken": true,
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Fidelio",
@@ -1711,10 +1882,18 @@
 					}
 				}
 			},
+			"alignment": [
+				"L",
+				"G"
+			],
 			"hp": {
 				"average": 80,
 				"formula": "10d8"
 			},
+			"languages": [
+				"Common"
+			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -1775,6 +1954,36 @@
 			"hasToken": true
 		},
 		{
+			"name": "Flying Wand",
+			"source": "WDMM",
+			"page": 105,
+			"_copy": {
+				"name": "Flying Sword",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "\\bsword\\b",
+						"with": "wand"
+					}
+				}
+			},
+			"action": [
+				{
+					"name": "Magic Missile",
+					"entries": [
+						"The wand shoots a dart of magical force at one creature that it can detect within 60 feet of it. The target takes 3 ({@damage 1d4 + 1}) force damage as the dart hits it unerringly."
+					]
+				}
+			],
+			"tokenCredit": "Hayden Stutz",
+			"tokenCustom": true,
+			"damageTags": [
+				"O"
+			],
+			"hasToken": true
+		},
+		{
 			"name": "Giant Flying Spider",
 			"source": "WDMM",
 			"page": 150,
@@ -1790,85 +1999,50 @@
 			"hasToken": true
 		},
 		{
-			"name": "Giant Mutated Drow",
+			"name": "Giant Gelatinous Cube",
 			"source": "WDMM",
-			"page": 143,
+			"page": 241,
 			"_copy": {
-				"name": "Cloud Giant",
+				"name": "Gelatinous Cube",
 				"source": "MM",
 				"_mod": {
-					"*": {
-						"mode": "replaceTxt",
-						"replace": "giant",
-						"with": "drow",
-						"flags": "i"
-					},
-					"trait": {
-						"mode": "appendArr",
-						"items": [
-							{
-								"name": "Fey Ancestry",
+					"trait": [
+						{
+							"mode": "replaceArr",
+							"replace": "Ooze Cube",
+							"items": {
+								"name": "Ooze Cube",
 								"entries": [
-									"The drow has advantage on saving throws against being charmed, and magic can't put the drow to sleep."
-								]
-							},
-							{
-								"name": "Sunlight Sensitivity",
-								"entries": [
-									"While in sunlight, the drow has disadvantage on attack rolls, as well as on Wisdom ({@skill Perception}) checks that rely on sight."
+									"The cube takes up its entire space. Other creatures can enter the space, but a creature that does so is subjected to the cube's Engulf and has disadvantage on the saving throw.",
+									"Creatures inside the cube can be seen but have {@quickref Cover||3||total cover}.",
+									"A creature within 5 feet of the cube can take an action to pull a creature or object out of the cube. Doing so requires a successful {@dc 12} Strength check, and the creature making the attempt takes 10 ({@damage 3d6}) acid damage.",
+									"The cube can hold up to nine Large creatures or up to thirty-six Medium or smaller creatures inside it at a time."
 								]
 							}
-						]
+						},
+						{
+							"mode": "appendArr",
+							"items": [
+								{
+									"name": "Enlarged",
+									"entries": [
+										"The cube makes Strength checks and Strength saving throws with advantage. When the cube shrinks back to normal size, any creatures that it can no longer contain are expelled into unoccupied spaces around it."
+									]
+								}
+							]
+						}
+					],
+					"action": {
+						"mode": "prependArr",
+						"items": {
+							"name": "Multiattack",
+							"entries": [
+								"The cube makes four pseudopod attacks."
+							]
+						}
 					}
 				}
 			},
-			"type": "giant",
-			"alignment": [
-				"N",
-				"E"
-			],
-			"senses": [
-				"darkvision 120 ft."
-			],
-			"languages": [
-				"Elvish",
-				"Undercommon"
-			],
-			"spellcasting": [
-				{
-					"name": "Innate Spellcasting",
-					"type": "spellcasting",
-					"headerEntries": [
-						"The drow's innate spellcasting ability is Charisma (spell save {@dc 15}). The drow can innately cast the following spells, requiring no material components:"
-					],
-					"will": [
-						"{@spell dancing lights}"
-					],
-					"daily": {
-						"1e": [
-							"{@spell darkness}",
-							"{@spell faerie fire}"
-						]
-					},
-					"ability": "cha"
-				}
-			],
-			"traitTags": [
-				"Fey Ancestry",
-				"Keen Senses",
-				"Sunlight Sensitivity"
-			],
-			"senseTags": [
-				"SD"
-			],
-			"languageTags": [
-				"C",
-				"E",
-				"GI"
-			],
-			"savingThrowForcedSpell": [
-				"dexterity"
-			],
 			"hasToken": true
 		},
 		{
@@ -1925,6 +2099,9 @@
 							}
 						]
 					}
+				},
+				"_preserve": {
+					"legendaryGroup": true
 				}
 			},
 			"languages": [
@@ -2000,56 +2177,6 @@
 				"constitution",
 				"dexterity",
 				"wisdom"
-			],
-			"hasToken": true,
-			"hasFluffImages": true
-		},
-		{
-			"name": "Gorzil's Gang Troglodyte",
-			"source": "WDMM",
-			"page": 150,
-			"_copy": {
-				"name": "Troglodyte",
-				"source": "MM",
-				"_mod": {
-					"action": [
-						{
-							"mode": "replaceArr",
-							"replace": "Multiattack",
-							"items": {
-								"name": "Multiattack",
-								"entries": [
-									"The troglodyte makes three attacks: one with its bite and two with its longsword."
-								]
-							}
-						},
-						{
-							"mode": "replaceArr",
-							"replace": "Claw",
-							"items": {
-								"name": "Longsword",
-								"entries": [
-									"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) slashing damage, or 7 ({@damage 1d10 + 2}) slashing damage if used with two hands."
-								]
-							}
-						}
-					]
-				}
-			},
-			"ac": [
-				{
-					"ac": 14,
-					"from": [
-						"{@item breastplate|phb}"
-					]
-				}
-			],
-			"languages": [
-				"understands Undercommon but can't speak"
-			],
-			"languageTags": [
-				"CS",
-				"U"
 			],
 			"hasToken": true
 		},
@@ -2383,6 +2510,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"damageTags": [
 				"B"
 			],
@@ -2444,6 +2572,44 @@
 			"hasToken": true
 		},
 		{
+			"name": "Hammer-Handed Golem",
+			"source": "WDMM",
+			"page": 259,
+			"_copy": {
+				"name": "Stone Golem",
+				"source": "MM",
+				"_mod": {
+					"action": [
+						{
+							"mode": "replaceArr",
+							"replace": "Multiattack",
+							"items": [
+								{
+									"name": "Multiattack",
+									"entries": [
+										"The golem makes two mallet attacks."
+									]
+								}
+							]
+						},
+						{
+							"mode": "replaceArr",
+							"replace": "Slam",
+							"items": [
+								{
+									"name": "Mallet",
+									"entries": [
+										"{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}19 ({@damage 3d8 + 6}) bludgeoning damage, and the target must succeed on a {@dc 17} Constitution saving throw or be {@condition stunned} until the end of its next turn."
+									]
+								}
+							]
+						}
+					]
+				}
+			},
+			"hasToken": true
+		},
+		{
 			"name": "Haungharassk",
 			"isNpc": true,
 			"isNamedCreature": true,
@@ -2496,6 +2662,7 @@
 				}
 			],
 			"familiar": true,
+			"tokenCustom": true,
 			"traitTags": [
 				"Spider Climb"
 			],
@@ -2536,6 +2703,7 @@
 				"Infernal",
 				"Undercommon"
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -2546,10 +2714,30 @@
 				"U"
 			],
 			"spellcastingTags": [
-				"CW",
-				"I"
+				"CW"
 			],
 			"hasToken": true
+		},
+		{
+			"name": "Hrossk",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WDMM",
+			"page": 183,
+			"_copy": {
+				"name": "Fire Giant",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the giant",
+						"with": "Hrossk",
+						"flags": "i"
+					}
+				}
+			},
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Huge Gray Ooze",
@@ -2594,6 +2782,8 @@
 					]
 				}
 			],
+			"tokenCredit": "Slay the Spire 2",
+			"tokenCustom": true,
 			"actionTags": [
 				"Multiattack"
 			],
@@ -2664,7 +2854,7 @@
 			"source": "WDMM",
 			"page": 165,
 			"size": [
-				"M"
+				"L"
 			],
 			"type": "construct",
 			"alignment": [
@@ -2694,6 +2884,20 @@
 				"poison",
 				"psychic"
 			],
+			"trait": [
+				{
+					"name": "Spider Climb",
+					"entries": [
+						"The iron spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+					]
+				},
+				{
+					"name": "Antimagic Susceptibility",
+					"entries": [
+						"The iron spider is {@condition incapacitated} while in the area of an {@spell antimagic field}. If targeted by {@spell dispel magic}, the iron spider must succeed on a Constitution saving throw against the caster's spell save DC or fall {@condition unconscious} for 1 minute."
+					]
+				}
+			],
 			"action": [
 				{
 					"name": "Web Cable",
@@ -2702,10 +2906,16 @@
 					]
 				}
 			],
+			"tokenCustom": true,
+			"traitTags": [
+				"Antimagic Susceptibility",
+				"Spider Climb"
+			],
 			"senseTags": [
 				"B"
 			],
-			"hasToken": true
+			"hasToken": true,
+			"hasFluff": true
 		},
 		{
 			"name": "Junior Drow Priestess of Lolth",
@@ -2732,6 +2942,10 @@
 				"N",
 				"E"
 			],
+			"languages": [
+				"Elvish",
+				"Undercommon"
+			],
 			"traitTags": [
 				"Fey Ancestry",
 				"Sunlight Sensitivity"
@@ -2741,7 +2955,7 @@
 			],
 			"languageTags": [
 				"E",
-				"X"
+				"U"
 			],
 			"spellcastingTags": [
 				"CC",
@@ -2750,7 +2964,7 @@
 			"hasToken": true
 		},
 		{
-			"name": "Kavil",
+			"name": "Kavil Mereshanter",
 			"isNpc": true,
 			"isNamedCreature": true,
 			"source": "WDMM",
@@ -2884,6 +3098,7 @@
 				"name": "Keresta Delvingstone",
 				"source": "WDMM"
 			},
+			"tokenCustom": true,
 			"damageTagsSpell": [
 				"I",
 				"N",
@@ -2955,7 +3170,7 @@
 		{
 			"name": "Large Mimic",
 			"source": "WDMM",
-			"page": 76,
+			"page": 26,
 			"_copy": {
 				"name": "Mimic",
 				"source": "MM"
@@ -2964,8 +3179,8 @@
 				"L"
 			],
 			"hp": {
-				"average": 67,
-				"formula": "9d10 + 18"
+				"average": 75,
+				"formula": "10d10 + 20"
 			},
 			"hasToken": true
 		},
@@ -3133,6 +3348,7 @@
 				"blinded",
 				"deafened"
 			],
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -3259,6 +3475,7 @@
 				"and Undercommon but can't speak"
 			],
 			"cr": "12",
+			"tokenCustom": true,
 			"languageTags": [
 				"AB",
 				"C",
@@ -3353,15 +3570,6 @@
 								]
 							}
 						}
-					},
-					"trait": {
-						"mode": "prependArr",
-						"items": {
-							"name": "Fey Ancestry",
-							"entries": [
-								"Marta has advantage on saving throws against being {@condition charmed}, and magic can't put her to sleep."
-							]
-						}
 					}
 				}
 			},
@@ -3376,6 +3584,7 @@
 				"Elvish",
 				"Undercommon"
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Fey Ancestry"
 			],
@@ -3433,6 +3642,7 @@
 				"Draconic",
 				"Dwarvish"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"D",
@@ -3458,6 +3668,10 @@
 					]
 				}
 			],
+			"hp": {
+				"average": 24,
+				"formula": "3d8"
+			},
 			"senses": [
 				"darkvision 60 ft."
 			],
@@ -3472,6 +3686,7 @@
 				"petrified",
 				"poisoned"
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -3508,6 +3723,7 @@
 				"average": 42,
 				"formula": "7d6"
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -3743,6 +3959,89 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Mutated Drow",
+			"source": "WDMM",
+			"page": 143,
+			"_copy": {
+				"name": "Cloud Giant",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "giant",
+						"with": "drow",
+						"flags": "i"
+					},
+					"trait": {
+						"mode": "appendArr",
+						"items": [
+							{
+								"name": "Fey Ancestry",
+								"entries": [
+									"The drow has advantage on saving throws against being charmed, and magic can't put the drow to sleep."
+								]
+							},
+							{
+								"name": "Sunlight Sensitivity",
+								"entries": [
+									"While in sunlight, the drow has disadvantage on attack rolls, as well as on Wisdom ({@skill Perception}) checks that rely on sight."
+								]
+							}
+						]
+					}
+				}
+			},
+			"type": "giant",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"senses": [
+				"darkvision 120 ft."
+			],
+			"languages": [
+				"Elvish",
+				"Undercommon"
+			],
+			"spellcasting": [
+				{
+					"name": "Innate Spellcasting",
+					"type": "spellcasting",
+					"headerEntries": [
+						"The drow's innate spellcasting ability is Charisma (spell save {@dc 15}). The drow can innately cast the following spells, requiring no material components:"
+					],
+					"will": [
+						"{@spell dancing lights}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell darkness}",
+							"{@spell faerie fire}"
+						]
+					},
+					"ability": "cha"
+				}
+			],
+			"tokenCustom": true,
+			"traitTags": [
+				"Fey Ancestry",
+				"Keen Senses",
+				"Sunlight Sensitivity"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"languageTags": [
+				"C",
+				"E",
+				"GI"
+			],
+			"savingThrowForcedSpell": [
+				"dexterity"
+			],
+			"hasToken": true
+		},
+		{
 			"name": "Nerozar the Defeated",
 			"isNpc": true,
 			"isNamedCreature": true,
@@ -3770,27 +4069,23 @@
 									"style": "list-hang-notitle",
 									"items": [
 										{
-											"type": "item",
+											"type": "itemSub",
 											"name": "1. Paralyzing Ray",
-											"style": "italic",
 											"entry": "The targeted creature must succeed on a {@dc 14} Constitution saving throw or be {@condition paralyzed} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 										},
 										{
-											"type": "item",
+											"type": "itemSub",
 											"name": "2. Fear Ray",
-											"style": "italic",
 											"entry": "The targeted creature must succeed on a {@dc 14} Wisdom saving throw or be {@condition frightened} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 										},
 										{
-											"type": "item",
+											"type": "itemSub",
 											"name": "3. Enervation Ray",
-											"style": "italic",
 											"entry": "The targeted creature must make a {@dc 14} Constitution saving throw, taking 36 ({@damage 8d8}) necrotic damage on a failed save, or half as much damage on a successful one."
 										},
 										{
-											"type": "item",
+											"type": "itemSub",
 											"name": "4. Telekinetic Ray",
-											"style": "italic",
 											"entry": "If the target is a creature, it must succeed on a {@dc 14} Strength saving throw, or the zombie moves it up to 30 feet in any direction. It is restrained by the ray's telekinetic grip until the start of the zombie's next turn or until the zombie is incapacitated. If the target is an object weighing 300 pounds or less that isn't being worn or carried, it is moved up to 30 feet in any direction. The zombie can also exert fine control on objects with this ray, such as manipulating a simple tool or opening a door or container."
 										}
 									]
@@ -3851,6 +4146,10 @@
 				}
 			},
 			"type": "undead",
+			"alignment": [
+				"C",
+				"E"
+			],
 			"senses": [
 				"darkvision 60 ft."
 			],
@@ -3860,14 +4159,17 @@
 				"Draconic",
 				"Dwarvish",
 				"Giant",
-				"Terran"
+				"Terran",
+				"but can't speak (he uses {@spell Rary's telepathic bond} to communicate)"
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
 			"languageTags": [
 				"AU",
 				"C",
+				"CS",
 				"D",
 				"DR",
 				"GI",
@@ -3935,6 +4237,9 @@
 							]
 						}
 					}
+				},
+				"_preserve": {
+					"legendaryGroup": true
 				}
 			},
 			"size": [
@@ -3997,6 +4302,7 @@
 			"languages": [
 				"Common"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C"
 			],
@@ -4083,6 +4389,12 @@
 					]
 				}
 			},
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"human"
+				]
+			},
 			"alignment": [
 				"L",
 				"N"
@@ -4090,6 +4402,7 @@
 			"languages": [
 				"Common"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C"
 			],
@@ -4156,6 +4469,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"SD"
 			],
@@ -4198,8 +4512,30 @@
 			"languages": null,
 			"cr": "0",
 			"action": null,
+			"tokenCustom": true,
 			"languageTags": [],
 			"hasToken": true
+		},
+		{
+			"name": "Rishindar",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WDMM",
+			"page": 202,
+			"_copy": {
+				"name": "Githzerai Zerth",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the githzerai",
+						"with": "Rishindar",
+						"flags": "i"
+					}
+				}
+			},
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Rowboat Mimic",
@@ -4226,17 +4562,41 @@
 				"name": "Behir",
 				"source": "MM"
 			},
-			"legendary": [
+			"spellcasting": [
 				{
 					"name": "Lesser Magic",
-					"entries": [
-						"The behir casts {@spell color spray} or {@spell sleep}, requiring no components."
+					"type": "spellcasting",
+					"headerEntries": [
+						"The behir casts {@spell color spray} or {@spell sleep}, requiring no components. Its spellcasting ability is Charisma (spell save {@dc 13})."
+					],
+					"legendary": {
+						"1e": [
+							"{@spell color spray}",
+							"{@spell sleep}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "legendary",
+					"hidden": [
+						"legendary"
 					]
 				},
 				{
 					"name": "Greater Magic (Costs 2 Actions)",
-					"entries": [
+					"type": "spellcasting",
+					"headerEntries": [
 						"The behir casts {@spell invisibility} or {@spell misty step}, requiring no components."
+					],
+					"legendary": {
+						"2e": [
+							"{@spell invisibility}",
+							"{@spell misty step}"
+						]
+					},
+					"ability": "cha",
+					"displayAs": "legendary",
+					"hidden": [
+						"legendary"
 					]
 				}
 			],
@@ -4448,7 +4808,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in dim light or darkness, the assassin can take the Hide action as a bonus action."
+						"While in dim light or darkness, the assassin can take the {@action Hide} action as a bonus action."
 					]
 				},
 				{
@@ -4468,7 +4828,7 @@
 				{
 					"name": "Shadow Blade",
 					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}7 ({@damage 1d6 + 4}) piercing damage plus 10 ({@damage 3d6}) necrotic damage. Unless the target is immune to necrotic damage, the target's Strength score is reduced by {@dice 1d4} each time it is hit by this attack. The target dies if its Strength is reduced to 0. The reduction lasts until the target finishes a short or long rest. If a non-evil humanoid dies from this attack, a shadow (see the Monster Manual) rises from the corpse {@dice 1d4} hours later."
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}7 ({@damage 1d6 + 4}) piercing damage plus 10 ({@damage 3d6}) necrotic damage. Unless the target is immune to necrotic damage, the target's Strength score is reduced by {@dice 1d4} each time it is hit by this attack. The target dies if its Strength is reduced to 0. The reduction lasts until the target finishes a short or long rest. If a non-evil humanoid dies from this attack, a {@creature shadow} (see the Monster Manual) rises from the corpse {@dice 1d4} hours later."
 					]
 				}
 			],
@@ -4619,6 +4979,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Immutable Form"
 			],
@@ -4673,6 +5034,7 @@
 				"L",
 				"E"
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -4704,6 +5066,7 @@
 				"Common",
 				"Halfling"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"C",
 				"H"
@@ -4726,6 +5089,10 @@
 					}
 				}
 			},
+			"cr": {
+				"cr": "0",
+				"xp": 0
+			},
 			"action": null,
 			"damageTags": [],
 			"miscTags": [],
@@ -4741,6 +5108,12 @@
 				"name": "Adult Silver Dragon",
 				"source": "MM",
 				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the dragon",
+						"with": "Stalagma",
+						"flags": "i"
+					},
 					"action": {
 						"mode": "replaceArr",
 						"replace": "Breath Weapons {@recharge 5}",
@@ -4778,6 +5151,7 @@
 				"Dwarvish",
 				"Terran"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"D",
 				"DR",
@@ -4806,17 +5180,18 @@
 						"with": "statue",
 						"flags": "i"
 					},
-					"trait": {
+					"bonus": {
 						"mode": "appendArr",
 						"items": {
 							"name": "Magic Theft",
 							"entries": [
-								"As a bonus action, the golem targets one creature it can see within 30 feet of it. The target must succeed on a {@dc 17} Charisma saving throw, or all magic items in its possession are teleported to the bottom of the pit in {@adventure area 31|WDMM|15|31. Hall of Embers}."
+								"The golem targets one creature it can see within 30 feet of it. The target must succeed on a {@dc 17} Charisma saving throw, or all magic items in its possession are teleported to the bottom of the pit in {@adventure area 31|WDMM|15|31. Hall of Embers}."
 							]
 						}
 					}
 				}
 			},
+			"tokenCustom": true,
 			"hasToken": true
 		},
 		{
@@ -4847,6 +5222,7 @@
 				"Infernal",
 				"and Undercommon but can't speak"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"AB",
 				"C",
@@ -4894,6 +5270,7 @@
 				"Common",
 				"Giant"
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -4954,13 +5331,17 @@
 				"N",
 				"E"
 			],
+			"languages": [
+				"Common",
+				"Dwarvish"
+			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
 			"languageTags": [
 				"C",
-				"D",
-				"X"
+				"D"
 			],
 			"damageTags": [
 				"B",
@@ -4997,6 +5378,7 @@
 				"C",
 				"E"
 			],
+			"tokenCustom": true,
 			"traitTags": [
 				"Amphibious",
 				"Sneak Attack"
@@ -5245,12 +5627,24 @@
 						"name": "Legendary Shadow Dragon",
 						"source": "MM"
 					}
-				]
+				],
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the dragon",
+						"with": "Umbraxakar",
+						"flags": "i"
+					}
+				}
 			},
 			"alignment": [
 				"N",
 				"E"
 			],
+			"legendaryGroup": {
+				"name": "Shadow Dragon (Bronze Dragon)",
+				"source": "MM"
+			},
 			"traitTags": [
 				"Amphibious",
 				"Legendary Resistances",
@@ -5320,6 +5714,7 @@
 					]
 				}
 			],
+			"tokenCustom": true,
 			"hasToken": true,
 			"hasFluff": true
 		},
@@ -5370,6 +5765,7 @@
 				"Troglodyte",
 				"Undercommon"
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"SD"
 			],
@@ -5432,6 +5828,7 @@
 				"Deep Speech",
 				"Undercommon"
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"B"
 			],
@@ -5442,6 +5839,27 @@
 				"U"
 			],
 			"hasToken": true
+		},
+		{
+			"name": "Vond",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WDMM",
+			"page": 202,
+			"_copy": {
+				"name": "Githzerai Zerth",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the githzerai",
+						"with": "Vond",
+						"flags": "i"
+					}
+				}
+			},
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Werebat",
@@ -5528,7 +5946,7 @@
 				{
 					"name": "Nimble Escape (Humanoid Form Only)",
 					"entries": [
-						"The werebat can take the Disengage or Hide action as a bonus action on each of its turns."
+						"The werebat can take the {@action Disengage} or {@action Hide} action as a bonus action on each of its turns."
 					]
 				},
 				{
@@ -5548,7 +5966,7 @@
 				{
 					"name": "Bite (Bat or Hybrid Form Only)",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one creature. {@h}6 ({@damage 1d6 + 3}) piercing damage, and the werebat gains temporary hit points equal to the damage dealt. If the target is a humanoid, it must succeed on a {@dc 10} Constitution saving throw or be cursed with werebat lycanthropy."
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one creature. {@h}6 ({@damage 1d6 + 3}) piercing damage, and the werebat gains temporary hit points equal to the damage dealt. If the target is a humanoid, it must succeed on a {@dc 10} Constitution saving throw or be cursed with werebat {@variantrule Player Characters as Lycanthropes|MM|lycanthropy}."
 					]
 				},
 				{
@@ -5683,7 +6101,107 @@
 				"E"
 			],
 			"hasToken": true,
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Xarann A'Daragon",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WDMM",
+			"page": 145,
+			"_copy": {
+				"name": "Assassin",
+				"source": "MM",
+				"_templates": [
+					{
+						"name": "Drow (Levitate)",
+						"source": "PHB"
+					}
+				],
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the assassin",
+						"with": "Xarann",
+						"flags": "i"
+					},
+					"trait": {
+						"mode": "appendArr",
+						"items": {
+							"name": "Special Equipment",
+							"entries": [
+								"Xarann wears a {@item Piwafwi (Cloak of Elvenkind)|OotA|piwafwi}, a drow-made {@item cloak of elvenkind}. It loses its magic if exposed to sunlight for 1 hour without interruption."
+							]
+						}
+					}
+				}
+			},
+			"alignment": [
+				"N",
+				"E"
+			],
+			"languages": [
+				"Elvish",
+				"Undercommon"
+			],
+			"languageTags": [
+				"E",
+				"U"
+			],
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Xorta",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WDMM",
+			"page": 98,
+			"_copy": {
+				"name": "Stone Giant",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the giant",
+						"with": "Xorta",
+						"flags": "i"
+					}
+				}
+			},
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Yrlakka",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WDMM",
+			"page": 202,
+			"_copy": {
+				"name": "Githzerai Zerth",
+				"source": "MM",
+				"_mod": {
+					"*": {
+						"mode": "replaceTxt",
+						"replace": "the githzerai",
+						"with": "Yrlakka",
+						"flags": "i"
+					},
+					"trait": {
+						"mode": "appendArr",
+						"items": {
+							"name": "Special Equipment",
+							"entries": [
+								"Yrlakka carries a {@item Potion of Fire Resistance||potion of resistance (fire)} in a tiny crystal vial fastened to a cord around his right ankle, and he has a {@item wand of magic detection} hanging from his belt."
+							]
+						}
+					}
+				}
+			},
+			"hasToken": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Zalthar Shadowdusk",
@@ -5738,6 +6256,7 @@
 				"Common",
 				"Deep Speech"
 			],
+			"tokenCustom": true,
 			"languageTags": [
 				"AB",
 				"C",
@@ -5815,12 +6334,12 @@
 				"Common",
 				"Dwarvish"
 			],
-			"cr": "13",
+			"cr": "14",
 			"trait": [
 				{
 					"name": "Dwarven Resilience",
 					"entries": [
-						"Augrek has advantage on saving throws against poison."
+						"Zorak has advantage on saving throws against poison, and has resistance against poison damage."
 					]
 				},
 				{
@@ -5847,7 +6366,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"Zorak regains 20 hit points at the start of his turn if he has at least 1 hit point and isn't in sunlight or running water. If Zorak takes radiant damage or damage from holy water, this trait doesn't function at the start of Zorak's next turn."
+						"Zorak regains 20 hit points at the start of his turn if he has at least 1 hit point and isn't in sunlight or running water. If Zorak takes radiant damage or damage from {@item Holy Water (Flask)|PHB|holy water}, this trait doesn't function at the start of Zorak's next turn."
 					]
 				},
 				{
@@ -5958,6 +6477,7 @@
 				"name": "Vampire",
 				"source": "MM"
 			},
+			"tokenCustom": true,
 			"attachedItems": [
 				"dwarven thrower|dmg"
 			],
@@ -6031,6 +6551,10 @@
 					}
 				}
 			},
+			"alignment": [
+				"C",
+				"G"
+			],
 			"languages": [
 				"Aquan",
 				"Auran",
@@ -6039,6 +6563,7 @@
 				"Ignan",
 				"Terran"
 			],
+			"tokenCustom": true,
 			"senseTags": [
 				"D"
 			],
@@ -6062,14 +6587,30 @@
 				"name": "Drow House Captain",
 				"source": "MTF",
 				"_mod": {
-					"*": {
-						"mode": "replaceTxt",
-						"replace": "the drow",
-						"with": "Zress",
-						"flags": "i"
-					}
+					"*": [
+						{
+							"mode": "replaceTxt",
+							"replace": "the drow",
+							"with": "Zress",
+							"flags": "i"
+						},
+						{
+							"mode": "replaceTxt",
+							"replace": "\\bhis\\b",
+							"with": "her"
+						}
+					]
 				}
 			},
+			"ac": [
+				{
+					"ac": 18,
+					"from": [
+						"{@item mithral plate armor|dmg}"
+					]
+				}
+			],
+			"tokenCustom": true,
 			"hasToken": true
 		}
 	]

--- a/json/bestiary/bestiary-wtthc.json
+++ b/json/bestiary/bestiary-wtthc.json
@@ -1,0 +1,1526 @@
+{
+	"_meta": {
+		"dependencies": {
+			"monster": [
+				"XMM"
+			]
+		},
+		"otherSources": {
+			"monster": {
+				"XMM": "HotB"
+			}
+		}
+	},
+	"monster": [
+		{
+			"name": "Ankheg",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Ankheg",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Barbed Devil",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Barbed Devil",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Bearded Devil",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Bearded Devil",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Commoner",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Commoner",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Corrupted Rat",
+			"source": "WttHC",
+			"size": [
+				"T"
+			],
+			"type": "monstrosity",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				10
+			],
+			"hp": {
+				"average": 1,
+				"formula": "1d4 - 1"
+			},
+			"speed": {
+				"walk": 20,
+				"climb": 20
+			},
+			"str": 2,
+			"dex": 11,
+			"con": 9,
+			"int": 2,
+			"wis": 11,
+			"cha": 4,
+			"skill": {
+				"perception": "+2",
+				"stealth": "+2"
+			},
+			"senses": [
+				"Darkvision 30 ft."
+			],
+			"passive": 11,
+			"cr": "0",
+			"trait": [
+				{
+					"name": "Agile",
+					"entries": [
+						"The rat doesn't provoke Opportunity Attacks when it moves out of an enemy's reach."
+					]
+				},
+				{
+					"name": "Death Burst",
+					"entries": [
+						"The rat explodes when it dies. {@actSave con} {@dc 9}, each creature in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the rat. {@actSaveFail} 1 Acid damage."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 2}, reach 5 ft. {@h}1 Piercing damage."
+					]
+				}
+			],
+			"traitTags": [
+				"Death Burst"
+			],
+			"senseTags": [
+				"D"
+			],
+			"damageTags": [
+				"A",
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Cultist of Demogorgon",
+			"source": "WttHC",
+			"size": [
+				"S",
+				"M"
+			],
+			"type": "humanoid",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 9,
+				"formula": "2d8"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 11,
+			"dex": 14,
+			"con": 10,
+			"int": 10,
+			"wis": 11,
+			"cha": 10,
+			"save": {
+				"wis": "+2"
+			},
+			"skill": {
+				"deception": "+2",
+				"religion": "+2"
+			},
+			"passive": 10,
+			"languages": [
+				"Common"
+			],
+			"cr": "1/8",
+			"action": [
+				{
+					"name": "Ritual Sickle",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}{@damage 1d4 + 2} Slashing damage plus 1 Necrotic damage."
+					]
+				}
+			],
+			"languageTags": [
+				"C"
+			],
+			"damageTags": [
+				"N"
+			],
+			"miscTags": [
+				"MA",
+				"MLW"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Dardew",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WttHC",
+			"size": [
+				"M"
+			],
+			"type": "fiend",
+			"alignment": [
+				"C",
+				"N"
+			],
+			"ac": [
+				19
+			],
+			"hp": {
+				"average": 105,
+				"formula": "14d8 + 42"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": 60
+			},
+			"str": 18,
+			"dex": 18,
+			"con": 16,
+			"int": 14,
+			"wis": 12,
+			"cha": 16,
+			"save": {
+				"int": "+5",
+				"cha": "+6"
+			},
+			"skill": {
+				"deception": "+6",
+				"perception": "+4",
+				"performance": "+9"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 14,
+			"resist": [
+				"cold",
+				"fire",
+				"lightning",
+				"poison"
+			],
+			"conditionImmune": [
+				"poisoned"
+			],
+			"languages": [
+				"Abyssal",
+				"Common",
+				"Infernal"
+			],
+			"cr": "5",
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Dardew makes two attacks, using Fiery Claw or Power Chord in any combination."
+					]
+				},
+				{
+					"name": "Fiery Claw",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Slashing damage plus 7 ({@damage 2d6}) Fire damage."
+					]
+				},
+				{
+					"name": "Power Chord",
+					"entries": [
+						"{@actSave con} {@dc 14}, one creature Dardew can see within 120 ft. {@actSaveFail} 13 ({@damage 3d6 + 3}) Thunder damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Silver Tongue",
+					"entries": [
+						"{@actSave cha} {@dc 14}, one creature Dardew can see within 60 feet. {@actSaveFail} The creature has the {@condition Charmed|XPHB} condition until the start of Dardew's next turn."
+					]
+				}
+			],
+			"senseTags": [
+				"SD"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"AB",
+				"C",
+				"I"
+			],
+			"damageTags": [
+				"F",
+				"S",
+				"T"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"charmed"
+			],
+			"savingThrowForced": [
+				"charisma",
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Demobat",
+			"source": "WttHC",
+			"size": [
+				"T"
+			],
+			"type": {
+				"type": "fiend",
+				"tags": [
+					"demon"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 21,
+				"formula": "6d4 + 6"
+			},
+			"speed": {
+				"walk": 10,
+				"fly": 40
+			},
+			"str": 4,
+			"dex": 16,
+			"con": 12,
+			"int": 2,
+			"wis": 10,
+			"cha": 6,
+			"senses": [
+				"Blindsight 60 ft."
+			],
+			"passive": 10,
+			"resist": [
+				"cold",
+				"lightning"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"poisoned"
+			],
+			"cr": "1/2",
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 5} (with {@variantrule Advantage|XPHB} if the target is {@condition Grappled|XPHB} by a Demobat), reach 5 ft. {@h}10 ({@damage 2d6 + 3}) Piercing damage."
+					]
+				},
+				{
+					"name": "Tentacles",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}7 ({@damage 1d8 + 3}) Slashing damage. If the target is a Medium or smaller creature, the target has the {@condition Grappled|XPHB} condition (escape {@dc 13}) from all four tentacles."
+					]
+				}
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Tentacles"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"grappled"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Demodog",
+			"source": "WttHC",
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "fiend",
+				"tags": [
+					"demon"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				14
+			],
+			"hp": {
+				"average": 27,
+				"formula": "6d6 + 6"
+			},
+			"speed": {
+				"walk": 50
+			},
+			"str": 16,
+			"dex": 15,
+			"con": 12,
+			"int": 6,
+			"wis": 12,
+			"cha": 6,
+			"skill": {
+				"stealth": "+4"
+			},
+			"senses": [
+				"Blindsight 60 ft."
+			],
+			"passive": 11,
+			"resist": [
+				"cold",
+				"lightning"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"poisoned"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Pack Tactics",
+					"entries": [
+						"The demodog has {@variantrule Advantage|XPHB} on an attack roll against a creature if at least one of the demodog's allies is within 5 feet of the creature and the ally doesn't have the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}8 ({@damage 1d10 + 3}) Piercing damage. If the target is a Medium or smaller creature, it has the {@condition Prone|XPHB} condition."
+					]
+				}
+			],
+			"traitTags": [
+				"Pack Tactics"
+			],
+			"senseTags": [
+				"B"
+			],
+			"damageTags": [
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"prone"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Demodragon",
+			"source": "WttHC",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "fiend",
+				"tags": [
+					"demon"
+				]
+			},
+			"ac": [
+				16
+			],
+			"hp": {
+				"average": 102,
+				"formula": "12d12 + 24"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 60
+			},
+			"initiative": {
+				"proficiency": 1
+			},
+			"str": 19,
+			"dex": 10,
+			"con": 15,
+			"int": 8,
+			"wis": 12,
+			"cha": 10,
+			"save": {
+				"con": "+5",
+				"wis": "+4"
+			},
+			"senses": [
+				"Blindsight 120 ft."
+			],
+			"passive": 11,
+			"resist": [
+				"acid",
+				"cold",
+				"lightning"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"cr": "5",
+			"trait": [
+				{
+					"name": "Baleful Presence",
+					"entries": [
+						"Sources of light in a 120-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the demodragon flicker wildly. Nonmagical sources of {@variantrule Bright Light|XPHB} in that area instead shed {@variantrule Dim Light|XPHB}."
+					]
+				},
+				{
+					"name": "Regeneration",
+					"entries": [
+						"The demodragon regains 10 {@variantrule Hit Points|XPHB} at the start of each of its turns if it has at least 1 {@variantrule Hit Points|XPHB|Hit Point}"
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The demodragon makes two Bite attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 7}, reach 10 ft. {@h}11 ({@damage 2d6 + 4}) Piercing damage plus 4 ({@damage 1d8}) Acid damage."
+					]
+				},
+				{
+					"name": "Acid Breath {@recharge 5}",
+					"entries": [
+						"{@actSave dex} {@dc 13}, each creature in a 30-foot-long, 5-foot-wide {@variantrule Line [Area of Effect]|XPHB|Line}. {@actSaveFail} 22 ({@damage 4d10}) Acid damage. {@actSaveSuccess} Half damage."
+					]
+				}
+			],
+			"traitTags": [
+				"Regeneration"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"damageTags": [
+				"A",
+				"P"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"savingThrowForced": [
+				"dexterity"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Demogorgon Spawn",
+			"source": "WttHC",
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "fiend",
+				"tags": [
+					"demon"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				15
+			],
+			"hp": {
+				"average": 44,
+				"formula": "8d8 + 8"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 17,
+			"dex": 15,
+			"con": 13,
+			"int": 8,
+			"wis": 12,
+			"cha": 7,
+			"skill": {
+				"perception": "+3",
+				"stealth": "+4"
+			},
+			"senses": [
+				"Blindsight 60 ft."
+			],
+			"passive": 13,
+			"resist": [
+				"cold",
+				"lightning"
+			],
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"cr": "2",
+			"trait": [
+				{
+					"name": "Baleful Presence",
+					"entries": [
+						"Sources of light in a 60-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the spawn flicker wildly. Nonmagical sources of {@variantrule Bright Light|XPHB} in that area instead shed {@variantrule Dim Light|XPHB}."
+					]
+				},
+				{
+					"name": "Regeneration",
+					"entries": [
+						"The spawn regains 5 {@variantrule Hit Points|XPHB} at the start of each of its turns if it has at least 1 {@variantrule Hit Points|XPHB|Hit Point}."
+					]
+				},
+				{
+					"name": "Running Leap",
+					"entries": [
+						"With a 10-foot running start, the spawn can {@variantrule Long Jump|XPHB} up to 30 feet."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The spawn makes two Claw attacks."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 10 ft. {@h}6 ({@damage 1d6 + 3}) Slashing damage."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}5 ({@damage 1d4 + 3}) Piercing damage. If the target is a Medium or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 13}). While {@condition Grappled|XPHB}, the target has the {@condition Blinded|XPHB} condition."
+					]
+				}
+			],
+			"traitTags": [
+				"Regeneration"
+			],
+			"senseTags": [
+				"B"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"blinded",
+				"grappled"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Dretch",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Dretch",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Flizzlebin",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WttHC",
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"gnome"
+				]
+			},
+			"alignment": [
+				"C",
+				"G"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 38,
+				"formula": "7d6 + 14"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 8,
+			"dex": 14,
+			"con": 15,
+			"int": 16,
+			"wis": 10,
+			"cha": 12,
+			"skill": {
+				"arcana": "+5",
+				"stealth": "+4"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 10,
+			"languages": [
+				"Common",
+				"Dwarvish",
+				"Gnomish"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"Flizzlebin has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"name": "Ventriloquist",
+					"entries": [
+						"Flizzlebin can project his voice from anywhere within 1 mile of himself."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Dazzling Confetti",
+					"entries": [
+						"{@atkr m,r} {@hit 5}, reach 5 ft. or range 60 ft. {@h}10 ({@damage 2d6 + 3}) Radiant damage."
+					]
+				},
+				{
+					"name": "Vanishing Trick (3/Day)",
+					"entries": [
+						"Flizzlebin has the {@condition Invisible|XPHB} condition for 10 minutes. This effect ends early immediately after Flizzlebin makes an attack roll, deals damage, or has the {@condition Incapacitated|XPHB} condition, or if his hat is removed."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Distracting Glitter",
+					"entries": [
+						"{@actTrigger} Flizzlebin is hit by an attack roll. {@actResponse} Flizzlebin adds 2 to his AC against that attack, possibly causing it to miss."
+					]
+				}
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"D"
+			],
+			"languageTags": [
+				"C",
+				"D",
+				"G"
+			],
+			"damageTags": [
+				"R"
+			],
+			"miscTags": [
+				"MA",
+				"RA"
+			],
+			"conditionInflict": [
+				"incapacitated",
+				"invisible"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Giant Corrupted Rat",
+			"source": "WttHC",
+			"size": [
+				"S"
+			],
+			"type": "monstrosity",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 18,
+				"formula": "4d6"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": 30
+			},
+			"str": 7,
+			"dex": 16,
+			"con": 12,
+			"int": 2,
+			"wis": 10,
+			"cha": 4,
+			"skill": {
+				"perception": "+12",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 60 ft."
+			],
+			"passive": 12,
+			"cr": "1/2",
+			"trait": [
+				{
+					"name": "Death Burst",
+					"entries": [
+						"The rat explodes when it dies. Constitution {@variantrule Saving Throw|XPHB} {@dc 11}, each creature in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the rat. {@actSaveFail} 5 ({@damage 2d4}) Acid damage. {@actSaveSuccess} Half damage."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 5}, Reach 5 ft. {@h}6 ({@damage 1d6 + 3}) Piercing damage plus 5 ({@damage 2d4}) Acid damage."
+					]
+				}
+			],
+			"traitTags": [
+				"Death Burst"
+			],
+			"senseTags": [
+				"D"
+			],
+			"damageTags": [
+				"A",
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Giant Spider",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Giant Spider",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Gnoll Warrior",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Gnoll Warrior",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Goblin Warrior",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Goblin Warrior",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Guard",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Guard",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Hell Hound",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Hell Hound",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Imp Trickster",
+			"source": "WttHC",
+			"size": [
+				"T"
+			],
+			"type": {
+				"type": "fiend",
+				"tags": [
+					"devil"
+				]
+			},
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 21,
+				"formula": "6d4"
+			},
+			"speed": {
+				"walk": 20,
+				"fly": 40,
+				"climb": 20
+			},
+			"str": 6,
+			"dex": 17,
+			"con": 13,
+			"int": 11,
+			"wis": 12,
+			"cha": 14,
+			"skill": {
+				"deception": "+4",
+				"insight": "+3",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 11,
+			"resist": [
+				"cold"
+			],
+			"immune": [
+				"fire",
+				"poison"
+			],
+			"conditionImmune": [
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Infernal"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The imp has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Sting",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}{@damage 1d6 + 3} Piercing damage plus {@damage 2d6} Poison damage."
+					]
+				},
+				{
+					"name": "Invisibility",
+					"entries": [
+						"The imp has the {@condition Invisible|XPHB} condition for 1 minute. This effect ends early immediately after the imp makes an attack roll or deals damage, or if the imp has the {@condition Incapacitated|XPHB} condition."
+					]
+				},
+				{
+					"name": "Shape-Shift",
+					"entries": [
+						"The imp shape-shifts to resemble a rat ({@variantrule Speed|XPHB} 20 ft.), a raven (20 ft., Fly 60 ft.), or a spider (20 ft., Climb 20 ft.), or it returns to its true form. Its game statistics are the same in each form, except for its {@variantrule Speed|XPHB}. Any equipment it is wearing or carrying isn't transformed."
+					]
+				}
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"languageTags": [
+				"C",
+				"I"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"incapacitated",
+				"invisible"
+			],
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Korex",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WttHC",
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"elf"
+				]
+			},
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"average": 52,
+				"formula": "8d8"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 13,
+			"dex": 16,
+			"con": 14,
+			"int": 8,
+			"wis": 12,
+			"cha": 15,
+			"skill": {
+				"perception": "+3",
+				"performance": "+4",
+				"stealth": "+5"
+			},
+			"senses": [
+				"Darkvision 120 ft."
+			],
+			"passive": 13,
+			"immune": [
+				"poison"
+			],
+			"conditionImmune": [
+				"poisoned"
+			],
+			"languages": [
+				"Common",
+				"Elvish"
+			],
+			"cr": "2",
+			"gear": [
+				"pipes of pestilence|wtthc"
+			],
+			"trait": [
+				{
+					"name": "Sewer Speech",
+					"entries": [
+						"Korex can comprehend and verbally communicate with Monstrosities."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Rancid Knife",
+					"entries": [
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}8 ({@damage 2d4 + 3}) Piercing damage plus 7 ({@damage 2d6}) Poison damage, and the target has the {@condition Poisoned|XPHB} condition until the start of Korex's next turn."
+					]
+				},
+				{
+					"name": "Entrancing Pipes",
+					"entries": [
+						"{@actSave wis} {@dc 12}, one creature Korex can see within 120 feet. {@actSaveFail} 14 ({@damage 4d6}) Psychic damage, and the target has the {@condition Charmed|XPHB} condition until the start of Korex's next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Skitter",
+					"entries": [
+						"Korex takes the {@action Dash|XPHB} or {@action Disengage|XPHB} action."
+					]
+				}
+			],
+			"senseTags": [
+				"SD"
+			],
+			"languageTags": [
+				"C",
+				"E"
+			],
+			"damageTags": [
+				"I",
+				"P",
+				"Y"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"charmed",
+				"poisoned"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Medusa",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Medusa",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Myconid Adult",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Myconid Adult",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Needle Blight",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Needle Blight",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Rilly June",
+			"isNpc": true,
+			"isNamedCreature": true,
+			"source": "WttHC",
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "humanoid",
+				"tags": [
+					"halfling"
+				]
+			},
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 13,
+				"formula": "3d6"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 14,
+			"dex": 14,
+			"con": 13,
+			"int": 10,
+			"wis": 13,
+			"cha": 10,
+			"save": {
+				"wis": "+3"
+			},
+			"skill": {
+				"nature": "+2",
+				"perception": "+3",
+				"survival": "+3"
+			},
+			"passive": 13,
+			"languages": [
+				"Common",
+				"Halfling"
+			],
+			"cr": "1/2",
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"Rilly June makes two Hayfork attacks."
+					]
+				},
+				{
+					"name": "Hayfork",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}6 ({@damage 1d8 + 2}) Piercing damage."
+					]
+				},
+				{
+					"name": "G'wan, Git! (1/Day)",
+					"entries": [
+						"{@actSave wis} {@dc 11}, one creature Rilly June can see within 60 feet. {@actSaveFail} 10 ({@damage 3d6}) Psychic damage, and the target has the {@condition Frightened|XPHB} condition until the end of its next turn. {@actSaveSuccess} Half damage only."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"C",
+				"H"
+			],
+			"damageTags": [
+				"P",
+				"Y"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"conditionInflict": [
+				"frightened"
+			],
+			"savingThrowForced": [
+				"wisdom"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Scarecrow",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Scarecrow",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Shadow",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Shadow",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Shrieker Fungus",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Shrieker Fungus",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Swarm of Corrupted Rats",
+			"source": "WttHC",
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "monstrosity",
+				"swarmSize": "T"
+			},
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 27,
+				"formula": "6d8"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": 30
+			},
+			"str": 9,
+			"dex": 14,
+			"con": 10,
+			"int": 2,
+			"wis": 11,
+			"cha": 4,
+			"save": {
+				"dex": "+4"
+			},
+			"senses": [
+				"Darkvision 30 ft."
+			],
+			"passive": 10,
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"slashing"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"prone",
+				"restrained",
+				"stunned"
+			],
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Death Burst",
+					"entries": [
+						"The rat explodes when it dies. {@actSave con} {@dc 10}, each creature in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the rat. {@actSaveFail} {@damage 2d4} Acid Damage. {@actSaveSuccess} Half damage."
+					]
+				},
+				{
+					"name": "Swarm",
+					"entries": [
+						"The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny rat. The swarm can't regain {@variantrule Hit Points|XPHB}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atkr m} {@hit 4}, Reach 5 ft. {@h}6 ({@damage 2d4 + 2}) Piercing damage or {@damage 1d4 + 2} Piercing damage if the swarm is Bloodied."
+					]
+				}
+			],
+			"traitTags": [
+				"Death Burst"
+			],
+			"senseTags": [
+				"D"
+			],
+			"damageTags": [
+				"P"
+			],
+			"miscTags": [
+				"MA"
+			],
+			"savingThrowForced": [
+				"constitution"
+			],
+			"hasToken": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Vine Blight Tangler",
+			"source": "WttHC",
+			"size": [
+				"M"
+			],
+			"type": "plant",
+			"alignment": [
+				"N",
+				"E"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 19,
+				"formula": "3d8"
+			},
+			"speed": {
+				"walk": 20
+			},
+			"str": 15,
+			"dex": 8,
+			"con": 14,
+			"int": 5,
+			"wis": 10,
+			"cha": 3,
+			"skill": {
+				"stealth": "+1"
+			},
+			"senses": [
+				"Blindsight 60 ft."
+			],
+			"passive": 10,
+			"conditionImmune": [
+				"deafened"
+			],
+			"languages": [
+				"Common"
+			],
+			"cr": "1/2",
+			"action": [
+				{
+					"name": "Constricting Vine",
+					"entries": [
+						"{@atkr m} {@hit 4}, reach 10 ft. {@h}{@damage 1d10 + 2} Bludgeoning damage. If the target is a Large or smaller creature, it has the {@condition Grappled|XPHB} condition (escape {@dc 12}) from one of three vines."
+					]
+				},
+				{
+					"name": "Entangling Vines {@recharge 5}",
+					"entries": [
+						"Grasping vines momentarily appear on each enemy in a 10-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point of the blight's choice within 60 feet of it. Each target must succeed on a {@dc 12} Strength saving throw or have the {@condition Restrained|XPHB} condition until the start of the blight's next turn."
+					]
+				}
+			],
+			"senseTags": [
+				"B"
+			],
+			"languageTags": [
+				"C"
+			],
+			"miscTags": [
+				"AOE",
+				"MA",
+				"RCH"
+			],
+			"conditionInflict": [
+				"grappled",
+				"restrained"
+			],
+			"savingThrowForced": [
+				"strength"
+			],
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Violet Fungus",
+			"source": "WttHC",
+			"isReprinted": true,
+			"_copy": {
+				"name": "Violet Fungus",
+				"source": "XMM"
+			},
+			"hasToken": true,
+			"hasFluff": true,
+			"hasFluffImages": true
+		}
+	]
+}

--- a/json/bestiary/bestiary-xdmg.json
+++ b/json/bestiary/bestiary-xdmg.json
@@ -33,7 +33,7 @@
 			"wis": 16,
 			"cha": 16,
 			"senses": [
-				"truesight 60 ft."
+				"Truesight 60 ft."
 			],
 			"passive": 13,
 			"immune": [
@@ -57,7 +57,7 @@
 				{
 					"name": "Incorporeal Movement",
 					"entries": [
-						"The avatar can move through other creatures and objects as if they were Difficult Terrain. It takes 5 ({@damage 1d10}) Force damage if it ends its turn inside an object."
+						"The avatar can move through other creatures and objects as if they were {@variantrule Difficult Terrain|XPHB}. It takes 5 ({@damage 1d10}) Force damage if it ends its turn inside an object."
 					]
 				}
 			],
@@ -126,7 +126,7 @@
 			"wis": 10,
 			"cha": 3,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"cr": {

--- a/json/bestiary/bestiary-xmm.json
+++ b/json/bestiary/bestiary-xmm.json
@@ -4,6 +4,9 @@
 			"name": "Aarakocra Aeromancer",
 			"source": "XMM",
 			"page": 10,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -217,6 +220,11 @@
 			"name": "Aberrant Cultist",
 			"source": "XMM",
 			"page": 86,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -255,7 +263,7 @@
 				"religion": "+6"
 			},
 			"senses": [
-				"darkvision 90 ft."
+				"Darkvision 90 ft."
 			],
 			"passive": 17,
 			"languages": [
@@ -366,6 +374,9 @@
 			"page": 12,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -405,7 +416,7 @@
 				"perception": "+10"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 20,
 			"languages": [
@@ -503,7 +514,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/aboleth.mp3"
+				"path": "bestiary/aboleth.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -583,7 +594,7 @@
 				"stealth": "+8"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 19,
 			"immune": [
@@ -641,7 +652,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/abominable-yeti.mp3"
+				"path": "bestiary/abominable-yeti.opus"
 			},
 			"senseTags": [
 				"D"
@@ -681,10 +692,10 @@
 			"page": 39,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"FRAiF"
 			],
 			"size": [
 				"H"
@@ -729,8 +740,8 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 21,
 			"immune": [
@@ -834,7 +845,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-dragon.mp3"
+				"path": "bestiary/black-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -893,10 +904,9 @@
 			"page": 49,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DotSC"
 			],
 			"size": [
 				"H"
@@ -941,8 +951,8 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 22,
 			"immune": [
@@ -1042,7 +1052,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-dragon.mp3"
+				"path": "bestiary/blue-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -1144,8 +1154,8 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 21,
 			"immune": [
@@ -1170,7 +1180,7 @@
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Minor Illusion|XPHB}",
 						"{@spell Scorching Ray|XPHB}",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)",
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)",
 						"{@spell Speak with Animals|XPHB}"
 					],
 					"daily": {
@@ -1251,7 +1261,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brass-dragon.mp3"
+				"path": "bestiary/brass-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -1350,8 +1360,8 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 22,
 			"immune": [
@@ -1375,7 +1385,7 @@
 					"will": [
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Guiding Bolt|XPHB} (level 2 version)",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)",
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)",
 						"{@spell Speak with Animals|XPHB}",
 						"{@spell Thaumaturgy|XPHB}"
 					],
@@ -1463,7 +1473,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bronze-dragon.mp3"
+				"path": "bestiary/bronze-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -1522,10 +1532,10 @@
 			"page": 79,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"FRAiF"
 			],
 			"size": [
 				"H"
@@ -1571,8 +1581,8 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 22,
 			"immune": [
@@ -1597,7 +1607,7 @@
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Mind Spike|XPHB} (level 4 version)",
 						"{@spell Minor Illusion|XPHB}",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
 					],
 					"daily": {
 						"1e": [
@@ -1677,7 +1687,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/copper-dragon.mp3"
+				"path": "bestiary/copper-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -1733,6 +1743,9 @@
 			"page": 145,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -1778,8 +1791,8 @@
 				"stealth": "+8"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 24,
 			"immune": [
@@ -1803,7 +1816,7 @@
 					"will": [
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Guiding Bolt|XPHB} (level 2 version)",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
 					],
 					"daily": {
 						"1e": [
@@ -1890,7 +1903,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gold-dragon.mp3"
+				"path": "bestiary/gold-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -1952,6 +1965,9 @@
 			"page": 153,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -1997,8 +2013,8 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 22,
 			"immune": [
@@ -2103,7 +2119,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-dragon.mp3"
+				"path": "bestiary/green-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -2161,6 +2177,9 @@
 			"page": 255,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -2204,8 +2223,8 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 23,
 			"immune": [
@@ -2303,7 +2322,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-dragon.mp3"
+				"path": "bestiary/red-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -2403,8 +2422,8 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 21,
 			"immune": [
@@ -2429,7 +2448,7 @@
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Hold Monster|XPHB}",
 						"{@spell Ice Knife|XPHB}",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
 					],
 					"daily": {
 						"1e": [
@@ -2510,7 +2529,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/silver-dragon.mp3"
+				"path": "bestiary/silver-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -2572,10 +2591,10 @@
 			"page": 329,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"FRAiF"
 			],
 			"size": [
 				"H"
@@ -2621,8 +2640,8 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 21,
 			"immune": [
@@ -2717,7 +2736,7 @@
 			"dragonAge": "adult",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/white-dragon.mp3"
+				"path": "bestiary/white-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -2768,6 +2787,12 @@
 			"page": 13,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FFotR",
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -2797,7 +2822,7 @@
 			"wis": 10,
 			"cha": 6,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -2859,7 +2884,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/air-elemental.mp3"
+				"path": "bestiary/air-elemental.opus"
 			},
 			"senseTags": [
 				"D"
@@ -2897,6 +2922,9 @@
 			"page": 348,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -2949,7 +2977,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/allosaurus.mp3"
+				"path": "bestiary/allosaurus.opus"
 			},
 			"damageTags": [
 				"P",
@@ -2974,6 +3002,9 @@
 			"page": 40,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"LFL"
+			],
 			"size": [
 				"G"
 			],
@@ -3017,8 +3048,8 @@
 				"stealth": "+9"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 26,
 			"immune": [
@@ -3123,7 +3154,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-dragon.mp3"
+				"path": "bestiary/black-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -3182,10 +3213,10 @@
 			"page": 50,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DotSC",
+				"FRAiF"
 			],
 			"size": [
 				"G"
@@ -3230,8 +3261,8 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 27,
 			"immune": [
@@ -3331,7 +3362,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-dragon.mp3"
+				"path": "bestiary/blue-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -3433,8 +3464,8 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 24,
 			"immune": [
@@ -3459,7 +3490,7 @@
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Minor Illusion|XPHB}",
 						"{@spell Scorching Ray|XPHB} (level 3 version)",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)",
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)",
 						"{@spell Speak with Animals|XPHB}"
 					],
 					"daily": {
@@ -3540,7 +3571,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brass-dragon.mp3"
+				"path": "bestiary/brass-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -3639,8 +3670,8 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 27,
 			"immune": [
@@ -3664,7 +3695,7 @@
 					"will": [
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Guiding Bolt|XPHB} (level 2 version)",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)",
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)",
 						"{@spell Speak with Animals|XPHB}",
 						"{@spell Thaumaturgy|XPHB}"
 					],
@@ -3754,7 +3785,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bronze-dragon.mp3"
+				"path": "bestiary/bronze-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -3815,6 +3846,9 @@
 			"page": 80,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"G"
 			],
@@ -3859,8 +3893,8 @@
 				"stealth": "+8"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 27,
 			"immune": [
@@ -3885,7 +3919,7 @@
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Mind Spike|XPHB} (level 5 version)",
 						"{@spell Minor Illusion|XPHB}",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
 					],
 					"daily": {
 						"1e": [
@@ -3966,7 +4000,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/copper-dragon.mp3"
+				"path": "bestiary/copper-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -4022,6 +4056,10 @@
 			"page": 146,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"LFL"
+			],
 			"size": [
 				"G"
 			],
@@ -4067,8 +4105,8 @@
 				"stealth": "+9"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 27,
 			"immune": [
@@ -4092,7 +4130,7 @@
 					"will": [
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Guiding Bolt|XPHB} (level 4 version)",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
 					],
 					"daily": {
 						"1e": [
@@ -4180,7 +4218,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gold-dragon.mp3"
+				"path": "bestiary/gold-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -4287,8 +4325,8 @@
 				"stealth": "+8"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 27,
 			"immune": [
@@ -4394,7 +4432,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-dragon.mp3"
+				"path": "bestiary/green-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -4453,6 +4491,9 @@
 			"page": 256,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"LFL"
+			],
 			"size": [
 				"G"
 			],
@@ -4496,8 +4537,8 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 26,
 			"immune": [
@@ -4596,7 +4637,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-dragon.mp3"
+				"path": "bestiary/red-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -4696,8 +4737,8 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 26,
 			"immune": [
@@ -4722,7 +4763,7 @@
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Hold Monster|XPHB}",
 						"{@spell Ice Knife|XPHB} (level 2 version)",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
 					],
 					"daily": {
 						"1e": [
@@ -4805,7 +4846,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/silver-dragon.mp3"
+				"path": "bestiary/silver-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -4912,8 +4953,8 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 23,
 			"immune": [
@@ -5008,7 +5049,7 @@
 			"dragonAge": "ancient",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/white-dragon.mp3"
+				"path": "bestiary/white-dragon.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -5057,6 +5098,9 @@
 			"name": "Animal Lord",
 			"source": "XMM",
 			"page": 15,
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"M"
 			],
@@ -5100,7 +5144,7 @@
 				"stealth": "+13"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 28,
 			"resist": [
@@ -5422,6 +5466,12 @@
 			"page": 16,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"LFL",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -5449,7 +5499,7 @@
 			"wis": 3,
 			"cha": 1,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 6,
 			"immune": [
@@ -5485,7 +5535,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/animated-armor.mp3"
+				"path": "bestiary/animated-armor.opus"
 			},
 			"senseTags": [
 				"B"
@@ -5507,6 +5557,10 @@
 			"name": "Animated Broom",
 			"source": "XMM",
 			"page": 16,
+			"referenceSources": [
+				"EFA",
+				"LFL"
+			],
 			"size": [
 				"S"
 			],
@@ -5539,7 +5593,7 @@
 			"wis": 5,
 			"cha": 1,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 7,
 			"immune": [
@@ -5560,7 +5614,7 @@
 				{
 					"name": "Flyby",
 					"entries": [
-						"The broom doesn't provoke an Opportunity Attack when it flies out of an enemy's reach."
+						"The broom doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
 					]
 				}
 			],
@@ -5597,6 +5651,12 @@
 			"page": 17,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"BQDD",
+				"EFA",
+				"HotB",
+				"RHW"
+			],
 			"size": [
 				"S"
 			],
@@ -5632,7 +5692,7 @@
 				"dex": "+4"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 7,
 			"immune": [
@@ -5679,10 +5739,12 @@
 			"page": 17,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BD",
+				"EFA",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -5711,7 +5773,7 @@
 			"wis": 3,
 			"cha": 1,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 6,
 			"immune": [
@@ -5759,6 +5821,9 @@
 			"page": 18,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -5784,8 +5849,8 @@
 			"wis": 13,
 			"cha": 6,
 			"senses": [
-				"darkvision 60 ft.",
-				"tremorsense 60 ft."
+				"Darkvision 60 ft.",
+				"Tremorsense 60 ft."
 			],
 			"passive": 11,
 			"cr": "2",
@@ -5817,7 +5882,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ankheg.mp3"
+				"path": "bestiary/ankheg.opus"
 			},
 			"traitTags": [
 				"Tunneler"
@@ -5904,7 +5969,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ankylosaurus.mp3"
+				"path": "bestiary/ankylosaurus.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -5934,6 +5999,9 @@
 					"source": "XPHB",
 					"page": 346
 				}
+			],
+			"referenceSources": [
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -5990,7 +6058,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ape.mp3"
+				"path": "bestiary/ape.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -6013,6 +6081,9 @@
 			],
 			"source": "XMM",
 			"page": 19,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -6063,7 +6134,7 @@
 				"perception": "+7"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 17,
 			"resist": [
@@ -6182,7 +6253,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/arcanaloth.mp3"
+				"path": "bestiary/arcanaloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -6236,6 +6307,9 @@
 			"name": "Arch-hag",
 			"source": "XMM",
 			"page": 21,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -6273,7 +6347,7 @@
 				"persuasion": "+21"
 			},
 			"senses": [
-				"truesight 60 ft."
+				"Truesight 60 ft."
 			],
 			"passive": 21,
 			"resist": [
@@ -6486,6 +6560,9 @@
 			"page": 349,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -6567,6 +6644,12 @@
 			"page": 199,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"NF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -6727,7 +6810,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/archmage.mp3"
+				"path": "bestiary/archmage.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -6769,10 +6852,13 @@
 			"name": "Archpriest",
 			"source": "XMM",
 			"page": 248,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"EFA",
+				"FRAiF",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -6938,10 +7024,15 @@
 			"page": 22,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"ABH",
+				"DrDe",
+				"DrDe-BtS",
+				"DrDe-TDoN",
+				"EFA",
+				"FRAiF",
+				"LFL",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -7025,7 +7116,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"The assassin takes the Dash, Disengage, or Hide action."
+						"The assassin takes the {@action Dash|XPHB}, {@action Disengage|XPHB}, or {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -7038,7 +7129,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/assassin.mp3"
+				"path": "bestiary/assassin.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -7058,7 +7149,6 @@
 				"RNG"
 			],
 			"conditionInflict": [
-				"incapacitated",
 				"poisoned"
 			],
 			"hasToken": true,
@@ -7071,6 +7161,9 @@
 			"page": 23,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"S"
 			],
@@ -7118,7 +7211,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/awakened-shrub.mp3"
+				"path": "bestiary/awakened-shrub.opus"
 			},
 			"languageTags": [
 				"C",
@@ -7140,6 +7233,11 @@
 			"page": 23,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -7188,7 +7286,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/awakened-tree.mp3"
+				"path": "bestiary/awakened-tree.opus"
 			},
 			"languageTags": [
 				"C",
@@ -7211,6 +7309,9 @@
 			"page": 24,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -7251,7 +7352,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/axe-beak.mp3"
+				"path": "bestiary/axe-beak.opus"
 			},
 			"damageTags": [
 				"S"
@@ -7267,6 +7368,9 @@
 			"name": "Azer Pyromancer",
 			"source": "XMM",
 			"page": 25,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -7408,9 +7512,6 @@
 				"MA",
 				"RA"
 			],
-			"conditionInflict": [
-				"incapacitated"
-			],
 			"savingThrowForcedSpell": [
 				"dexterity"
 			],
@@ -7424,6 +7525,9 @@
 			"page": 25,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -7508,9 +7612,6 @@
 				"AOE",
 				"MA"
 			],
-			"conditionInflict": [
-				"incapacitated"
-			],
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -7570,7 +7671,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/baboon.mp3"
+				"path": "bestiary/baboon.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -7625,7 +7726,7 @@
 				"perception": "+3"
 			},
 			"senses": [
-				"darkvision 30 ft."
+				"Darkvision 30 ft."
 			],
 			"passive": 13,
 			"resist": [
@@ -7646,7 +7747,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/badger.mp3"
+				"path": "bestiary/badger.opus"
 			},
 			"senseTags": [
 				"D"
@@ -7711,7 +7812,7 @@
 				"perception": "+9"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 19,
 			"resist": [
@@ -7793,7 +7894,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/balor.mp3"
+				"path": "bestiary/balor.opus"
 			},
 			"traitTags": [
 				"Death Burst",
@@ -7837,13 +7938,16 @@
 			"page": 27,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "BQGT"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"ABH",
+				"BQGT",
+				"DrDe",
+				"DrDe-BD",
+				"DrDe-DotSC",
+				"EFA",
+				"FRAiF",
+				"HotB",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -7902,7 +8006,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bandit.mp3"
+				"path": "bestiary/bandit.opus"
 			},
 			"languageTags": [
 				"C",
@@ -7928,6 +8032,12 @@
 			"page": 27,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"ABH",
+				"EFA",
+				"FFotR",
+				"FRAiF"
+			],
 			"size": [
 				"S",
 				"M"
@@ -8008,7 +8118,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bandit-captain.mp3"
+				"path": "bestiary/bandit-captain.opus"
 			},
 			"actionTags": [
 				"Multiattack",
@@ -8036,6 +8146,9 @@
 			"name": "Bandit Crime Lord",
 			"source": "XMM",
 			"page": 28,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"S",
 				"M"
@@ -8146,9 +8259,6 @@
 				"RA",
 				"RNG"
 			],
-			"conditionInflict": [
-				"incapacitated"
-			],
 			"hasToken": true,
 			"hasFluff": true,
 			"hasFluffImages": true
@@ -8157,6 +8267,10 @@
 			"name": "Bandit Deceiver",
 			"source": "XMM",
 			"page": 28,
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"S",
 				"M"
@@ -8297,6 +8411,10 @@
 			"name": "Banshee",
 			"source": "XMM",
 			"page": 29,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -8330,7 +8448,7 @@
 				"wis": "+2"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -8411,7 +8529,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/banshee.mp3"
+				"path": "bestiary/banshee.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement"
@@ -8455,6 +8573,9 @@
 			"page": 30,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -8497,7 +8618,7 @@
 				"perception": "+8"
 			},
 			"senses": [
-				"darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+				"Darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
 			],
 			"passive": 18,
 			"resist": [
@@ -8568,7 +8689,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/barbed-devil.mp3"
+				"path": "bestiary/barbed-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -8608,6 +8729,9 @@
 			],
 			"source": "XMM",
 			"page": 31,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -8647,8 +8771,8 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -8731,7 +8855,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/barlgura.mp3"
+				"path": "bestiary/barlgura.opus"
 			},
 			"senseTags": [
 				"B",
@@ -8779,10 +8903,11 @@
 			"page": 32,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DotSC",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -8808,7 +8933,7 @@
 			"wis": 8,
 			"cha": 7,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"cr": "3",
@@ -8837,7 +8962,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/basilisk.mp3"
+				"path": "bestiary/basilisk.opus"
 			},
 			"senseTags": [
 				"D"
@@ -8897,7 +9022,7 @@
 			"wis": 12,
 			"cha": 4,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 11,
 			"cr": "0",
@@ -8918,7 +9043,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bat.mp3"
+				"path": "bestiary/bat.opus"
 			},
 			"senseTags": [
 				"B"
@@ -8942,6 +9067,9 @@
 			"page": 33,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -8977,7 +9105,7 @@
 				"cha": "+4"
 			},
 			"senses": [
-				"darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+				"Darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
 			],
 			"passive": 10,
 			"resist": [
@@ -9031,7 +9159,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bearded-devil.mp3"
+				"path": "bestiary/bearded-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -9072,10 +9200,10 @@
 			"page": 34,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF"
 			],
 			"size": [
 				"H"
@@ -9107,7 +9235,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 90 ft."
+				"Darkvision 90 ft."
 			],
 			"passive": 16,
 			"immune": [
@@ -9160,7 +9288,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/behir.mp3"
+				"path": "bestiary/behir.opus"
 			},
 			"senseTags": [
 				"D"
@@ -9204,6 +9332,11 @@
 			],
 			"source": "XMM",
 			"page": 36,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -9244,7 +9377,7 @@
 				"perception": "+12"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 22,
 			"conditionImmune": [
@@ -9397,7 +9530,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/beholder.mp3"
+				"path": "bestiary/beholder.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -9452,6 +9585,10 @@
 			],
 			"source": "XMM",
 			"page": 347,
+			"referenceSources": [
+				"NF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -9485,7 +9622,7 @@
 				"wis": "+2"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"immune": [
@@ -9569,7 +9706,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/beholder-zombie.mp3"
+				"path": "bestiary/beholder-zombie.opus"
 			},
 			"traitTags": [
 				"Undead Fortitude"
@@ -9614,13 +9751,14 @@
 			"page": 37,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"EFA",
+				"FRAiF",
+				"FRHoF",
+				"RHW",
+				"ScoEE"
 			],
 			"size": [
 				"S",
@@ -9659,7 +9797,7 @@
 				{
 					"name": "Bloodied Frenzy",
 					"entries": [
-						"While {@variantrule Bloodied|XPHB}, the berserker has {@variantrule Advantage|XPHB} on attack rolls and saving throws."
+						"While {@status Bloodied|XPHB}, the berserker has {@variantrule Advantage|XPHB} on attack rolls and saving throws."
 					]
 				}
 			],
@@ -9680,7 +9818,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/berserker.mp3"
+				"path": "bestiary/berserker.opus"
 			},
 			"languageTags": [
 				"C"
@@ -9700,6 +9838,9 @@
 			"name": "Berserker Commander",
 			"source": "XMM",
 			"page": 37,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"S",
 				"M"
@@ -9755,7 +9896,7 @@
 				{
 					"name": "Bloodied Frenzy",
 					"entries": [
-						"While {@variantrule Bloodied|XPHB}, the berserker has {@variantrule Advantage|XPHB} on attack rolls and saving throws."
+						"While {@status Bloodied|XPHB}, the berserker has {@variantrule Advantage|XPHB} on attack rolls and saving throws."
 					]
 				}
 			],
@@ -9856,7 +9997,7 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"cr": "1/2",
@@ -9879,7 +10020,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-bear.mp3"
+				"path": "bestiary/black-bear.opus"
 			},
 			"senseTags": [
 				"D"
@@ -9949,8 +10090,8 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -9997,7 +10138,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-dragon-wyrmling.mp3"
+				"path": "bestiary/black-dragon-wyrmling.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -10033,10 +10174,12 @@
 			"page": 42,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -10063,7 +10206,7 @@
 			"wis": 6,
 			"cha": 1,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 8,
 			"immune": [
@@ -10115,7 +10258,7 @@
 				{
 					"name": "Split",
 					"entries": [
-						"{@actTrigger} While the pudding is Large or Medium and has 10+ {@variantrule Hit Points|XPHB}, it becomes {@variantrule Bloodied|XPHB} or is subjected to Lightning or Slashing damage. {@actResponse} The pudding splits into two new Black Puddings. Each new pudding is one size smaller than the original pudding and acts on its {@variantrule Initiative|XPHB}. The original pudding's {@variantrule Hit Points|XPHB} are divided evenly between the new puddings (round down)."
+						"{@actTrigger} While the pudding is Large or Medium and has 10+ {@variantrule Hit Points|XPHB}, it becomes {@status Bloodied|XPHB} or is subjected to Lightning or Slashing damage. {@actResponse} The pudding splits into two new Black Puddings. Each new pudding is one size smaller than the original pudding and acts on its {@variantrule Initiative|XPHB}. The original pudding's {@variantrule Hit Points|XPHB} are divided evenly between the new puddings (round down)."
 					]
 				}
 			],
@@ -10124,7 +10267,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-pudding.mp3"
+				"path": "bestiary/black-pudding.opus"
 			},
 			"traitTags": [
 				"Amorphous",
@@ -10150,10 +10293,10 @@
 			"page": 46,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "UtHftLH"
-				}
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"UtHftLH"
 			],
 			"size": [
 				"M"
@@ -10184,10 +10327,11 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"languages": [
+				"Blink Dog",
 				"understands Elvish and Sylvan but can't speak them"
 			],
 			"cr": "1/4",
@@ -10213,7 +10357,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blink-dog.mp3"
+				"path": "bestiary/blink-dog.opus"
 			},
 			"senseTags": [
 				"D"
@@ -10224,6 +10368,7 @@
 			"languageTags": [
 				"CS",
 				"E",
+				"OTH",
 				"S"
 			],
 			"damageTags": [
@@ -10243,6 +10388,11 @@
 			],
 			"source": "XMM",
 			"page": 47,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"G"
 			],
@@ -10280,7 +10430,7 @@
 				"con": "+16"
 			},
 			"senses": [
-				"blindsight 120 ft."
+				"Blindsight 120 ft."
 			],
 			"passive": 13,
 			"resist": [
@@ -10457,7 +10607,7 @@
 				{
 					"name": "Beak",
 					"entries": [
-						"{@atkr m} {@hit 4}, reach 5 ft. {@h}4 ({@damage 1d4 + 2}) Piercing damage, or 6 ({@damage 1d8 + 2}) Piercing damage if the target is {@variantrule Bloodied|XPHB}."
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}4 ({@damage 1d4 + 2}) Piercing damage, or 6 ({@damage 1d8 + 2}) Piercing damage if the target is {@status Bloodied|XPHB}."
 					]
 				}
 			],
@@ -10471,7 +10621,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blood-hawk.mp3"
+				"path": "bestiary/blood-hawk.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -10538,8 +10688,8 @@
 				"stealth": "+2"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -10579,7 +10729,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-dragon-wyrmling.mp3"
+				"path": "bestiary/blue-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -10610,10 +10760,11 @@
 			"name": "Blue Slaad",
 			"source": "XMM",
 			"page": 285,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -10643,7 +10794,7 @@
 				"perception": "+1"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -10693,7 +10844,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-slaad.mp3"
+				"path": "bestiary/blue-slaad.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -10715,6 +10866,7 @@
 			],
 			"miscTags": [
 				"CUR",
+				"HPR",
 				"MA",
 				"RCH"
 			],
@@ -10766,7 +10918,7 @@
 				{
 					"name": "Bloodied Fury",
 					"entries": [
-						"While {@variantrule Bloodied|XPHB}, the boar has {@variantrule Advantage|XPHB} on attack rolls."
+						"While {@status Bloodied|XPHB}, the boar has {@variantrule Advantage|XPHB} on attack rolls."
 					]
 				}
 			],
@@ -10785,7 +10937,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/boar.mp3"
+				"path": "bestiary/boar.opus"
 			},
 			"damageTags": [
 				"P"
@@ -10809,6 +10961,9 @@
 			"page": 52,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -10853,7 +11008,7 @@
 				"insight": "+6"
 			},
 			"senses": [
-				"darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+				"Darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
 			],
 			"passive": 12,
 			"resist": [
@@ -10912,7 +11067,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bone-devil.mp3"
+				"path": "bestiary/bone-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -10973,7 +11128,7 @@
 			"wis": 15,
 			"cha": 15,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -11131,8 +11286,8 @@
 				"stealth": "+2"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -11171,7 +11326,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brass-dragon-wyrmling.mp3"
+				"path": "bestiary/brass-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -11233,7 +11388,7 @@
 				"perception": "+10"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 20,
 			"immune": [
@@ -11367,8 +11522,8 @@
 				"stealth": "+2"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -11421,7 +11576,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bronze-dragon-wyrmling.mp3"
+				"path": "bestiary/bronze-dragon-wyrmling.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -11467,6 +11622,9 @@
 					"page": 347
 				}
 			],
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -11495,7 +11653,7 @@
 				"perception": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "1",
@@ -11526,7 +11684,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brown-bear.mp3"
+				"path": "bestiary/brown-bear.opus"
 			},
 			"senseTags": [
 				"D"
@@ -11557,6 +11715,9 @@
 			"page": 62,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -11595,7 +11756,7 @@
 				"survival": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"languages": [
@@ -11696,13 +11857,13 @@
 			"page": 62,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "UtHftLH"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"BQDD",
+				"DrDe",
+				"DrDe-BD",
+				"FRAiF",
+				"HotB",
+				"UtHftLH"
 			],
 			"size": [
 				"M"
@@ -11738,7 +11899,7 @@
 				"survival": "+2"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -11815,10 +11976,10 @@
 			"page": 63,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -11848,8 +12009,8 @@
 				"perception": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft.",
-				"tremorsense 120 ft."
+				"Darkvision 60 ft.",
+				"Tremorsense 120 ft."
 			],
 			"passive": 16,
 			"cr": "5",
@@ -11888,7 +12049,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bulette.mp3"
+				"path": "bestiary/bulette.opus"
 			},
 			"senseTags": [
 				"D",
@@ -11918,6 +12079,9 @@
 			"name": "Bulette Pup",
 			"source": "XMM",
 			"page": 63,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -11946,8 +12110,8 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"darkvision 30 ft.",
-				"tremorsense 60 ft."
+				"Darkvision 30 ft.",
+				"Tremorsense 60 ft."
 			],
 			"passive": 14,
 			"cr": "2",
@@ -11991,10 +12155,8 @@
 			"source": "XMM",
 			"page": 64,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "UtHftLH"
-				}
+			"referenceSources": [
+				"UtHftLH"
 			],
 			"size": [
 				"M"
@@ -12142,10 +12304,9 @@
 			"source": "XMM",
 			"page": 64,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "UtHftLH"
-				}
+			"referenceSources": [
+				"FRAiF",
+				"UtHftLH"
 			],
 			"size": [
 				"M"
@@ -12240,6 +12401,9 @@
 			"name": "Cambion",
 			"source": "XMM",
 			"page": 65,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -12277,7 +12441,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 14,
 			"resist": [
@@ -12345,7 +12509,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cambion.mp3"
+				"path": "bestiary/cambion.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -12395,10 +12559,11 @@
 				{
 					"source": "XPHB",
 					"page": 347
-				},
-				{
-					"source": "HBTD"
 				}
+			],
+			"referenceSources": [
+				"FRAiF",
+				"HBTD"
 			],
 			"size": [
 				"L"
@@ -12427,7 +12592,7 @@
 				"con": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"cr": "1/8",
@@ -12444,7 +12609,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/camel.mp3"
+				"path": "bestiary/camel.opus"
 			},
 			"senseTags": [
 				"D"
@@ -12464,6 +12629,11 @@
 			"source": "XMM",
 			"page": 66,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"HotB",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -12492,7 +12662,7 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"cr": "2",
@@ -12530,7 +12700,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/carrion-crawler.mp3"
+				"path": "bestiary/carrion-crawler.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -12571,6 +12741,9 @@
 					"page": 347
 				}
 			],
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"T"
 			],
@@ -12603,7 +12776,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "0",
@@ -12632,7 +12805,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cat.mp3"
+				"path": "bestiary/cat.opus"
 			},
 			"senseTags": [
 				"D"
@@ -12653,6 +12826,9 @@
 			"page": 67,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -12761,6 +12937,10 @@
 			"name": "Centaur Warden",
 			"source": "XMM",
 			"page": 67,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -12894,6 +13074,11 @@
 			"page": 68,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -12931,7 +13116,7 @@
 				"wis": "+4"
 			},
 			"senses": [
-				"darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+				"Darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
 			],
 			"passive": 11,
 			"resist": [
@@ -13001,7 +13186,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/chain-devil.mp3"
+				"path": "bestiary/chain-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -13045,6 +13230,9 @@
 			],
 			"source": "XMM",
 			"page": 69,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -13086,8 +13274,8 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 120 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -13137,7 +13325,7 @@
 				{
 					"name": "Drone",
 					"entries": [
-						"{@actSave con} {@dc 12}, each creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the chasme (demons automatically succeed on this save). {@actSaveFail} The target has the {@condition Unconscious|XPHB} condition and repeats the save at the end of each of its turns. The target succeeds automatically after 10 minutes or if it takes damage or a creature within 5 feet of it takes an action to empty a flask of Holy Water on it. {@actSaveSuccess} The target is immune to this chasme's Drone for 24 hours."
+						"{@actSave con} {@dc 12}, each creature in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the chasme (demons automatically succeed on this save). {@actSaveFail} The target has the {@condition Unconscious|XPHB} condition and repeats the save at the end of each of its turns. The target succeeds automatically after 10 minutes or if it takes damage or a creature within 5 feet of it takes an action to empty a flask of {@item Holy Water|XPHB} on it. {@actSaveSuccess} The target is immune to this chasme's Drone for 24 hours."
 					]
 				}
 			],
@@ -13149,7 +13337,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/chasme.mp3"
+				"path": "bestiary/chasme.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -13168,6 +13356,7 @@
 				"P"
 			],
 			"miscTags": [
+				"HPR",
 				"MA"
 			],
 			"conditionInflict": [
@@ -13186,10 +13375,11 @@
 			"page": 70,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -13220,7 +13410,7 @@
 				"perception": "+8"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 18,
 			"languages": [
@@ -13269,7 +13459,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/chimera.mp3"
+				"path": "bestiary/chimera.opus"
 			},
 			"senseTags": [
 				"D"
@@ -13307,6 +13497,9 @@
 			"page": 71,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -13336,7 +13529,7 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -13393,7 +13586,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/chuul.mp3"
+				"path": "bestiary/chuul.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -13460,7 +13653,7 @@
 			"wis": 8,
 			"cha": 1,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"resist": [
@@ -13495,7 +13688,7 @@
 				{
 					"name": "Berserk",
 					"entries": [
-						"Whenever the golem starts its turn {@variantrule Bloodied|XPHB}, roll {@dice 1d6}. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it continues to be berserk until it is destroyed or it is no longer {@variantrule Bloodied|XPHB}."
+						"Whenever the golem starts its turn {@status Bloodied|XPHB}, roll {@dice 1d6}. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it continues to be berserk until it is destroyed or it is no longer {@status Bloodied|XPHB}."
 					]
 				},
 				{
@@ -13529,7 +13722,7 @@
 				{
 					"name": "Hasten {@recharge 5}",
 					"entries": [
-						"The golem takes the Dash and Disengage actions."
+						"The golem takes the {@action Dash|XPHB} and {@action Disengage|XPHB} actions."
 					]
 				}
 			],
@@ -13541,7 +13734,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/clay-golem.mp3"
+				"path": "bestiary/clay-golem.opus"
 			},
 			"traitTags": [
 				"Damage Absorption",
@@ -13563,6 +13756,7 @@
 				"B"
 			],
 			"miscTags": [
+				"HPR",
 				"MA"
 			],
 			"hasToken": true,
@@ -13575,10 +13769,10 @@
 			"page": 73,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -13612,7 +13806,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 12,
 			"conditionImmune": [
@@ -13685,7 +13879,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cloaker.mp3"
+				"path": "bestiary/cloaker.opus"
 			},
 			"traitTags": [
 				"Light Sensitivity"
@@ -13728,6 +13922,9 @@
 			"page": 74,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -13839,7 +14036,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cloud-giant.mp3"
+				"path": "bestiary/cloud-giant.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -13880,10 +14077,9 @@
 			"page": 75,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BD"
 			],
 			"size": [
 				"S"
@@ -13910,7 +14106,7 @@
 			"wis": 13,
 			"cha": 5,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"conditionImmune": [
@@ -13930,7 +14126,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cockatrice.mp3"
+				"path": "bestiary/cockatrice.opus"
 			},
 			"senseTags": [
 				"D"
@@ -13984,7 +14180,7 @@
 				"wis": "+6"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 13,
 			"conditionImmune": [
@@ -13995,7 +14191,7 @@
 				{
 					"name": "Flyby",
 					"entries": [
-						"The cockatrice doesn't provoke an Opportunity Attack when it flies out of an enemy's reach."
+						"The cockatrice doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
 					]
 				}
 			],
@@ -14102,7 +14298,7 @@
 				"wis": "+8"
 			},
 			"senses": [
-				"truesight 300 ft."
+				"Truesight 300 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -14241,10 +14437,21 @@
 			"page": 77,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"ABH",
+				"BQDD",
+				"DrDe",
+				"DrDe-ACfaS",
+				"DrDe-BD",
+				"DrDe-BtS",
+				"DrDe-DaS",
+				"DrDe-TDoN",
+				"DrDe-TWoO",
+				"FRAiF",
+				"HotB",
+				"LFL",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -14302,7 +14509,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/commoner.mp3"
+				"path": "bestiary/commoner.opus"
 			},
 			"languageTags": [
 				"C"
@@ -14328,13 +14535,12 @@
 				{
 					"source": "XPHB",
 					"page": 348
-				},
-				{
-					"source": "HBTD"
-				},
-				{
-					"source": "DrDe"
 				}
+			],
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS",
+				"HBTD"
 			],
 			"size": [
 				"L"
@@ -14365,7 +14571,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 10 ft."
+				"Blindsight 10 ft."
 			],
 			"passive": 12,
 			"cr": "1/4",
@@ -14391,7 +14597,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/constrictor-snake.mp3"
+				"path": "bestiary/constrictor-snake.opus"
 			},
 			"senseTags": [
 				"B"
@@ -14422,6 +14628,9 @@
 			"page": 78,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"HotB"
+			],
 			"size": [
 				"M"
 			],
@@ -14465,8 +14674,8 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -14505,7 +14714,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/copper-dragon-wyrmling.mp3"
+				"path": "bestiary/copper-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -14538,6 +14747,10 @@
 			"page": 82,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"M"
 			],
@@ -14568,7 +14781,7 @@
 				"wis": "+7"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -14595,7 +14808,7 @@
 						"{@spell Detect Evil and Good|XPHB}",
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Detect Thoughts|XPHB}",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
 					],
 					"daily": {
 						"1e": [
@@ -14662,7 +14875,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/couatl.mp3"
+				"path": "bestiary/couatl.opus"
 			},
 			"senseTags": [
 				"U"
@@ -14743,7 +14956,7 @@
 				"stealth": "+2"
 			},
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 9,
 			"cr": "0",
@@ -14770,7 +14983,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/crab.mp3"
+				"path": "bestiary/crab.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -14792,6 +15005,9 @@
 			"name": "Crawling Claw",
 			"source": "XMM",
 			"page": 83,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"T"
 			],
@@ -14818,7 +15034,7 @@
 			"wis": 10,
 			"cha": 4,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -14849,7 +15065,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/crawling-claw.mp3"
+				"path": "bestiary/crawling-claw.opus"
 			},
 			"senseTags": [
 				"B"
@@ -14935,7 +15151,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/crocodile.mp3"
+				"path": "bestiary/crocodile.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -14960,10 +15176,12 @@
 			"page": 84,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				}
+			"referenceSources": [
+				"BQDD",
+				"FRAiF",
+				"FRHoF",
+				"HotB",
+				"ScoEE"
 			],
 			"size": [
 				"S",
@@ -15022,7 +15240,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/cultist.mp3"
+				"path": "bestiary/cultist.opus"
 			},
 			"languageTags": [
 				"C"
@@ -15045,13 +15263,13 @@
 			"page": 85,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"FRHoF",
+				"RHW",
+				"ScoEE"
 			],
 			"size": [
 				"S",
@@ -15180,6 +15398,10 @@
 			"name": "Cultist Hierophant",
 			"source": "XMM",
 			"page": 85,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -15312,6 +15534,9 @@
 			"name": "Cyclops Oracle",
 			"source": "XMM",
 			"page": 88,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -15348,7 +15573,7 @@
 				"perception": "+12"
 			},
 			"senses": [
-				"truesight 30 ft."
+				"Truesight 30 ft."
 			],
 			"passive": 22,
 			"languages": [
@@ -15443,10 +15668,10 @@
 			"name": "Cyclops Sentry",
 			"source": "XMM",
 			"page": 88,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF"
 			],
 			"size": [
 				"H"
@@ -15545,10 +15770,11 @@
 			],
 			"source": "XMM",
 			"page": 89,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DotSC",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -15589,7 +15815,7 @@
 				"wis": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 11,
 			"conditionImmune": [
@@ -15681,7 +15907,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dao.mp3"
+				"path": "bestiary/dao.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -15730,10 +15956,10 @@
 			"page": 90,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"FRAiF"
 			],
 			"size": [
 				"S"
@@ -15766,7 +15992,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 10,
 			"cr": "1/2",
@@ -15791,7 +16017,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/darkmantle.mp3"
+				"path": "bestiary/darkmantle.opus"
 			},
 			"senseTags": [
 				"B"
@@ -15813,6 +16039,11 @@
 			"name": "Death Cultist",
 			"source": "XMM",
 			"page": 86,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -15943,6 +16174,10 @@
 			"page": 91,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -15972,7 +16207,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 15,
 			"conditionImmune": [
@@ -16003,7 +16238,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/death-dog.mp3"
+				"path": "bestiary/death-dog.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -16015,6 +16250,7 @@
 				"P"
 			],
 			"miscTags": [
+				"HPR",
 				"MA"
 			],
 			"conditionInflict": [
@@ -16031,10 +16267,12 @@
 			"name": "Death Knight",
 			"source": "XMM",
 			"page": 92,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"FRHoF",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -16069,7 +16307,7 @@
 				"wis": "+9"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 13,
 			"immune": [
@@ -16189,7 +16427,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/death-knight.mp3"
+				"path": "bestiary/death-knight.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -16221,10 +16459,8 @@
 			],
 			"miscTags": [
 				"AOE",
+				"HPR",
 				"MA"
-			],
-			"conditionInflict": [
-				"incapacitated"
 			],
 			"conditionInflictSpell": [
 				"prone"
@@ -16245,6 +16481,10 @@
 			"name": "Death Knight Aspirant",
 			"source": "XMM",
 			"page": 93,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -16278,7 +16518,7 @@
 				"wis": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 11,
 			"immune": [
@@ -16394,9 +16634,6 @@
 				"AOE",
 				"MA"
 			],
-			"conditionInflict": [
-				"incapacitated"
-			],
 			"conditionInflictSpell": [
 				"prone"
 			],
@@ -16446,8 +16683,8 @@
 				"perception": "+8"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 60 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 18,
 			"resist": [
@@ -16533,7 +16770,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/death-slaad.mp3"
+				"path": "bestiary/death-slaad.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -16584,6 +16821,10 @@
 			],
 			"source": "XMM",
 			"page": 95,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -16629,7 +16870,7 @@
 				"perception": "+12"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 22,
 			"immune": [
@@ -16790,7 +17031,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/death-tyrant.mp3"
+				"path": "bestiary/death-tyrant.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -16844,6 +17085,9 @@
 			"page": 352,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"M"
 			],
@@ -16871,7 +17115,7 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"cr": "0",
@@ -16879,7 +17123,7 @@
 				{
 					"name": "Agile",
 					"entries": [
-						"The deer doesn't provoke an Opportunity Attack when it moves out of an enemy's reach."
+						"The deer doesn't provoke an {@action Opportunity Attack|XPHB} when it moves out of an enemy's reach."
 					]
 				}
 			],
@@ -16898,7 +17142,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deer.mp3"
+				"path": "bestiary/deer.opus"
 			},
 			"senseTags": [
 				"D"
@@ -16917,6 +17161,9 @@
 			"name": "Demilich",
 			"source": "XMM",
 			"page": 96,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"T"
 			],
@@ -16950,12 +17197,13 @@
 			"wis": 17,
 			"cha": 20,
 			"save": {
+				"dex": "+11",
 				"con": "+6",
 				"int": "+11",
 				"wis": "+9"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 13,
 			"resist": [
@@ -17050,7 +17298,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/demilich.mp3"
+				"path": "bestiary/demilich.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -17067,6 +17315,7 @@
 			],
 			"miscTags": [
 				"AOE",
+				"HPR",
 				"MA",
 				"RA"
 			],
@@ -17093,6 +17342,9 @@
 			"page": 97,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"M"
 			],
@@ -17136,7 +17388,7 @@
 				"perception": "+9"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 19,
 			"resist": [
@@ -17160,7 +17412,7 @@
 					],
 					"will": [
 						"{@spell Detect Evil and Good|XPHB}",
-						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no Concentration or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
+						"{@spell Shapechange|XPHB} (Beast or Humanoid form only, no {@variantrule Temporary Hit Points|XPHB} gained from the spell, and no {@status Concentration|XPHB} or {@variantrule Temporary Hit Points|XPHB} required to maintain the spell)"
 					],
 					"daily": {
 						"1e": [
@@ -17227,7 +17479,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/deva.mp3"
+				"path": "bestiary/deva.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -17269,6 +17521,10 @@
 					"page": 348
 				}
 			],
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -17297,7 +17553,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"cr": "1",
@@ -17323,7 +17579,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dire-wolf.mp3"
+				"path": "bestiary/dire-wolf.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -17348,6 +17604,9 @@
 			"name": "Dire Worg",
 			"source": "XMM",
 			"page": 335,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -17380,7 +17639,7 @@
 				"perception": "+11"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 21,
 			"languages": [
@@ -17469,6 +17728,11 @@
 			"name": "Displacer Beast",
 			"source": "XMM",
 			"page": 98,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -17497,7 +17761,7 @@
 			"wis": 12,
 			"cha": 8,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"languages": [
@@ -17543,7 +17807,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/displacer-beast.mp3"
+				"path": "bestiary/displacer-beast.opus"
 			},
 			"senseTags": [
 				"D"
@@ -17564,7 +17828,6 @@
 				"MA"
 			],
 			"conditionInflict": [
-				"incapacitated",
 				"prone"
 			],
 			"hasToken": true,
@@ -17580,10 +17843,10 @@
 			"page": 99,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -17624,7 +17887,7 @@
 				"wis": "+7"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 13,
 			"immune": [
@@ -17720,7 +17983,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/djinni.mp3"
+				"path": "bestiary/djinni.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -17769,13 +18032,13 @@
 			"page": 100,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "HBTD"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TDoN",
+				"FRAiF",
+				"FRHoF",
+				"HBTD",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -17805,7 +18068,7 @@
 				"insight": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"conditionImmune": [
@@ -17869,7 +18132,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/doppelganger.mp3"
+				"path": "bestiary/doppelganger.opus"
 			},
 			"senseTags": [
 				"D"
@@ -17906,6 +18169,10 @@
 			"name": "Dracolich",
 			"source": "XMM",
 			"page": 102,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"H",
 				"G"
@@ -17945,8 +18212,8 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 24,
 			"immune": [
@@ -18169,7 +18436,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/draft-horse.mp3"
+				"path": "bestiary/draft-horse.opus"
 			},
 			"damageTags": [
 				"B"
@@ -18187,6 +18454,9 @@
 			"page": 103,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"G"
 			],
@@ -18219,7 +18489,7 @@
 				"wis": "+7"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -18273,7 +18543,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dragon-turtle.mp3"
+				"path": "bestiary/dragon-turtle.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -18348,7 +18618,7 @@
 			"wis": 8,
 			"cha": 3,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"resist": [
@@ -18385,7 +18655,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dretch.mp3"
+				"path": "bestiary/dretch.opus"
 			},
 			"senseTags": [
 				"D"
@@ -18416,6 +18686,11 @@
 			"page": 105,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -18446,7 +18721,7 @@
 				"stealth": "+10"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 16,
 			"languages": [
@@ -18524,7 +18799,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/drider.mp3"
+				"path": "bestiary/drider.opus"
 			},
 			"traitTags": [
 				"Spider Climb",
@@ -18572,10 +18847,13 @@
 			"page": 106,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"DrDe-TFV",
+				"EFA",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -18671,7 +18949,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/druid.mp3"
+				"path": "bestiary/druid.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -18715,10 +18993,12 @@
 			"page": 107,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BD",
+				"DrDe-DaS",
+				"FRAiF",
+				"FRHoF"
 			],
 			"size": [
 				"M"
@@ -18748,7 +19028,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"languages": [
@@ -18828,7 +19108,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/dryad.mp3"
+				"path": "bestiary/dryad.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -18873,6 +19153,9 @@
 			"page": 206,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"S"
 			],
@@ -18903,7 +19186,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -18966,7 +19249,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mephit.mp3"
+				"path": "bestiary/mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -19061,7 +19344,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/eagle.mp3"
+				"path": "bestiary/eagle.opus"
 			},
 			"damageTags": [
 				"S"
@@ -19079,10 +19362,10 @@
 			"page": 108,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -19109,8 +19392,8 @@
 			"wis": 10,
 			"cha": 5,
 			"senses": [
-				"darkvision 60 ft.",
-				"tremorsense 60 ft."
+				"Darkvision 60 ft.",
+				"Tremorsense 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -19171,7 +19454,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/earth-elemental.mp3"
+				"path": "bestiary/earth-elemental.opus"
 			},
 			"traitTags": [
 				"Siege Monster"
@@ -19211,6 +19494,10 @@
 			"page": 109,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -19249,7 +19536,7 @@
 				"cha": "+8"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -19333,7 +19620,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/efreeti.mp3"
+				"path": "bestiary/efreeti.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -19425,7 +19712,7 @@
 				"cha": "+6"
 			},
 			"senses": [
-				"truesight 150 ft."
+				"Truesight 150 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -19610,6 +19897,10 @@
 			"name": "Elemental Cultist",
 			"source": "XMM",
 			"page": 87,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -19735,10 +20026,10 @@
 				{
 					"source": "XPHB",
 					"page": 349
-				},
-				{
-					"source": "HBTD"
 				}
+			],
+			"referenceSources": [
+				"HBTD"
 			],
 			"size": [
 				"H"
@@ -19792,7 +20083,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/elephant.mp3"
+				"path": "bestiary/elephant.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -19826,6 +20117,9 @@
 					"page": 349
 				}
 			],
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -19853,7 +20147,7 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"cr": "1/4",
@@ -19872,7 +20166,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/elk.mp3"
+				"path": "bestiary/elk.opus"
 			},
 			"senseTags": [
 				"D"
@@ -19897,6 +20191,9 @@
 			],
 			"source": "XMM",
 			"page": 113,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -19948,7 +20245,7 @@
 				"perception": "+13"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 23,
 			"resist": [
@@ -20050,7 +20347,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/empyrean.mp3"
+				"path": "bestiary/empyrean.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -20099,6 +20396,9 @@
 			],
 			"source": "XMM",
 			"page": 112,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -20143,7 +20443,7 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"truesight 30 ft."
+				"Truesight 30 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -20255,6 +20555,10 @@
 			"page": 114,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"M"
 			],
@@ -20298,7 +20602,7 @@
 				"persuasion": "+8"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 16,
 			"resist": [
@@ -20371,7 +20675,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/erinyes.mp3"
+				"path": "bestiary/erinyes.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -20411,6 +20715,9 @@
 			"page": 115,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -20442,7 +20749,7 @@
 				"survival": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "2",
@@ -20502,7 +20809,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ettercap.mp3"
+				"path": "bestiary/ettercap.opus"
 			},
 			"traitTags": [
 				"Spider Climb",
@@ -20539,6 +20846,10 @@
 			"page": 116,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"NF"
+			],
 			"size": [
 				"L"
 			],
@@ -20567,7 +20878,7 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"conditionImmune": [
@@ -20616,7 +20927,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ettin.mp3"
+				"path": "bestiary/ettin.opus"
 			},
 			"senseTags": [
 				"D"
@@ -20646,6 +20957,9 @@
 			"name": "Faerie Dragon Adult",
 			"source": "XMM",
 			"page": 117,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"T"
 			],
@@ -20668,16 +20982,16 @@
 			"str": 3,
 			"dex": 20,
 			"con": 13,
-			"int": 12,
+			"int": 14,
 			"wis": 12,
-			"cha": 14,
+			"cha": 16,
 			"skill": {
 				"arcana": "+4",
 				"perception": "+3",
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"languages": [
@@ -20795,6 +21109,9 @@
 			"name": "Faerie Dragon Youth",
 			"source": "XMM",
 			"page": 117,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"T"
 			],
@@ -20826,7 +21143,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"languages": [
@@ -20934,6 +21251,10 @@
 			"name": "Fiend Cultist",
 			"source": "XMM",
 			"page": 87,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -20971,7 +21292,7 @@
 				"religion": "+4"
 			},
 			"senses": [
-				"darkvision 90 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+				"Darkvision 90 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
 			],
 			"passive": 17,
 			"languages": [
@@ -21079,13 +21400,11 @@
 			"page": 118,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF",
+				"ScoEE"
 			],
 			"size": [
 				"L"
@@ -21111,7 +21430,7 @@
 			"wis": 10,
 			"cha": 7,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -21183,7 +21502,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fire-elemental.mp3"
+				"path": "bestiary/fire-elemental.opus"
 			},
 			"traitTags": [
 				"Illumination"
@@ -21203,6 +21522,7 @@
 				"F"
 			],
 			"miscTags": [
+				"AOE",
 				"MA"
 			],
 			"hasToken": true,
@@ -21215,6 +21535,9 @@
 			"page": 119,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -21288,7 +21611,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fire-giant.mp3"
+				"path": "bestiary/fire-giant.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -21314,10 +21637,13 @@
 			"name": "Flameskull",
 			"source": "XMM",
 			"page": 120,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DotSC",
+				"DrDe-TFV",
+				"DrDe-TWoO",
+				"FRAiF",
+				"NF"
 			],
 			"size": [
 				"T"
@@ -21353,7 +21679,7 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -21411,7 +21737,7 @@
 				{
 					"name": "Undead Restoration",
 					"entries": [
-						"If the flameskull is destroyed, it regains all its {@variantrule Hit Points|XPHB} in 1 hour unless Holy Water is sprinkled on its remains or the {@spell Dispel Evil and Good|XPHB} spell is cast on them."
+						"If the flameskull is destroyed, it regains all its {@variantrule Hit Points|XPHB} in 1 hour unless {@item Holy Water|XPHB} is sprinkled on its remains or the {@spell Dispel Evil and Good|XPHB} spell is cast on them."
 					]
 				}
 			],
@@ -21437,7 +21763,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flameskull.mp3"
+				"path": "bestiary/flameskull.opus"
 			},
 			"traitTags": [
 				"Illumination",
@@ -21464,6 +21790,7 @@
 				"O"
 			],
 			"miscTags": [
+				"AOE",
 				"MA",
 				"RA"
 			],
@@ -21478,10 +21805,11 @@
 			"name": "Flaming Skeleton",
 			"source": "XMM",
 			"page": 283,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"DrDe-TWoO",
+				"FRAiF"
 			],
 			"size": [
 				"M"
@@ -21508,7 +21836,7 @@
 			"wis": 15,
 			"cha": 8,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -21602,6 +21930,10 @@
 			"page": 121,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -21626,7 +21958,7 @@
 			"wis": 10,
 			"cha": 5,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -21655,8 +21987,8 @@
 				{
 					"name": "Berserk",
 					"entries": [
-						"Whenever the golem starts its turn {@variantrule Bloodied|XPHB}, roll {@dice 1d6}. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it remains so until it is destroyed or it is no longer {@variantrule Bloodied|XPHB}.",
-						"The golem's creator, if within 60 feet of the berserk golem, can try to calm it by taking an action to make a {@dc 15} Charisma ({@skill Persuasion|XPHB}) check; the golem must be able to hear its creator. If this check succeeds, the golem ceases being berserk until the start of its next turn, at which point it resumes rolling for the Berserk trait again if it is still {@variantrule Bloodied|XPHB}."
+						"Whenever the golem starts its turn {@status Bloodied|XPHB}, roll {@dice 1d6}. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it remains so until it is destroyed or it is no longer {@status Bloodied|XPHB}.",
+						"The golem's creator, if within 60 feet of the berserk golem, can try to calm it by taking an action to make a {@dc 15} Charisma ({@skill Persuasion|XPHB}) check; the golem must be able to hear its creator. If this check succeeds, the golem ceases being berserk until the start of its next turn, at which point it resumes rolling for the Berserk trait again if it is still {@status Bloodied|XPHB}."
 					]
 				},
 				{
@@ -21700,7 +22032,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flesh-golem.mp3"
+				"path": "bestiary/flesh-golem.opus"
 			},
 			"traitTags": [
 				"Damage Absorption",
@@ -21733,6 +22065,9 @@
 			"name": "Flumph",
 			"source": "XMM",
 			"page": 122,
+			"referenceSources": [
+				"NF"
+			],
 			"size": [
 				"S"
 			],
@@ -21768,7 +22103,7 @@
 				"religion": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"vulnerable": [
@@ -21820,7 +22155,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flumph.mp3"
+				"path": "bestiary/flumph.opus"
 			},
 			"senseTags": [
 				"D"
@@ -21856,6 +22191,10 @@
 			"page": 353,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"T"
 			],
@@ -21882,7 +22221,7 @@
 			"wis": 12,
 			"cha": 5,
 			"senses": [
-				"blindsight 10 ft."
+				"Blindsight 10 ft."
 			],
 			"passive": 11,
 			"cr": "1/8",
@@ -21890,7 +22229,7 @@
 				{
 					"name": "Flyby",
 					"entries": [
-						"The snake doesn't provoke an Opportunity Attack when it flies out of an enemy's reach."
+						"The snake doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
 					]
 				}
 			],
@@ -21909,7 +22248,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/flying-snake.mp3"
+				"path": "bestiary/flying-snake.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -21932,6 +22271,10 @@
 			"name": "Fomorian",
 			"source": "XMM",
 			"page": 123,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -21961,7 +22304,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 18,
 			"languages": [
@@ -21997,7 +22340,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/fomorian.mp3"
+				"path": "bestiary/fomorian.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -22066,7 +22409,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"darkvision 30 ft."
+				"Darkvision 30 ft."
 			],
 			"passive": 11,
 			"cr": "0",
@@ -22099,7 +22442,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/frog.mp3"
+				"path": "bestiary/frog.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -22123,10 +22466,10 @@
 			"page": 124,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"FRAiF"
 			],
 			"size": [
 				"H"
@@ -22209,7 +22552,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/frost-giant.mp3"
+				"path": "bestiary/frost-giant.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -22235,10 +22578,10 @@
 			"name": "Galeb Duhr",
 			"source": "XMM",
 			"page": 127,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"FRAiF"
 			],
 			"size": [
 				"M"
@@ -22267,8 +22610,8 @@
 			"wis": 12,
 			"cha": 11,
 			"senses": [
-				"darkvision 60 ft.",
-				"tremorsense 60 ft."
+				"Darkvision 60 ft.",
+				"Tremorsense 60 ft."
 			],
 			"passive": 11,
 			"immune": [
@@ -22309,7 +22652,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/galeb-duhr.mp3"
+				"path": "bestiary/galeb-duhr.opus"
 			},
 			"senseTags": [
 				"D",
@@ -22338,10 +22681,11 @@
 			"page": 128,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DotSC",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -22375,7 +22719,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -22394,7 +22738,7 @@
 				{
 					"name": "Flyby",
 					"entries": [
-						"The gargoyle doesn't provoke an Opportunity Attack when it flies out of an enemy's reach."
+						"The gargoyle doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
 					]
 				}
 			],
@@ -22421,7 +22765,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gargoyle.mp3"
+				"path": "bestiary/gargoyle.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -22450,6 +22794,9 @@
 			"name": "Gas Spore Fungus",
 			"source": "XMM",
 			"page": 125,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -22479,7 +22826,7 @@
 			"wis": 1,
 			"cha": 1,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 5,
 			"immune": [
@@ -22542,6 +22889,10 @@
 			"page": 129,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"HotB"
+			],
 			"size": [
 				"L"
 			],
@@ -22566,7 +22917,7 @@
 			"wis": 6,
 			"cha": 1,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 8,
 			"immune": [
@@ -22619,7 +22970,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gelatinous-cube.mp3"
+				"path": "bestiary/gelatinous-cube.opus"
 			},
 			"senseTags": [
 				"B"
@@ -22646,10 +22997,11 @@
 			"page": 130,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -22679,7 +23031,7 @@
 				"wis": "+2"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -22729,7 +23081,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ghast.mp3"
+				"path": "bestiary/ghast.opus"
 			},
 			"senseTags": [
 				"D"
@@ -22760,10 +23112,11 @@
 			"name": "Ghast Gravecaller",
 			"source": "XMM",
 			"page": 130,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -22794,7 +23147,7 @@
 				"wis": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -22901,10 +23254,14 @@
 			"page": 131,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"DrDe-TWoO",
+				"FRAiF",
+				"FRHoF",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -22935,7 +23292,7 @@
 			"wis": 12,
 			"cha": 17,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -23034,9 +23391,10 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ghost.mp3"
+				"path": "bestiary/ghost.opus"
 			},
 			"traitTags": [
+				"Ethereal Sight",
 				"Incorporeal Movement"
 			],
 			"senseTags": [
@@ -23081,10 +23439,11 @@
 			"page": 132,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -23111,7 +23470,7 @@
 			"wis": 10,
 			"cha": 6,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -23156,7 +23515,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ghoul.mp3"
+				"path": "bestiary/ghoul.opus"
 			},
 			"senseTags": [
 				"D"
@@ -23191,6 +23550,9 @@
 			"page": 354,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -23258,7 +23620,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-ape.mp3"
+				"path": "bestiary/giant-ape.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -23285,10 +23647,10 @@
 			"name": "Giant Axe Beak",
 			"source": "XMM",
 			"page": 24,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"NF"
 			],
 			"size": [
 				"H"
@@ -23404,7 +23766,7 @@
 				"perception": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"resist": [
@@ -23424,7 +23786,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-badger.mp3"
+				"path": "bestiary/giant-badger.opus"
 			},
 			"senseTags": [
 				"D"
@@ -23470,7 +23832,7 @@
 			"wis": 12,
 			"cha": 6,
 			"senses": [
-				"blindsight 120 ft."
+				"Blindsight 120 ft."
 			],
 			"passive": 11,
 			"cr": "1/4",
@@ -23489,7 +23851,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-bat.mp3"
+				"path": "bestiary/giant-bat.opus"
 			},
 			"senseTags": [
 				"B"
@@ -23510,6 +23872,10 @@
 			"page": 355,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -23542,7 +23908,7 @@
 				{
 					"name": "Bloodied Fury",
 					"entries": [
-						"The boar has {@variantrule Advantage|XPHB} on melee attack rolls while it is {@variantrule Bloodied|XPHB}."
+						"The boar has {@variantrule Advantage|XPHB} on melee attack rolls while it is {@status Bloodied|XPHB}."
 					]
 				}
 			],
@@ -23561,7 +23927,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-boar.mp3"
+				"path": "bestiary/giant-boar.opus"
 			},
 			"damageTags": [
 				"P"
@@ -23582,13 +23948,11 @@
 			"page": 355,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "BQGT"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"BQGT",
+				"DrDe",
+				"DrDe-DaS",
+				"HotB"
 			],
 			"size": [
 				"S"
@@ -23615,7 +23979,7 @@
 			"wis": 7,
 			"cha": 3,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 8,
 			"cr": "1/4",
@@ -23633,7 +23997,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-centipede.mp3"
+				"path": "bestiary/giant-centipede.opus"
 			},
 			"senseTags": [
 				"B"
@@ -23685,7 +24049,7 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"blindsight 10 ft."
+				"Blindsight 10 ft."
 			],
 			"passive": 12,
 			"cr": "2",
@@ -23717,7 +24081,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-constrictor-snake.mp3"
+				"path": "bestiary/giant-constrictor-snake.opus"
 			},
 			"senseTags": [
 				"B"
@@ -23755,6 +24119,10 @@
 					"page": 350
 				}
 			],
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -23783,7 +24151,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 9,
 			"cr": "1/8",
@@ -23809,7 +24177,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-crab.mp3"
+				"path": "bestiary/giant-crab.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -23836,10 +24204,10 @@
 			"page": 356,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"RHW"
 			],
 			"size": [
 				"H"
@@ -23904,7 +24272,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-crocodile.mp3"
+				"path": "bestiary/giant-crocodile.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -23994,7 +24362,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-eagle.mp3"
+				"path": "bestiary/giant-eagle.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -24023,6 +24391,9 @@
 			"page": 356,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"H"
 			],
@@ -24058,7 +24429,7 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"darkvision 90 ft."
+				"Darkvision 90 ft."
 			],
 			"passive": 14,
 			"resist": [
@@ -24086,7 +24457,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-elk.mp3"
+				"path": "bestiary/giant-elk.opus"
 			},
 			"senseTags": [
 				"D"
@@ -24119,6 +24490,9 @@
 			"page": 357,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"HotB"
+			],
 			"size": [
 				"S"
 			],
@@ -24144,7 +24518,7 @@
 			"wis": 7,
 			"cha": 3,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 8,
 			"resist": [
@@ -24173,7 +24547,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-fire-beetle.mp3"
+				"path": "bestiary/giant-fire-beetle.opus"
 			},
 			"traitTags": [
 				"Illumination"
@@ -24198,6 +24572,9 @@
 			"page": 357,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -24227,7 +24604,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 30 ft."
+				"Darkvision 30 ft."
 			],
 			"passive": 12,
 			"cr": "1/4",
@@ -24266,7 +24643,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-frog.mp3"
+				"path": "bestiary/giant-frog.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -24304,6 +24681,9 @@
 					"page": 350
 				}
 			],
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -24335,7 +24715,7 @@
 				"perception": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "1/2",
@@ -24354,7 +24734,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-goat.mp3"
+				"path": "bestiary/giant-goat.opus"
 			},
 			"senseTags": [
 				"D"
@@ -24378,6 +24758,9 @@
 			"page": 357,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -24405,7 +24788,7 @@
 				"perception": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "1",
@@ -24421,7 +24804,7 @@
 				{
 					"name": "Rampage (1/Day)",
 					"entries": [
-						"Immediately after dealing damage to a creature that was already {@variantrule Bloodied|XPHB}, the hyena can move up to half its {@variantrule Speed|XPHB}, and it makes one Bite attack."
+						"Immediately after dealing damage to a creature that was already {@status Bloodied|XPHB}, the hyena can move up to half its {@variantrule Speed|XPHB}, and it makes one Bite attack."
 					]
 				}
 			],
@@ -24433,7 +24816,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-hyena.mp3"
+				"path": "bestiary/giant-hyena.opus"
 			},
 			"senseTags": [
 				"D"
@@ -24482,7 +24865,7 @@
 				"dex": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"cr": "1/4",
@@ -24511,7 +24894,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-lizard.mp3"
+				"path": "bestiary/giant-lizard.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -24564,7 +24947,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"cr": "1",
@@ -24597,7 +24980,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-octopus.mp3"
+				"path": "bestiary/giant-octopus.opus"
 			},
 			"traitTags": [
 				"Water Breathing"
@@ -24629,6 +25012,9 @@
 			"page": 358,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -24661,7 +25047,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 16,
 			"resist": [
@@ -24698,7 +25084,7 @@
 				{
 					"name": "Flyby",
 					"entries": [
-						"The owl doesn't provoke an Opportunity Attack when it flies out of an enemy's reach."
+						"The owl doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
 					]
 				}
 			],
@@ -24717,7 +25103,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-owl.mp3"
+				"path": "bestiary/giant-owl.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -24751,6 +25137,10 @@
 			"page": 358,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"S"
 			],
@@ -24782,7 +25172,7 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"cr": "1/8",
@@ -24810,7 +25200,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-rat.mp3"
+				"path": "bestiary/giant-rat.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -24834,6 +25224,11 @@
 			"page": 359,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"NF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -24858,7 +25253,7 @@
 			"wis": 9,
 			"cha": 3,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 9,
 			"cr": "3",
@@ -24887,7 +25282,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-scorpion.mp3"
+				"path": "bestiary/giant-scorpion.opus"
 			},
 			"senseTags": [
 				"B"
@@ -24994,6 +25389,11 @@
 			"page": 359,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -25025,7 +25425,7 @@
 				"perception": "+3"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 13,
 			"cr": "5",
@@ -25056,7 +25456,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-shark.mp3"
+				"path": "bestiary/giant-shark.opus"
 			},
 			"traitTags": [
 				"Water Breathing"
@@ -25089,6 +25489,12 @@
 					"page": 351
 				}
 			],
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"HotB",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -25118,7 +25524,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"cr": "1",
@@ -25159,7 +25565,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-spider.mp3"
+				"path": "bestiary/giant-spider.opus"
 			},
 			"traitTags": [
 				"Spider Climb",
@@ -25221,7 +25627,7 @@
 				"perception": "+6"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 16,
 			"cr": "6",
@@ -25295,6 +25701,9 @@
 			"page": 360,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -25320,7 +25729,7 @@
 			"wis": 10,
 			"cha": 3,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"cr": "1",
@@ -25360,7 +25769,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-toad.mp3"
+				"path": "bestiary/giant-toad.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -25392,10 +25801,9 @@
 			"page": 361,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS"
 			],
 			"size": [
 				"M"
@@ -25425,7 +25833,7 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"blindsight 10 ft."
+				"Blindsight 10 ft."
 			],
 			"passive": 12,
 			"cr": "1/4",
@@ -25495,7 +25903,7 @@
 				"perception": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"resist": [
@@ -25528,7 +25936,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-vulture.mp3"
+				"path": "bestiary/giant-vulture.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -25589,7 +25997,7 @@
 				{
 					"name": "Flyby",
 					"entries": [
-						"The wasp doesn't provoke an Opportunity Attack when it flies out of an enemy's reach."
+						"The wasp doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
 					]
 				}
 			],
@@ -25608,7 +26016,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-wasp.mp3"
+				"path": "bestiary/giant-wasp.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -25666,7 +26074,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "1/8",
@@ -25685,7 +26093,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-weasel.mp3"
+				"path": "bestiary/giant-weasel.opus"
 			},
 			"senseTags": [
 				"D"
@@ -25706,6 +26114,9 @@
 			"page": 362,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -25735,8 +26146,8 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "1/4",
@@ -25765,7 +26176,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/giant-wolf-spider.mp3"
+				"path": "bestiary/giant-wolf-spider.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -25791,6 +26202,10 @@
 			"page": 133,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -25817,7 +26232,7 @@
 			"wis": 10,
 			"cha": 6,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"conditionImmune": [
@@ -25878,7 +26293,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gibbering-mouther.mp3"
+				"path": "bestiary/gibbering-mouther.opus"
 			},
 			"senseTags": [
 				"D"
@@ -25955,7 +26370,7 @@
 				"perception": "+8"
 			},
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 18,
 			"languages": [
@@ -25972,7 +26387,7 @@
 						"The githyanki casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 18}, {@hit 10} to hit with spell attacks):"
 					],
 					"will": [
-						"{@spell Mage Hand|XPHB} (the hand is Invisible)"
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})"
 					],
 					"daily": {
 						"2e": [
@@ -26067,10 +26482,11 @@
 			"name": "Githyanki Knight",
 			"source": "XMM",
 			"page": 135,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC",
+				"DrDe-TFV",
+				"FRAiF"
 			],
 			"size": [
 				"M"
@@ -26126,7 +26542,7 @@
 						"The githyanki casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 13}):"
 					],
 					"will": [
-						"{@spell Mage Hand|XPHB} (the hand is Invisible)"
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})"
 					],
 					"daily": {
 						"2e": [
@@ -26181,7 +26597,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githyanki-knight.mp3"
+				"path": "bestiary/githyanki-knight.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -26268,7 +26684,7 @@
 						"The githyanki casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability:"
 					],
 					"will": [
-						"{@spell Mage Hand|XPHB} (the hand is Invisible)"
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})"
 					],
 					"daily": {
 						"2": [
@@ -26318,7 +26734,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githyanki-warrior.mp3"
+				"path": "bestiary/githyanki-warrior.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -26401,7 +26817,7 @@
 						"The githzerai casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability:"
 					],
 					"will": [
-						"{@spell Mage Hand|XPHB} (the hand is Invisible)"
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})"
 					],
 					"daily": {
 						"1": [
@@ -26470,7 +26886,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githzerai-monk.mp3"
+				"path": "bestiary/githzerai-monk.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -26559,7 +26975,7 @@
 						"The githzerai casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 16}):"
 					],
 					"will": [
-						"{@spell Mage Hand|XPHB} (the hand is Invisible)"
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})"
 					],
 					"daily": {
 						"1e": [
@@ -26690,7 +27106,7 @@
 						"The githzerai casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability (spell save {@dc 14}):"
 					],
 					"will": [
-						"{@spell Mage Hand|XPHB} (the hand is Invisible)"
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})"
 					],
 					"daily": {
 						"1e": [
@@ -26761,7 +27177,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/githzerai-zerth.mp3"
+				"path": "bestiary/githzerai-zerth.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -26842,7 +27258,7 @@
 				"perception": "+7"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 17,
 			"resist": [
@@ -26925,7 +27341,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/glabrezu.mp3"
+				"path": "bestiary/glabrezu.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -26974,6 +27390,10 @@
 			"page": 139,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"S",
 				"M"
@@ -27061,7 +27481,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gladiator.mp3"
+				"path": "bestiary/gladiator.opus"
 			},
 			"actionTags": [
 				"Multiattack",
@@ -27131,7 +27551,7 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"languages": [
@@ -27164,7 +27584,7 @@
 				{
 					"name": "Rampage (2/Day)",
 					"entries": [
-						"Immediately after dealing damage to a creature that is already {@variantrule Bloodied|XPHB}, the gnoll moves up to half its {@variantrule Speed|XPHB}, and it makes one Abyssal Strike attack."
+						"Immediately after dealing damage to a creature that is already {@status Bloodied|XPHB}, the gnoll moves up to half its {@variantrule Speed|XPHB}, and it makes one Abyssal Strike attack."
 					]
 				}
 			],
@@ -27208,6 +27628,9 @@
 			"name": "Gnoll Fang of Yeenoghu",
 			"source": "XMM",
 			"page": 141,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -27241,7 +27664,7 @@
 				"cha": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -27273,7 +27696,7 @@
 				{
 					"name": "Rampage (2/Day)",
 					"entries": [
-						"Immediately after dealing damage to a creature that is already {@variantrule Bloodied|XPHB}, the gnoll moves up to half its {@variantrule Speed|XPHB}, and it makes one Bite attack."
+						"Immediately after dealing damage to a creature that is already {@status Bloodied|XPHB}, the gnoll moves up to half its {@variantrule Speed|XPHB}, and it makes one Bite attack."
 					]
 				}
 			],
@@ -27289,7 +27712,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll-fang-of-yeenoghu.mp3"
+				"path": "bestiary/gnoll-fang-of-yeenoghu.opus"
 			},
 			"senseTags": [
 				"D"
@@ -27321,6 +27744,9 @@
 			"name": "Gnoll Pack Lord",
 			"source": "XMM",
 			"page": 140,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -27349,7 +27775,7 @@
 			"wis": 11,
 			"cha": 9,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -27386,7 +27812,7 @@
 				{
 					"name": "Rampage (2/Day)",
 					"entries": [
-						"Immediately after dealing damage to a creature that is already {@variantrule Bloodied|XPHB}, the gnoll moves up to half its {@variantrule Speed|XPHB}, and it makes one Bone Whip attack."
+						"Immediately after dealing damage to a creature that is already {@status Bloodied|XPHB}, the gnoll moves up to half its {@variantrule Speed|XPHB}, and it makes one Bone Whip attack."
 					]
 				}
 			],
@@ -27402,7 +27828,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gnoll-pack-lord.mp3"
+				"path": "bestiary/gnoll-pack-lord.opus"
 			},
 			"senseTags": [
 				"D"
@@ -27434,6 +27860,10 @@
 			"page": 140,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"HotB"
+			],
 			"size": [
 				"M"
 			],
@@ -27459,7 +27889,7 @@
 			"wis": 10,
 			"cha": 7,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -27484,7 +27914,7 @@
 				{
 					"name": "Rampage (1/Day)",
 					"entries": [
-						"Immediately after dealing damage to a creature that is already {@variantrule Bloodied|XPHB}, the gnoll moves up to half its {@variantrule Speed|XPHB}, and it makes one Rend attack."
+						"Immediately after dealing damage to a creature that is already {@status Bloodied|XPHB}, the gnoll moves up to half its {@variantrule Speed|XPHB}, and it makes one Rend attack."
 					]
 				}
 			],
@@ -27525,10 +27955,11 @@
 				{
 					"source": "XPHB",
 					"page": 351
-				},
-				{
-					"source": "DrDe"
 				}
+			],
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TDoN"
 			],
 			"size": [
 				"M"
@@ -27561,7 +27992,7 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"cr": "0",
@@ -27582,7 +28013,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/goat.mp3"
+				"path": "bestiary/goat.opus"
 			},
 			"senseTags": [
 				"D"
@@ -27606,6 +28037,10 @@
 			"page": 143,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"HotB"
+			],
 			"size": [
 				"S"
 			],
@@ -27639,7 +28074,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"languages": [
@@ -27677,7 +28112,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The goblin takes the Disengage or Hide action."
+						"The goblin takes the {@action Disengage|XPHB} or {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -27703,7 +28138,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/goblin-boss.mp3"
+				"path": "bestiary/goblin-boss.opus"
 			},
 			"senseTags": [
 				"D"
@@ -27736,6 +28171,10 @@
 			],
 			"source": "XMM",
 			"page": 143,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S"
 			],
@@ -27770,7 +28209,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -27911,7 +28350,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"languages": [
@@ -27937,7 +28376,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The goblin takes the Disengage or Hide action."
+						"The goblin takes the {@action Disengage|XPHB} or {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -27982,13 +28421,13 @@
 			"page": 142,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "BQGT"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"BQGT",
+				"DrDe",
+				"DrDe-BD",
+				"FRAiF",
+				"HotB",
+				"RHW"
 			],
 			"size": [
 				"S"
@@ -28023,7 +28462,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"languages": [
@@ -28055,7 +28494,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The goblin takes the Disengage or Hide action."
+						"The goblin takes the {@action Disengage|XPHB} or {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -28101,10 +28540,9 @@
 			"page": 144,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BD"
 			],
 			"size": [
 				"M"
@@ -28149,8 +28587,8 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -28204,7 +28642,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gold-dragon-wyrmlin.mp3"
+				"path": "bestiary/gold-dragon-wyrmlin.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -28241,6 +28679,9 @@
 			"page": 148,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA"
+			],
 			"size": [
 				"L"
 			],
@@ -28268,7 +28709,7 @@
 				"perception": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 17,
 			"conditionImmune": [
@@ -28308,7 +28749,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gorgon.mp3"
+				"path": "bestiary/gorgon.opus"
 			},
 			"senseTags": [
 				"D"
@@ -28343,6 +28784,9 @@
 			],
 			"source": "XMM",
 			"page": 150,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -28386,7 +28830,7 @@
 				"survival": "+7"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 17,
 			"resist": [
@@ -28460,7 +28904,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/goristro.mp3"
+				"path": "bestiary/goristro.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -28494,6 +28938,9 @@
 			"name": "Graveyard Revenant",
 			"source": "XMM",
 			"page": 260,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -28524,7 +28971,7 @@
 				"cha": "+7"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 13,
 			"resist": [
@@ -28619,10 +29066,9 @@
 			"page": 151,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				}
+			"referenceSources": [
+				"FRAiF",
+				"ScoEE"
 			],
 			"size": [
 				"M"
@@ -28652,7 +29098,7 @@
 				"stealth": "+2"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 8,
 			"resist": [
@@ -28699,7 +29145,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gray-ooze.mp3"
+				"path": "bestiary/gray-ooze.opus"
 			},
 			"traitTags": [
 				"Amorphous"
@@ -28721,6 +29167,9 @@
 			"name": "Gray Slaad",
 			"source": "XMM",
 			"page": 286,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -28753,8 +29202,8 @@
 				"perception": "+7"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 60 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 17,
 			"resist": [
@@ -28839,7 +29288,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gray-slaad.mp3"
+				"path": "bestiary/gray-slaad.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -28891,10 +29340,10 @@
 			"page": 152,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"DrDe-DaS"
 			],
 			"size": [
 				"M"
@@ -28939,8 +29388,8 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -28990,7 +29439,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-dragon-wyrmling.mp3"
+				"path": "bestiary/green-dragon-wyrmling.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -29026,10 +29475,12 @@
 			"page": 156,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BD",
+				"DrDe-TFV",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -29063,7 +29514,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"languages": [
@@ -29103,7 +29554,7 @@
 					"will": [
 						"{@spell Dancing Lights|XPHB}",
 						"{@spell Disguise Self|XPHB} (24-hour duration)",
-						"{@spell Invisibility|XPHB} (self only, and the hag leaves no tracks while Invisible)",
+						"{@spell Invisibility|XPHB} (self only, and the hag leaves no tracks while {@condition Invisible|XPHB})",
 						"{@spell Minor Illusion|XPHB}",
 						"{@spell Ray of Sickness|XPHB} (level 3 version)"
 					],
@@ -29149,7 +29600,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-hag.mp3"
+				"path": "bestiary/green-hag.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -29194,6 +29645,9 @@
 			"name": "Green Slaad",
 			"source": "XMM",
 			"page": 286,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -29226,8 +29680,8 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 60 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"resist": [
@@ -29308,7 +29762,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-slaad.mp3"
+				"path": "bestiary/green-slaad.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -29355,6 +29809,10 @@
 			"name": "Grell",
 			"source": "XMM",
 			"page": 157,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -29392,7 +29850,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -29439,7 +29897,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grell.mp3"
+				"path": "bestiary/grell.opus"
 			},
 			"senseTags": [
 				"B"
@@ -29475,6 +29933,9 @@
 			"page": 158,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -29503,7 +29964,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"cr": "2",
@@ -29536,7 +29997,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grick.mp3"
+				"path": "bestiary/grick.opus"
 			},
 			"senseTags": [
 				"D"
@@ -29563,10 +30024,11 @@
 			"name": "Grick Ancient",
 			"source": "XMM",
 			"page": 158,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"DrDe-TFV",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -29596,7 +30058,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"cr": "7",
@@ -29663,6 +30125,10 @@
 			"page": 159,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"NF"
+			],
 			"size": [
 				"L"
 			],
@@ -29691,7 +30157,7 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"cr": "2",
@@ -29718,7 +30184,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/griffon.mp3"
+				"path": "bestiary/griffon.opus"
 			},
 			"senseTags": [
 				"D"
@@ -29745,6 +30211,9 @@
 			"page": 160,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -29776,7 +30245,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 13,
 			"cr": "1/4",
@@ -29793,7 +30262,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/grimlock.mp3"
+				"path": "bestiary/grimlock.opus"
 			},
 			"senseTags": [
 				"B"
@@ -29815,10 +30284,16 @@
 			"page": 162,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS",
+				"DrDe-TFV",
+				"EFA",
+				"FRAiF",
+				"FRHoF",
+				"HotB",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -29874,7 +30349,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guard.mp3"
+				"path": "bestiary/guard.opus"
 			},
 			"languageTags": [
 				"C"
@@ -29898,6 +30373,14 @@
 			"page": 162,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FFotR",
+				"FRAiF",
+				"HotB",
+				"LFL",
+				"NF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -29996,6 +30479,10 @@
 			"page": 161,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -30035,7 +30522,7 @@
 				"religion": "+11"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -30113,7 +30600,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/guardian-naga.mp3"
+				"path": "bestiary/guardian-naga.opus"
 			},
 			"senseTags": [
 				"D"
@@ -30162,6 +30649,10 @@
 			"name": "Gulthias Blight",
 			"source": "XMM",
 			"page": 45,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"G"
 			],
@@ -30193,7 +30684,7 @@
 				"perception": "+9"
 			},
 			"senses": [
-				"blindsight 120 ft."
+				"Blindsight 120 ft."
 			],
 			"passive": 19,
 			"resist": [
@@ -30261,6 +30752,7 @@
 				"P"
 			],
 			"miscTags": [
+				"HPR",
 				"MA",
 				"RA",
 				"RCH"
@@ -30282,6 +30774,9 @@
 			"page": 163,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -30318,8 +30813,8 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -30406,6 +30901,11 @@
 			"page": 164,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -30461,7 +30961,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/harpy.mp3"
+				"path": "bestiary/harpy.opus"
 			},
 			"languageTags": [
 				"C"
@@ -30487,6 +30987,10 @@
 			"name": "Haunting Revenant",
 			"source": "XMM",
 			"page": 260,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"G"
 			],
@@ -30518,7 +31022,7 @@
 				"wis": "+8"
 			},
 			"senses": [
-				"truesight 60 ft."
+				"Truesight 60 ft."
 			],
 			"passive": 14,
 			"resist": [
@@ -30562,7 +31066,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The revenant makes two {@variantrule Object|XPHB} Slam attacks and uses Invitation."
+						"The revenant makes two Object Slam attacks and uses Invitation."
 					]
 				},
 				{
@@ -30626,6 +31130,9 @@
 					"page": 352
 				}
 			],
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"T"
 			],
@@ -30674,7 +31181,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hawk.mp3"
+				"path": "bestiary/hawk.opus"
 			},
 			"damageTags": [
 				"S"
@@ -30692,6 +31199,10 @@
 			"page": 165,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -30720,7 +31231,7 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"immune": [
@@ -30765,7 +31276,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hell-hound.mp3"
+				"path": "bestiary/hell-hound.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -30799,6 +31310,14 @@
 			"name": "Helmed Horror",
 			"source": "XMM",
 			"page": 166,
+			"referenceSources": [
+				"ABH",
+				"EFA",
+				"FFotR",
+				"FRAiF",
+				"FRHoF",
+				"NF"
+			],
 			"size": [
 				"M"
 			],
@@ -30834,7 +31353,7 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -30895,7 +31414,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/helmed-horror.mp3"
+				"path": "bestiary/helmed-horror.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -30932,6 +31451,9 @@
 			"page": 167,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -30970,7 +31492,7 @@
 				"wis": "+4"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -31038,7 +31560,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hezrou.mp3"
+				"path": "bestiary/hezrou.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -31076,10 +31598,11 @@
 			"page": 168,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"DrDe-TFV",
+				"FRAiF"
 			],
 			"size": [
 				"H"
@@ -31144,7 +31667,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hill-giant.mp3"
+				"path": "bestiary/hill-giant.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -31208,7 +31731,7 @@
 				{
 					"name": "Flyby",
 					"entries": [
-						"The hippogriff doesn't provoke an Opportunity Attack when it flies out of an enemy's reach."
+						"The hippogriff doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
 					]
 				}
 			],
@@ -31233,7 +31756,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hippogriff.mp3"
+				"path": "bestiary/hippogriff.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -31341,6 +31864,10 @@
 			"page": 171,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -31374,7 +31901,7 @@
 			"wis": 10,
 			"cha": 13,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -31430,7 +31957,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hobgoblin-captain.mp3"
+				"path": "bestiary/hobgoblin-captain.opus"
 			},
 			"senseTags": [
 				"D"
@@ -31464,6 +31991,9 @@
 			],
 			"source": "XMM",
 			"page": 171,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -31503,7 +32033,7 @@
 				"cha": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -31571,7 +32101,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hobgoblin-warlord.mp3"
+				"path": "bestiary/hobgoblin-warlord.opus"
 			},
 			"senseTags": [
 				"D"
@@ -31607,6 +32137,10 @@
 			"page": 170,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"HotB"
+			],
 			"size": [
 				"M"
 			],
@@ -31640,7 +32174,7 @@
 			"wis": 10,
 			"cha": 9,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -31720,6 +32254,9 @@
 			"page": 172,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"T"
 			],
@@ -31749,7 +32286,7 @@
 				"cha": "+0"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -31784,7 +32321,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/homunculus.mp3"
+				"path": "bestiary/homunculus.opus"
 			},
 			"senseTags": [
 				"D"
@@ -31815,6 +32352,10 @@
 			"name": "Hook Horror",
 			"source": "XMM",
 			"page": 173,
+			"referenceSources": [
+				"FRAiF",
+				"NF"
+			],
 			"size": [
 				"L"
 			],
@@ -31846,8 +32387,8 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 15,
 			"languages": [
@@ -31873,7 +32414,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hook-horror.mp3"
+				"path": "bestiary/hook-horror.opus"
 			},
 			"senseTags": [
 				"B",
@@ -31905,6 +32446,9 @@
 			"page": 174,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -31945,7 +32489,7 @@
 				"cha": "+8"
 			},
 			"senses": [
-				"darkvision 150 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+				"Darkvision 150 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
 			],
 			"passive": 13,
 			"immune": [
@@ -32007,7 +32551,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/horned-devil.mp3"
+				"path": "bestiary/horned-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -32046,6 +32590,9 @@
 			"page": 363,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -32074,7 +32621,7 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 12,
 			"cr": "2",
@@ -32099,7 +32646,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hunter-shark.mp3"
+				"path": "bestiary/hunter-shark.opus"
 			},
 			"traitTags": [
 				"Water Breathing"
@@ -32123,10 +32670,11 @@
 			"page": 175,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"H"
@@ -32159,7 +32707,7 @@
 				"perception": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 16,
 			"conditionImmune": [
@@ -32214,7 +32762,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hydra.mp3"
+				"path": "bestiary/hydra.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -32269,7 +32817,7 @@
 				"perception": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "0",
@@ -32298,7 +32846,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/hyena.mp3"
+				"path": "bestiary/hyena.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -32325,6 +32873,9 @@
 			"page": 176,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -32369,7 +32920,7 @@
 				"persuasion": "+9"
 			},
 			"senses": [
-				"blindsight 120 ft."
+				"Blindsight 120 ft."
 			],
 			"passive": 17,
 			"immune": [
@@ -32445,7 +32996,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ice-devil.mp3"
+				"path": "bestiary/ice-devil.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -32492,10 +33043,12 @@
 			"page": 206,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BD",
+				"DrDe-SD",
+				"FRAiF",
+				"NF"
 			],
 			"size": [
 				"S"
@@ -32527,7 +33080,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -32591,7 +33144,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ice-mephit.mp3"
+				"path": "bestiary/ice-mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -32639,6 +33192,11 @@
 					"page": 352
 				}
 			],
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"T"
 			],
@@ -32675,7 +33233,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+				"Darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
 			],
 			"passive": 11,
 			"resist": [
@@ -32737,7 +33295,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/imp.mp3"
+				"path": "bestiary/imp.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -32773,10 +33331,11 @@
 			"page": 178,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				}
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW",
+				"ScoEE"
 			],
 			"size": [
 				"M"
@@ -32811,7 +33370,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -32886,7 +33445,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/succubus-incubus.mp3"
+				"path": "bestiary/succubus-incubus.opus"
 			},
 			"senseTags": [
 				"D"
@@ -32935,6 +33494,10 @@
 			"name": "Intellect Devourer",
 			"source": "XMM",
 			"page": 179,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"T"
 			],
@@ -32964,7 +33527,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 12,
 			"resist": [
@@ -33014,7 +33577,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/intellect-devourer.mp3"
+				"path": "bestiary/intellect-devourer.opus"
 			},
 			"senseTags": [
 				"B"
@@ -33051,10 +33614,12 @@
 			"page": 180,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC",
+				"LFL",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -33092,7 +33657,7 @@
 				"stealth": "+10"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 18,
 			"resist": [
@@ -33157,7 +33722,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/invisible-stalker.mp3"
+				"path": "bestiary/invisible-stalker.opus"
 			},
 			"senseTags": [
 				"D"
@@ -33194,6 +33759,9 @@
 			"page": 181,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -33221,7 +33789,7 @@
 			"wis": 11,
 			"cha": 1,
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -33295,7 +33863,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/iron-golem.mp3"
+				"path": "bestiary/iron-golem.opus"
 			},
 			"traitTags": [
 				"Damage Absorption",
@@ -33365,7 +33933,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 90 ft."
+				"Darkvision 90 ft."
 			],
 			"passive": 15,
 			"cr": "0",
@@ -33384,7 +33952,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/jackal.mp3"
+				"path": "bestiary/jackal.opus"
 			},
 			"senseTags": [
 				"D"
@@ -33403,6 +33971,9 @@
 			"name": "Jackalwere",
 			"source": "XMM",
 			"page": 182,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"S"
 			],
@@ -33433,7 +34004,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 90 ft."
+				"Darkvision 90 ft."
 			],
 			"passive": 14,
 			"languages": [
@@ -33491,7 +34062,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/jackalwere.mp3"
+				"path": "bestiary/jackalwere.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -33526,6 +34097,9 @@
 			"name": "Juvenile Shadow Dragon",
 			"source": "XMM",
 			"page": 275,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -33563,8 +34137,8 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"resist": [
@@ -33618,7 +34192,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the dragon takes the Hide action."
+						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the dragon takes the {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -33663,6 +34237,10 @@
 			"name": "Kenku",
 			"source": "XMM",
 			"page": 183,
+			"referenceSources": [
+				"ABH",
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -33692,7 +34270,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"languages": [
@@ -33746,7 +34324,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kenku.mp3"
+				"path": "bestiary/kenku.opus"
 			},
 			"traitTags": [
 				"Mimicry"
@@ -33782,6 +34360,9 @@
 			"page": 364,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -33811,7 +34392,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 120 ft."
+				"Blindsight 120 ft."
 			],
 			"passive": 13,
 			"cr": "3",
@@ -33836,7 +34417,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/killer-whale.mp3"
+				"path": "bestiary/killer-whale.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -33860,16 +34441,14 @@
 			"page": 184,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				},
-				{
-					"source": "HBTD"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"FRAiF",
+				"FRHoF",
+				"HBTD",
+				"HotB",
+				"ScoEE"
 			],
 			"size": [
 				"S",
@@ -33949,7 +34528,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/knight.mp3"
+				"path": "bestiary/knight.opus"
 			},
 			"actionTags": [
 				"Multiattack",
@@ -33980,6 +34559,10 @@
 			"page": 185,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"HotB"
+			],
 			"size": [
 				"S"
 			],
@@ -34004,7 +34587,7 @@
 			"wis": 7,
 			"cha": 8,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 8,
 			"languages": [
@@ -34087,6 +34670,11 @@
 			"page": 187,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"G"
 			],
@@ -34131,7 +34719,7 @@
 				"perception": "+11"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 21,
 			"immune": [
@@ -34234,7 +34822,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kraken.mp3"
+				"path": "bestiary/kraken.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -34284,6 +34872,11 @@
 			"name": "Kuo-toa",
 			"source": "XMM",
 			"page": 189,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -34313,8 +34906,8 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"darkvision 120 ft.",
-				"truesight 30 ft."
+				"Darkvision 120 ft.",
+				"Truesight 30 ft."
 			],
 			"passive": 14,
 			"languages": [
@@ -34369,7 +34962,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kuo-toa.mp3"
+				"path": "bestiary/kuo-toa.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -34408,6 +35001,10 @@
 			"name": "Kuo-toa Archpriest",
 			"source": "XMM",
 			"page": 191,
+			"referenceSources": [
+				"EFA",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -34438,8 +35035,8 @@
 				"religion": "+4"
 			},
 			"senses": [
-				"darkvision 120 ft.",
-				"truesight 30 ft."
+				"Darkvision 120 ft.",
+				"Truesight 30 ft."
 			],
 			"passive": 19,
 			"languages": [
@@ -34524,7 +35121,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kuo-toa-archpriest.mp3"
+				"path": "bestiary/kuo-toa-archpriest.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -34571,6 +35168,10 @@
 			"name": "Kuo-toa Monitor",
 			"source": "XMM",
 			"page": 190,
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -34601,8 +35202,8 @@
 				"religion": "+3"
 			},
 			"senses": [
-				"darkvision 120 ft.",
-				"truesight 30 ft."
+				"Darkvision 120 ft.",
+				"Truesight 30 ft."
 			],
 			"passive": 16,
 			"languages": [
@@ -34646,7 +35247,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kuo-toa-monitor.mp3"
+				"path": "bestiary/kuo-toa-monitor.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -34679,6 +35280,9 @@
 			"name": "Kuo-toa Whip",
 			"source": "XMM",
 			"page": 190,
+			"referenceSources": [
+				"EFA"
+			],
 			"size": [
 				"M"
 			],
@@ -34709,8 +35313,8 @@
 				"religion": "+3"
 			},
 			"senses": [
-				"darkvision 120 ft.",
-				"truesight 30 ft."
+				"Darkvision 120 ft.",
+				"Truesight 30 ft."
 			],
 			"passive": 16,
 			"languages": [
@@ -34773,7 +35377,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/kuo-toa-whip.mp3"
+				"path": "bestiary/kuo-toa-whip.opus"
 			},
 			"traitTags": [
 				"Amphibious",
@@ -34809,6 +35413,9 @@
 			"name": "Lacedon Ghoul",
 			"source": "XMM",
 			"page": 132,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -34835,7 +35442,7 @@
 			"wis": 10,
 			"cha": 6,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -34921,6 +35528,9 @@
 			"page": 192,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -34951,7 +35561,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"languages": [
@@ -35017,7 +35627,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lamia.mp3"
+				"path": "bestiary/lamia.opus"
 			},
 			"senseTags": [
 				"D"
@@ -35084,7 +35694,7 @@
 			"wis": 10,
 			"cha": 2,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -35159,7 +35769,7 @@
 			"wis": 11,
 			"cha": 3,
 			"senses": [
-				"darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+				"Darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
 			],
 			"passive": 10,
 			"resist": [
@@ -35182,7 +35792,7 @@
 				{
 					"name": "Hellish Restoration",
 					"entries": [
-						"If the lemure dies in the Nine Hells, it revives with all its {@variantrule Hit Points|XPHB} in {@dice 1d10} days unless it is killed by a creature under the effects of a {@spell Bless|XPHB} spell or its remains are sprinkled with Holy Water."
+						"If the lemure dies in the Nine Hells, it revives with all its {@variantrule Hit Points|XPHB} in {@dice 1d10} days unless it is killed by a creature under the effects of a {@spell Bless|XPHB} spell or its remains are sprinkled with {@item Holy Water|XPHB}."
 					]
 				}
 			],
@@ -35199,7 +35809,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lemure.mp3"
+				"path": "bestiary/lemure.opus"
 			},
 			"traitTags": [
 				"Devil's Sight"
@@ -35227,10 +35837,12 @@
 			"page": 196,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -35277,7 +35889,7 @@
 				"perception": "+9"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 19,
 			"resist": [
@@ -35433,7 +36045,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lich.mp3"
+				"path": "bestiary/lich.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -35498,6 +36110,10 @@
 					"page": 352
 				}
 			],
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -35526,7 +36142,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "1",
@@ -35572,7 +36188,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lion.mp3"
+				"path": "bestiary/lion.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -35636,7 +36252,7 @@
 			"wis": 8,
 			"cha": 3,
 			"senses": [
-				"darkvision 30 ft."
+				"Darkvision 30 ft."
 			],
 			"passive": 9,
 			"cr": "0",
@@ -35666,7 +36282,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/lizard.mp3"
+				"path": "bestiary/lizard.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -35688,6 +36304,9 @@
 			"name": "Lizardfolk Geomancer",
 			"source": "XMM",
 			"page": 197,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -35812,6 +36431,10 @@
 			"name": "Lizardfolk Sovereign",
 			"source": "XMM",
 			"page": 197,
+			"referenceSources": [
+				"NF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -35846,7 +36469,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"conditionImmune": [
@@ -35924,13 +36547,17 @@
 			"page": 199,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "UtHftLH"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"DrDe-DotSC",
+				"EFA",
+				"FRAiF",
+				"FRHoF",
+				"LFL",
+				"NF",
+				"RHW",
+				"UtHftLH"
 			],
 			"size": [
 				"S",
@@ -35972,7 +36599,7 @@
 			},
 			"passive": 14,
 			"languages": [
-				"Common and any three languages"
+				"Common plus three other languages"
 			],
 			"cr": "6",
 			"gear": [
@@ -36064,7 +36691,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mage.mp3"
+				"path": "bestiary/mage.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -36102,6 +36729,12 @@
 			"name": "Mage Apprentice",
 			"source": "XMM",
 			"page": 198,
+			"referenceSources": [
+				"ABH",
+				"EFA",
+				"FRAiF",
+				"NF"
+			],
 			"size": [
 				"S",
 				"M"
@@ -36247,7 +36880,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -36292,7 +36925,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/magma-mephit.mp3"
+				"path": "bestiary/magma-mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -36353,7 +36986,7 @@
 			"wis": 11,
 			"cha": 10,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -36392,7 +37025,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/magmin.mp3"
+				"path": "bestiary/magmin.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -36424,10 +37057,11 @@
 			"page": 365,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"FRAiF",
+				"NF"
 			],
 			"size": [
 				"H"
@@ -36488,7 +37122,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mammoth.mp3"
+				"path": "bestiary/mammoth.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -36548,7 +37182,7 @@
 			"wis": 8,
 			"cha": 4,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"resist": [
@@ -36581,7 +37215,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/manes.mp3"
+				"path": "bestiary/manes.opus"
 			},
 			"senseTags": [
 				"D"
@@ -36607,6 +37241,9 @@
 			],
 			"source": "XMM",
 			"page": 201,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -36637,7 +37274,7 @@
 			"wis": 8,
 			"cha": 3,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"resist": [
@@ -36686,7 +37323,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the manes takes the Hide action."
+						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the manes takes the {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -36723,10 +37360,10 @@
 			"page": 202,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -36754,7 +37391,7 @@
 			"wis": 12,
 			"cha": 8,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"languages": [
@@ -36793,7 +37430,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/manticore.mp3"
+				"path": "bestiary/manticore.opus"
 			},
 			"senseTags": [
 				"D"
@@ -36823,10 +37460,10 @@
 			],
 			"source": "XMM",
 			"page": 203,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -36867,8 +37504,8 @@
 				"cha": "+8"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 13,
 			"resist": [
@@ -36973,7 +37610,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/marid.mp3"
+				"path": "bestiary/marid.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -37071,7 +37708,7 @@
 				"perception": "+8"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 18,
 			"resist": [
@@ -37153,7 +37790,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/marilith.mp3"
+				"path": "bestiary/marilith.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -37199,10 +37836,13 @@
 				{
 					"source": "XPHB",
 					"page": 353
-				},
-				{
-					"source": "DrDe"
 				}
+			],
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS",
+				"FRAiF",
+				"FRHoF"
 			],
 			"size": [
 				"M"
@@ -37231,7 +37871,7 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"cr": "1/8",
@@ -37250,7 +37890,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mastiff.mp3"
+				"path": "bestiary/mastiff.opus"
 			},
 			"senseTags": [
 				"D"
@@ -37274,6 +37914,10 @@
 			"page": 205,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -37310,7 +37954,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 150 ft."
+				"Darkvision 150 ft."
 			],
 			"passive": 14,
 			"languages": [
@@ -37359,7 +38003,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/medusa.mp3"
+				"path": "bestiary/medusa.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -37397,6 +38041,9 @@
 			"page": 209,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -37476,6 +38123,10 @@
 			"name": "Merfolk Wavebender",
 			"source": "XMM",
 			"page": 209,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"M"
 			],
@@ -37619,6 +38270,10 @@
 			"page": 210,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"LFL"
+			],
 			"size": [
 				"L"
 			],
@@ -37645,7 +38300,7 @@
 			"wis": 10,
 			"cha": 9,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -37696,7 +38351,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/merrow.mp3"
+				"path": "bestiary/merrow.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -37734,6 +38389,10 @@
 			],
 			"source": "XMM",
 			"page": 211,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"M"
 			],
@@ -37770,8 +38429,8 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 60 ft."
+				"Blindsight 60 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -37859,7 +38518,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mezzoloth.mp3"
+				"path": "bestiary/mezzoloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -37911,10 +38570,12 @@
 			"page": 212,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC",
+				"FRAiF",
+				"HotB",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -37946,7 +38607,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"immune": [
@@ -37995,7 +38656,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mimic.mp3"
+				"path": "bestiary/mimic.opus"
 			},
 			"senseTags": [
 				"D"
@@ -38019,10 +38680,11 @@
 			"name": "Mind Flayer",
 			"source": "XMM",
 			"page": 214,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -38069,7 +38731,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 16,
 			"resist": [
@@ -38139,7 +38801,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mind-flayer.mp3"
+				"path": "bestiary/mind-flayer.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -38232,7 +38894,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 17,
 			"immune": [
@@ -38261,7 +38923,7 @@
 						"{@spell Detect Magic|XPHB}",
 						"{@spell Detect Thoughts|XPHB}",
 						"{@spell Disguise Self|XPHB}",
-						"{@spell Mage Hand|XPHB} (the hand is Invisible)"
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})"
 					],
 					"daily": {
 						"1e": [
@@ -38330,7 +38992,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mind-flayer-arcanist.mp3"
+				"path": "bestiary/mind-flayer-arcanist.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -38381,6 +39043,10 @@
 			"page": 215,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"HotB",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -38410,7 +39076,7 @@
 				"survival": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 17,
 			"languages": [
@@ -38466,6 +39132,9 @@
 			"page": 283,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -38491,7 +39160,7 @@
 			"wis": 8,
 			"cha": 5,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"immune": [
@@ -38529,7 +39198,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/minotaur-skeleton.mp3"
+				"path": "bestiary/minotaur-skeleton.opus"
 			},
 			"senseTags": [
 				"D"
@@ -38556,10 +39225,10 @@
 			"name": "Modron Duodrone",
 			"source": "XMM",
 			"page": 217,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC",
+				"FRAiF"
 			],
 			"size": [
 				"M"
@@ -38586,7 +39255,7 @@
 			"wis": 10,
 			"cha": 7,
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 10,
 			"conditionImmune": [
@@ -38671,7 +39340,7 @@
 			"wis": 10,
 			"cha": 5,
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 10,
 			"conditionImmune": [
@@ -38755,7 +39424,7 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 14,
 			"conditionImmune": [
@@ -38830,10 +39499,9 @@
 			"name": "Modron Quadrone",
 			"source": "XMM",
 			"page": 218,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC"
 			],
 			"size": [
 				"M"
@@ -38864,7 +39532,7 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 12,
 			"conditionImmune": [
@@ -38929,10 +39597,9 @@
 			"name": "Modron Tridrone",
 			"source": "XMM",
 			"page": 217,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC"
 			],
 			"size": [
 				"M"
@@ -38959,7 +39626,7 @@
 			"wis": 10,
 			"cha": 9,
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 10,
 			"conditionImmune": [
@@ -39020,10 +39687,9 @@
 			"name": "Mud Mephit",
 			"source": "XMM",
 			"page": 207,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS"
 			],
 			"size": [
 				"S"
@@ -39055,7 +39721,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -39096,7 +39762,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mud-mephit.mp3"
+				"path": "bestiary/mud-mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -39138,10 +39804,10 @@
 				{
 					"source": "XPHB",
 					"page": 353
-				},
-				{
-					"source": "HBTD"
 				}
+			],
+			"referenceSources": [
+				"HBTD"
 			],
 			"size": [
 				"M"
@@ -39194,7 +39860,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mule.mp3"
+				"path": "bestiary/mule.opus"
 			},
 			"traitTags": [
 				"Beast of Burden"
@@ -39215,10 +39881,13 @@
 			"page": 219,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BD",
+				"DrDe-DotSC",
+				"DrDe-TWoO",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -39249,7 +39918,7 @@
 				"wis": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"immune": [
@@ -39299,7 +39968,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mummy.mp3"
+				"path": "bestiary/mummy.opus"
 			},
 			"senseTags": [
 				"D"
@@ -39317,6 +39986,7 @@
 			],
 			"miscTags": [
 				"CUR",
+				"HPR",
 				"MA"
 			],
 			"conditionInflict": [
@@ -39335,10 +40005,11 @@
 			"page": 221,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DotSC",
+				"DrDe-TWoO",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -39383,7 +40054,7 @@
 				"religion": "+5"
 			},
 			"senses": [
-				"truesight 60 ft."
+				"Truesight 60 ft."
 			],
 			"passive": 19,
 			"immune": [
@@ -39528,7 +40199,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/mummy-lord.mp3"
+				"path": "bestiary/mummy-lord.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -39557,6 +40228,7 @@
 			],
 			"miscTags": [
 				"CUR",
+				"HPR",
 				"MA",
 				"RA"
 			],
@@ -39585,6 +40257,11 @@
 			"name": "Myconid Adult",
 			"source": "XMM",
 			"page": 223,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -39610,7 +40287,7 @@
 			"wis": 13,
 			"cha": 7,
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 11,
 			"languages": [
@@ -39653,7 +40330,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/myconid-adult.mp3"
+				"path": "bestiary/myconid-adult.opus"
 			},
 			"altArt": [
 				{
@@ -39688,6 +40365,9 @@
 			"name": "Myconid Sovereign",
 			"source": "XMM",
 			"page": 223,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -39713,7 +40393,7 @@
 			"wis": 15,
 			"cha": 10,
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 12,
 			"languages": [
@@ -39768,7 +40448,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/myconid-sovere.mp3"
+				"path": "bestiary/myconid-sovere.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -39800,6 +40480,9 @@
 			"name": "Myconid Spore Servant",
 			"source": "XMM",
 			"page": 223,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"S",
 				"M"
@@ -39825,7 +40508,7 @@
 			"wis": 6,
 			"cha": 1,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 8,
 			"immune": [
@@ -39877,6 +40560,10 @@
 			"name": "Myconid Sprout",
 			"source": "XMM",
 			"page": 222,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"S"
 			],
@@ -39902,7 +40589,7 @@
 			"wis": 11,
 			"cha": 5,
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -39939,7 +40626,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/myconid-sprout.mp3"
+				"path": "bestiary/myconid-sprout.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -40007,7 +40694,7 @@
 				"cha": "+7"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -40084,7 +40771,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nalfeshnee.mp3"
+				"path": "bestiary/nalfeshnee.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -40123,6 +40810,9 @@
 			"name": "Needle Blight",
 			"source": "XMM",
 			"page": 43,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -40148,7 +40838,7 @@
 			"wis": 8,
 			"cha": 3,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 9,
 			"conditionImmune": [
@@ -40177,7 +40867,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/needle-blight.mp3"
+				"path": "bestiary/needle-blight.opus"
 			},
 			"senseTags": [
 				"B"
@@ -40204,6 +40894,10 @@
 			"page": 225,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -40238,7 +40932,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -40363,7 +41057,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/night-hag.mp3"
+				"path": "bestiary/night-hag.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -40391,6 +41085,7 @@
 				"O"
 			],
 			"miscTags": [
+				"HPR",
 				"MA"
 			],
 			"savingThrowForcedSpell": [
@@ -40407,6 +41102,11 @@
 			"page": 226,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -40479,7 +41179,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nightmare.mp3"
+				"path": "bestiary/nightmare.opus"
 			},
 			"traitTags": [
 				"Illumination"
@@ -40508,10 +41208,18 @@
 			"page": 227,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"DrDe-DaS",
+				"DrDe-TDoN",
+				"DrDe-TFV",
+				"EFA",
+				"FRAiF",
+				"HotB",
+				"LFL",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -40575,7 +41283,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/noble.mp3"
+				"path": "bestiary/noble.opus"
 			},
 			"actionTags": [
 				"Parry"
@@ -40599,10 +41307,12 @@
 			"name": "Noble Prodigy",
 			"source": "XMM",
 			"page": 227,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"EFA",
+				"FRAiF",
+				"NF"
 			],
 			"size": [
 				"S",
@@ -40746,6 +41456,10 @@
 			"source": "XMM",
 			"page": 228,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"HotB"
+			],
 			"size": [
 				"M"
 			],
@@ -40777,7 +41491,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 14,
 			"languages": [
@@ -40820,7 +41534,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nothic.mp3"
+				"path": "bestiary/nothic.opus"
 			},
 			"senseTags": [
 				"U"
@@ -40853,6 +41567,9 @@
 			],
 			"source": "XMM",
 			"page": 229,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -40891,7 +41608,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 14,
 			"resist": [
@@ -40955,7 +41672,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/nycaloth.mp3"
+				"path": "bestiary/nycaloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -41018,7 +41735,7 @@
 			"wis": 6,
 			"cha": 1,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 8,
 			"resist": [
@@ -41064,7 +41781,7 @@
 				{
 					"name": "Split",
 					"entries": [
-						"{@actTrigger} While the jelly is Large or Medium and has 10+ {@variantrule Hit Points|XPHB}, it becomes {@variantrule Bloodied|XPHB} or is subjected to Lightning or Slashing damage. {@actResponse} The jelly splits into two new Ochre Jellies. Each new jelly is one size smaller than the original jelly and acts on its {@variantrule Initiative|XPHB}. The original jelly's {@variantrule Hit Points|XPHB} are divided evenly between the new jellies (round down)."
+						"{@actTrigger} While the jelly is Large or Medium and has 10+ {@variantrule Hit Points|XPHB}, it becomes {@status Bloodied|XPHB} or is subjected to Lightning or Slashing damage. {@actResponse} The jelly splits into two new Ochre Jellies. Each new jelly is one size smaller than the original jelly and acts on its {@variantrule Initiative|XPHB}. The original jelly's {@variantrule Hit Points|XPHB} are divided evenly between the new jellies (round down)."
 					]
 				}
 			],
@@ -41073,7 +41790,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ochre-jelly.mp3"
+				"path": "bestiary/ochre-jelly.opus"
 			},
 			"traitTags": [
 				"Amorphous",
@@ -41133,7 +41850,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 30 ft."
+				"Darkvision 30 ft."
 			],
 			"passive": 12,
 			"cr": "0",
@@ -41173,7 +41890,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/octopus.mp3"
+				"path": "bestiary/octopus.opus"
 			},
 			"traitTags": [
 				"Water Breathing"
@@ -41200,13 +41917,13 @@
 			"page": 231,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BD",
+				"EFA",
+				"FRAiF",
+				"HotB",
+				"ScoEE"
 			],
 			"size": [
 				"L"
@@ -41233,7 +41950,7 @@
 			"wis": 7,
 			"cha": 7,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 8,
 			"languages": [
@@ -41277,7 +41994,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre.mp3"
+				"path": "bestiary/ogre.opus"
 			},
 			"senseTags": [
 				"D"
@@ -41306,13 +42023,12 @@
 			"page": 346,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "HBTD"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"HBTD",
+				"HotB",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -41342,7 +42058,7 @@
 				"wis": "+0"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 8,
 			"immune": [
@@ -41379,7 +42095,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ogre-zombie.mp3"
+				"path": "bestiary/ogre-zombie.opus"
 			},
 			"traitTags": [
 				"Undead Fortitude"
@@ -41406,6 +42122,10 @@
 			"name": "Ogrillon Ogre",
 			"source": "XMM",
 			"page": 231,
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -41431,7 +42151,7 @@
 			"wis": 9,
 			"cha": 10,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"languages": [
@@ -41500,10 +42220,10 @@
 			"page": 232,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TDoN",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -41546,7 +42266,7 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"resist": [
@@ -41634,7 +42354,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/oni.mp3"
+				"path": "bestiary/oni.opus"
 			},
 			"traitTags": [
 				"Regeneration"
@@ -41684,6 +42404,10 @@
 			"page": 233,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"NF"
+			],
 			"size": [
 				"L"
 			],
@@ -41711,7 +42435,7 @@
 				"con": "+7"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 11,
 			"languages": [
@@ -41752,7 +42476,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/otyugh.mp3"
+				"path": "bestiary/otyugh.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -41770,6 +42494,7 @@
 				"P"
 			],
 			"miscTags": [
+				"HPR",
 				"MA",
 				"RCH"
 			],
@@ -41796,6 +42521,9 @@
 					"source": "XPHB",
 					"page": 354
 				}
+			],
+			"referenceSources": [
+				"FRHoF"
 			],
 			"size": [
 				"T"
@@ -41826,7 +42554,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 15,
 			"cr": "0",
@@ -41854,7 +42582,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/owl.mp3"
+				"path": "bestiary/owl.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -41878,10 +42606,12 @@
 			"page": 234,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF",
+				"FRHoF",
+				"HotB"
 			],
 			"size": [
 				"L"
@@ -41911,7 +42641,7 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"cr": "3",
@@ -41934,7 +42664,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/owlbear.mp3"
+				"path": "bestiary/owlbear.opus"
 			},
 			"senseTags": [
 				"D"
@@ -41964,6 +42694,10 @@
 					"page": 354
 				}
 			],
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -41990,10 +42724,10 @@
 			"cha": 7,
 			"skill": {
 				"perception": "+4",
-				"stealth": "+6"
+				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"cr": "1/4",
@@ -42009,7 +42743,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The panther takes the Disengage or Hide action."
+						"The panther takes the {@action Disengage|XPHB} or {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -42020,7 +42754,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/panther.mp3"
+				"path": "bestiary/panther.opus"
 			},
 			"senseTags": [
 				"D"
@@ -42041,6 +42775,10 @@
 			"page": 235,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"NF"
+			],
 			"size": [
 				"L"
 			],
@@ -42099,7 +42837,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pegasus.mp3"
+				"path": "bestiary/pegasus.opus"
 			},
 			"languageTags": [
 				"C",
@@ -42123,10 +42861,11 @@
 			"name": "Performer",
 			"source": "XMM",
 			"page": 236,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -42211,6 +42950,9 @@
 			"name": "Performer Legend",
 			"source": "XMM",
 			"page": 237,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -42345,10 +43087,12 @@
 			"name": "Performer Maestro",
 			"source": "XMM",
 			"page": 237,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"EFA",
+				"FRAiF",
+				"LFL"
 			],
 			"size": [
 				"S",
@@ -42483,6 +43227,11 @@
 			"name": "Peryton",
 			"source": "XMM",
 			"page": 238,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"M"
 			],
@@ -42524,7 +43273,7 @@
 				{
 					"name": "Flyby",
 					"entries": [
-						"The peryton doesn't provoke an Opportunity Attack when it flies out of an enemy's reach."
+						"The peryton doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
 					]
 				}
 			],
@@ -42557,7 +43306,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/peryton.mp3"
+				"path": "bestiary/peryton.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -42586,6 +43335,10 @@
 			"page": 239,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -42614,7 +43367,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"cr": "3",
@@ -42674,9 +43427,10 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/phase-spider.mp3"
+				"path": "bestiary/phase-spider.opus"
 			},
 			"traitTags": [
+				"Ethereal Sight",
 				"Spider Climb",
 				"Web Walker"
 			],
@@ -42705,10 +43459,10 @@
 			"name": "Piercer",
 			"source": "XMM",
 			"page": 240,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"FRAiF"
 			],
 			"size": [
 				"M"
@@ -42741,8 +43495,8 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 60 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 8,
 			"cr": "1/2",
@@ -42776,7 +43530,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/piercer.mp3"
+				"path": "bestiary/piercer.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -42829,7 +43583,7 @@
 			"wis": 7,
 			"cha": 2,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 8,
 			"cr": "0",
@@ -42875,13 +43629,14 @@
 			"page": 241,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"ABH",
+				"DrDe",
+				"DrDe-BtS",
+				"EFA",
+				"FRAiF",
+				"RHW",
+				"ScoEE"
 			],
 			"size": [
 				"S",
@@ -43125,13 +43880,13 @@
 			"page": 242,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"EFA",
+				"FRAiF",
+				"RHW",
+				"ScoEE"
 			],
 			"size": [
 				"S",
@@ -43299,7 +44054,7 @@
 				"persuasion": "+19"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 20,
 			"resist": [
@@ -43397,7 +44152,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pit-fiend.mp3"
+				"path": "bestiary/pit-fiend.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -43454,6 +44209,10 @@
 			"name": "Pixie",
 			"source": "XMM",
 			"page": 244,
+			"referenceSources": [
+				"FRHoF",
+				"LFL"
+			],
 			"size": [
 				"T"
 			],
@@ -43536,7 +44295,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pixie.mp3"
+				"path": "bestiary/pixie.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -43570,6 +44329,9 @@
 			"name": "Pixie Wonderbringer",
 			"source": "XMM",
 			"page": 244,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"T"
 			],
@@ -43722,6 +44484,9 @@
 			"page": 245,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -43769,7 +44534,7 @@
 				"perception": "+11"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 21,
 			"resist": [
@@ -43874,7 +44639,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/planetar.mp3"
+				"path": "bestiary/planetar.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -43923,6 +44688,10 @@
 			"page": 366,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -43980,7 +44749,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/plesiosaurus.mp3"
+				"path": "bestiary/plesiosaurus.opus"
 			},
 			"traitTags": [
 				"Hold Breath"
@@ -44002,6 +44771,10 @@
 			"page": 367,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -44031,7 +44804,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -44057,7 +44830,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/polar-bear.mp3"
+				"path": "bestiary/polar-bear.opus"
 			},
 			"senseTags": [
 				"D"
@@ -44079,6 +44852,10 @@
 			"name": "Poltergeist",
 			"source": "XMM",
 			"page": 246,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -44110,7 +44887,7 @@
 			"wis": 10,
 			"cha": 14,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -44187,7 +44964,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/poltergeist.mp3"
+				"path": "bestiary/poltergeist.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement"
@@ -44271,7 +45048,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pony.mp3"
+				"path": "bestiary/pony.opus"
 			},
 			"damageTags": [
 				"B"
@@ -44289,10 +45066,15 @@
 			"page": 248,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"DrDe-TDoN",
+				"EFA",
+				"FRAiF",
+				"FRHoF",
+				"LFL",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -44407,7 +45189,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/priest.mp3"
+				"path": "bestiary/priest.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -44445,10 +45227,11 @@
 			"page": 247,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"DrDe-DaS",
+				"FRAiF"
 			],
 			"size": [
 				"S",
@@ -44574,6 +45357,10 @@
 			"name": "Primeval Owlbear",
 			"source": "XMM",
 			"page": 234,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -44610,7 +45397,7 @@
 				"perception": "+8"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 18,
 			"cr": "7",
@@ -44714,8 +45501,8 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"languages": [
@@ -44761,9 +45548,10 @@
 			"treasure": [
 				"arcana"
 			],
+			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pseudodragon.mp3"
+				"path": "bestiary/pseudodragon.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -44831,7 +45619,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 8,
 			"resist": [
@@ -44913,6 +45701,9 @@
 			"page": 367,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -44951,7 +45742,7 @@
 				{
 					"name": "Flyby",
 					"entries": [
-						"The pteranodon doesn't provoke an Opportunity Attack when it flies out of an enemy's reach."
+						"The pteranodon doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
 					]
 				}
 			],
@@ -44970,7 +45761,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/pteranodon.mp3"
+				"path": "bestiary/pteranodon.opus"
 			},
 			"traitTags": [
 				"Flyby"
@@ -44991,10 +45782,10 @@
 			"page": 250,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"RHW"
 			],
 			"size": [
 				"G"
@@ -45028,8 +45819,8 @@
 				"wis": "+4"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"tremorsense 60 ft."
+				"Blindsight 30 ft.",
+				"Tremorsense 60 ft."
 			],
 			"passive": 9,
 			"cr": "15",
@@ -45076,7 +45867,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/purple-worm.mp3"
+				"path": "bestiary/purple-worm.opus"
 			},
 			"traitTags": [
 				"Tunneler"
@@ -45144,7 +45935,7 @@
 				"athletics": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 11,
 			"immune": [
@@ -45161,7 +45952,7 @@
 				{
 					"name": "Bloodied Fury",
 					"entries": [
-						"While {@variantrule Bloodied|XPHB}, the quaggoth has {@variantrule Advantage|XPHB} on attack rolls."
+						"While {@status Bloodied|XPHB}, the quaggoth has {@variantrule Advantage|XPHB} on attack rolls."
 					]
 				}
 			],
@@ -45175,7 +45966,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"{@atkr m} {@hit 5}, reach 5 ft. {@h}6 ({@damage 1d6 + 3}) Slashing damage, or 13 ({@damage 3d6 + 3}) Slashing damage if the quaggoth is {@variantrule Bloodied|XPHB}."
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}6 ({@damage 1d6 + 3}) Slashing damage, or 13 ({@damage 3d6 + 3}) Slashing damage if the quaggoth is {@status Bloodied|XPHB}."
 					]
 				}
 			],
@@ -45184,7 +45975,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quaggoth.mp3"
+				"path": "bestiary/quaggoth.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -45238,7 +46029,7 @@
 				"athletics": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -45259,7 +46050,7 @@
 						"The quaggoth casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability (spell save {@dc 12}):"
 					],
 					"will": [
-						"{@spell Mage Hand|XPHB} (the hand is Invisible)",
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})",
 						"{@spell Minor Illusion|XPHB}"
 					],
 					"daily": {
@@ -45293,7 +46084,7 @@
 				{
 					"name": "Bloodied Fury",
 					"entries": [
-						"While {@variantrule Bloodied|XPHB}, the quaggoth has {@variantrule Advantage|XPHB} on attack rolls."
+						"While {@status Bloodied|XPHB}, the quaggoth has {@variantrule Advantage|XPHB} on attack rolls."
 					]
 				}
 			],
@@ -45316,7 +46107,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quaggoth-thonot.mp3"
+				"path": "bestiary/quaggoth-thonot.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -45362,6 +46153,10 @@
 					"page": 355
 				}
 			],
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"T"
 			],
@@ -45395,7 +46190,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -45462,9 +46257,10 @@
 			"environment": [
 				"planar, abyss"
 			],
+			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/quasit.mp3"
+				"path": "bestiary/quasit.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -45503,6 +46299,10 @@
 			"name": "Questing Knight",
 			"source": "XMM",
 			"page": 184,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -45643,6 +46443,10 @@
 			"page": 253,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"ABH",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -45676,7 +46480,7 @@
 				"perception": "+8"
 			},
 			"senses": [
-				"truesight 60 ft."
+				"Truesight 60 ft."
 			],
 			"passive": 18,
 			"vulnerable": [
@@ -45684,7 +46488,7 @@
 					"vulnerable": [
 						"piercing"
 					],
-					"note": "damage from weapons wielded by creatures under the effect of a Bless spell",
+					"note": "damage from weapons wielded by creatures under the effect of a {@spell Bless|XPHB} spell",
 					"cond": true
 				}
 			],
@@ -45766,7 +46570,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rakshasa.mp3"
+				"path": "bestiary/rakshasa.opus"
 			},
 			"senseTags": [
 				"U"
@@ -45815,6 +46619,9 @@
 					"page": 355
 				}
 			],
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"T"
 			],
@@ -45843,7 +46650,7 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"darkvision 30 ft."
+				"Darkvision 30 ft."
 			],
 			"passive": 12,
 			"cr": "0",
@@ -45872,7 +46679,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rat.mp3"
+				"path": "bestiary/rat.opus"
 			},
 			"senseTags": [
 				"D"
@@ -45897,10 +46704,11 @@
 				{
 					"source": "XPHB",
 					"page": 355
-				},
-				{
-					"source": "DrDe"
 				}
+			],
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS"
 			],
 			"size": [
 				"T"
@@ -45955,7 +46763,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/raven.mp3"
+				"path": "bestiary/raven.opus"
 			},
 			"traitTags": [
 				"Mimicry"
@@ -45979,6 +46787,9 @@
 			"page": 254,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"HotB"
+			],
 			"size": [
 				"M"
 			],
@@ -46022,8 +46833,8 @@
 				"stealth": "+2"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -46063,7 +46874,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-dragon-wyrmling.mp3"
+				"path": "bestiary/red-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -46094,6 +46905,10 @@
 			"name": "Red Slaad",
 			"source": "XMM",
 			"page": 285,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -46122,7 +46937,7 @@
 				"perception": "+1"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -46173,7 +46988,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-slaad.mp3"
+				"path": "bestiary/red-slaad.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -46216,6 +47031,9 @@
 					"page": 356
 				}
 			],
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -46244,7 +47062,7 @@
 				"perception": "+2"
 			},
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 12,
 			"cr": "1/2",
@@ -46275,7 +47093,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/reef-shark.mp3"
+				"path": "bestiary/reef-shark.opus"
 			},
 			"traitTags": [
 				"Pack Tactics",
@@ -46300,6 +47118,9 @@
 			"page": 258,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -46328,8 +47149,8 @@
 			"wis": 10,
 			"cha": 5,
 			"senses": [
-				"darkvision 60 ft.",
-				"tremorsense 60 ft."
+				"Darkvision 60 ft.",
+				"Tremorsense 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -46367,7 +47188,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/remorhaz.mp3"
+				"path": "bestiary/remorhaz.opus"
 			},
 			"senseTags": [
 				"D",
@@ -46402,6 +47223,10 @@
 			"name": "Revenant",
 			"source": "XMM",
 			"page": 259,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -46432,7 +47257,7 @@
 				"cha": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"resist": [
@@ -46506,7 +47331,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/revenant.mp3"
+				"path": "bestiary/revenant.opus"
 			},
 			"traitTags": [
 				"Regeneration"
@@ -46544,10 +47369,10 @@
 			"source": "XMM",
 			"page": 368,
 			"srd52": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"EFA"
 			],
 			"size": [
 				"L"
@@ -46587,7 +47412,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rhinoceros.mp3"
+				"path": "bestiary/rhinoceros.opus"
 			},
 			"damageTags": [
 				"P"
@@ -46613,6 +47438,9 @@
 					"source": "XPHB",
 					"page": 356
 				}
+			],
+			"referenceSources": [
+				"FRHoF"
 			],
 			"size": [
 				"L"
@@ -46653,7 +47481,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/riding-horse.mp3"
+				"path": "bestiary/riding-horse.opus"
 			},
 			"damageTags": [
 				"B"
@@ -46671,10 +47499,11 @@
 			"page": 261,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"EFA",
+				"RHW"
 			],
 			"size": [
 				"G"
@@ -46752,7 +47581,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/roc.mp3"
+				"path": "bestiary/roc.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -46779,10 +47608,10 @@
 			"page": 262,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -46817,7 +47646,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 16,
 			"cr": "5",
@@ -46864,7 +47693,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/roper.mp3"
+				"path": "bestiary/roper.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -46897,6 +47726,10 @@
 			"page": 263,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -46921,7 +47754,7 @@
 			"wis": 13,
 			"cha": 6,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"cr": "1/2",
@@ -46972,7 +47805,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/rust-monster.mp3"
+				"path": "bestiary/rust-monster.opus"
 			},
 			"senseTags": [
 				"D"
@@ -46999,6 +47832,9 @@
 			"page": 369,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"NF"
+			],
 			"size": [
 				"L"
 			],
@@ -47031,7 +47867,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"cr": "2",
@@ -47061,7 +47897,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The tiger takes the Disengage or Hide action."
+						"The tiger takes the {@action Disengage|XPHB} or {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -47072,7 +47908,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/saber-toothed-tiger.mp3"
+				"path": "bestiary/saber-toothed-tiger.opus"
 			},
 			"senseTags": [
 				"D"
@@ -47094,6 +47930,10 @@
 			"name": "Sahuagin Baron",
 			"source": "XMM",
 			"page": 265,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -47131,7 +47971,7 @@
 				"perception": "+7"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 17,
 			"resist": [
@@ -47197,7 +48037,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sahuagin-baron.mp3"
+				"path": "bestiary/sahuagin-baron.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -47230,6 +48070,10 @@
 			"name": "Sahuagin Priest",
 			"source": "XMM",
 			"page": 265,
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -47260,7 +48104,7 @@
 				"religion": "+3"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 16,
 			"resist": [
@@ -47385,6 +48229,11 @@
 			"page": 264,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -47414,7 +48263,7 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -47499,6 +48348,9 @@
 			"page": 267,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -47525,7 +48377,7 @@
 			"wis": 10,
 			"cha": 12,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -47575,7 +48427,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/salamander.mp3"
+				"path": "bestiary/salamander.opus"
 			},
 			"senseTags": [
 				"D"
@@ -47639,7 +48491,7 @@
 			"wis": 10,
 			"cha": 8,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -47697,6 +48549,9 @@
 			"name": "Salamander Inferno Master",
 			"source": "XMM",
 			"page": 267,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -47730,7 +48585,7 @@
 				"wis": "+5"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -47829,6 +48684,11 @@
 			"page": 268,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -47896,7 +48756,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/satyr.mp3"
+				"path": "bestiary/satyr.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -47924,6 +48784,9 @@
 			"name": "Satyr Revelmaster",
 			"source": "XMM",
 			"page": 268,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -48056,6 +48919,11 @@
 			"name": "Scarecrow",
 			"source": "XMM",
 			"page": 269,
+			"referenceSources": [
+				"EFA",
+				"LFL",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -48084,7 +48952,7 @@
 			"wis": 10,
 			"cha": 13,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -48125,7 +48993,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/scarecrow.mp3"
+				"path": "bestiary/scarecrow.opus"
 			},
 			"senseTags": [
 				"D"
@@ -48187,7 +49055,7 @@
 			"wis": 8,
 			"cha": 2,
 			"senses": [
-				"blindsight 10 ft."
+				"Blindsight 10 ft."
 			],
 			"passive": 9,
 			"cr": "0",
@@ -48205,7 +49073,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/scorpion.mp3"
+				"path": "bestiary/scorpion.opus"
 			},
 			"senseTags": [
 				"B"
@@ -48227,13 +49095,13 @@
 			"page": 270,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "HBTD"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS",
+				"DrDe-TDoN",
+				"FRAiF",
+				"FRHoF",
+				"HBTD"
 			],
 			"size": [
 				"S",
@@ -48304,7 +49172,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/scout.mp3"
+				"path": "bestiary/scout.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -48330,6 +49198,11 @@
 			"name": "Scout Captain",
 			"source": "XMM",
 			"page": 270,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"LFL"
+			],
 			"size": [
 				"S",
 				"M"
@@ -48446,6 +49319,9 @@
 			"page": 271,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -48472,7 +49348,7 @@
 			"wis": 12,
 			"cha": 13,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"languages": [
@@ -48556,7 +49432,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sea-hag.mp3"
+				"path": "bestiary/sea-hag.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -48665,10 +49541,11 @@
 			"page": 272,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "HBTD"
-				}
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"HBTD",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -48698,7 +49575,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -48753,7 +49630,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the shadow takes the Hide action."
+						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the shadow takes the {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -48764,7 +49641,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shadow.mp3"
+				"path": "bestiary/shadow.opus"
 			},
 			"traitTags": [
 				"Amorphous"
@@ -48789,6 +49666,11 @@
 			],
 			"source": "XMM",
 			"page": 273,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -48831,7 +49713,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -48896,7 +49778,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the demon takes the Hide action."
+						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the demon takes the {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -48905,7 +49787,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shadow-demon.mp3"
+				"path": "bestiary/shadow-demon.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -48933,6 +49815,10 @@
 			"name": "Shadow Dragon",
 			"source": "XMM",
 			"page": 275,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -48971,8 +49857,8 @@
 				"stealth": "+14"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 21,
 			"resist": [
@@ -49035,7 +49921,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the dragon takes the Hide action."
+						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the dragon takes the {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -49102,10 +49988,11 @@
 			"page": 276,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -49135,7 +50022,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -49184,7 +50071,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shambling-mound.mp3"
+				"path": "bestiary/shambling-mound.opus"
 			},
 			"traitTags": [
 				"Damage Absorption"
@@ -49219,10 +50106,13 @@
 			"page": 277,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"EFA",
+				"FRAiF",
+				"FRHoF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -49248,8 +50138,8 @@
 			"wis": 10,
 			"cha": 3,
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -49314,7 +50204,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/shield-guardian.mp3"
+				"path": "bestiary/shield-guardian.opus"
 			},
 			"traitTags": [
 				"Regeneration"
@@ -49372,7 +50262,7 @@
 			"wis": 3,
 			"cha": 1,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 6,
 			"conditionImmune": [
@@ -49412,10 +50302,9 @@
 			"page": 278,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO"
 			],
 			"size": [
 				"M"
@@ -49459,8 +50348,8 @@
 				"stealth": "+2"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -49506,7 +50395,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/silver-dragon-wyrmling.mp3"
+				"path": "bestiary/silver-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -49547,13 +50436,16 @@
 				{
 					"source": "XPHB",
 					"page": 356
-				},
-				{
-					"source": "HBTD"
-				},
-				{
-					"source": "DrDe"
 				}
+			],
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"EFA",
+				"FRAiF",
+				"HBTD",
+				"HotB",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -49580,7 +50472,7 @@
 			"wis": 8,
 			"cha": 5,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"immune": [
@@ -49620,9 +50512,10 @@
 				"underdark",
 				"urban"
 			],
+			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/skeleton.mp3"
+				"path": "bestiary/skeleton.opus"
 			},
 			"senseTags": [
 				"D"
@@ -49656,6 +50549,9 @@
 					"page": 357
 				}
 			],
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"T"
 			],
@@ -49685,7 +50581,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 7,
 			"resist": [
@@ -49721,9 +50617,10 @@
 			"treasure": [
 				"any"
 			],
+			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/slaad-tadpole.mp3"
+				"path": "bestiary/slaad-tadpole.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -49749,10 +50646,10 @@
 			"name": "Smoke Mephit",
 			"source": "XMM",
 			"page": 208,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF"
 			],
 			"size": [
 				"S"
@@ -49784,7 +50681,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -49826,7 +50723,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/smoke-mephit.mp3"
+				"path": "bestiary/smoke-mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -49910,7 +50807,7 @@
 				"perception": "+14"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 24,
 			"immune": [
@@ -50036,7 +50933,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/solar.mp3"
+				"path": "bestiary/solar.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -50086,10 +50983,9 @@
 			],
 			"source": "XMM",
 			"page": 289,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC"
 			],
 			"size": [
 				"M"
@@ -50129,7 +51025,7 @@
 				"perception": "+6"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 16,
 			"conditionImmune": [
@@ -50211,7 +51107,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spectator.mp3"
+				"path": "bestiary/spectator.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -50252,13 +51148,12 @@
 			"page": 290,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "HBTD"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"HBTD",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -50290,7 +51185,7 @@
 			"wis": 10,
 			"cha": 11,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -50350,7 +51245,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/specter.mp3"
+				"path": "bestiary/specter.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -50369,6 +51264,7 @@
 				"O"
 			],
 			"miscTags": [
+				"HPR",
 				"MA"
 			],
 			"hasToken": true,
@@ -50381,10 +51277,11 @@
 			"page": 293,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DotSC",
+				"EFA",
+				"FRHoF"
 			],
 			"size": [
 				"L"
@@ -50421,7 +51318,7 @@
 				"religion": "+12"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 18,
 			"resist": [
@@ -50569,6 +51466,10 @@
 			"name": "Sphinx of Secrets",
 			"source": "XMM",
 			"page": 292,
+			"referenceSources": [
+				"EFA",
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -50603,7 +51504,7 @@
 				"religion": "+7"
 			},
 			"senses": [
-				"truesight 60 ft."
+				"Truesight 60 ft."
 			],
 			"passive": 17,
 			"resist": [
@@ -50674,7 +51575,7 @@
 				{
 					"name": "Curse of the Riddle",
 					"entries": [
-						"{@actSave int} {@dc 15}, one creature the sphinx can see within 60 feet. {@actSaveFail} 21 ({@damage 6d6}) Psychic damage, and the target is cursed with a riddle. The cursed target has {@variantrule Disadvantage|XPHB} on ability checks and attack rolls. In addition, if it takes the Magic action, it must succeed on a {@dc 15} Intelligence saving throw or that action is wasted. The cursed target can take a Study action to make a {@dc 15} Intelligence check, solving the riddle and ending the curse on a success. The curse ends early if the sphinx curses another target."
+						"{@actSave int} {@dc 15}, one creature the sphinx can see within 60 feet. {@actSaveFail} 21 ({@damage 6d6}) Psychic damage, and the target is cursed with a riddle. The cursed target has {@variantrule Disadvantage|XPHB} on ability checks and attack rolls. In addition, if it takes the {@action Magic|XPHB} action, it must succeed on a {@dc 15} Intelligence saving throw or that action is wasted. The cursed target can take a {@action Study|XPHB} action to make a {@dc 15} Intelligence check, solving the riddle and ending the curse on a success. The curse ends early if the sphinx curses another target."
 					]
 				}
 			],
@@ -50763,7 +51664,7 @@
 				"religion": "+15"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 22,
 			"resist": [
@@ -50947,6 +51848,9 @@
 					"page": 357
 				}
 			],
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"T"
 			],
@@ -50978,7 +51882,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -51022,6 +51926,7 @@
 			"treasure": [
 				"arcana"
 			],
+			"familiar": true,
 			"traitTags": [
 				"Magic Resistance"
 			],
@@ -51055,6 +51960,9 @@
 					"page": 357
 				}
 			],
+			"referenceSources": [
+				"FRHoF"
+			],
 			"size": [
 				"T"
 			],
@@ -51083,7 +51991,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 30 ft."
+				"Darkvision 30 ft."
 			],
 			"passive": 10,
 			"cr": "0",
@@ -51119,7 +52027,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spider.mp3"
+				"path": "bestiary/spider.opus"
 			},
 			"traitTags": [
 				"Spider Climb",
@@ -51177,7 +52085,7 @@
 			"wis": 14,
 			"cha": 8,
 			"senses": [
-				"darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+				"Darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
 			],
 			"passive": 12,
 			"resist": [
@@ -51198,7 +52106,7 @@
 				{
 					"name": "Flyby",
 					"entries": [
-						"The devil doesn't provoke an Opportunity Attack when it flies out of an enemy's reach."
+						"The devil doesn't provoke an {@action Opportunity Attack|XPHB} when it flies out of an enemy's reach."
 					]
 				},
 				{
@@ -51233,7 +52141,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spined-devil.mp3"
+				"path": "bestiary/spined-devil.opus"
 			},
 			"traitTags": [
 				"Devil's Sight",
@@ -51268,10 +52176,10 @@
 			"page": 297,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -51304,7 +52212,7 @@
 				"cha": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -51381,7 +52289,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spirit-naga.mp3"
+				"path": "bestiary/spirit-naga.opus"
 			},
 			"senseTags": [
 				"D"
@@ -51432,6 +52340,13 @@
 					"source": "XPHB",
 					"page": 358
 				}
+			],
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"LFL",
+				"RHW",
+				"UtHftLH"
 			],
 			"size": [
 				"T"
@@ -51513,9 +52428,10 @@
 			"treasure": [
 				"armaments"
 			],
+			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/sprite.mp3"
+				"path": "bestiary/sprite.opus"
 			},
 			"languageTags": [
 				"C",
@@ -51551,6 +52467,14 @@
 			"page": 295,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"FRHoF",
+				"LFL",
+				"NF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -51615,7 +52539,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"The spy takes the Dash, Disengage, or Hide action."
+						"The spy takes the {@action Dash|XPHB}, {@action Disengage|XPHB}, or {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -51628,7 +52552,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/spy.mp3"
+				"path": "bestiary/spy.opus"
 			},
 			"languageTags": [
 				"C",
@@ -51652,6 +52576,12 @@
 			"name": "Spy Master",
 			"source": "XMM",
 			"page": 295,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"LFL",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -51734,7 +52664,7 @@
 				{
 					"name": "Cunning Action",
 					"entries": [
-						"The spy takes the Dash, Disengage, or Hide action."
+						"The spy takes the {@action Dash|XPHB}, {@action Disengage|XPHB}, or {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -51779,6 +52709,9 @@
 			"page": 208,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"HotB"
+			],
 			"size": [
 				"S"
 			],
@@ -51808,7 +52741,7 @@
 				"stealth": "+2"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -51856,7 +52789,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/steam-mephit.mp3"
+				"path": "bestiary/steam-mephit.opus"
 			},
 			"traitTags": [
 				"Death Burst"
@@ -51879,9 +52812,6 @@
 			"miscTags": [
 				"MA"
 			],
-			"conditionInflict": [
-				"incapacitated"
-			],
 			"savingThrowForced": [
 				"constitution",
 				"dexterity"
@@ -51896,6 +52826,11 @@
 			"page": 299,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"HotB",
+				"RHW"
+			],
 			"size": [
 				"T"
 			],
@@ -51921,7 +52856,7 @@
 			"wis": 8,
 			"cha": 6,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"cr": "1/8",
@@ -51946,7 +52881,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stirge.mp3"
+				"path": "bestiary/stirge.opus"
 			},
 			"senseTags": [
 				"D"
@@ -51968,6 +52903,10 @@
 			"page": 300,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -52005,7 +52944,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"languages": [
@@ -52049,7 +52988,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stone-giant.mp3"
+				"path": "bestiary/stone-giant.opus"
 			},
 			"senseTags": [
 				"D"
@@ -52086,10 +53025,11 @@
 			"page": 301,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				}
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW",
+				"ScoEE"
 			],
 			"size": [
 				"L"
@@ -52118,7 +53058,7 @@
 			"wis": 11,
 			"cha": 1,
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -52195,7 +53135,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/stone-golem.mp3"
+				"path": "bestiary/stone-golem.opus"
 			},
 			"traitTags": [
 				"Immutable Form",
@@ -52236,6 +53176,9 @@
 			"page": 302,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"H"
 			],
@@ -52282,8 +53225,8 @@
 				"perception": "+10"
 			},
 			"senses": [
-				"darkvision 120 ft.",
-				"truesight 30 ft."
+				"Darkvision 120 ft.",
+				"Truesight 30 ft."
 			],
 			"passive": 20,
 			"resist": [
@@ -52361,7 +53304,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/storm-giant.mp3"
+				"path": "bestiary/storm-giant.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -52403,10 +53346,11 @@
 			"page": 303,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				}
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW",
+				"ScoEE"
 			],
 			"size": [
 				"M"
@@ -52441,7 +53385,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"resist": [
@@ -52507,7 +53451,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/succubus-incubus.mp3"
+				"path": "bestiary/succubus-incubus.opus"
 			},
 			"senseTags": [
 				"D"
@@ -52525,6 +53469,7 @@
 				"Y"
 			],
 			"miscTags": [
+				"HPR",
 				"MA"
 			],
 			"savingThrowForced": [
@@ -52540,10 +53485,8 @@
 			"page": 370,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "HBTD"
-				}
+			"referenceSources": [
+				"HBTD"
 			],
 			"size": [
 				"L"
@@ -52573,7 +53516,7 @@
 			"wis": 12,
 			"cha": 4,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -52604,7 +53547,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 2d4}) Piercing damage, or 2 ({@damage 1d4}) Piercing damage if the swarm is {@variantrule Bloodied|XPHB}."
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 2d4}) Piercing damage, or 2 ({@damage 1d4}) Piercing damage if the swarm is {@status Bloodied|XPHB}."
 					]
 				}
 			],
@@ -52616,7 +53559,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-bats.mp3"
+				"path": "bestiary/swarm-of-bats.opus"
 			},
 			"senseTags": [
 				"B"
@@ -52637,13 +53580,12 @@
 			"page": 83,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "HBTD"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"HBTD",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -52674,7 +53616,7 @@
 			"wis": 10,
 			"cha": 4,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -52715,7 +53657,7 @@
 				{
 					"name": "Swarm of Grasping Hands",
 					"entries": [
-						"{@atkr m} {@hit 4}, reach 5 ft. {@h}20 ({@damage 4d8 + 2}) Necrotic damage, or 11 ({@damage 2d8 + 2}) Necrotic damage if the swarm is {@variantrule Bloodied|XPHB}. If the target is a Medium or smaller creature, it has the {@condition Prone|XPHB} condition."
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}20 ({@damage 4d8 + 2}) Necrotic damage, or 11 ({@damage 2d8 + 2}) Necrotic damage if the swarm is {@status Bloodied|XPHB}. If the target is a Medium or smaller creature, it has the {@condition Prone|XPHB} condition."
 					]
 				}
 			],
@@ -52749,6 +53691,9 @@
 			],
 			"source": "XMM",
 			"page": 104,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -52780,7 +53725,7 @@
 			"wis": 8,
 			"cha": 3,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"resist": [
@@ -52833,7 +53778,7 @@
 				{
 					"name": "Rend",
 					"entries": [
-						"{@atkr m} {@hit 4}, reach 5 ft. {@h}12 ({@damage 3d6 + 2}) Slashing damage, or 9 ({@damage 3d4 + 2}) Slashing damage if the swarm is {@variantrule Bloodied|XPHB}."
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}12 ({@damage 3d6 + 2}) Slashing damage, or 9 ({@damage 3d4 + 2}) Slashing damage if the swarm is {@status Bloodied|XPHB}."
 					]
 				}
 			],
@@ -52872,10 +53817,10 @@
 			"page": 370,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS",
+				"FRAiF"
 			],
 			"size": [
 				"M"
@@ -52912,7 +53857,7 @@
 			"wis": 7,
 			"cha": 1,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 8,
 			"resist": [
@@ -52949,7 +53894,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"{@atkr m} {@hit 3}, reach 5 ft. {@h}6 ({@damage 2d4 + 1}) Poison damage, or 3 ({@damage 1d4 + 1}) Poison damage if the swarm is {@variantrule Bloodied|XPHB}."
+						"{@atkr m} {@hit 3}, reach 5 ft. {@h}6 ({@damage 2d4 + 1}) Poison damage, or 3 ({@damage 1d4 + 1}) Poison damage if the swarm is {@status Bloodied|XPHB}."
 					]
 				}
 			],
@@ -52964,7 +53909,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-insects.mp3"
+				"path": "bestiary/swarm-of-insects.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -52986,6 +53931,9 @@
 			"name": "Swarm of Larvae",
 			"source": "XMM",
 			"page": 193,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -53014,7 +53962,7 @@
 			"wis": 12,
 			"cha": 2,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -53048,7 +53996,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"{@atkr m} {@hit 4}, reach 5 ft. {@h}9 ({@damage 2d6 + 2}) Necrotic damage, or 7 ({@damage 2d4 + 2}) Necrotic damage if the swarm is {@variantrule Bloodied|XPHB}."
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}9 ({@damage 2d6 + 2}) Necrotic damage, or 7 ({@damage 2d4 + 2}) Necrotic damage if the swarm is {@status Bloodied|XPHB}."
 					]
 				}
 			],
@@ -53079,6 +54027,9 @@
 			],
 			"source": "XMM",
 			"page": 194,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -53110,7 +54061,7 @@
 			"wis": 12,
 			"cha": 3,
 			"senses": [
-				"darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
+				"Darkvision 120 ft. (unimpeded by magical {@variantrule Darkness|XPHB})"
 			],
 			"passive": 11,
 			"resist": [
@@ -53142,7 +54093,7 @@
 				{
 					"name": "Hellish Restoration",
 					"entries": [
-						"If the swarm dies in the Nine Hells, it revives with all its {@variantrule Hit Points|XPHB} in {@dice 1d10} days unless it is killed by a creature under the effects of a {@spell Bless|XPHB} spell or its remains are sprinkled with Holy Water."
+						"If the swarm dies in the Nine Hells, it revives with all its {@variantrule Hit Points|XPHB} in {@dice 1d10} days unless it is killed by a creature under the effects of a {@spell Bless|XPHB} spell or its remains are sprinkled with {@item Holy Water|XPHB}."
 					]
 				},
 				{
@@ -53162,7 +54113,7 @@
 				{
 					"name": "Vile Slime",
 					"entries": [
-						"{@atkr m} {@hit 4}, reach 5 ft. {@h}11 ({@damage 2d8 + 2}) Poison damage, or 9 ({@damage 2d6 + 2}) Poison damage if the swarm is {@variantrule Bloodied|XPHB}."
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}11 ({@damage 2d8 + 2}) Poison damage, or 9 ({@damage 2d6 + 2}) Poison damage if the swarm is {@status Bloodied|XPHB}."
 					]
 				}
 			],
@@ -53226,7 +54177,7 @@
 			"wis": 7,
 			"cha": 2,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 8,
 			"resist": [
@@ -53263,7 +54214,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"{@atkr m} {@hit 5} (with {@variantrule Advantage|XPHB} if the target doesn't have all its {@variantrule Hit Points|XPHB}), reach 5 ft. {@h}8 ({@damage 2d4 + 3}) Piercing damage, or 5 ({@damage 1d4 + 3}) Piercing damage if the swarm is {@variantrule Bloodied|XPHB}."
+						"{@atkr m} {@hit 5} (with {@variantrule Advantage|XPHB} if the target doesn't have all its {@variantrule Hit Points|XPHB}), reach 5 ft. {@h}8 ({@damage 2d4 + 3}) Piercing damage, or 5 ({@damage 1d4 + 3}) Piercing damage if the swarm is {@status Bloodied|XPHB}."
 					]
 				}
 			],
@@ -53292,6 +54243,9 @@
 			"page": 370,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -53320,7 +54274,7 @@
 			"wis": 10,
 			"cha": 3,
 			"senses": [
-				"darkvision 30 ft."
+				"Darkvision 30 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -53351,7 +54305,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"{@atkr m} {@hit 2}, reach 5 ft. {@h}5 ({@damage 2d4}) Piercing damage, or 2 ({@damage 1d4}) Piercing damage if the swarm is {@variantrule Bloodied|XPHB}."
+						"{@atkr m} {@hit 2}, reach 5 ft. {@h}5 ({@damage 2d4}) Piercing damage, or 2 ({@damage 1d4}) Piercing damage if the swarm is {@status Bloodied|XPHB}."
 					]
 				}
 			],
@@ -53363,7 +54317,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-rats.mp3"
+				"path": "bestiary/swarm-of-rats.opus"
 			},
 			"senseTags": [
 				"D"
@@ -53384,6 +54338,9 @@
 			"page": 371,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -53443,7 +54400,7 @@
 				{
 					"name": "Beaks",
 					"entries": [
-						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 1d6 + 2}) Piercing damage, or 2 ({@damage 1d4}) Piercing damage if the swarm is {@variantrule Bloodied|XPHB}."
+						"{@atkr m} {@hit 4}, reach 5 ft. {@h}5 ({@damage 1d6 + 2}) Piercing damage, or 2 ({@damage 1d4}) Piercing damage if the swarm is {@status Bloodied|XPHB}."
 					]
 				},
 				{
@@ -53460,7 +54417,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/swarm-of-ravens.mp3"
+				"path": "bestiary/swarm-of-ravens.opus"
 			},
 			"damageTags": [
 				"P"
@@ -53482,6 +54439,9 @@
 			"name": "Swarm of Stirges",
 			"source": "XMM",
 			"page": 299,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -53510,7 +54470,7 @@
 			"wis": 8,
 			"cha": 6,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"resist": [
@@ -53541,7 +54501,7 @@
 				{
 					"name": "Swarm of Proboscises",
 					"entries": [
-						"{@atkr m} {@hit 5}, reach 5 ft. {@h}14 ({@damage 2d10 + 3}) Piercing damage, or 8 ({@damage 1d10 + 3}) Piercing damage if the swarm is {@variantrule Bloodied|XPHB}. If the target is a Medium or smaller creature in the swarm's space, the target has the {@condition Grappled|XPHB} condition (escape {@dc 13}). Until the grapple ends, the target takes 7 ({@damage 2d6}) Necrotic damage at the end of each of its turns."
+						"{@atkr m} {@hit 5}, reach 5 ft. {@h}14 ({@damage 2d10 + 3}) Piercing damage, or 8 ({@damage 1d10 + 3}) Piercing damage if the swarm is {@status Bloodied|XPHB}. If the target is a Medium or smaller creature in the swarm's space, the target has the {@condition Grappled|XPHB} condition (escape {@dc 13}). Until the grapple ends, the target takes 7 ({@damage 2d6}) Necrotic damage at the end of each of its turns."
 					]
 				}
 			],
@@ -53578,6 +54538,9 @@
 			"page": 371,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -53606,7 +54569,7 @@
 			"wis": 10,
 			"cha": 3,
 			"senses": [
-				"blindsight 10 ft."
+				"Blindsight 10 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -53637,7 +54600,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"{@atkr m} {@hit 6}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Piercing damage\u2014or 6 ({@damage 1d4 + 4}) Piercing damage if the swarm is {@variantrule Bloodied|XPHB}\u2014plus 10 ({@damage 3d6}) Poison damage."
+						"{@atkr m} {@hit 6}, reach 5 ft. {@h}8 ({@damage 1d8 + 4}) Piercing damage\u2014or 6 ({@damage 1d4 + 4}) Piercing damage if the swarm is {@status Bloodied|XPHB}\u2014plus 10 ({@damage 3d6}) Poison damage."
 					]
 				}
 			],
@@ -53715,7 +54678,7 @@
 				"perception": "+9"
 			},
 			"senses": [
-				"blindsight 120 ft."
+				"Blindsight 120 ft."
 			],
 			"passive": 19,
 			"resist": [
@@ -53821,7 +54784,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tarrasque.mp3"
+				"path": "bestiary/tarrasque.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -53863,6 +54826,9 @@
 			"name": "Thri-kreen Marauder",
 			"source": "XMM",
 			"page": 306,
+			"referenceSources": [
+				"EFA"
+			],
 			"size": [
 				"M"
 			],
@@ -53892,7 +54858,7 @@
 				"survival": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"languages": [
@@ -54002,7 +54968,7 @@
 				"stealth": "+8"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"resist": [
@@ -54020,7 +54986,7 @@
 						"The thri-kreen casts one of the following spells, requiring no spell components and using Intelligence as the spellcasting ability (spell save {@dc 15}):"
 					],
 					"will": [
-						"{@spell Mage Hand|XPHB} (the hand is Invisible)"
+						"{@spell Mage Hand|XPHB} (the hand is {@condition Invisible|XPHB})"
 					],
 					"daily": {
 						"1e": [
@@ -54128,7 +55094,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "1",
@@ -54144,7 +55110,7 @@
 				{
 					"name": "Nimble Escape",
 					"entries": [
-						"The tiger takes the Disengage or Hide action."
+						"The tiger takes the {@action Disengage|XPHB} or {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -54154,7 +55120,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tiger.mp3"
+				"path": "bestiary/tiger.opus"
 			},
 			"senseTags": [
 				"D"
@@ -54178,10 +55144,13 @@
 			"page": 307,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"ABH",
+				"DrDe",
+				"DrDe-BD",
+				"DrDe-BtS",
+				"EFA",
+				"FRAiF"
 			],
 			"size": [
 				"S",
@@ -54271,13 +55240,15 @@
 			"page": 307,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "ScoEE"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"ABH",
+				"DrDe",
+				"DrDe-TFV",
+				"EFA",
+				"FRAiF",
+				"NF",
+				"RHW",
+				"ScoEE"
 			],
 			"size": [
 				"S",
@@ -54382,10 +55353,13 @@
 			"page": 308,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF",
+				"FRHoF",
+				"LFL",
+				"RHW"
 			],
 			"size": [
 				"H"
@@ -54468,7 +55442,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/treant.mp3"
+				"path": "bestiary/treant.opus"
 			},
 			"traitTags": [
 				"Siege Monster"
@@ -54498,6 +55472,10 @@
 			"name": "Tree Blight",
 			"source": "XMM",
 			"page": 44,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -54526,7 +55504,7 @@
 			"wis": 10,
 			"cha": 3,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 10,
 			"conditionImmune": [
@@ -54655,7 +55633,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/triceratops.mp3"
+				"path": "bestiary/triceratops.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -54677,6 +55655,9 @@
 			"name": "Troglodyte",
 			"source": "XMM",
 			"page": 309,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -54706,7 +55687,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -54743,7 +55724,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/troglodyte.mp3"
+				"path": "bestiary/troglodyte.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity"
@@ -54776,10 +55757,13 @@
 			"page": 310,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"DrDe-TFV",
+				"FRAiF",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -54809,7 +55793,7 @@
 				"perception": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"languages": [
@@ -54820,7 +55804,7 @@
 				{
 					"name": "Loathsome Limbs (4/Day)",
 					"entries": [
-						"If the troll ends any turn {@variantrule Bloodied|XPHB} and took 15+ Slashing damage during that turn, one of the troll's limbs is severed, falls into the troll's space, and becomes a {@creature Troll Limb|XMM}. The limb acts immediately after the troll's turn. The troll has 1 {@condition Exhaustion|XPHB} level for each missing limb, and it grows replacement limbs the next time it regains {@variantrule Hit Points|XPHB}."
+						"If the troll ends any turn {@status Bloodied|XPHB} and took 15+ Slashing damage during that turn, one of the troll's limbs is severed, falls into the troll's space, and becomes a {@creature Troll Limb|XMM}. The limb acts immediately after the troll's turn. The troll has 1 {@condition Exhaustion|XPHB} level for each missing limb, and it grows replacement limbs the next time it regains {@variantrule Hit Points|XPHB}."
 					]
 				},
 				{
@@ -54862,7 +55846,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/troll.mp3"
+				"path": "bestiary/troll.opus"
 			},
 			"traitTags": [
 				"Regeneration"
@@ -54918,7 +55902,7 @@
 			"wis": 9,
 			"cha": 1,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"cr": "1/2",
@@ -54972,10 +55956,11 @@
 			"name": "Twig Blight",
 			"source": "XMM",
 			"page": 43,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS",
+				"FRAiF",
+				"FRHoF"
 			],
 			"size": [
 				"S"
@@ -55005,7 +55990,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 9,
 			"vulnerable": [
@@ -55039,7 +56024,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/twig-blight.mp3"
+				"path": "bestiary/twig-blight.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -55070,6 +56055,10 @@
 			"page": 372,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"H"
 			],
@@ -55135,7 +56124,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/tyrannosaurus-rex.mp3"
+				"path": "bestiary/tyrannosaurus-rex.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -55164,6 +56153,9 @@
 			],
 			"source": "XMM",
 			"page": 311,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -55207,7 +56199,7 @@
 				"stealth": "+8"
 			},
 			"senses": [
-				"truesight 120 ft."
+				"Truesight 120 ft."
 			],
 			"passive": 17,
 			"resist": [
@@ -55314,7 +56306,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/ultroloth.mp3"
+				"path": "bestiary/ultroloth.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -55371,6 +56363,10 @@
 			"name": "Umber Hulk",
 			"source": "XMM",
 			"page": 312,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -55400,8 +56396,8 @@
 			"wis": 10,
 			"cha": 10,
 			"senses": [
-				"darkvision 120 ft.",
-				"tremorsense 60 ft."
+				"Darkvision 120 ft.",
+				"Tremorsense 60 ft."
 			],
 			"passive": 10,
 			"languages": [
@@ -55464,7 +56460,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/umber-hulk.mp3"
+				"path": "bestiary/umber-hulk.opus"
 			},
 			"traitTags": [
 				"Tunneler"
@@ -55496,8 +56492,13 @@
 		{
 			"name": "Unicorn",
 			"source": "XMM",
+			"page": 313,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"L"
 			],
@@ -55526,7 +56527,7 @@
 			"wis": 17,
 			"cha": 16,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"immune": [
@@ -55646,7 +56647,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/unicorn.mp3"
+				"path": "bestiary/unicorn.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -55691,10 +56692,11 @@
 			"page": 317,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -55736,7 +56738,7 @@
 				"stealth": "+9"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 17,
 			"resist": [
@@ -55754,7 +56756,7 @@
 					"name": "Charm {@recharge 5}",
 					"type": "spellcasting",
 					"headerEntries": [
-						"The vampire casts {@spell Charm Person|XPHB}, requiring no spell components and using Charisma as the spellcasting ability (spell save {@dc 17}), and the duration is 24 hours. The Charmed target is a willing recipient of the vampire's Bite, the damage of which doesn't end the spell. When the spell ends, the target is unaware it was Charmed by the vampire."
+						"The vampire casts {@spell Charm Person|XPHB}, requiring no spell components and using Charisma as the spellcasting ability (spell save {@dc 17}), and the duration is 24 hours. The {@condition Charmed|XPHB} target is a willing recipient of the vampire's Bite, the damage of which doesn't end the spell. When the spell ends, the target is unaware it was {@condition Charmed|XPHB} by the vampire."
 					],
 					"recharge": {
 						"5": [
@@ -55898,7 +56900,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vampire.mp3"
+				"path": "bestiary/vampire.opus"
 			},
 			"traitTags": [
 				"Legendary Resistances",
@@ -55918,20 +56920,18 @@
 				"A",
 				"B",
 				"N",
-				"P",
-				"R"
+				"P"
 			],
 			"spellcastingTags": [
 				"O"
 			],
 			"miscTags": [
+				"HPR",
 				"MA"
 			],
 			"conditionInflict": [
 				"charmed",
-				"grappled",
-				"incapacitated",
-				"paralyzed"
+				"grappled"
 			],
 			"conditionInflictSpell": [
 				"charmed",
@@ -55956,6 +56956,10 @@
 			"page": 314,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"EFA",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -55995,7 +56999,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"resist": [
@@ -56046,7 +57050,7 @@
 				{
 					"name": "Deathless Agility",
 					"entries": [
-						"The familiar takes the Dash or Disengage action."
+						"The familiar takes the {@action Dash|XPHB} or {@action Disengage|XPHB} action."
 					]
 				}
 			],
@@ -56089,6 +57093,11 @@
 			"name": "Vampire Nightbringer",
 			"source": "XMM",
 			"page": 316,
+			"referenceSources": [
+				"ABH",
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -56128,7 +57137,7 @@
 				"stealth": "+7"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 15,
 			"immune": [
@@ -56176,7 +57185,7 @@
 				{
 					"name": "Shadow Stealth",
 					"entries": [
-						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the vampire takes the Hide action."
+						"While in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, the vampire takes the {@action Hide|XPHB} action."
 					]
 				}
 			],
@@ -56204,10 +57213,10 @@
 				"C",
 				"N",
 				"P",
-				"R",
 				"S"
 			],
 			"miscTags": [
+				"HPR",
 				"MA"
 			],
 			"hasToken": true,
@@ -56220,6 +57229,11 @@
 			"page": 315,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"ABH",
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -56254,7 +57268,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"resist": [
@@ -56336,7 +57350,7 @@
 				{
 					"name": "Deathless Agility",
 					"entries": [
-						"The vampire takes the Dash or Disengage action."
+						"The vampire takes the {@action Dash|XPHB} or {@action Disengage|XPHB} action."
 					]
 				}
 			],
@@ -56349,7 +57363,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vampire-spawn.mp3"
+				"path": "bestiary/vampire-spawn.opus"
 			},
 			"traitTags": [
 				"Spider Climb"
@@ -56368,15 +57382,14 @@
 				"A",
 				"N",
 				"P",
-				"R",
 				"S"
 			],
 			"miscTags": [
+				"HPR",
 				"MA"
 			],
 			"conditionInflict": [
-				"grappled",
-				"incapacitated"
+				"grappled"
 			],
 			"savingThrowForced": [
 				"constitution"
@@ -56389,6 +57402,9 @@
 			"name": "Vampire Umbral Lord",
 			"source": "XMM",
 			"page": 318,
+			"referenceSources": [
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -56435,7 +57451,7 @@
 				"stealth": "+9"
 			},
 			"senses": [
-				"blindsight 120 ft."
+				"Blindsight 120 ft."
 			],
 			"passive": 23,
 			"immune": [
@@ -56606,7 +57622,6 @@
 			"damageTags": [
 				"A",
 				"N",
-				"R",
 				"S"
 			],
 			"damageTagsSpell": [
@@ -56617,12 +57632,11 @@
 				"O"
 			],
 			"miscTags": [
+				"HPR",
 				"MA",
 				"RA"
 			],
 			"conditionInflict": [
-				"incapacitated",
-				"paralyzed",
 				"poisoned"
 			],
 			"conditionInflictSpell": [
@@ -56653,10 +57667,11 @@
 				{
 					"source": "XPHB",
 					"page": 358
-				},
-				{
-					"source": "DrDe"
 				}
+			],
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS"
 			],
 			"size": [
 				"T"
@@ -56683,7 +57698,7 @@
 			"wis": 10,
 			"cha": 3,
 			"senses": [
-				"blindsight 10 ft."
+				"Blindsight 10 ft."
 			],
 			"passive": 10,
 			"cr": "1/8",
@@ -56703,6 +57718,7 @@
 				"hill",
 				"swamp"
 			],
+			"familiar": true,
 			"senseTags": [
 				"B"
 			],
@@ -56721,10 +57737,11 @@
 			"name": "Vine Blight",
 			"source": "XMM",
 			"page": 44,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -56754,7 +57771,7 @@
 				"stealth": "+1"
 			},
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 10,
 			"conditionImmune": [
@@ -56796,7 +57813,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vine-blight.mp3"
+				"path": "bestiary/vine-blight.opus"
 			},
 			"senseTags": [
 				"B"
@@ -56833,6 +57850,9 @@
 			"page": 126,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"M"
 			],
@@ -56857,7 +57877,7 @@
 			"wis": 3,
 			"cha": 1,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 6,
 			"conditionImmune": [
@@ -56886,7 +57906,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/violet-fungus.mp3"
+				"path": "bestiary/violet-fungus.opus"
 			},
 			"senseTags": [
 				"B"
@@ -56909,10 +57929,11 @@
 			"name": "Violet Fungus Necrohulk",
 			"source": "XMM",
 			"page": 126,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-BtS",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -56942,7 +57963,7 @@
 			"wis": 14,
 			"cha": 10,
 			"senses": [
-				"blindsight 60 ft."
+				"Blindsight 60 ft."
 			],
 			"passive": 12,
 			"immune": [
@@ -57026,6 +58047,9 @@
 			"page": 319,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -57062,7 +58086,7 @@
 				"cha": "+2"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 11,
 			"resist": [
@@ -57110,7 +58134,7 @@
 				{
 					"name": "Spores {@recharge}",
 					"entries": [
-						"{@actSave con} {@dc 15}, each creature in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the vrock. {@actSaveFail} The target has the {@condition Poisoned|XPHB} condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. While {@condition Poisoned|XPHB}, the target takes 5 ({@damage 1d10}) Poison damage at the start of each of its turns. Emptying a flask of Holy Water on the target ends the effect early."
+						"{@actSave con} {@dc 15}, each creature in a 20-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the vrock. {@actSaveFail} The target has the {@condition Poisoned|XPHB} condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. While {@condition Poisoned|XPHB}, the target takes 5 ({@damage 1d10}) Poison damage at the start of each of its turns. Emptying a flask of {@item Holy Water|XPHB} on the target ends the effect early."
 					]
 				},
 				{
@@ -57128,7 +58152,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vrock.mp3"
+				"path": "bestiary/vrock.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -57168,6 +58192,10 @@
 			"page": 372,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF"
+			],
 			"size": [
 				"M"
 			],
@@ -57221,7 +58249,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/vulture.mp3"
+				"path": "bestiary/vulture.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -57247,6 +58275,10 @@
 					"source": "XPHB",
 					"page": 359
 				}
+			],
+			"referenceSources": [
+				"FRAiF",
+				"UtHftLH"
 			],
 			"size": [
 				"L"
@@ -57289,7 +58321,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/war-horse.mp3"
+				"path": "bestiary/war-horse.opus"
 			},
 			"damageTags": [
 				"B"
@@ -57334,7 +58366,7 @@
 			"wis": 8,
 			"cha": 5,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 9,
 			"immune": [
@@ -57363,7 +58395,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/warhorse-skeleton.mp3"
+				"path": "bestiary/warhorse-skeleton.opus"
 			},
 			"senseTags": [
 				"D"
@@ -57385,6 +58417,11 @@
 			"name": "Warrior Commander",
 			"source": "XMM",
 			"page": 321,
+			"referenceSources": [
+				"EFA",
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -57522,6 +58559,11 @@
 			"page": 320,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -57602,10 +58644,12 @@
 			"page": 320,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"FFotR",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -57710,10 +58754,11 @@
 			"page": 322,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC",
+				"FRAiF",
+				"FRHoF"
 			],
 			"size": [
 				"L"
@@ -57740,7 +58785,7 @@
 			"wis": 10,
 			"cha": 8,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -57806,7 +58851,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/water-elemental.mp3"
+				"path": "bestiary/water-elemental.opus"
 			},
 			"senseTags": [
 				"D"
@@ -57840,6 +58885,9 @@
 			"name": "Water Weird",
 			"source": "XMM",
 			"page": 323,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -57865,7 +58913,7 @@
 			"wis": 10,
 			"cha": 10,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -57919,7 +58967,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/water-weird.mp3"
+				"path": "bestiary/water-weird.opus"
 			},
 			"senseTags": [
 				"B"
@@ -57956,6 +59004,9 @@
 					"page": 359
 				}
 			],
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"T"
 			],
@@ -57986,7 +59037,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"cr": "0",
@@ -58006,7 +59057,7 @@
 			"familiar": true,
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/weasel.mp3"
+				"path": "bestiary/weasel.opus"
 			},
 			"senseTags": [
 				"D"
@@ -58030,6 +59081,11 @@
 			"page": 324,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -58079,7 +59135,7 @@
 				"perception": "+7"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 17,
 			"languages": [
@@ -58136,7 +59192,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/werebear.mp3"
+				"path": "bestiary/werebear.opus"
 			},
 			"senseTags": [
 				"D"
@@ -58175,6 +59231,9 @@
 			"page": 325,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"S",
 				"M"
@@ -58274,7 +59333,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wereboar.mp3"
+				"path": "bestiary/wereboar.opus"
 			},
 			"actionTags": [
 				"Multiattack"
@@ -58312,6 +59371,10 @@
 			"page": 325,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -58348,7 +59411,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"languages": [
@@ -58401,7 +59464,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wererat.mp3"
+				"path": "bestiary/wererat.opus"
 			},
 			"senseTags": [
 				"D"
@@ -58439,6 +59502,10 @@
 			"page": 326,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -58481,7 +59548,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"languages": [
@@ -58521,7 +59588,7 @@
 				{
 					"name": "Prowl (Tiger or Hybrid Form Only)",
 					"entries": [
-						"The weretiger moves up to its {@variantrule Speed|XPHB} without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks}. At the end of this movement, the weretiger can take the Hide action."
+						"The weretiger moves up to its {@variantrule Speed|XPHB} without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks}. At the end of this movement, the weretiger can take the {@action Hide|XPHB} action."
 					]
 				},
 				{
@@ -58541,7 +59608,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/weretiger.mp3"
+				"path": "bestiary/weretiger.opus"
 			},
 			"senseTags": [
 				"D"
@@ -58579,6 +59646,10 @@
 			"page": 327,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"S",
 				"M"
@@ -58625,7 +59696,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"languages": [
@@ -58686,7 +59757,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/werewolf.mp3"
+				"path": "bestiary/werewolf.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -58771,8 +59842,8 @@
 				"stealth": "+2"
 			},
 			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
+				"Blindsight 10 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -58819,7 +59890,7 @@
 			"dragonAge": "wyrmling",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/white-dragon-wyrmling.mp3"
+				"path": "bestiary/white-dragon-wyrmling.opus"
 			},
 			"senseTags": [
 				"B",
@@ -58852,6 +59923,10 @@
 			"page": 332,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -58884,7 +59959,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"resist": [
@@ -58951,7 +60026,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wight.mp3"
+				"path": "bestiary/wight.opus"
 			},
 			"traitTags": [
 				"Sunlight Sensitivity"
@@ -58972,6 +60047,7 @@
 				"S"
 			],
 			"miscTags": [
+				"HPR",
 				"MA",
 				"RA"
 			],
@@ -58988,6 +60064,11 @@
 			"page": 333,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"T"
 			],
@@ -59018,7 +60099,7 @@
 			"wis": 14,
 			"cha": 11,
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 12,
 			"resist": [
@@ -59097,7 +60178,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/will-o-wisp.mp3"
+				"path": "bestiary/will-o-wisp.opus"
 			},
 			"traitTags": [
 				"Illumination",
@@ -59129,10 +60210,10 @@
 			"name": "Winged Kobold",
 			"source": "XMM",
 			"page": 185,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-ACfaS",
+				"DrDe-FWtVC"
 			],
 			"size": [
 				"S"
@@ -59159,7 +60240,7 @@
 			"wis": 7,
 			"cha": 8,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 8,
 			"languages": [
@@ -59211,7 +60292,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/winged-kobold.mp3"
+				"path": "bestiary/winged-kobold.opus"
 			},
 			"traitTags": [
 				"Pack Tactics",
@@ -59241,10 +60322,12 @@
 			"page": 334,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"FRAiF",
+				"NF",
+				"RHW"
 			],
 			"size": [
 				"L"
@@ -59310,7 +60393,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/winter-wolf.mp3"
+				"path": "bestiary/winter-wolf.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -59351,6 +60434,11 @@
 					"page": 359
 				}
 			],
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -59379,7 +60467,7 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"cr": "1/4",
@@ -59406,7 +60494,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wolf.mp3"
+				"path": "bestiary/wolf.opus"
 			},
 			"traitTags": [
 				"Pack Tactics"
@@ -59433,10 +60521,9 @@
 			"page": 335,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "UtHftLH"
-				}
+			"referenceSources": [
+				"FRAiF",
+				"UtHftLH"
 			],
 			"size": [
 				"L"
@@ -59466,7 +60553,7 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"languages": [
@@ -59490,7 +60577,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/worg.mp3"
+				"path": "bestiary/worg.opus"
 			},
 			"senseTags": [
 				"D"
@@ -59515,13 +60602,13 @@
 			"page": 336,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "HBTD"
-				},
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TWoO",
+				"FRAiF",
+				"FRHoF",
+				"HBTD",
+				"RHW"
 			],
 			"size": [
 				"S",
@@ -59554,7 +60641,7 @@
 			"wis": 14,
 			"cha": 15,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"resist": [
@@ -59618,7 +60705,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wraith.mp3"
+				"path": "bestiary/wraith.opus"
 			},
 			"traitTags": [
 				"Incorporeal Movement",
@@ -59636,6 +60723,7 @@
 				"O"
 			],
 			"miscTags": [
+				"HPR",
 				"MA"
 			],
 			"hasToken": true,
@@ -59648,10 +60736,11 @@
 			"page": 337,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"EFA",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -59681,7 +60770,7 @@
 				"perception": "+4"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 14,
 			"cr": "6",
@@ -59714,7 +60803,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/wyvern.mp3"
+				"path": "bestiary/wyvern.opus"
 			},
 			"senseTags": [
 				"SD"
@@ -59772,8 +60861,8 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft.",
-				"tremorsense 60 ft."
+				"Darkvision 60 ft.",
+				"Tremorsense 60 ft."
 			],
 			"passive": 16,
 			"immune": [
@@ -59839,7 +60928,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/xorn.mp3"
+				"path": "bestiary/xorn.opus"
 			},
 			"senseTags": [
 				"D",
@@ -59867,6 +60956,11 @@
 			"name": "Yeti",
 			"source": "XMM",
 			"page": 339,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"NF"
+			],
 			"size": [
 				"L"
 			],
@@ -59897,7 +60991,7 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 15,
 			"immune": [
@@ -59949,7 +61043,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yeti.mp3"
+				"path": "bestiary/yeti.opus"
 			},
 			"senseTags": [
 				"D"
@@ -59986,6 +61080,11 @@
 			],
 			"source": "XMM",
 			"page": 341,
+			"referenceSources": [
+				"FRAiF",
+				"FRHoF",
+				"RHW"
+			],
 			"size": [
 				"M"
 			],
@@ -60030,7 +61129,7 @@
 				"insight": "+6"
 			},
 			"senses": [
-				"darkvision 120 ft."
+				"Darkvision 120 ft."
 			],
 			"passive": 12,
 			"resist": [
@@ -60132,7 +61231,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yochlol.mp3"
+				"path": "bestiary/yochlol.opus"
 			},
 			"traitTags": [
 				"Magic Resistance",
@@ -60193,6 +61292,9 @@
 			"page": 38,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -60236,8 +61338,8 @@
 				"stealth": "+5"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 16,
 			"immune": [
@@ -60285,7 +61387,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/black-dragon.mp3"
+				"path": "bestiary/black-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -60326,6 +61428,11 @@
 			"page": 48,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FFotR",
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -60369,8 +61476,8 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 19,
 			"immune": [
@@ -60411,7 +61518,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/blue-dragon.mp3"
+				"path": "bestiary/blue-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -60449,10 +61556,9 @@
 			"page": 54,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-FWtVC"
 			],
 			"size": [
 				"L"
@@ -60498,8 +61604,8 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 16,
 			"immune": [
@@ -60545,7 +61651,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/brass-dragon.mp3"
+				"path": "bestiary/brass-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -60588,10 +61694,9 @@
 			"page": 58,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TDoN"
 			],
 			"size": [
 				"L"
@@ -60637,8 +61742,8 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 17,
 			"immune": [
@@ -60692,7 +61797,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/bronze-dragon.mp3"
+				"path": "bestiary/bronze-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -60737,6 +61842,10 @@
 			"page": 78,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -60781,8 +61890,8 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 17,
 			"immune": [
@@ -60828,7 +61937,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/copper-dragon.mp3"
+				"path": "bestiary/copper-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -60912,8 +62021,8 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 19,
 			"immune": [
@@ -60968,7 +62077,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/gold-dragon.mp3"
+				"path": "bestiary/gold-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -61010,6 +62119,9 @@
 			"page": 152,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"size": [
 				"L"
 			],
@@ -61054,8 +62166,8 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 17,
 			"immune": [
@@ -61106,7 +62218,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/green-dragon.mp3"
+				"path": "bestiary/green-dragon.opus"
 			},
 			"traitTags": [
 				"Amphibious"
@@ -61147,10 +62259,10 @@
 			"page": 254,
 			"srd52": true,
 			"basicRules2024": true,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV",
+				"FRAiF"
 			],
 			"size": [
 				"L"
@@ -61195,8 +62307,8 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 18,
 			"immune": [
@@ -61237,7 +62349,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/red-dragon.mp3"
+				"path": "bestiary/red-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -61270,10 +62382,10 @@
 			"name": "Young Remorhaz",
 			"source": "XMM",
 			"page": 258,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-SD",
+				"NF"
 			],
 			"size": [
 				"L"
@@ -61300,8 +62412,8 @@
 			"wis": 10,
 			"cha": 4,
 			"senses": [
-				"darkvision 60 ft.",
-				"tremorsense 60 ft."
+				"Darkvision 60 ft.",
+				"Tremorsense 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -61330,7 +62442,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/remorhaz.mp3"
+				"path": "bestiary/remorhaz.opus"
 			},
 			"senseTags": [
 				"D",
@@ -61399,8 +62511,8 @@
 				"stealth": "+4"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 18,
 			"immune": [
@@ -61447,7 +62559,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/silver-dragon.mp3"
+				"path": "bestiary/silver-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -61533,8 +62645,8 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 120 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 120 ft."
 			],
 			"passive": 16,
 			"immune": [
@@ -61582,7 +62694,7 @@
 			"dragonAge": "young",
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/white-dragon.mp3"
+				"path": "bestiary/white-dragon.opus"
 			},
 			"senseTags": [
 				"B",
@@ -61615,6 +62727,10 @@
 			"name": "Yuan-ti Abomination",
 			"source": "XMM",
 			"page": 345,
+			"referenceSources": [
+				"FRAiF",
+				"RHW"
+			],
 			"size": [
 				"L"
 			],
@@ -61648,7 +62764,7 @@
 				"stealth": "+6"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 17,
 			"immune": [
@@ -61735,7 +62851,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-abomination.mp3"
+				"path": "bestiary/yuan-ti-abomination.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -61816,7 +62932,7 @@
 				"stealth": "+3"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 14,
 			"immune": [
@@ -61930,10 +63046,11 @@
 			"name": "Yuan-ti Malison (Type 1)",
 			"source": "XMM",
 			"page": 343,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-DaS",
+				"FRAiF",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -61967,7 +63084,7 @@
 				"stealth": "+4 (+6 while in snake form)"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"immune": [
@@ -62048,7 +63165,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-malison.mp3"
+				"path": "bestiary/yuan-ti-malison.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -62121,7 +63238,7 @@
 				"stealth": "+4 (+6 while in snake form)"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"immune": [
@@ -62196,7 +63313,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-malison.mp3"
+				"path": "bestiary/yuan-ti-malison.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -62237,10 +63354,9 @@
 			"name": "Yuan-ti Malison (Type 3)",
 			"source": "XMM",
 			"page": 344,
-			"otherSources": [
-				{
-					"source": "DrDe"
-				}
+			"referenceSources": [
+				"DrDe",
+				"DrDe-TFV"
 			],
 			"size": [
 				"M"
@@ -62271,7 +63387,7 @@
 				"stealth": "+4 (+6 while in snake form)"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 13,
 			"immune": [
@@ -62352,7 +63468,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/yuan-ti-malison.mp3"
+				"path": "bestiary/yuan-ti-malison.opus"
 			},
 			"traitTags": [
 				"Magic Resistance"
@@ -62406,13 +63522,18 @@
 				{
 					"source": "XPHB",
 					"page": 359
-				},
-				{
-					"source": "HBTD"
-				},
-				{
-					"source": "DrDe"
 				}
+			],
+			"referenceSources": [
+				"BQDD",
+				"DrDe",
+				"DrDe-DaS",
+				"DrDe-TWoO",
+				"EFA",
+				"FRAiF",
+				"HBTD",
+				"HotB",
+				"RHW"
 			],
 			"size": [
 				"M"
@@ -62442,7 +63563,7 @@
 				"wis": "+0"
 			},
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 8,
 			"immune": [
@@ -62479,7 +63600,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "bestiary/zombie.mp3"
+				"path": "bestiary/zombie.opus"
 			},
 			"traitTags": [
 				"Undead Fortitude"

--- a/json/bestiary/bestiary-xphb.json
+++ b/json/bestiary/bestiary-xphb.json
@@ -36,7 +36,7 @@
 			"wis": 10,
 			"cha": 6,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -51,7 +51,7 @@
 				{
 					"name": "Regeneration (Slaad Only)",
 					"entries": [
-						"The spirit regains 5 Hit Points at the start of its turn if it has at least 1 Hit Point."
+						"The spirit regains 5 {@variantrule Hit Points|XPHB} at the start of its turn if it has at least 1 {@variantrule Hit Points|XPHB|Hit Point}."
 					]
 				},
 				{
@@ -71,7 +71,7 @@
 				{
 					"name": "Claw (Slaad Only)",
 					"entries": [
-						"{@atkr m} {@hitYourSpellAttack Bonus equals your spell attack modifier}, reach 5 ft. {@h}{@damage 1d10 + 3 + summonSpellLevel} Slashing damage, and the target can't regain Hit Points until the start of the spirit's next turn."
+						"{@atkr m} {@hitYourSpellAttack Bonus equals your spell attack modifier}, reach 5 ft. {@h}{@damage 1d10 + 3 + summonSpellLevel} Slashing damage, and the target can't regain {@variantrule Hit Points|XPHB} until the start of the spirit's next turn."
 					]
 				},
 				{
@@ -87,6 +87,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.1,
 			"traitTags": [
 				"Regeneration"
 			],
@@ -143,13 +144,63 @@
 						"canHover": true
 					},
 					"trait": null,
+					"foundryTokenScale": 1.1,
 					"traitTags": null,
 					"damageTags": [
 						"Y"
 					],
 					"miscTags": [
 						"RA"
-					]
+					],
+					"hasToken": true
+				},
+				{
+					"name": "Aberrant Spirit (Mind Flayer)",
+					"source": "XPHB",
+					"_mod": {
+						"trait": [
+							{
+								"mode": "removeArr",
+								"names": [
+									"Regeneration (Slaad Only)"
+								]
+							},
+							{
+								"mode": "renameArr",
+								"renames": {
+									"rename": "Whispering Aura (Mind Flayer Only)",
+									"with": "Whispering Aura"
+								}
+							}
+						],
+						"action": [
+							{
+								"mode": "removeArr",
+								"names": [
+									"Eye Ray (Beholderkin Only)",
+									"Claw (Slaad Only)"
+								]
+							},
+							{
+								"mode": "renameArr",
+								"renames": {
+									"rename": "Psychic Slam (Mind Flayer Only)",
+									"with": "Psychic Slam"
+								}
+							}
+						]
+					},
+					"speed": {
+						"walk": 30
+					},
+					"traitTags": null,
+					"damageTags": [
+						"Y"
+					],
+					"miscTags": [
+						"RA"
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Aberrant Spirit (Slaad)",
@@ -198,56 +249,8 @@
 					],
 					"miscTags": [
 						"MA"
-					]
-				},
-				{
-					"name": "Aberrant Spirit (Star Spawn)",
-					"source": "XPHB",
-					"_mod": {
-						"trait": [
-							{
-								"mode": "removeArr",
-								"names": [
-									"Regeneration (Slaad Only)"
-								]
-							},
-							{
-								"mode": "renameArr",
-								"renames": {
-									"rename": "Whispering Aura (Mind Flayer Only)",
-									"with": "Whispering Aura"
-								}
-							}
-						],
-						"action": [
-							{
-								"mode": "removeArr",
-								"names": [
-									"Eye Ray (Beholderkin Only)",
-									"Claw (Slaad Only)"
-								]
-							},
-							{
-								"mode": "renameArr",
-								"renames": {
-									"rename": "Psychic Slam (Mind Flayer Only)",
-									"with": "Psychic Slam"
-								}
-							}
-						]
-					},
-					"speed": {
-						"walk": 30
-					},
-					"traitTags": [
-						"Regeneration"
 					],
-					"damageTags": [
-						"Y"
-					],
-					"miscTags": [
-						"RA"
-					]
+					"hasToken": true
 				}
 			]
 		},
@@ -255,6 +258,7 @@
 			"name": "Animated Object",
 			"source": "XPHB",
 			"page": 240,
+			"srd52": true,
 			"summonedBySpell": "Animate Objects|XPHB",
 			"summonedBySpellLevel": 5,
 			"size": [
@@ -284,7 +288,7 @@
 			"wis": 3,
 			"cha": 1,
 			"senses": [
-				"blindsight 30 ft."
+				"Blindsight 30 ft."
 			],
 			"passive": 6,
 			"languages": [
@@ -299,6 +303,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.3,
 			"senseTags": [
 				"B"
 			],
@@ -386,7 +391,7 @@
 			"wis": 14,
 			"cha": 11,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"languages": [
@@ -409,6 +414,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.3,
 			"miscTags": [
 				"MA"
 			],
@@ -449,7 +455,7 @@
 			"wis": 14,
 			"cha": 11,
 			"senses": [
-				"darkvision 90 ft."
+				"Darkvision 90 ft."
 			],
 			"passive": 12,
 			"languages": [
@@ -478,6 +484,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.3,
 			"traitTags": [
 				"Amphibious"
 			],
@@ -521,7 +528,7 @@
 			"wis": 14,
 			"cha": 11,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"languages": [
@@ -550,6 +557,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.3,
 			"traitTags": [
 				"Flyby"
 			],
@@ -602,7 +610,7 @@
 			"wis": 14,
 			"cha": 5,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"languages": [
@@ -619,7 +627,7 @@
 				{
 					"name": "Pack Tactics (Land and Water Only)",
 					"entries": [
-						"The spirit has Advantage on an attack roll against a creature if at least one of the spirit's allies is within 5 feet of the creature and the ally doesn't have the {@condition Incapacitated|XPHB} condition."
+						"The spirit has {@variantrule Advantage|XPHB} on an attack roll against a creature if at least one of the spirit's allies is within 5 feet of the creature and the ally doesn't have the {@condition Incapacitated|XPHB} condition."
 					]
 				},
 				{
@@ -643,6 +651,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.3,
 			"traitTags": [
 				"Flyby",
 				"Pack Tactics",
@@ -690,7 +699,8 @@
 					},
 					"traitTags": [
 						"Flyby"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Bestial Spirit (Land)",
@@ -720,9 +730,11 @@
 						"walk": 30,
 						"climb": 30
 					},
+					"foundryTokenScale": 1.3,
 					"traitTags": [
 						"Pack Tactics"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Bestial Spirit (Water)",
@@ -754,7 +766,8 @@
 					"traitTags": [
 						"Pack Tactics",
 						"Water Breathing"
-					]
+					],
+					"hasToken": true
 				}
 			]
 		},
@@ -790,7 +803,7 @@
 			"wis": 14,
 			"cha": 16,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"resist": [
@@ -821,16 +834,17 @@
 				{
 					"name": "Radiant Mace (Defender Only)",
 					"entries": [
-						"{@atkr m} {@hitYourSpellAttack Bonus equals your spell attack modifier}, reach 5 ft. {@h}{@damage 1d10 + 3 + summonSpellLevel} Radiant damage, and the spirit can choose itself or another creature it can see within 10 feet of the target. The chosen creature gains {@dice 1d10} Temporary Hit Points."
+						"{@atkr m} {@hitYourSpellAttack Bonus equals your spell attack modifier}, reach 5 ft. {@h}{@damage 1d10 + 3 + summonSpellLevel} Radiant damage, and the spirit can choose itself or another creature it can see within 10 feet of the target. The chosen creature gains {@dice 1d10} {@variantrule Temporary Hit Points|XPHB}."
 					]
 				},
 				{
 					"name": "Healing Touch (1/Day)",
 					"entries": [
-						"The spirit touches another creature. The target regains Hit Points equal to {@dice 2d8 + summonSpellLevel}."
+						"The spirit touches another creature. The target regains {@variantrule Hit Points|XPHB} equal to {@dice 2d8 + summonSpellLevel}."
 					]
 				}
 			],
+			"foundryTokenScale": 1.1,
 			"actionTags": [
 				"Multiattack"
 			],
@@ -868,10 +882,12 @@
 							"special": "11 + the spell's level"
 						}
 					],
+					"foundryTokenScale": 1.1,
 					"miscTags": [
 						"RA",
 						"RW"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Celestial Spirit (Defender)",
@@ -896,10 +912,12 @@
 							"special": "13 + the spell's level"
 						}
 					],
+					"foundryTokenScale": 1.1,
 					"miscTags": [
 						"MA",
 						"MLW"
-					]
+					],
+					"hasToken": true
 				}
 			]
 		},
@@ -934,7 +952,7 @@
 			"wis": 11,
 			"cha": 5,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -961,7 +979,7 @@
 				{
 					"name": "Stony Lethargy (Stone Only)",
 					"entries": [
-						"When a creature starts its turn within 10 feet of the spirit, the spirit can target it with magical energy if the spirit can see it. {@actSave wis} DC equals your spell save DC, the target. {@actSaveFail} Until the start of its next turn, the target can't make {@action Opportunity Attack|XPHB|Opportunity Attacks}, and its Speed is halved."
+						"When a creature starts its turn within 10 feet of the spirit, the spirit can target it with magical energy if the spirit can see it. {@actSave wis} DC equals your spell save DC, the target. {@actSaveFail} Until the start of its next turn, the target can't make {@action Opportunity Attack|XPHB|Opportunity Attacks}, and its {@variantrule Speed|XPHB} is halved."
 					]
 				}
 			],
@@ -983,10 +1001,11 @@
 				{
 					"name": "Berserk Lashing (Clay Only)",
 					"entries": [
-						"{@actTrigger} The spirit takes damage from a creature. {@actResponse} The spirit makes a Slam attack against that creature if possible, or the spirit moves up to half its Speed toward that creature without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks}."
+						"{@actTrigger} The spirit takes damage from a creature. {@actResponse} The spirit makes a Slam attack against that creature if possible, or the spirit moves up to half its {@variantrule Speed|XPHB} toward that creature without provoking {@action Opportunity Attack|XPHB|Opportunity Attacks}."
 					]
 				}
 			],
+			"foundryTokenScale": 1.3,
 			"actionTags": [
 				"Multiattack"
 			],
@@ -1020,7 +1039,8 @@
 					"trait": null,
 					"damageTags": [
 						"B"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Construct Spirit (Metal)",
@@ -1040,7 +1060,8 @@
 							}
 						]
 					},
-					"reaction": null
+					"reaction": null,
+					"hasToken": true
 				},
 				{
 					"name": "Construct Spirit (Stone)",
@@ -1061,9 +1082,11 @@
 						]
 					},
 					"reaction": null,
+					"foundryTokenScale": 1.3,
 					"damageTags": [
 						"B"
-					]
+					],
+					"hasToken": true
 				}
 			]
 		},
@@ -1071,6 +1094,7 @@
 			"name": "Draconic Spirit",
 			"source": "XPHB",
 			"page": 325,
+			"srd52": true,
 			"summonedBySpell": "Summon Dragon|XPHB",
 			"summonedBySpellLevel": 5,
 			"size": [
@@ -1100,8 +1124,8 @@
 			"wis": 14,
 			"cha": 14,
 			"senses": [
-				"blindsight 30 ft.",
-				"darkvision 60 ft."
+				"Blindsight 30 ft.",
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"resist": [
@@ -1125,7 +1149,7 @@
 				{
 					"name": "Shared Resistances",
 					"entries": [
-						"When you summon the spirit, choose one of its Resistances. You have Resistance to the chosen damage type until the spell ends."
+						"When you summon the spirit, choose one of its Resistances. You have {@variantrule Resistance|XPHB} to the chosen damage type until the spell ends."
 					]
 				}
 			],
@@ -1145,10 +1169,11 @@
 				{
 					"name": "Breath Weapon",
 					"entries": [
-						"{@actSave dex} DC equals your spell save DC, each creature in a 30-foot Cone. {@actSaveFail} {@damage 2d6} damage of a type this spirit has Resistance to (your choice when you cast the spell). {@actSaveSuccess} Half damage."
+						"{@actSave dex} DC equals your spell save DC, each creature in a 30-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} {@damage 2d6} damage of a type this spirit has {@variantrule Resistance|XPHB} to (your choice when you cast the spell). {@actSaveSuccess} Half damage."
 					]
 				}
 			],
+			"foundryTokenScale": 2,
 			"actionTags": [
 				"Breath Weapon",
 				"Multiattack"
@@ -1163,7 +1188,68 @@
 				"dexterity"
 			],
 			"hasToken": true,
-			"hasFluffImages": true
+			"hasFluffImages": true,
+			"_versions": [
+				{
+					"_abstract": {
+						"name": "Draconic Spirit ({{resist}})",
+						"source": "XPHB",
+						"_mod": {
+							"trait": [
+								{
+									"mode": "replaceArr",
+									"replace": "Shared Resistances",
+									"items": {
+										"name": "Shared Resistances",
+										"entries": [
+											"You have {@variantrule Resistance|XPHB} to {{resist}} damage until the spell ends."
+										]
+									}
+								}
+							],
+							"action": [
+								{
+									"mode": "replaceArr",
+									"replace": "Breath Weapon",
+									"items": {
+										"name": "Breath Weapon",
+										"entries": [
+											"{@actSave dex} DC equals your spell save DC, each creature in a 30-foot {@variantrule Cone [Area of Effect]|XPHB|Cone}. {@actSaveFail} {@damage 2d6} {{resist}} damage. {@actSaveSuccess} Half damage."
+										]
+									}
+								}
+							]
+						}
+					},
+					"_implementations": [
+						{
+							"_variables": {
+								"resist": "Acid"
+							}
+						},
+						{
+							"_variables": {
+								"resist": "Cold"
+							}
+						},
+						{
+							"_variables": {
+								"resist": "Fire"
+							}
+						},
+						{
+							"_variables": {
+								"resist": "Lightning"
+							}
+						},
+						{
+							"_variables": {
+								"resist": "Poison"
+							}
+						}
+					]
+				}
+			]
 		},
 		{
 			"name": "Elemental Spirit",
@@ -1209,7 +1295,7 @@
 			"wis": 10,
 			"cha": 16,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -1262,7 +1348,7 @@
 				{
 					"name": "Amorphous Form (Air, Fire, and Water Only)",
 					"entries": [
-						"The spirit can move through a space as narrow as 1 inch wide without it counting as Difficult Terrain."
+						"The spirit can move through a space as narrow as 1 inch wide without it counting as {@variantrule Difficult Terrain|XPHB}."
 					]
 				}
 			],
@@ -1280,6 +1366,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.1,
 			"traitTags": [
 				"Amorphous"
 			],
@@ -1331,9 +1418,11 @@
 					"immune": [
 						"poison"
 					],
+					"foundryTokenScale": 1.1,
 					"damageTags": [
 						"B"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Elemental Spirit (Earth)",
@@ -1362,9 +1451,11 @@
 						"poison"
 					],
 					"trait": null,
+					"foundryTokenScale": 1.1,
 					"damageTags": [
 						"B"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Elemental Spirit (Fire)",
@@ -1397,9 +1488,11 @@
 						"poison",
 						"fire"
 					],
+					"foundryTokenScale": 1.1,
 					"damageTags": [
 						"F"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Elemental Spirit (Water)",
@@ -1435,9 +1528,11 @@
 					"immune": [
 						"poison"
 					],
+					"foundryTokenScale": 1.1,
 					"damageTags": [
 						"B"
-					]
+					],
+					"hasToken": true
 				}
 			]
 		},
@@ -1473,7 +1568,7 @@
 			"wis": 11,
 			"cha": 16,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"conditionImmune": [
@@ -1511,7 +1606,7 @@
 									"name": "Fuming",
 									"type": "item",
 									"entries": [
-										"The spirit has Advantage on the next attack roll it makes before the end of this turn."
+										"The spirit has {@variantrule Advantage|XPHB} on the next attack roll it makes before the end of this turn."
 									]
 								},
 								{
@@ -1525,7 +1620,7 @@
 									"name": "Tricksy",
 									"type": "item",
 									"entries": [
-										"The spirit fills a 10-foot Cube within 5 feet of it with magical Darkness, which lasts until the end of its next turn."
+										"The spirit fills a 10-foot {@variantrule Cube [Area of Effect]|XPHB|Cube} within 5 feet of it with magical Darkness, which lasts until the end of its next turn."
 									]
 								}
 							]
@@ -1533,6 +1628,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.3,
 			"senseTags": [
 				"D"
 			],
@@ -1564,7 +1660,7 @@
 						{
 							"name": "Fey Step",
 							"entries": [
-								"The spirit magically teleports up to 30 feet to an unoccupied space it can see. The spirit has Advantage on the next attack roll it makes before the end of this turn."
+								"The spirit magically teleports up to 30 feet to an unoccupied space it can see. The spirit has {@variantrule Advantage|XPHB} on the next attack roll it makes before the end of this turn."
 							]
 						}
 					]
@@ -1588,7 +1684,7 @@
 						{
 							"name": "Fey Step",
 							"entries": [
-								"The spirit magically teleports up to 30 feet to an unoccupied space it can see. The spirit fills a 10-foot Cube within 5 feet of it with magical Darkness, which lasts until the end of its next turn."
+								"The spirit magically teleports up to 30 feet to an unoccupied space it can see. The spirit fills a 10-foot {@variantrule Cube [Area of Effect]|XPHB|Cube} within 5 feet of it with magical Darkness, which lasts until the end of its next turn."
 							]
 						}
 					]
@@ -1634,7 +1730,7 @@
 			"wis": 10,
 			"cha": 16,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"resist": [
@@ -1656,19 +1752,19 @@
 				{
 					"name": "Death Throes (Demon Only)",
 					"entries": [
-						"When the spirit drops to 0 Hit Points or the spell ends, the spirit explodes. {@actSave dex} DC equals your spell save DC, each creature in a 10-foot Emanation originating from the spirit. {@actSaveFail} {@damage 2d10} plus this spell's level Fire damage. {@actSaveSuccess} Half damage."
+						"When the spirit drops to 0 {@variantrule Hit Points|XPHB} or the spell ends, the spirit explodes. {@actSave dex} DC equals your spell save DC, each creature in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the spirit. {@actSaveFail} {@damage 2d10} plus this spell's level Fire damage. {@actSaveSuccess} Half damage."
 					]
 				},
 				{
 					"name": "Devil's Sight (Devil Only)",
 					"entries": [
-						"Magical Darkness doesn't impede the spirit's Darkvision."
+						"Magical {@variantrule Darkness|XPHB} doesn't impede the spirit's Darkvision."
 					]
 				},
 				{
 					"name": "Magic Resistance",
 					"entries": [
-						"The spirit has Advantage on saving throws against spells and other magical effects."
+						"The spirit has {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
 					]
 				}
 			],
@@ -1698,6 +1794,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.1,
 			"traitTags": [
 				"Death Burst",
 				"Devil's Sight",
@@ -1768,7 +1865,8 @@
 					],
 					"damageTags": [
 						"F"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Fiendish Spirit (Devil)",
@@ -1811,13 +1909,15 @@
 						"walk": 40,
 						"fly": 60
 					},
+					"foundryTokenScale": 1.1,
 					"traitTags": [
 						"Devil's Sight",
 						"Magic Resistance"
 					],
 					"damageTags": [
 						"N"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Fiendish Spirit (Yugoloth)",
@@ -1860,7 +1960,8 @@
 					],
 					"damageTags": [
 						"F"
-					]
+					],
+					"hasToken": true
 				}
 			]
 		},
@@ -1901,7 +2002,7 @@
 			"wis": 14,
 			"cha": 3,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 12,
 			"languages": [
@@ -1932,7 +2033,7 @@
 				{
 					"name": "Web Bolt (Spider Only)",
 					"entries": [
-						"{@atkr r} {@hitYourSpellAttack Bonus equals your spell attack modifier}, range 60 ft. {@h}{@damage 1d10 + 3 + summonSpellLevel} Bludgeoning damage, and the target's Speed is reduced to 0 until the start of the insect's next turn."
+						"{@atkr r} {@hitYourSpellAttack Bonus equals your spell attack modifier}, range 60 ft. {@h}{@damage 1d10 + 3 + summonSpellLevel} Bludgeoning damage, and the target's {@variantrule Speed|XPHB} is reduced to 0 until the start of the insect's next turn."
 					]
 				}
 			],
@@ -1944,6 +2045,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.1,
 			"traitTags": [
 				"Spider Climb"
 			],
@@ -1984,7 +2086,9 @@
 					"speed": {
 						"walk": 40,
 						"climb": 40
-					}
+					},
+					"foundryTokenScale": 1.1,
+					"hasToken": true
 				},
 				{
 					"name": "Giant Insect (Spider)",
@@ -2004,7 +2108,8 @@
 						"walk": 40,
 						"climb": 40
 					},
-					"bonus": null
+					"bonus": null,
+					"hasToken": true
 				},
 				{
 					"name": "Giant Insect (Wasp)",
@@ -2024,7 +2129,8 @@
 						"climb": 40,
 						"fly": 40
 					},
-					"bonus": null
+					"bonus": null,
+					"hasToken": true
 				}
 			]
 		},
@@ -2032,6 +2138,7 @@
 			"name": "Otherworldly Steed",
 			"source": "XPHB",
 			"page": 273,
+			"srd52": true,
 			"summonedBySpell": "Find Steed|XPHB",
 			"summonedBySpellLevel": 2,
 			"size": [
@@ -2079,7 +2186,7 @@
 				{
 					"name": "Life Bond",
 					"entries": [
-						"When you regain Hit Points from a level 1+ spell, the steed regains the same number of Hit Points if you're within 5 feet of it."
+						"When you regain {@variantrule Hit Points|XPHB} from a level 1+ spell, the steed regains the same number of {@variantrule Hit Points|XPHB} if you're within 5 feet of it."
 					]
 				}
 			],
@@ -2107,10 +2214,11 @@
 				{
 					"name": "Healing Touch (Celestial Only; Recharges after a Long Rest)",
 					"entries": [
-						"One creature within 5 feet of the steed regains a number of Hit Points equal to {@dice 2d8 + summonSpellLevel}."
+						"One creature within 5 feet of the steed regains a number of {@variantrule Hit Points|XPHB} equal to {@dice 2d8 + summonSpellLevel}."
 					]
 				}
 			],
+			"foundryTokenScale": 1.1,
 			"languageTags": [
 				"TP"
 			],
@@ -2270,7 +2378,7 @@
 			"wis": 10,
 			"cha": 9,
 			"senses": [
-				"darkvision 60 ft."
+				"Darkvision 60 ft."
 			],
 			"passive": 10,
 			"immune": [
@@ -2291,13 +2399,13 @@
 				{
 					"name": "Festering Aura (Putrid Only)",
 					"entries": [
-						"{@actSave con} DC equals your spell save DC, any creature (other than you) that starts its turn within a 5-foot Emanation originating from the spirit. {@actSaveFail} The creature has the {@condition Poisoned|XPHB} condition until the start of its next turn."
+						"{@actSave con} DC equals your spell save DC, any creature (other than you) that starts its turn within a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the spirit. {@actSaveFail} The creature has the {@condition Poisoned|XPHB} condition until the start of its next turn."
 					]
 				},
 				{
 					"name": "Incorporeal Passage (Ghostly Only)",
 					"entries": [
-						"The spirit can move through other creatures and objects as if they were Difficult Terrain. If it ends its turn inside an object, it is shunted to the nearest unoccupied space and takes {@damage 1d10} Force damage for every 5 feet traveled."
+						"The spirit can move through other creatures and objects as if they were {@variantrule Difficult Terrain|XPHB}. If it ends its turn inside an object, it is shunted to the nearest unoccupied space and takes {@damage 1d10} Force damage for every 5 feet traveled."
 					]
 				}
 			],
@@ -2327,6 +2435,7 @@
 					]
 				}
 			],
+			"foundryTokenScale": 1.3,
 			"traitTags": [
 				"Incorporeal Movement"
 			],
@@ -2401,12 +2510,14 @@
 						},
 						"canHover": true
 					},
+					"foundryTokenScale": 1.3,
 					"damageTags": [
 						"N"
 					],
 					"conditionInflict": [
 						"frightened"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Undead Spirit (Putrid)",
@@ -2456,7 +2567,8 @@
 					"conditionInflict": [
 						"paralyzed",
 						"poisoned"
-					]
+					],
+					"hasToken": true
 				},
 				{
 					"name": "Undead Spirit (Skeletal)",
@@ -2490,7 +2602,8 @@
 					"damageTags": [
 						"N"
 					],
-					"conditionInflict": null
+					"conditionInflict": null,
+					"hasToken": true
 				}
 			]
 		}

--- a/json/books.json
+++ b/json/books.json
@@ -3883,6 +3883,27 @@
 			]
 		},
 		{
+			"name": "Monstrous Compendium Volume 1: Spelljammer Creatures",
+			"id": "MCV1SC",
+			"source": "MCV1SC",
+			"group": "supplement-alt",
+			"cover": {
+				"type": "internal",
+				"path": "covers/MCV1SC.webp"
+			},
+			"published": "2022-04-21",
+			"author": "Wizards RPG Team",
+			"contents": [
+				{
+					"name": "Monstrous Compendium Vol. One: Spelljammer Creatures",
+					"headers": [
+						"Creature Summaries",
+						"Credits"
+					]
+				}
+			]
+		},
+		{
 			"name": "Tarot Deck",
 			"id": "TD",
 			"source": "TD",
@@ -8154,6 +8175,10 @@
 				},
 				{
 					"name": "Dragonmarked Intrigue",
+					"ordinal": {
+						"type": "chapter",
+						"identifier": 5
+					},
 					"headers": [
 						"Dragonmarked Characters",
 						"Dragonmarked Conflicts",
@@ -8198,6 +8223,624 @@
 				},
 				{
 					"name": "Credits"
+				}
+			]
+		},
+		{
+			"name": "Crochet: A Book of Many Patterns",
+			"id": "CaBoMP",
+			"source": "CaBoMP",
+			"group": "homecraft",
+			"cover": {
+				"type": "internal",
+				"path": "covers/CaBoMP.webp"
+			},
+			"published": "2026-03-31",
+			"author": "Stacy King",
+			"contents": [
+				{
+					"name": "Introduction",
+					"headers": [
+						"About This Book"
+					]
+				},
+				{
+					"name": "Amigurumi",
+					"headers": [
+						"Gelatinous Cube",
+						"Beholder",
+						"Displacer Beast",
+						"Mind Flayer",
+						"Owlbear Cub",
+						"Eye and Hand of Vecna",
+						"Red Dragon"
+					]
+				},
+				{
+					"name": "Wearables",
+					"headers": [
+						"Quiver of Ehlonna",
+						"Platinum Dragon Cowl",
+						"Bracers of Archery",
+						"Minsc's Hat of Winter Warming",
+						"Purple Worm Scarf",
+						"Gloves of Missile Snaring",
+						"Spellbook Pouch Belt Bag",
+						"Mantle of Spell Resistance",
+						"Bag of Holding"
+					]
+				},
+				{
+					"name": "Household Items",
+					"headers": [
+						"Schools of Magic Granny Squares",
+						"D20 Pillow",
+						"Mimic Dice Bag",
+						"Soul Coin Coaster"
+					]
+				},
+				{
+					"name": "Crochet Glossary Terms",
+					"headers": [
+						"Special Stitches"
+					]
+				},
+				{
+					"name": "Yarn List and Charts",
+					"headers": [
+						"Yarn Used in Patterns",
+						"Charts from Patterns"
+					]
+				},
+				{
+					"name": "Credits"
+				}
+			]
+		},
+		{
+			"name": "Dungeon Master's Screen; Ravenloft: The Horrors Within",
+			"id": "XScreenRHW",
+			"source": "XScreenRHW",
+			"group": "screen",
+			"cover": {
+				"type": "internal",
+				"path": "covers/XScreenRHW.webp"
+			},
+			"published": "2026-06-16",
+			"author": "Wizards RPG Team",
+			"contents": [
+				{
+					"name": "DM Screen",
+					"headers": [
+						"Conditions",
+						"Tables"
+					]
+				}
+			]
+		},
+		{
+			"name": "Ravenloft: The Horrors Within",
+			"id": "RHW",
+			"source": "RHW",
+			"group": "setting",
+			"cover": {
+				"type": "internal",
+				"path": "covers/RHW.webp"
+			},
+			"published": "2026-06-16",
+			"author": "Wizards RPG Team",
+			"contents": [
+				{
+					"name": "Introduction: Domains of Dread",
+					"headers": [
+						"Using This Book",
+						"Secrets of Ravenloft",
+						{
+							"depth": 1,
+							"header": "1: Ravenloft Is Malleable"
+						},
+						{
+							"depth": 1,
+							"header": "2: The Dark Powers Reign"
+						},
+						{
+							"depth": 1,
+							"header": "3: Domains Imprison Darklords"
+						},
+						{
+							"depth": 1,
+							"header": "4: The Mists' Clutches"
+						},
+						{
+							"depth": 1,
+							"header": "5: Heroes Are Few"
+						},
+						{
+							"depth": 1,
+							"header": "6: Isolated Islands"
+						},
+						{
+							"depth": 1,
+							"header": "7: Rule of Fear"
+						},
+						"The Land of the Mists",
+						"Adventures by Level",
+						"Pronunciation Guide"
+					]
+				},
+				{
+					"name": "Character Options",
+					"ordinal": {
+						"type": "chapter",
+						"identifier": 1
+					},
+					"headers": [
+						"Haunted Heroes",
+						"Subclasses",
+						"Backgrounds",
+						"Species",
+						"Feats"
+					]
+				},
+				{
+					"name": "Domains of Ravenloft",
+					"ordinal": {
+						"type": "chapter",
+						"identifier": 2
+					},
+					"headers": [
+						"Tarokka and the Mists",
+						"Domains of Ravenloft Guide",
+						"Barovia",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Barovia",
+							"depth": 1
+						},
+						{
+							"header": "Strahd von Zarovich",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Barovia",
+							"depth": 1
+						},
+						"Borca",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Borca",
+							"depth": 1
+						},
+						{
+							"header": "Ivana Boritsi",
+							"depth": 1
+						},
+						{
+							"header": "Ivan Dilisnya",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Borca",
+							"depth": 1
+						},
+						"Darkon",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Darkon",
+							"depth": 1
+						},
+						{
+							"header": "Azalin Rex",
+							"depth": 1
+						},
+						{
+							"header": "Fractures of Darkon",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Darkon",
+							"depth": 1
+						},
+						"Dementlieu",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Dementlieu",
+							"depth": 1
+						},
+						{
+							"header": "Saidra d'Honaire",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Dementlieu",
+							"depth": 1
+						},
+						"Falkovnia",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Falkovnia",
+							"depth": 1
+						},
+						{
+							"header": "Vladeska Drakov",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Falkovnia",
+							"depth": 1
+						},
+						"Har'Akir",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Har'Akir",
+							"depth": 1
+						},
+						{
+							"header": "Ankhtepot",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Har'Akir",
+							"depth": 1
+						},
+						"Hazlan",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Hazlan",
+							"depth": 1
+						},
+						{
+							"header": "Hazlik",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Hazlan",
+							"depth": 1
+						},
+						"Innsmouth",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Innsmouth",
+							"depth": 1
+						},
+						{
+							"header": "Cthulhu",
+							"depth": 1
+						},
+						{
+							"header": "Cults of Innsmouth",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Innsmouth",
+							"depth": 1
+						},
+						"Kalakeri",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Kalakeri",
+							"depth": 1
+						},
+						{
+							"header": "Ramya Vasavadan",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Kalakeri",
+							"depth": 1
+						},
+						"Kartakass",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Kartakass",
+							"depth": 1
+						},
+						{
+							"header": "Harkon Lukas",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Kartakass",
+							"depth": 1
+						},
+						"Lamordia",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Lamordia",
+							"depth": 1
+						},
+						{
+							"header": "Viktra Mordenheim",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Lamordia",
+							"depth": 1
+						},
+						"Mordent",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Mordent",
+							"depth": 1
+						},
+						{
+							"header": "Wilfred Godefroy",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Mordent",
+							"depth": 1
+						},
+						"Shadowlands",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in the Shadowlands",
+							"depth": 1
+						},
+						{
+							"header": "Ebonbane",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in the Shadowlands",
+							"depth": 1
+						},
+						"Sithicus",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Sithicus",
+							"depth": 1
+						},
+						{
+							"header": "Lord Soth",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Sithicus",
+							"depth": 1
+						},
+						"Tepest",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Tepest",
+							"depth": 1
+						},
+						{
+							"header": "Mother Lorinda",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Tepest",
+							"depth": 1
+						},
+						"Valachan",
+						{
+							"header": "Domain Features",
+							"depth": 1
+						},
+						{
+							"header": "Locations in Valachan",
+							"depth": 1
+						},
+						{
+							"header": "Chakuna",
+							"depth": 1
+						},
+						{
+							"header": "Adventures in Valachan",
+							"depth": 1
+						},
+						"Other Domains of Dread",
+						{
+							"header": "The Agency",
+							"depth": 1
+						},
+						{
+							"header": "Bluetspur",
+							"depth": 1
+						},
+						{
+							"header": "Carnival",
+							"depth": 1
+						},
+						{
+							"header": "Cyre 1313, the Mourning Rail",
+							"depth": 1
+						},
+						{
+							"header": "Forlorn",
+							"depth": 1
+						},
+						{
+							"header": "Ghastria",
+							"depth": 1
+						},
+						{
+							"header": "G'henna",
+							"depth": 1
+						},
+						{
+							"header": "I'Cath",
+							"depth": 1
+						},
+						{
+							"header": "Invidia",
+							"depth": 1
+						},
+						{
+							"header": "Kalidnay",
+							"depth": 1
+						},
+						{
+							"header": "Keening",
+							"depth": 1
+						},
+						{
+							"header": "Klorr",
+							"depth": 1
+						},
+						{
+							"header": "Markovia",
+							"depth": 1
+						},
+						{
+							"header": "Nightmare Lands",
+							"depth": 1
+						},
+						{
+							"header": "Niranjan",
+							"depth": 1
+						},
+						{
+							"header": "Nova Vaasa",
+							"depth": 1
+						},
+						{
+							"header": "Odaire",
+							"depth": 1
+						},
+						{
+							"header": "Richemulot",
+							"depth": 1
+						},
+						{
+							"header": "Rider's Bridge",
+							"depth": 1
+						},
+						{
+							"header": "Risibilos",
+							"depth": 1
+						},
+						{
+							"header": "Scaena",
+							"depth": 1
+						},
+						{
+							"header": "Sea of Sorrows",
+							"depth": 1
+						},
+						{
+							"header": "Souragne",
+							"depth": 1
+						},
+						{
+							"header": "Staunton Bluffs",
+							"depth": 1
+						},
+						{
+							"header": "Tovag",
+							"depth": 1
+						},
+						{
+							"header": "Zherisia",
+							"depth": 1
+						},
+						{
+							"header": "Random Domains",
+							"depth": 1
+						}
+					]
+				},
+				{
+					"name": "Ravenloft Adventures",
+					"ordinal": {
+						"type": "chapter",
+						"identifier": 3
+					},
+					"headers": [
+						"Campaigns in the Mists",
+						"Using Domains of Dread",
+						"Using Darklords",
+						"Escaping Ravenloft",
+						"Enemies and Allies",
+						"Horror Atmosphere",
+						"Horror Roleplaying",
+						"Haunted Bastions"
+					]
+				},
+				{
+					"name": "Creating Domains of Dread",
+					"ordinal": {
+						"type": "chapter",
+						"identifier": 4
+					},
+					"headers": [
+						"Creating a Darklord",
+						"Creating a Domain",
+						"Unleash Your Horror",
+						"Genres of Horror"
+					]
+				},
+				{
+					"name": "Denizens of the Mists",
+					"ordinal": {
+						"type": "chapter",
+						"identifier": 5
+					},
+					"headers": [
+						"Horror Monsters",
+						"Bestiary"
+					]
+				},
+				{
+					"name": "Appendix: Tarokka Deck",
+					"headers": [
+						"Composition",
+						"Tarokka Readings",
+						"Tarokka Techniques"
+					]
+				},
+				{
+					"name": "Credits",
+					"headers": [
+						"Ravenloft: The Horrors Within",
+						"D&D Studio Team"
+					]
 				}
 			]
 		}

--- a/json/class/class-artificer.json
+++ b/json/class/class-artificer.json
@@ -1510,6 +1510,48 @@
 				"Superior Atlas|Artificer|EFA|Cartographer|EFA|15|EFA"
 			],
 			"hasFluffImages": true
+		},
+		{
+			"name": "Reanimator",
+			"shortName": "Reanimator",
+			"source": "RHW",
+			"className": "Artificer",
+			"classSource": "EFA",
+			"additionalSpells": [
+				{
+					"prepared": {
+						"3": [
+							"false life|xphb",
+							"spare the dying|xphb",
+							"witch bolt|xphb"
+						],
+						"5": [
+							"blindness/deafness|xphb",
+							"enhance ability|xphb"
+						],
+						"9": [
+							"animate dead|xphb",
+							"lightning bolt|xphb"
+						],
+						"13": [
+							"blight|xphb",
+							"death ward|xphb"
+						],
+						"17": [
+							"antilife shell|xphb",
+							"raise dead|xphb"
+						]
+					}
+				}
+			],
+			"subclassFeatures": [
+				"Reanimator|Artificer|EFA|Reanimator|RHW|3|RHW",
+				"Strange Modifications|Artificer|EFA|Reanimator|RHW|5|RHW",
+				"Improved Reanimation|Artificer|EFA|Reanimator|RHW|9|RHW",
+				"Macabre Modifications|Artificer|EFA|Reanimator|RHW|9|RHW",
+				"Refined Reanimation|Artificer|EFA|Reanimator|RHW|15|RHW"
+			],
+			"hasFluffImages": true
 		}
 	],
 	"classFeature": [
@@ -1981,7 +2023,7 @@
 			"classSource": "EFA",
 			"level": 3,
 			"entries": [
-				"You gain an Artificer subclass of your choice. The {@subclass Alchemist|Artificer|EFA|EFA}, {@subclass Armorer|Artificer|EFA|EFA}, {@subclass Artillerist|Artificer|EFA|EFA}, and {@subclass Battle Smith|Artificer|EFA|EFA}, and {@subclass Cartographer|Artificer|EFA|EFA} subclasses are detailed after this class's description. A subclass is a specialization that grants you features at certain Artificer levels. For the rest of your career, you gain each of your subclass's features that are of your Artificer level or lower."
+				"You gain an Artificer subclass of your choice. The {@subclass Alchemist|Artificer|EFA|EFA}, {@subclass Armorer|Artificer|EFA|EFA}, {@subclass Artillerist|Artificer|EFA|EFA}, {@subclass Battle Smith|Artificer|EFA|EFA}, and {@subclass Cartographer|Artificer|EFA|EFA} subclasses are detailed after this class's description. A subclass is a specialization that grants you features at certain Artificer levels. For the rest of your career, you gain each of your subclass's features that are of your Artificer level or lower."
 			]
 		},
 		{
@@ -3982,6 +4024,233 @@
 			]
 		},
 		{
+			"name": "Reanimated Companion",
+			"source": "RHW",
+			"className": "Artificer",
+			"classSource": "EFA",
+			"subclassShortName": "Reanimator",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"Using {@item Tinker's Tools|XPHB} or another type of {@item Artisan's Tools|XPHB} with which you have proficiency, you can take a {@action Magic|XPHB} action to create a {@creature Reanimated Companion|RHW} through the power of necromancy and science. The companion manifests in an unoccupied space within 5 feet of you. You determine the companion's appearance; your choices don't affect the companion's game statistics.",
+				"The companion is {@variantrule Friendly [Attitude]|XPHB|Friendly} to you and your allies and obeys you. It lasts until you finish a {@variantrule Long Rest|XPHB} or until you take a {@action Magic|XPHB} action to dismiss it early, at which point it harmlessly collapses into a pile of viscera. It immediately drops to 0 {@variantrule Hit Points|XPHB} and dies (triggering its Death Burst trait) if you die.",
+				"Once you create a companion, you can't do so again until you finish a {@variantrule Long Rest|XPHB} or expend a spell slot to create one. You can have only one companion at a time and can't create one while your companion is present.",
+				{
+					"type": "entries",
+					"name": "The Companion in Combat",
+					"entries": [
+						"In combat, the companion acts during your turn. It can move and take its {@variantrule Reaction|XPHB} on its own, but the only action it takes is the {@action Dodge|XPHB} action unless you take a {@variantrule Bonus Action|XPHB} to command it to take an action. If you have the {@condition Incapacitated|XPHB} condition, the companion acts on its own and isn't limited to the {@action Dodge|XPHB} action."
+					]
+				}
+			]
+		},
+		{
+			"name": "Reanimator",
+			"source": "RHW",
+			"className": "Artificer",
+			"classSource": "EFA",
+			"subclassShortName": "Reanimator",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"{@i Reassemble Corpses and Raise the Dead}",
+				"Reanimators defy the laws of nature in pursuit of gruesome experiments. These grim Artificers stitch together servants from disparate corpses, use foul magic to strengthen the living, and transform the art of necromancy into a terrifying science.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Reanimator Spells|Artificer|EFA|Reanimator|RHW|3|RHW"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Reanimator's Skill Set|Artificer|EFA|Reanimator|RHW|3|RHW"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Reanimated Companion|Artificer|EFA|Reanimator|RHW|3|RHW"
+				}
+			]
+		},
+		{
+			"name": "Reanimator Spells",
+			"source": "RHW",
+			"className": "Artificer",
+			"classSource": "EFA",
+			"subclassShortName": "Reanimator",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"When you reach an Artificer level specified in the Reanimator Spells table, you thereafter always have the listed spells prepared.",
+				{
+					"type": "table",
+					"caption": "Reanimator Spells",
+					"colLabels": [
+						"Artificer Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3",
+							"{@spell False Life|XPHB}, {@spell Spare the Dying|XPHB}, {@spell Witch Bolt|XPHB}"
+						],
+						[
+							"5",
+							"{@spell Blindness/Deafness|XPHB}, {@spell Enhance Ability|XPHB}"
+						],
+						[
+							"9",
+							"{@spell Animate Dead|XPHB}, {@spell Lightning Bolt|XPHB}"
+						],
+						[
+							"13",
+							"{@spell Blight|XPHB}, {@spell Death Ward|XPHB}"
+						],
+						[
+							"17",
+							"{@spell Antilife Shell|XPHB}, {@spell Raise Dead|XPHB}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Reanimator's Skill Set",
+			"source": "RHW",
+			"className": "Artificer",
+			"classSource": "EFA",
+			"subclassShortName": "Reanimator",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Jolt to Life",
+					"entries": [
+						"When you cast {@spell Spare the Dying|XPHB}, you can modify the spell so that it sends a jolt of electricity through the target, reviving it. The target regains a number of {@variantrule Hit Points|XPHB} equal to your Artificer level, and each creature of your choice in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the target makes a Dexterity saving throw against your spell save DC, taking {@damage 2d4} Lightning damage on a failed save or half as much damage on a successful one.",
+						"You can modify the spell this way a number of times equal to your Intelligence modifier, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}. The Lightning damage of this feature increases by {@dice 1d4} when you reach Artificer levels 11 ({@dice 3d4}) and 17 ({@dice 4d4})."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Reanimator's Tools",
+					"entries": [
+						"You gain proficiency with {@item Alchemist's Supplies|XPHB}. If you already have this proficiency, you gain proficiency with one other type of {@item Artisan's Tools|XPHB} of your choice."
+					]
+				}
+			]
+		},
+		{
+			"name": "Strange Modifications",
+			"source": "RHW",
+			"className": "Artificer",
+			"classSource": "EFA",
+			"subclassShortName": "Reanimator",
+			"subclassSource": "RHW",
+			"level": 5,
+			"header": 2,
+			"entries": [
+				"Whenever you create a {@creature Reanimated Companion|RHW}, it gains one of the following options of your choice; choose when you create the companion.",
+				{
+					"type": "entries",
+					"name": "Arcane Conduit",
+					"entries": [
+						"You can cast spells as though you were in the companion's space, but you must use your own senses. Once per turn, when you cast an Artificer spell from the Evocation or Necromancy school and deal damage while your companion is within 120 feet of you, you can add your Intelligence modifier to one damage roll of that spell."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Ferocity",
+					"entries": [
+						"The damage die of the companion's Dreadful Swipe increases to {@dice 1d6}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Improved Reanimation",
+			"source": "RHW",
+			"className": "Artificer",
+			"classSource": "EFA",
+			"subclassShortName": "Reanimator",
+			"subclassSource": "RHW",
+			"level": 9,
+			"header": 2,
+			"entries": [
+				"The damage of your {@creature Reanimated Companion|RHW|Reanimated Companion's} Death Burst increases to {@dice 4d4}. Necrotic damage dealt by your companion ignores {@spell Resistance|XPHB}."
+			]
+		},
+		{
+			"name": "Macabre Modifications",
+			"source": "RHW",
+			"className": "Artificer",
+			"classSource": "EFA",
+			"subclassShortName": "Reanimator",
+			"subclassSource": "RHW",
+			"level": 9,
+			"header": 2,
+			"entries": [
+				"You experiment and alter your companion further. Whenever you create a {@creature Reanimated Companion|RHW}, the companion now gains two options for Strange Modifications, instead of one. Additionally, when picking options for Strange Modifications, you can also choose from the following options.",
+				{
+					"type": "entries",
+					"name": "Bloated",
+					"entries": [
+						"The companion becomes Large. Whenever it hits a Large or smaller creature with its Dreadful Swipe action, that creature is pushed up to 10 feet away from the companion. Additionally, you can add your Intelligence modifier to the damage dealt by the companion's Death Burst."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Gaunt",
+					"entries": [
+						"The companion's {@variantrule Speed|XPHB} increases to 45 feet, and it gains a {@variantrule Climb Speed|XPHB} equal to its {@variantrule Speed|XPHB}. It can climb difficult surfaces, including along ceilings, without needing to make an ability check. In addition, whenever a creature of your choice starts its turn within a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from your companion, the creature must succeed on a Wisdom saving throw against your spell save DC or have the {@condition Frightened|XPHB} condition until the start of its next turn."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Moist",
+					"entries": [
+						"The companion gains a {@variantrule Swim Speed|XPHB} equal to its {@variantrule Speed|XPHB}, and it can move through a space as narrow as 1 inch without expending extra movement to do so. In addition, whenever the companion is hit by an attack roll from a creature within 10 feet of itself, the attacker takes Acid damage equal to your Intelligence modifier."
+					]
+				}
+			]
+		},
+		{
+			"name": "Refined Reanimation",
+			"source": "RHW",
+			"className": "Artificer",
+			"classSource": "EFA",
+			"subclassShortName": "Reanimator",
+			"subclassSource": "RHW",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"You have mastered the science of revivification, granting you the following benefits.",
+				{
+					"type": "entries",
+					"name": "Facilitated Revival",
+					"entries": [
+						"You can cast {@spell Raise Dead|XPHB} once without expending a spell slot and without Material components, provided you use {@item Tinker's Tools|XPHB} or another type of {@item Artisan's Tools|XPHB} with which you have proficiency as the {@variantrule Spellcasting Focus|XPHB}. Once you use this feature, you can't use it again until you finish a {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Life Transfer",
+					"entries": [
+						"You can siphon the animating magic of your {@creature Reanimated Companion|RHW} to bolster yourself. When you or your companion takes damage, you can take a {@variantrule Reaction|XPHB} to gain a number of {@variantrule Hit Points|XPHB} equal to your companion's current {@variantrule Hit Points|XPHB}. The companion then immediately drops to 0 {@variantrule Hit Points|XPHB} and dies (triggering its Death Burst trait)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Superior Modifications",
+					"entries": [
+						"Whenever you create a {@creature Reanimated Companion|RHW}, the companion now gains three options for Strange Modifications."
+					]
+				}
+			]
+		},
+		{
 			"name": "Alchemist",
 			"source": "TCE",
 			"page": 14,
@@ -5019,7 +5288,7 @@
 					"type": "list",
 					"items": [
 						"The extra damage and the healing of your Arcane Jolt both increase to {@damage 4d6}.",
-						"Your steel defender gains a +2 bonus to Armor Class.",
+						"Your steel defender gains a +2 bonus to {@variantrule Armor Class|XPHB}.",
 						"Whenever your steel defender uses its Deflect Attack, the attacker takes force damage equal to {@damage 1d4} + your Intelligence modifier."
 					]
 				}

--- a/json/class/class-barbarian.json
+++ b/json/class/class-barbarian.json
@@ -2410,7 +2410,7 @@
 			"subclassSource": "PHB",
 			"level": 14,
 			"entries": [
-				"While you're raging, you can use a bonus action on your turn to knock a Large or smaller creature {@condition prone} when you hit it with melee weapon attack."
+				"While you're raging, you can use a bonus action on your turn to knock a Large or smaller creature {@condition prone} when you hit it with a melee weapon attack."
 			]
 		},
 		{

--- a/json/class/class-bard.json
+++ b/json/class/class-bard.json
@@ -1714,6 +1714,9 @@
 			"className": "Bard",
 			"classSource": "PHB",
 			"page": 28,
+			"reprintedAs": [
+				"Spirits|Bard|XPHB|RHW"
+			],
 			"edition": "classic",
 			"additionalSpells": [
 				{
@@ -1737,6 +1740,9 @@
 			"source": "VRGR",
 			"className": "Bard",
 			"classSource": "XPHB",
+			"reprintedAs": [
+				"Spirits|Bard|XPHB|RHW"
+			],
 			"_copy": {
 				"name": "College of Spirits",
 				"source": "VRGR",
@@ -1890,6 +1896,33 @@
 				"College of the Moon|Bard|XPHB|Moon|FRHoF|3|FRHoF",
 				"Blessing of Moonlight|Bard|XPHB|Moon|FRHoF|6|FRHoF",
 				"Eventide's Splendor|Bard|XPHB|Moon|FRHoF|14|FRHoF"
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "College of Spirits",
+			"shortName": "Spirits",
+			"source": "RHW",
+			"className": "Bard",
+			"classSource": "XPHB",
+			"edition": "one",
+			"additionalSpells": [
+				{
+					"prepared": {
+						"6": {
+							"daily": {
+								"1e": [
+									"spirit guardians|xphb"
+								]
+							}
+						}
+					}
+				}
+			],
+			"subclassFeatures": [
+				"College of Spirits|Bard|XPHB|Spirits|RHW|3|RHW",
+				"Empowered Channeling|Bard|XPHB|Spirits|RHW|6|RHW",
+				"Mystical Connection|Bard|XPHB|Spirits|RHW|14|RHW"
 			],
 			"hasFluffImages": true
 		}
@@ -2809,7 +2842,7 @@
 			"subclassSource": "TCE",
 			"level": 3,
 			"entries": [
-				"Bards believe the cosmos is a work of art-the creation of the first dragons and gods. That creative work included harmonies that continue to resound through existence today, a power known as the Song of Creation. The bards of the College of Creation draw on that primeval song through dance, music, and poetry, and their teachers share this lesson:",
+				"Bards believe the cosmos is a work of art\u2014the creation of the first dragons and gods. That creative work included harmonies that continue to resound through existence today, a power known as the Song of Creation. The bards of the College of Creation draw on that primeval song through dance, music, and poetry, and their teachers share this lesson:",
 				"\"Before the sun and the moon, there was the Song, and its music awoke the first dawn. Its melodies so delighted the stones and trees that some of them gained a voice of their own. And now they sing too. Learn the Song, students, and you too can teach the mountains to sing and dance.\"",
 				"Dwarves and gnomes often encourage their bards to become students of the Song of Creation. And among dragonborn, the Song of Creation is revered, for legends portray Bahamut and Tiamat-the greatest of dragons-as two of the song's first singers.",
 				{
@@ -3641,6 +3674,182 @@
 						"When you use Lunar Vitality, you can roll {@dice 1d6} and use the number rolled in place of expending a Bardic Inspiration die."
 					]
 				}
+			]
+		},
+		{
+			"name": "Channeler",
+			"source": "RHW",
+			"className": "Bard",
+			"classSource": "XPHB",
+			"subclassShortName": "Spirits",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"You learn how to contact spirits beyond the grave, letting their power and knowledge flow through you. You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Guiding Whispers",
+					"entries": [
+						"You know the {@spell Guidance|XPHB} cantrip. It has a range of 60 feet when you cast it."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spiritual Focus",
+					"entries": [
+						"You employ tools that aid you in channeling spirits. You gain a Gaming Set ({@item playing cards|XPHB}). You have proficiency with this Gaming Set, and you can use it or one of the following items as a {@variantrule Spellcasting Focus|XPHB} for your Bard spells: {@item Arcane Focus|XPHB} ({@item crystal|XPHB} or {@item orb|XPHB}), {@item Candle|XPHB}, or {@item Ink Pen|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "College of Spirits",
+			"source": "RHW",
+			"className": "Bard",
+			"classSource": "XPHB",
+			"subclassShortName": "Spirits",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"{@i Call Forth Spirits from Beyond the Grave}",
+				"Bards of the College of Spirits conjure legendary spirits to change the world. But such entities are capricious, and what a Bard summons isn't always entirely under their control.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Channeler|Bard|XPHB|Spirits|RHW|3|RHW"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Spirits from Beyond|Bard|XPHB|Spirits|RHW|3|RHW"
+				}
+			]
+		},
+		{
+			"name": "Spirits from Beyond",
+			"source": "RHW",
+			"className": "Bard",
+			"classSource": "XPHB",
+			"subclassShortName": "Spirits",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"You can call forth spirits of the dead to empower you and your allies. When you take a {@variantrule Bonus Action|XPHB} to give a creature a Bardic Inspiration die, you can call forth the powers of a random spirit. To determine the spirit you channel, roll the Bardic Inspiration die and refer to the Spirits from Beyond table. The spirit remains channeled until you unleash it or until you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}.",
+				{
+					"type": "entries",
+					"name": "Controlled Channeling",
+					"entries": [
+						"As a {@variantrule Bonus Action|XPHB}, you can expend a use of your Bardic Inspiration and channel a specific spirit. When you do so, choose the spirit from the Spirits from Beyond table rather than rolling. The chosen spirit's corresponding number must be less than or equal to the highest number on your Bardic Inspiration die; for example, if your Bardic Inspiration die is a {@dice d8}, you can choose to channel any spirit up to (and including) the Shade."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Unleashing a Spirit",
+					"entries": [
+						"As a {@action Magic|XPHB} action, you can unleash one of your channeled spirits. Choose one creature you can see within 30 feet of yourself as the spirit's target. The spirit then takes effect; if a spirit's effect requires a saving throw, the DC equals your Bard spell save DC.",
+						{
+							"type": "table",
+							"caption": "Spirits from Beyond",
+							"colLabels": [
+								"Bardic Insp. Die",
+								"Spirit and Unleash Effect"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"rows": [
+								[
+									"1",
+									"Beloved. The target regains {@variantrule Hit Points|XPHB} equal to a roll of your Bardic Inspiration die plus your Charisma modifier."
+								],
+								[
+									"2",
+									"Sharpshooter. The target takes Force damage equal to a roll of your Bardic Inspiration die plus your Charisma modifier."
+								],
+								[
+									"3",
+									"Avenger. Until the end of your next turn, any creature that hits the target with a melee attack roll takes Force damage equal to a roll of your Bardic Inspiration die."
+								],
+								[
+									"4",
+									"Renegade. The target can immediately take a {@variantrule Reaction|XPHB} to teleport up to 30 feet to an unoccupied space it can see."
+								],
+								[
+									"5",
+									"Fortune Teller. The target has {@variantrule Advantage|XPHB} on {@variantrule D20 Test|XPHB|D20 Tests} until the start of your next turn."
+								],
+								[
+									"6",
+									"Wayfarer. The target gains {@variantrule Temporary Hit Points|XPHB} equal to a roll of your Bardic Inspiration die plus your Bard level. While the target has these Temporary Hit Points, its {@variantrule Speed|XPHB} increases by 10 feet."
+								],
+								[
+									"7",
+									"Trickster. The target makes a Wisdom saving throw. On a failed save, the target takes Psychic damage equal to two rolls of your Bardic Inspiration die and has the {@condition Charmed|XPHB} condition until the start of your next turn. On a successful save, the target takes half as much damage only."
+								],
+								[
+									"8",
+									"Shade. The target has the {@condition Invisible|XPHB} condition until the end of its next turn or until the target makes an attack roll, deals damage, or casts a spell. When the invisibility ends, each creature in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the target must succeed on a Constitution saving throw or take Necrotic damage equal to two rolls of your Bardic Inspiration die."
+								],
+								[
+									"9",
+									"Arsonist. The target makes a Dexterity saving throw, taking Fire damage equal to four rolls of your Bardic Inspiration die on a failed save or half as much damage on a successful one."
+								],
+								[
+									"10",
+									"Coward. The target and each creature of your choice in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the target must succeed on a Wisdom saving throw or have the {@condition Frightened|XPHB} condition until the start of your next turn. While a creature is Frightened, its {@variantrule Speed|XPHB} is halved (round down), and it can take either an action or a {@variantrule Bonus Action|XPHB}, not both."
+								],
+								[
+									"11",
+									"Brute. Each creature of your choice in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from the target makes a Strength saving throw. On a failed save, a creature takes Thunder damage equal to three rolls of your Bardic Inspiration die and has the {@condition Prone|XPHB} condition. On a successful save, a creature takes half as much damage only."
+								],
+								[
+									"12",
+									"Priest. The target regains {@variantrule Hit Points|XPHB} equal to two rolls of your Bardic Inspiration die, and one of the following conditions of your choice ends on the target: {@condition Blinded|XPHB}, {@condition Charmed|XPHB}, {@condition Deafened|XPHB}, {@condition Paralyzed|XPHB}, {@condition Poisoned|XPHB}, or {@condition Stunned|XPHB}."
+								]
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Empowered Channeling",
+			"source": "RHW",
+			"className": "Bard",
+			"classSource": "XPHB",
+			"subclassShortName": "Spirits",
+			"subclassSource": "RHW",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Your ability to channel spirits improves. You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Power from Beyond",
+					"entries": [
+						"Once per turn, when you cast a Bard spell with a spell slot that deals damage or restores {@variantrule Hit Points|XPHB}, roll {@dice 1d6}. You gain a bonus equal to the number rolled to one of the spell's damage rolls or to the total {@variantrule Hit Points|XPHB} the spell restores."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spiritual Manifestation",
+					"entries": [
+						"You always have the {@spell Spirit Guardians|XPHB} spell prepared. You can cast the spell once without a spell slot, and you regain the ability to cast it in this way when you finish a Long Rest.",
+						"Whenever you cast the spell, you can modify it so the spirits also guard against worldly threats. When you cast the spell in this way, you and allies within the spell's {@variantrule Emanation [Area of Effect]|XPHB|Emanation} have {@table Cover|XPHB|Half Cover}. Once you modify the spell in this way, you can't do so again until you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Mystical Connection",
+			"source": "RHW",
+			"className": "Bard",
+			"classSource": "XPHB",
+			"subclassShortName": "Spirits",
+			"subclassSource": "RHW",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"You gain mastery over the spirits you call forth. Whenever you roll on the {@book Spirits from Beyond table|RHW|1|Spirits from Beyond}, you can roll the die twice and choose which of the two effects to bestow. If you roll the same number on both dice, you can instead choose any effect on the table."
 			]
 		},
 		{

--- a/json/class/class-cleric.json
+++ b/json/class/class-cleric.json
@@ -2260,6 +2260,9 @@
 			"className": "Cleric",
 			"classSource": "PHB",
 			"page": 19,
+			"reprintedAs": [
+				"Grave|Cleric|XPHB|RHW"
+			],
 			"edition": "classic",
 			"additionalSpells": [
 				{
@@ -2309,6 +2312,9 @@
 			"source": "XGE",
 			"className": "Cleric",
 			"classSource": "XPHB",
+			"reprintedAs": [
+				"Grave|Cleric|XPHB|RHW"
+			],
 			"_copy": {
 				"name": "Grave Domain",
 				"source": "XGE",
@@ -2788,6 +2794,45 @@
 				"Knowledge Domain|Cleric|XPHB|Knowledge|FRHoF|3|FRHoF",
 				"Unfettered Mind|Cleric|XPHB|Knowledge|FRHoF|6|FRHoF",
 				"Divine Foreknowledge|Cleric|XPHB|Knowledge|FRHoF|17|FRHoF"
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Grave Domain",
+			"shortName": "Grave",
+			"source": "RHW",
+			"className": "Cleric",
+			"classSource": "XPHB",
+			"edition": "one",
+			"additionalSpells": [
+				{
+					"prepared": {
+						"3": [
+							"detect evil and good|xphb",
+							"false life|xphb",
+							"gentle repose|xphb",
+							"ray of enfeeblement|xphb",
+							"spare the dying|xphb"
+						],
+						"5": [
+							"revivify|xphb",
+							"vampiric touch|xphb"
+						],
+						"7": [
+							"blight|xphb",
+							"death ward|xphb"
+						],
+						"9": [
+							"dispel evil and good|xphb",
+							"raise dead|xphb"
+						]
+					}
+				}
+			],
+			"subclassFeatures": [
+				"Grave Domain|Cleric|XPHB|Grave|RHW|3|RHW",
+				"Sentinel at Death's Door|Cleric|XPHB|Grave|RHW|6|RHW",
+				"Divine Reaper|Cleric|XPHB|Grave|RHW|17|RHW"
 			],
 			"hasFluffImages": true
 		}
@@ -7430,6 +7475,159 @@
 			}
 		},
 		{
+			"name": "Circle of Mortality",
+			"source": "RHW",
+			"className": "Cleric",
+			"classSource": "XPHB",
+			"subclassShortName": "Grave",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"You can manipulate the balance between life and death, granting you the following benefits.",
+				{
+					"type": "entries",
+					"name": "Pull of Death",
+					"entries": [
+						"Once per turn, when you deal damage to a creature that's missing any {@variantrule Hit Points|XPHB} by casting a spell or by hitting with an attack roll, that creature takes an extra {@damage 1d4} Necrotic damage. This extra damage increases to {@dice 1d6} when you reach Cleric level 11."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Return to Life",
+					"entries": [
+						"You can cast {@spell Spare the Dying|XPHB} as a {@variantrule Bonus Action|XPHB}.",
+						"Additionally, when you would normally roll one or more dice to restore {@variantrule Hit Points|XPHB} to a creature at 0 {@variantrule Hit Points|XPHB} with a spell or Channel Divinity, don't roll those dice for the healing; instead, use the highest number possible for each die. For example, instead of restoring {@dice 2d4} {@variantrule Hit Points|XPHB} to a creature at 0 {@variantrule Hit Points|XPHB} with a spell, you restore 8."
+					]
+				}
+			]
+		},
+		{
+			"name": "Grave Domain",
+			"source": "RHW",
+			"className": "Cleric",
+			"classSource": "XPHB",
+			"subclassShortName": "Grave",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"{@i Embody Deific Forces of Death}",
+				"The Grave Domain concerns itself with the boundary between life and death. To those who tap into this domain's power, death is a natural and inevitable part of the multiverse. Such Clerics seek to destroy undead and shepherd spirits.",
+				"The magic of this domain also allows these Clerics to stave off death for a time. But this is merely a delay of death, not a denial of it, for the grave will always claim its due.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Grave Domain Spells|Cleric|XPHB|Grave|RHW|3|RHW"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle of Mortality|Cleric|XPHB|Grave|RHW|3|RHW"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Path to the Grave|Cleric|XPHB|Grave|RHW|3|RHW"
+				}
+			]
+		},
+		{
+			"name": "Grave Domain Spells",
+			"source": "RHW",
+			"className": "Cleric",
+			"classSource": "XPHB",
+			"subclassShortName": "Grave",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"Your connection to this divine domain ensures you always have certain spells ready. When you reach a Cleric level specified in the Grave Domain Spells table, you thereafter always have the listed spells prepared.",
+				{
+					"type": "table",
+					"caption": "Grave Domain Spells",
+					"colLabels": [
+						"Cleric Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3",
+							"{@spell Detect Evil and Good|XPHB}, {@spell False Life|XPHB}, {@spell Gentle Repose|XPHB}, {@spell Ray of Enfeeblement|XPHB}, {@spell Spare the Dying|XPHB}"
+						],
+						[
+							"5",
+							"{@spell Revivify|XPHB}, {@spell Vampiric Touch|XPHB}"
+						],
+						[
+							"7",
+							"{@spell Blight|XPHB}, {@spell Death Ward|XPHB}"
+						],
+						[
+							"9",
+							"{@spell Dispel Evil and Good|XPHB}, {@spell Raise Dead|XPHB}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Path to the Grave",
+			"source": "RHW",
+			"className": "Cleric",
+			"classSource": "XPHB",
+			"subclassShortName": "Grave",
+			"subclassSource": "RHW",
+			"level": 3,
+			"consumes": {
+				"name": "Channel Divinity",
+				"amount": 1
+			},
+			"entries": [
+				"As a Bonus Action, you present your Holy Symbol and expend a use of Channel Divinity to curse one creature you can see within 30 feet of yourself until the start of your next turn. While cursed, the creature has {@variantrule Disadvantage|XPHB} on attack rolls and saving throws.",
+				"When you or an ally you can see hits the cursed target with an attack roll, you can end the curse early (no action required) to make the attack deal extra Necrotic or Radiant damage (your choice) equal to your Cleric level."
+			]
+		},
+		{
+			"name": "Sentinel at Death's Door",
+			"source": "RHW",
+			"className": "Cleric",
+			"classSource": "XPHB",
+			"subclassShortName": "Grave",
+			"subclassSource": "RHW",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"When you or a {@status Bloodied|XPHB} creature you can see within 60 feet of yourself is hit with an attack roll, you can take a {@variantrule Reaction|XPHB} to halve that attack's damage (round down). If the triggering attack roll was a {@variantrule Critical Hit|XPHB}, any effects triggered by a {@variantrule Critical Hit|XPHB} are canceled.",
+				"You can use this feature a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+			]
+		},
+		{
+			"name": "Divine Reaper",
+			"source": "RHW",
+			"className": "Cleric",
+			"classSource": "XPHB",
+			"subclassShortName": "Grave",
+			"subclassSource": "RHW",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"Your deep connection to this domain renders you a hallowed harbinger of death, granting you the following benefits.",
+				{
+					"type": "entries",
+					"name": "Enhanced Necromancy",
+					"entries": [
+						"When you cast a spell of level 5 or lower from the Necromancy school that targets one creature, or when you cast a spell from the {@book Grave Domain Spells table|RHW|1|Grave Domain Spells}, you can expend a use of Channel Divinity to target a second creature within the spell's range. If the spell requires costly or consumed Material components, you must provide Material components for each target."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Keeper of Souls",
+					"entries": [
+						"When an enemy dies within 60 feet of you, you or one creature you can see within 60 feet of yourself regains {@variantrule Hit Points|XPHB} equal to twice your Cleric level. You can't use this feature if you have the {@condition Incapacitated|XPHB} condition. Once you use this feature, you can't use it again until you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}, unless you expend a level 6+ spell slot (no action required) to restore your use of it."
+					]
+				}
+			]
+		},
+		{
 			"name": "Arcana Domain",
 			"source": "SCAG",
 			"className": "Cleric",
@@ -7804,7 +8002,7 @@
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"The healing spells you cast on others heal you as well. Immediately after you cast a spell with a spell slot that restores {@variantrule Hit Points|XPHB} to one creature other than you, you regain {@variantrule Hit Points|XPHB} equal to 2 plus the spell slot's level."
+				"The healing spells you cast on others heal you as well. Immediately after you cast a spell with a spell slot that restores {@variantrule Hit Points|XPHB} to one or more creatures other than yourself, you regain {@variantrule Hit Points|XPHB} equal to 2 plus the spell slot's level."
 			]
 		},
 		{

--- a/json/class/class-druid.json
+++ b/json/class/class-druid.json
@@ -4454,7 +4454,7 @@
 			"level": 10,
 			"header": 2,
 			"entries": [
-				"You are immune to the {@condition Poisoned|XPHB} condition, and you have {@variantrule Resistance|XPHB} to a damage type associated with your current land choice in the Circle Spells feature, as shown in the {@skill Nature|XPHB}'s Ward table.",
+				"You are immune to the {@condition Poisoned|XPHB} condition, and you have {@variantrule Resistance|XPHB} to a damage type associated with your current land choice in the Circle Spells feature, as shown in the Nature's Ward table.",
 				{
 					"type": "entries",
 					"entries": [
@@ -4505,7 +4505,7 @@
 			"level": 14,
 			"header": 2,
 			"entries": [
-				"As a {@action Magic|XPHB} action, you can expend a use of your Wild Shape and cause spectral trees and vines to appear in a 15-foot {@variantrule Cube [Area of Effect]|XPHB|Cube} on the ground within 120 feet of yourself. They last there for 1 minute or until you have the {@condition Incapacitated|XPHB} condition or die. You and your allies have {@variantrule Cover|XPHB|Half Cover} while in that area, and your allies gain the current {@variantrule Resistance|XPHB} of your {@skill Nature|XPHB}'s Ward while there.",
+				"As a {@action Magic|XPHB} action, you can expend a use of your Wild Shape and cause spectral trees and vines to appear in a 15-foot {@variantrule Cube [Area of Effect]|XPHB|Cube} on the ground within 120 feet of yourself. They last there for 1 minute or until you have the {@condition Incapacitated|XPHB} condition or die. You and your allies have {@variantrule Cover|XPHB|Half Cover} while in that area, and your allies gain the current {@variantrule Resistance|XPHB} of your Nature's Ward while there.",
 				"As a {@variantrule Bonus Action|XPHB}, you can move the {@variantrule Cube [Area of Effect]|XPHB|Cube} up to 60 feet to ground within 120 feet of yourself."
 			]
 		},

--- a/json/class/class-fighter.json
+++ b/json/class/class-fighter.json
@@ -507,7 +507,8 @@
 				"Additional Superiority Die|Fighter||Battle Master||15",
 				"Relentless|Fighter||Battle Master||15",
 				"Improved Combat Superiority (d12)|Fighter||Battle Master||18"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Battle Master",

--- a/json/class/class-mystic.json
+++ b/json/class/class-mystic.json
@@ -637,7 +637,7 @@
 			"level": 11,
 			"entries": [
 				"Beginning at 11th level, your mastery of psionic energy allows you to push your mind beyond its normal limits. As an action, you gain 9 special psi points that you can spend only on disciplines that require an action or a bonus action to use. You can use all 9 points on one discipline, or you can spread them across multiple disciplines. You can't also spend your normal psi points on these disciplines; you can spend only the special points gained from this feature. When you finish a long rest, you lose any of these special points that you haven't spent.",
-				"If more than one of the disciplines you activate with these points require {@status concentration}, you can concentrate on all of them. Activating one of them ends any effect you were already {@status concentration||concentrating} on, and if you begin {@status concentration||concentrating} on an effect that doesn't use these special points, the disciplines end that you're {@status concentration||concentrating} on.",
+				"If more than one of the disciplines you activate with these points require {@status concentration}, you can concentrate on all of them. Activating one of them ends any effect you were already {@status concentration||concentrating} on, and if you begin {@status concentration||concentrating} on an effect that doesn't use these special points, the disciplines that you're {@status concentration||concentrating} on end.",
 				"At 15th level, the pool of psi points you gain from this feature increases to 11.",
 				"You have one use of this feature, and you regain any expended use of it with a long rest. You gain one additional use of this feature at 13th, 15th, and 17th level."
 			]
@@ -683,7 +683,7 @@
 			"classSource": "UATheMysticClass",
 			"level": 14,
 			"entries": [
-				"At 14th level, your Potent Psionics damage increased to {@damage 2d8}."
+				"At 14th level, your Potent Psionics damage increases to {@damage 2d8}."
 			]
 		},
 		{
@@ -1357,7 +1357,7 @@
 					]
 				},
 				"The spell slot remains until you use it or finish a long rest. You must observe your psi limit when spending psi points to create a spell slot.",
-				"Whenever you gain a level in this class, you can replace on of the chosen wizard spells with a different {@filter wizard spell of 1st through 3rd level|spells|level=1;2;3|class=wizard}."
+				"Whenever you gain a level in this class, you can replace one of the chosen wizard spells with a different {@filter wizard spell of 1st through 3rd level|spells|level=1;2;3|class=wizard}."
 			]
 		},
 		{

--- a/json/class/class-paladin.json
+++ b/json/class/class-paladin.json
@@ -1196,7 +1196,7 @@
 							"hypnotic pattern"
 						],
 						"13": [
-							"Otiluke's resilient sphere",
+							"Otiluke's Resilient Sphere",
 							"stoneskin"
 						],
 						"17": [
@@ -4407,7 +4407,7 @@
 						],
 						[
 							"13th",
-							"{@spell Otiluke's resilient sphere}, {@spell stoneskin}"
+							"{@spell Otiluke's Resilient Sphere}, {@spell stoneskin}"
 						],
 						[
 							"17th",
@@ -5019,7 +5019,7 @@
 					"rows": [
 						[
 							"3rd",
-							"{@spell Protection from Evil And Good|XPHB}, {@spell Shield of Faith|XPHB}"
+							"{@spell Protection from Evil and Good|XPHB}, {@spell Shield of Faith|XPHB}"
 						],
 						[
 							"5th",

--- a/json/class/class-ranger.json
+++ b/json/class/class-ranger.json
@@ -1548,6 +1548,42 @@
 				"Frozen Haunt|Ranger|XPHB|Winter Walker|FRHoF|15|FRHoF"
 			],
 			"hasFluffImages": true
+		},
+		{
+			"name": "Hollow Warden",
+			"shortName": "Hollow Warden",
+			"source": "RHW",
+			"className": "Ranger",
+			"classSource": "XPHB",
+			"edition": "one",
+			"additionalSpells": [
+				{
+					"prepared": {
+						"3": [
+							"wrathful smite|xphb"
+						],
+						"5": [
+							"alter self|xphb"
+						],
+						"9": [
+							"phantom steed|xphb"
+						],
+						"13": [
+							"dominate beast|xphb"
+						],
+						"17": [
+							"steel wind strike|xphb"
+						]
+					}
+				}
+			],
+			"subclassFeatures": [
+				"Hollow Warden|Ranger|XPHB|Hollow Warden|RHW|3|RHW",
+				"Hungering Might|Ranger|XPHB|Hollow Warden|RHW|7|RHW",
+				"Rot and Violence|Ranger|XPHB|Hollow Warden|RHW|11|RHW",
+				"Ancient Might|Ranger|XPHB|Hollow Warden|RHW|15|RHW"
+			],
+			"hasFluffImages": true
 		}
 	],
 	"classFeature": [
@@ -4103,6 +4139,181 @@
 					"page": 6,
 					"entries": [
 						"You have {@variantrule Immunity|XPHB} to the {@condition Grappled|XPHB}, {@condition Prone|XPHB}, and {@condition Restrained|XPHB} conditions. You can move through creatures and objects as if they were {@variantrule Difficult Terrain|XPHB}, but you take {@damage 1d10} Force damage if you end your turn inside a creature or an object. If the form ends while you are inside a creature or an object, you are shunted to the nearest unoccupied space."
+					]
+				}
+			]
+		},
+		{
+			"name": "Hollow Warden",
+			"source": "RHW",
+			"className": "Ranger",
+			"classSource": "XPHB",
+			"subclassShortName": "Hollow Warden",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"{@i Draw on the Might of Ancient Wild Terrors}",
+				"Legends tell that the most ancient and bloodthirsty terrors lurk deep within the old places of the earth. Hollow Wardens venerate and draw power from such beings, transforming themselves into merciless and monstrous guardians that stalk jagged coastlines, steep mountain crags, and other dark and wild places.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Hollow Warden Spells|Ranger|XPHB|Hollow Warden|RHW|3|RHW"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Wrath of the Wild|Ranger|XPHB|Hollow Warden|RHW|3|RHW"
+				}
+			]
+		},
+		{
+			"name": "Hollow Warden Spells",
+			"source": "RHW",
+			"className": "Ranger",
+			"classSource": "XPHB",
+			"subclassShortName": "Hollow Warden",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"When you reach a Ranger level specified in the Hollow Warden Spells table, you thereafter always have the listed spell prepared.",
+				{
+					"type": "table",
+					"caption": "Hollow Warden Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spell"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3",
+							"{@spell Wrathful Smite|XPHB}"
+						],
+						[
+							"5",
+							"{@spell Alter Self|XPHB}"
+						],
+						[
+							"9",
+							"{@spell Phantom Steed|XPHB}"
+						],
+						[
+							"13",
+							"{@spell Dominate Beast|XPHB}"
+						],
+						[
+							"17",
+							"{@spell Steel Wind Strike|XPHB}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Wrath of the Wild",
+			"source": "RHW",
+			"className": "Ranger",
+			"classSource": "XPHB",
+			"subclassShortName": "Hollow Warden",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"You draw power from the strange and ancient horrors of the land, causing you to sprout unnatural growths, such as bloody antlers or putrid fangs, or causing your shadow to lengthen or twist around you. As a {@variantrule Bonus Action|XPHB}, you can expend a use of Favored {@variantrule Enemy|XPHB} to transform into a ghastly form, gaining the following benefits for 1 minute or until you have the {@condition Incapacitated|XPHB} condition, die, or end the transformation (no action required).",
+				{
+					"type": "entries",
+					"name": "Ancient Armor",
+					"entries": [
+						"You gain a +1 bonus to AC, as your body is wreathed in rotten bark and beastly bristles. This bonus increases to +2 when you reach Ranger level 11."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Prowling Retribution",
+					"entries": [
+						"Immediately after a creature you can see within 5 feet of yourself deals damage to you or one of your allies, you can make an {@action Opportunity Attack|XPHB} against that creature."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Unnerving Aura",
+					"entries": [
+						"When you transform and at the start of each of your subsequent turns, each creature of your choice in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from you makes a Wisdom saving throw against your spell save DC. On a failed save, a creature has the {@condition Frightened|XPHB} condition until the start of your next turn."
+					]
+				}
+			]
+		},
+		{
+			"name": "Hungering Might",
+			"source": "RHW",
+			"className": "Ranger",
+			"classSource": "XPHB",
+			"subclassShortName": "Hollow Warden",
+			"subclassSource": "RHW",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"You gain a bonus to Constitution saving throws equal to your Wisdom modifier (minimum of +1).",
+				"In addition, once per turn when you hit a creature with an attack roll while you are transformed using Wrath of the Wild, you regain a number of Hit Points equal to {@dice 1d10} plus your Wisdom modifier, provided you are {@status Bloodied|XPHB} when you hit."
+			]
+		},
+		{
+			"name": "Rot and Violence",
+			"source": "RHW",
+			"className": "Ranger",
+			"classSource": "XPHB",
+			"subclassShortName": "Hollow Warden",
+			"subclassSource": "RHW",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"Your dedication to wild eldritch beings alters you further. When transformed using Wrath of the Wild, you gain the following additional benefits.",
+				{
+					"type": "entries",
+					"name": "Menacing Aura",
+					"entries": [
+						"When a creature fails its saving throw against your Unnerving Aura, it also can't regain {@variantrule Hit Points|XPHB} or take {@variantrule Reaction|XPHB|Reactions} until the start of your next turn."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Strangling Roots",
+					"entries": [
+						"When you hit a creature with an attack roll using a weapon, you can activate the {@itemMastery Sap} or {@itemMastery Slow} mastery property in addition to a different mastery property you're using with that weapon."
+					]
+				}
+			]
+		},
+		{
+			"name": "Ancient Might",
+			"source": "RHW",
+			"className": "Ranger",
+			"classSource": "XPHB",
+			"subclassShortName": "Hollow Warden",
+			"subclassSource": "RHW",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"You become wholly suffused with the wild's ancient and terrible power, granting you the following benefits.",
+				{
+					"type": "entries",
+					"name": "Ominous Strikes",
+					"entries": [
+						"When you hit a creature that has the {@condition Frightened|XPHB} condition with an attack roll, that attack deals extra damage equal to your Wisdom modifier."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Persistent Wrath",
+					"entries": [
+						"If you're reduced to 0 {@variantrule Hit Points|XPHB} but not killed outright while transformed using Wrath of the Wild, you can surge with wild power. Your {@variantrule Hit Points|XPHB} instead change to a number equal to twice your Ranger level. Once you use this feature, you can't do so again until you finish a {@variantrule Long Rest|XPHB}. You can also expend a level 4+ spell slot (no action required) to restore your use of this feature."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Timeless",
+					"entries": [
+						"You have {@variantrule Immunity|XPHB} to the {@condition Exhaustion|XPHB} condition."
 					]
 				}
 			]

--- a/json/class/class-rogue.json
+++ b/json/class/class-rogue.json
@@ -1498,6 +1498,9 @@
 			"className": "Rogue",
 			"classSource": "PHB",
 			"page": 62,
+			"reprintedAs": [
+				"Phantom|Rogue|XPHB|RHW"
+			],
 			"edition": "classic",
 			"subclassFeatures": [
 				"Phantom|Rogue||Phantom|TCE|3",
@@ -1513,6 +1516,9 @@
 			"source": "TCE",
 			"className": "Rogue",
 			"classSource": "XPHB",
+			"reprintedAs": [
+				"Phantom|Rogue|XPHB|RHW"
+			],
 			"_copy": {
 				"name": "Phantom",
 				"source": "TCE",
@@ -2075,6 +2081,36 @@
 				"Strike Fear|Rogue|XPHB|Scion of the Three|FRHoF|9|FRHoF",
 				"Aura of Malevolence|Rogue|XPHB|Scion of the Three|FRHoF|13|FRHoF",
 				"Dread Incarnate|Rogue|XPHB|Scion of the Three|FRHoF|17|FRHoF"
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Phantom",
+			"shortName": "Phantom",
+			"source": "RHW",
+			"className": "Rogue",
+			"classSource": "XPHB",
+			"edition": "one",
+			"additionalSpells": [
+				{
+					"innate": {
+						"9": {
+							"rest": {
+								"1": [
+									"speak with dead|xphb"
+								]
+							}
+						}
+					},
+					"ability": "dex"
+				}
+			],
+			"subclassFeatures": [
+				"Phantom|Rogue|XPHB|Phantom|RHW|3|RHW",
+				"Tokens of the Departed|Rogue|XPHB|Phantom|RHW|9|RHW",
+				"Voice of Death|Rogue|XPHB|Phantom|RHW|9|RHW",
+				"Ghost Walk|Rogue|XPHB|Phantom|RHW|13|RHW",
+				"Death's Friend|Rogue|XPHB|Phantom|RHW|17|RHW"
 			],
 			"hasFluffImages": true
 		}
@@ -4062,6 +4098,178 @@
 					"page": 7,
 					"entries": [
 						"When you roll for your {@classFeature Sneak Attack|Rogue|XPHB|1|XPHB} damage, you can treat a roll of a 1 or 2 on the die as a 3."
+					]
+				}
+			]
+		},
+		{
+			"name": "Phantom",
+			"source": "RHW",
+			"className": "Rogue",
+			"classSource": "XPHB",
+			"subclassShortName": "Phantom",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"{@i Embrace Death and Wield Ghostly Power}",
+				"Some Rogues traverse the veil between life and death, shepherding opponents to the grave and slipping through the world as undetectable as a spirit. In these pursuits, a Rogue might discover a mystical connection to death itself. Such an individual becomes immersed in negative energy, infusing their strikes with deathly energy and stealing knowledge from souls who have passed on. Thieves' guilds value Rogues of this persuasion as highly effective information gatherers and spies.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Wails from the Grave|Rogue|XPHB|Phantom|RHW|3|RHW"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Whispers of the Dead|Rogue|XPHB|Phantom|RHW|3|RHW"
+				}
+			]
+		},
+		{
+			"name": "Wails from the Grave",
+			"source": "RHW",
+			"className": "Rogue",
+			"classSource": "XPHB",
+			"subclassShortName": "Phantom",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"Immediately after you deal Sneak Attack damage to a creature on your turn, you can target a second creature that you can see within 30 feet of the first creature. Roll half the number of Sneak Attack damage dice for your level (round up), and the second creature takes Necrotic damage equal to the roll's total as wails of the dead sound around it.",
+				"You can use this feature a number of times equal to your Dexterity modifier (minimum of once), and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+			]
+		},
+		{
+			"name": "Whispers of the Dead",
+			"source": "RHW",
+			"className": "Rogue",
+			"classSource": "XPHB",
+			"subclassShortName": "Phantom",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"Whenever you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}, you can choose one skill or tool proficiency that you lack and gain it, as a ghostly presence shares its knowledge with you. You lose this proficiency when you use this benefit again to choose a different proficiency."
+			]
+		},
+		{
+			"name": "Tokens of the Departed",
+			"source": "RHW",
+			"className": "Rogue",
+			"classSource": "XPHB",
+			"subclassShortName": "Phantom",
+			"subclassSource": "RHW",
+			"level": 9,
+			"header": 2,
+			"entries": [
+				"The spirits of the dead are drawn to you, and echoes of their past lives magically manifest as strange curios with resonant power.",
+				"You gain two soul trinkets. A soul trinket is a Tiny object (the DM determines the trinket's form or has you roll on the {@item Trinket|XPHB|Trinkets table} in the {@book Player's Handbook|XPHB} to generate it). If you move more than 30 feet from a trinket, the trinket immediately teleports to you, appearing somewhere on your person.",
+				{
+					"type": "entries",
+					"name": "Using Soul Trinkets",
+					"entries": [
+						"You can use soul trinkets in the following ways:",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Death's Knell",
+									"entry": "When you deal Sneak Attack damage on your turn, you can destroy one soul trinket and immediately use Wails from the Grave without expending a use of that feature."
+								},
+								{
+									"type": "item",
+									"name": "Life Essence",
+									"entry": "While you have at least one soul trinket, you have {@variantrule Advantage|XPHB} on {@variantrule Death Saving Throw|XPHB|Death Saving Throws} and Constitution saving throws."
+								},
+								{
+									"type": "item",
+									"name": "Spirit Query",
+									"entry": "You can take a {@action Magic|XPHB} action to destroy one soul trinket and immediately cast the {@spell Augury|XPHB} spell, requiring no spell components and using Constitution as the spellcasting modifier. If you know the creature with which the trinket is associated, you can ask the creature's spirit one question instead of casting the spell. In this case, the spirit appears to you and answers as concisely as possible in a language it knew in life."
+								}
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Gaining Additional Soul Trinkets",
+					"entries": [
+						"When a creature you can see within 30 feet of you dies, you can take a {@variantrule Reaction|XPHB} to gain another soul trinket, claiming a sliver of that creature's departing spirit. The new trinket appears somewhere on your person.",
+						"You can have a maximum of two soul trinkets at a time. If you try to gain a soul trinket while at your maximum, one of your existing trinkets is immediately destroyed and replaced by the new trinket. The maximum number of soul trinkets you can have increases when you reach Rogue levels 13 (three trinkets) and 17 (four trinkets).",
+						"Whenever you finish a {@variantrule Long Rest|XPHB} with fewer than two soul trinkets, you gain soul trinkets until you have two."
+					]
+				}
+			]
+		},
+		{
+			"name": "Voice of Death",
+			"source": "RHW",
+			"className": "Rogue",
+			"classSource": "XPHB",
+			"subclassShortName": "Phantom",
+			"subclassSource": "RHW",
+			"level": 9,
+			"header": 2,
+			"entries": [
+				"You can cast {@spell Speak with Dead|XPHB} once without a spell slot, requiring no spell components and using Dexterity as the spellcasting modifier. You regain the ability to cast it this way when you finish a Short or Long Rest.",
+				"When you cast the spell, you can target one of your soul trinkets from Tokens of the Departed instead of a corpse, allowing the spirit of the creature associated with the trinket to answer."
+			]
+		},
+		{
+			"name": "Ghost Walk",
+			"source": "RHW",
+			"className": "Rogue",
+			"classSource": "XPHB",
+			"subclassShortName": "Phantom",
+			"subclassSource": "RHW",
+			"level": 13,
+			"header": 2,
+			"entries": [
+				"As a {@variantrule Bonus Action|XPHB}, you assume a spectral form, gaining the benefits below for 10 minutes or until you end them (no action required). Once you use this feature, you can't use it again until you finish a {@variantrule Long Rest|XPHB} unless you destroy one of your soul trinkets from Tokens of the Departed (no action required) to restore your use of it.",
+				{
+					"type": "entries",
+					"name": "Flight",
+					"entries": [
+						"You gain a {@variantrule Fly Speed|XPHB} of 10 feet and can hover."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Hazy Form",
+					"entries": [
+						"Attack rolls have {@variantrule Disadvantage|XPHB} against you."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Incorporeal Movement",
+					"entries": [
+						"You can move through creatures and objects as if they were {@variantrule Difficult Terrain|XPHB}, but you take {@damage 1d10} Force damage if you end your turn inside a creature or an object."
+					]
+				}
+			]
+		},
+		{
+			"name": "Death's Friend",
+			"source": "RHW",
+			"className": "Rogue",
+			"classSource": "XPHB",
+			"subclassShortName": "Phantom",
+			"subclassSource": "RHW",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"Your association with death has become so close that you gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Death's Lament",
+					"entries": [
+						"When you use Wails from the Grave, you can deal the feature's Necrotic damage to both the first and the second creature."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Draw of Death",
+					"entries": [
+						"When you roll {@variantrule Initiative|XPHB}, you gain one soul trinket for your Tokens of the Departed if you have none remaining."
 					]
 				}
 			]

--- a/json/class/class-sorcerer.json
+++ b/json/class/class-sorcerer.json
@@ -1656,6 +1656,9 @@
 			"className": "Sorcerer",
 			"classSource": "PHB",
 			"page": 50,
+			"reprintedAs": [
+				"Shadow|Sorcerer|XPHB|RHW"
+			],
 			"edition": "classic",
 			"additionalSpells": [
 				{
@@ -1681,6 +1684,9 @@
 			"source": "XGE",
 			"className": "Sorcerer",
 			"classSource": "XPHB",
+			"reprintedAs": [
+				"Shadow|Sorcerer|XPHB|RHW"
+			],
 			"_copy": {
 				"name": "Shadow Magic",
 				"source": "XGE",
@@ -2190,6 +2196,55 @@
 				"Absorb Spells|Sorcerer|XPHB|Spellfire|FRHoF|6|FRHoF",
 				"Honed Spellfire|Sorcerer|XPHB|Spellfire|FRHoF|14|FRHoF",
 				"Crown of Spellfire|Sorcerer|XPHB|Spellfire|FRHoF|18|FRHoF"
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Shadow Sorcery",
+			"shortName": "Shadow",
+			"source": "RHW",
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"edition": "one",
+			"additionalSpells": [
+				{
+					"prepared": {
+						"3": [
+							"bane|xphb",
+							"darkness|xphb",
+							"inflict wounds|xphb",
+							"pass without trace|xphb"
+						],
+						"5": [
+							"hunger of hadar|xphb",
+							"nondetection|xphb"
+						],
+						"7": [
+							"greater invisibility|xphb",
+							"phantasmal killer|xphb"
+						],
+						"9": [
+							"contagion|xphb",
+							"creation|xphb"
+						]
+					},
+					"innate": {
+						"6": {
+							"resource": {
+								"3": [
+									"summon beast|xphb"
+								]
+							}
+						}
+					},
+					"resourceName": "Sorcery Point"
+				}
+			],
+			"subclassFeatures": [
+				"Shadow Sorcery|Sorcerer|XPHB|Shadow|RHW|3|RHW",
+				"Beasts of Ill Omen|Sorcerer|XPHB|Shadow|RHW|6|RHW",
+				"Shadow Walk|Sorcerer|XPHB|Shadow|RHW|14|RHW",
+				"Umbral Form|Sorcerer|XPHB|Shadow|RHW|18|RHW"
 			],
 			"hasFluffImages": true
 		}
@@ -4948,6 +5003,153 @@
 			}
 		},
 		{
+			"name": "Power of Shadow",
+			"source": "RHW",
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Shadow",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Eyes of the Dark",
+					"entries": [
+						"You have {@sense Darkvision|XPHB} with a range of 120 feet and {@sense Blindsight|XPHB} with a range of 10 feet. In addition, if a spell you cast creates an area of {@variantrule Darkness|XPHB}, you can see normally through that spell's Darkness."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Strength of the Grave",
+					"entries": [
+						"If you would drop to 0 {@variantrule Hit Points|XPHB} and not die outright, you can make a Charisma saving throw ({@dc 5} plus the damage taken). On a successful save, your {@variantrule Hit Points|XPHB} instead change to a number equal to your Charisma modifier plus your Sorcerer level. After you succeed on this save, you can't use this benefit again until you finish a {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Shadow Sorcery",
+			"source": "RHW",
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Shadow",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"{@i Bend Doom and Darkness to Your Will}",
+				"Your innate magic comes from the most nebulous and inscrutable forces of the Shadowfell or from other regions of supernatural darkness. You might trace your lineage to an entity from such a place, or perhaps you were exposed to the sinister energy of a shadow dragon and were transformed by it. Your shadowy magic allows you to command darkness, undeath, and woe.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Shadow Spells|Sorcerer|XPHB|Shadow|RHW|3|RHW"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Power of Shadow|Sorcerer|XPHB|Shadow|RHW|3|RHW"
+				}
+			]
+		},
+		{
+			"name": "Shadow Spells",
+			"source": "RHW",
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Shadow",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"When you reach a Sorcerer level specified in the Shadow Spells table, you thereafter always have the listed spells prepared.",
+				{
+					"type": "table",
+					"caption": "Shadow Spells",
+					"colLabels": [
+						"Sorcerer Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3",
+							"{@spell Bane|XPHB}, {@spell Darkness|XPHB}, {@spell Inflict Wounds|XPHB}, {@spell Pass Without Trace|XPHB}"
+						],
+						[
+							"5",
+							"{@spell Hunger of Hadar|XPHB}, {@spell Nondetection|XPHB}"
+						],
+						[
+							"7",
+							"{@spell Greater Invisibility|XPHB}, {@spell Phantasmal Killer|XPHB}"
+						],
+						[
+							"9",
+							"{@spell Contagion|XPHB}, {@spell Creation|XPHB}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Beasts of Ill Omen",
+			"source": "RHW",
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Shadow",
+			"subclassSource": "RHW",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"You can call forth a howling creature of shadow to hound your foes. You can spend 3 Sorcery Points to cast {@spell Summon Beast|XPHB} as a {@variantrule Bonus Action|XPHB} without expending a spell slot, without preparing the spell, and without Material components. The summoned creature appears as a beast made of shadow, and enemies within 5 feet of the summoned creature have {@variantrule Disadvantage|XPHB} on saving throws against spells you cast.",
+				"Whenever you cast the spell, you can modify it so that it doesn't require {@status Concentration|XPHB}. If you do so, the spell's duration becomes 1 minute for that casting, and the spell ends early if you cast the spell again."
+			]
+		},
+		{
+			"name": "Shadow Walk",
+			"source": "RHW",
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Shadow",
+			"subclassSource": "RHW",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"While you are in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}, you can take a {@variantrule Bonus Action|XPHB} to teleport up to 120 feet to an unoccupied space you can see that is also in {@variantrule Dim Light|XPHB} or {@variantrule Darkness|XPHB}."
+			]
+		},
+		{
+			"name": "Umbral Form",
+			"source": "RHW",
+			"className": "Sorcerer",
+			"classSource": "XPHB",
+			"subclassShortName": "Shadow",
+			"subclassSource": "RHW",
+			"level": 18,
+			"header": 2,
+			"consumes": {
+				"name": "Sorcery Point",
+				"amount": 6
+			},
+			"entries": [
+				"When you use Innate Sorcery, you can adopt a shadowy form, gaining the benefits below while your Innate Sorcery is active or until you end the form (no action required). Once you use this feature, you can't use it again until you finish a {@variantrule Long Rest|XPHB} unless you spend 6 Sorcery Points (no action required) to restore your use of it.",
+				{
+					"type": "entries",
+					"name": "Incorporeal Movement",
+					"entries": [
+						"You can move through creatures and objects as if they were {@variantrule Difficult Terrain|XPHB}, but you take {@damage 1d10} Force damage if you end your turn inside a creature or an object."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Shadow Resilience",
+					"entries": [
+						"You have {@variantrule Resistance|XPHB} to all damage except Force and Radiant damage."
+					]
+				}
+			]
+		},
+		{
 			"name": "Aberrant Mind",
 			"source": "TCE",
 			"className": "Sorcerer",
@@ -5653,7 +5855,7 @@
 						],
 						[
 							"17\u201320",
-							"You are subjected to an effect that lasts for 1 minute unless its description says otherwise. Roll {@dice 1d8} to determine the effect: on a 1, you're surrounded by faint, ethereal music only you and creatures within 5 feet of you can hear; on a 2, your size increases by one size category; on a 3, you grow a long beard made of feathers that remains until you sneeze, at which point the feathers explode from your face and vanish; on a 4, you must shout when you speak; on a 5, illusory butterflies flutter in the air within 10 feet of you; on a 6, an eye appears on your forehead, granting you {@variantrule Advantage|XPHB} on Wisdom ({@skill Perception|XPHB}) checks; on an 7, pink bubbles float out of your mouth whenever you speak; on an 8, your skin turns a vibrant shade of blue for 24 hours or until the effect is ended by a {@spell Remove Curse|XPHB} spell."
+							"You are subjected to an effect that lasts for 1 minute unless its description says otherwise. Roll {@dice 1d8} to determine the effect: on a 1, you're surrounded by faint, ethereal music only you and creatures within 5 feet of you can hear; on a 2, your size increases by one size category; on a 3, you grow a long beard made of feathers that remains until you sneeze, at which point the feathers explode from your face and vanish; on a 4, you must shout when you speak; on a 5, illusory butterflies flutter in the air within 10 feet of you; on a 6, an eye appears on your forehead, granting you {@variantrule Advantage|XPHB} on Wisdom ({@skill Perception|XPHB}) checks; on a 7, pink bubbles float out of your mouth whenever you speak; on an 8, your skin turns a vibrant shade of blue for 24 hours or until the effect is ended by a {@spell Remove Curse|XPHB} spell."
 						],
 						[
 							"21\u201324",
@@ -5733,7 +5935,7 @@
 						],
 						[
 							"97\u201300",
-							"Roll {@dice 1d6} On a 1, you regain {@dice 2d10} {@variantrule Hit Points|XPHB}; on a 2, one ally of your choice within 300 feet of you regains {@dice 2d10} {@variantrule Hit Points|XPHB}; on a 3, you regain your lowest-level expended spell slot; on a 4, one ally of your choice within 300 feet of you regains their lowest-level expended spell slot; on a 5, you regain all your expended Sorcery Points; on a 6, all the effects of row 17\u201320 affect you simultaneously."
+							"Roll {@dice 1d6}. On a 1, you regain {@dice 2d10} {@variantrule Hit Points|XPHB}; on a 2, one ally of your choice within 300 feet of you regains {@dice 2d10} {@variantrule Hit Points|XPHB}; on a 3, you regain your lowest-level expended spell slot; on a 4, one ally of your choice within 300 feet of you regains their lowest-level expended spell slot; on a 5, you regain all your expended Sorcery Points; on a 6, all the effects of row 17\u201320 affect you simultaneously."
 						]
 					],
 					"data": {

--- a/json/class/class-warlock.json
+++ b/json/class/class-warlock.json
@@ -1517,6 +1517,9 @@
 			"className": "Warlock",
 			"classSource": "PHB",
 			"page": 30,
+			"reprintedAs": [
+				"Undead|Warlock|XPHB|RHW"
+			],
 			"edition": "classic",
 			"additionalSpells": [
 				{
@@ -1558,6 +1561,9 @@
 			"source": "VRGR",
 			"className": "Warlock",
 			"classSource": "XPHB",
+			"reprintedAs": [
+				"Undead|Warlock|XPHB|RHW"
+			],
 			"_copy": {
 				"name": "The Undead",
 				"source": "VRGR",
@@ -1770,6 +1776,45 @@
 				"Eldritch Hex|Warlock|XPHB|Great Old One|XPHB|10",
 				"Thought Shield|Warlock|XPHB|Great Old One|XPHB|10",
 				"Create Thrall|Warlock|XPHB|Great Old One|XPHB|14"
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Undead Patron",
+			"shortName": "Undead",
+			"source": "RHW",
+			"className": "Warlock",
+			"classSource": "XPHB",
+			"edition": "one",
+			"additionalSpells": [
+				{
+					"prepared": {
+						"3": [
+							"bane|xphb",
+							"blindness/deafness|xphb",
+							"phantasmal force|xphb",
+							"ray of sickness|xphb"
+						],
+						"5": [
+							"speak with dead|xphb",
+							"summon undead|xphb"
+						],
+						"7": [
+							"greater invisibility|xphb",
+							"phantasmal killer|xphb"
+						],
+						"9": [
+							"antilife shell|xphb",
+							"cloudkill|xphb"
+						]
+					}
+				}
+			],
+			"subclassFeatures": [
+				"Undead Patron|Warlock|XPHB|Undead|RHW|3|RHW",
+				"Grave Touched|Warlock|XPHB|Undead|RHW|6|RHW",
+				"Necrotic Husk|Warlock|XPHB|Undead|RHW|10|RHW",
+				"Superior Dread|Warlock|XPHB|Undead|RHW|14|RHW"
 			],
 			"hasFluffImages": true
 		}
@@ -4020,6 +4065,200 @@
 					"page": true
 				}
 			}
+		},
+		{
+			"name": "Undead Patron",
+			"source": "RHW",
+			"className": "Warlock",
+			"classSource": "XPHB",
+			"subclassShortName": "Undead",
+			"subclassSource": "RHW",
+			"level": 3,
+			"entries": [
+				"{@i Defy Death for Profane Power}",
+				"You've made a pact with a creature that defies the cycle of life and death: a powerful lich, a vampire, or another entity of undeath. Having once been mortal, these ancient patrons know firsthand the paths of ambition and the routes past the doors of death. They eagerly share this profane knowledge and other secrets with those who work their will among the living.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Form of Dread|Warlock|XPHB|Undead|RHW|3|RHW"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Undead Spells|Warlock|XPHB|Undead|RHW|3|RHW"
+				}
+			]
+		},
+		{
+			"name": "Form of Dread",
+			"source": "RHW",
+			"className": "Warlock",
+			"classSource": "XPHB",
+			"subclassShortName": "Undead",
+			"subclassSource": "RHW",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"As a {@variantrule Bonus Action|XPHB}, you transform into an avatar of your patron's dreadful power, gaining the benefits below for 1 minute, until you have the {@condition Incapacitated|XPHB} condition, or until you end the form (no action required). You can transform a number of times equal to your Charisma modifier (minimum of once), and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}.",
+				{
+					"type": "entries",
+					"name": "Facsimile of Life",
+					"entries": [
+						"You gain {@variantrule Temporary Hit Points|XPHB} equal to {@dice 1d10} plus your Warlock level."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Fearless Form",
+					"entries": [
+						"You have Immunity to the {@condition Frightened|XPHB} condition. If you are Frightened when you transform, the condition immediately ends for you."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Frightful Avatar",
+					"entries": [
+						"Once per turn, when you hit a creature with an attack roll, you can force it to make a Wisdom saving throw against your spell save DC. On a failed save, the target has the {@condition Frightened|XPHB} condition until the end of your next turn."
+					]
+				}
+			]
+		},
+		{
+			"name": "Undead Spells",
+			"source": "RHW",
+			"className": "Warlock",
+			"classSource": "XPHB",
+			"subclassShortName": "Undead",
+			"subclassSource": "RHW",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"The magic of your patron ensures you always have certain spells ready; when you reach a Warlock level specified in the Undead Spells table, you thereafter always have the listed spells prepared.",
+				{
+					"type": "table",
+					"caption": "Undead Spells",
+					"colLabels": [
+						"Warlock Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3",
+							"{@spell Bane|XPHB}, {@spell Blindness/Deafness|XPHB}, {@spell Phantasmal Force|XPHB}, {@spell Ray of Sickness|XPHB}"
+						],
+						[
+							"5",
+							"{@spell Speak with Dead|XPHB}, {@spell Summon Undead|XPHB}"
+						],
+						[
+							"7",
+							"{@spell Greater Invisibility|XPHB}, {@spell Phantasmal Killer|XPHB}"
+						],
+						[
+							"9",
+							"{@spell Antilife Shell|XPHB}, {@spell Cloudkill|XPHB}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Grave Touched",
+			"source": "RHW",
+			"className": "Warlock",
+			"classSource": "XPHB",
+			"subclassShortName": "Undead",
+			"subclassSource": "RHW",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Your patron's powers have a profound effect on your body and magic, granting you the following benefits.",
+				{
+					"type": "entries",
+					"name": "Arcane Necrosis",
+					"entries": [
+						"Necrotic damage from your attacks, Warlock spells, and Warlock features ignores {@variantrule Resistance|XPHB} to Necrotic damage. Once per turn when you cast a spell that deals damage, you can change that spell's damage type to Necrotic."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Dreaded Necrosis",
+					"entries": [
+						"When you hit a creature with an attack roll and deal Necrotic damage while using your Form of Dread, you can roll one additional damage die when determining the Necrotic damage the target takes. You can use this benefit only once per turn."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Undead Endurance",
+					"entries": [
+						"You don't gain {@condition Exhaustion|XPHB} levels from {@hazard dehydration|XPHB}, {@hazard malnutrition|XPHB}, or {@hazard suffocation|XPHB}. In addition, you don't need to sleep, and magic can't put you to sleep."
+					]
+				}
+			]
+		},
+		{
+			"name": "Necrotic Husk",
+			"source": "RHW",
+			"className": "Warlock",
+			"classSource": "XPHB",
+			"subclassShortName": "Undead",
+			"subclassSource": "RHW",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Your connection to undeath saturates your body. You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Necrotic Resilience",
+					"entries": [
+						"You have {@variantrule Resistance|XPHB} to Necrotic damage. While using your Form of Dread, you have {@variantrule Immunity|XPHB} to Necrotic damage."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Unholy Resuscitation",
+					"entries": [
+						"If you drop to 0 Hit Points and don't die outright, you can cause your body to erupt with deathly energy. Each creature of your choice in a 30-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} originating from you makes a Constitution saving throw against your spell save DC, taking Necrotic damage equal to {@dice 2d10} plus your Charisma modifier on a failed save or half as much damage on a successful one. Your Hit Points then change to twice your Warlock level, and you gain 1 {@condition Exhaustion|XPHB} level.",
+						"Once you use this benefit, you can't use it again until you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Superior Dread",
+			"source": "RHW",
+			"className": "Warlock",
+			"classSource": "XPHB",
+			"subclassShortName": "Undead",
+			"subclassSource": "RHW",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Your Form of Dread improves, granting you the following benefits while you are using it.",
+				{
+					"type": "entries",
+					"name": "Dread Resistance",
+					"entries": [
+						"You have {@variantrule Resistance|XPHB} to Bludgeoning, Piercing, and Slashing damage."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Ghostly Flight",
+					"entries": [
+						"You have a {@variantrule Fly Speed|XPHB} equal to your {@variantrule Speed|XPHB} and can hover. You can move through creatures and objects as if they were {@variantrule Difficult Terrain|XPHB}, but you take {@damage 1d10} Force damage if you end your turn inside a creature or an object."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Profane Casting",
+					"entries": [
+						"Whenever you cast a Warlock spell from the Conjuration or Necromancy school, you cast it without any Verbal, Somatic, or Material components, except Material components that are costly or consumed."
+					]
+				}
+			]
 		},
 		{
 			"name": "The Undying",

--- a/json/conditionsdiseases.json
+++ b/json/conditionsdiseases.json
@@ -251,7 +251,7 @@
 							"type": "entries",
 							"name": "D20 Tests Affected",
 							"entries": [
-								"When you make a D20 Test the roll is reduced by 2 times your Exhaustion level."
+								"When you make a D20 Test, the roll is reduced by 2 times your Exhaustion level."
 							]
 						},
 						{
@@ -1058,7 +1058,7 @@
 			"page": 233,
 			"entries": [
 				"Any humanoid that spends 12 hours in the necropolis must succeed on a {@dc 15} Constitution saving throw or contract an arcane blight. This magical disease transforms the humanoid into a {@creature nothic}, but only after the victim experiences hallucinations and feelings of isolation and paranoia. Other symptoms include clammy skin, hair loss, and myopia (nearsightedness).",
-				"A player character infected with the arcane blight gains the following flaw: \"I don't trust anyone.\" This flaw, which supersedes any conflicting flaw, is fed by delusions that are difficult for the character to distinguish from reality. Common delusions include the belief that that allies are conspiring to steal the victim's riches or otherwise turn against the victim.",
+				"A player character infected with the arcane blight gains the following flaw: \"I don't trust anyone.\" This flaw, which supersedes any conflicting flaw, is fed by delusions that are difficult for the character to distinguish from reality. Common delusions include the belief that allies are conspiring to steal the victim's riches or otherwise turn against the victim.",
 				"Whenever it finishes a long rest, an infected humanoid must repeat the saving throw. On a successful save, the DC for future saves against the arcane blight drops by {@dice 1d6}. If the saving throw DC drops to 0, the creature overcomes the arcane blight and becomes immune to the effect of further exposure. A creature that fails three of these saving throws transforms into a {@creature nothic} under the DM's control. Only a {@spell wish} spell or divine intervention can undo this transformation.",
 				"A {@spell greater restoration} spell or similar magic ends the infection on the target, removing the flaw and all other symptoms, but this magic doesn't protect the target against further exposure."
 			]
@@ -1069,7 +1069,7 @@
 			"page": 227,
 			"entries": [
 				"Pain grips the creature's mind, and its eyes turn milky white. The creature has disadvantage on Wisdom checks and Wisdom saving throws and is {@condition blinded}.",
-				"{@note This disease can be inflicted with the {@spell contagion} spell.}"
+				"{@note This disease can be inflicted with the {@spell contagion|PHB} spell.}"
 			]
 		},
 		{
@@ -1157,7 +1157,7 @@
 			"page": 227,
 			"entries": [
 				"A raging fever sweeps through the creature's body. The creature has disadvantage on Strength checks, Strength saving throws, and attack rolls that use Strength.",
-				"{@note This disease can be inflicted with the {@spell contagion} spell.}"
+				"{@note This disease can be inflicted with the {@spell contagion|PHB} spell.}"
 			]
 		},
 		{
@@ -1166,7 +1166,7 @@
 			"page": 227,
 			"entries": [
 				"The creature's flesh decays. The creature has disadvantage on Charisma checks and vulnerability to all damage.",
-				"{@note This disease can be inflicted with the {@spell contagion} spell.}"
+				"{@note This disease can be inflicted with the {@spell contagion|PHB} spell.}"
 			]
 		},
 		{
@@ -1199,12 +1199,95 @@
 			]
 		},
 		{
+			"name": "Lichen Plague",
+			"source": "FRAiF",
+			"page": 98,
+			"type": "Magical Contagion",
+			"entries": [
+				"A Beast, Giant, Humanoid, or Monstrosity that comes into contact with bile lichen spores is at risk of contracting a horrible disease as the lichen takes root on its body and grows into its brain. A creature suffers the following effects {@dice 1d4} days after infection:",
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skinroot",
+							"entry": "The contagion first appears as a patch of green-yellow lichen no larger than 1 square inch on a random area of the body. When it finishes a Long Rest, the infected creature must succeed on a {@dc 14} Constitution saving throw or gain 1 Exhaustion level as the lichen spreads toward the creature's head. This Exhaustion level lasts until the contagion ends on the creature."
+						},
+						{
+							"type": "item",
+							"name": "Mindroot",
+							"entry": "A Humanoid that dies while infected with Lichen Plague rises immediately as a {@creature Zombie|XMM} under the DM's control."
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Fighting the Contagion",
+							"entries": [
+								"When it finishes a Long Rest, an infected creature makes a {@dc 14} Constitution saving throw. If the creature succeeds on three of these saving throws, the contagion ends on the creature and the creature is immune to Lichen Plague forever. The successful saves don't need to be consecutive."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Spreading the Contagion",
+							"entries": [
+								"Any Beast, Giant, Humanoid, or Monstrosity that makes skin contact with the lichen on an infected creature must succeed on a {@dc 14} Constitution saving throw or be infected with Lichen Plague. On a successful save, the creature can't catch Lichen Plague for the next 24 hours."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
 			"name": "Mindfire",
 			"source": "PHB",
 			"page": 227,
 			"entries": [
 				"The creature's mind becomes feverish. The creature has disadvantage on Intelligence checks and Intelligence saving throws, and the creature behaves as if under the effects of the {@spell confusion} spell during combat.",
-				"{@note This disease can be inflicted with the {@spell contagion} spell.}"
+				"{@note This disease can be inflicted with the {@spell contagion|PHB} spell.}"
+			]
+		},
+		{
+			"name": "Mudpox",
+			"source": "FRAiF",
+			"page": 98,
+			"type": "Magical Contagion",
+			"entries": [
+				"Contact with dead oozes from the Underdark mixed with snowmelt and mud has been making people sick. Any Beast or Humanoid that touches mud contaminated by Mudpox must succeed on a {@dc 12} Constitution saving throw or become infected, suffering the following effect:",
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Disrupted Digestion",
+							"entry": "Daily at dawn, the creature must succeed on a {@dc 12} Constitution saving throw or vomit up the food it ate the previous day, gaining 1 Exhaustion level. If the creature succeeds on this saving throw three consecutive times, the contagion ends."
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Fighting the Contagion",
+							"entries": [
+								"A {@spell Heal|XPHB} or {@spell Lesser Restoration|XPHB} spell ends the contagion immediately."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Spreading the Contagion",
+							"entries": [
+								"Any Humanoid that makes skin contact with a creature infected with Mudpox must succeed on a {@dc 12} Constitution saving throw or also become infected with the contagion. If the creature succeeds on this save, it can't catch the contagion from that particular infected creature for the next 24 hours."
+							]
+						}
+					]
+				}
 			]
 		},
 		{
@@ -1233,7 +1316,7 @@
 			"page": 227,
 			"entries": [
 				"The creature is overcome with shaking. The creature has disadvantage on Dexterity checks, Dexterity saving throws, and attack rolls that use Dexterity.",
-				"{@note This disease can be inflicted with the {@spell contagion} spell.}"
+				"{@note This disease can be inflicted with the {@spell contagion|PHB} spell.}"
 			]
 		},
 		{
@@ -1289,6 +1372,55 @@
 							"name": "Fighting the Contagion",
 							"entries": [
 								"Daily at dawn, an infected creature makes a {@dc 11} Constitution saving throw. On a failed save, the creature gains 1 {@condition Exhaustion|XPHB} level as its fatigue worsens. On a successful save, the creature's Exhaustion level decreases by 1. If the creature's Exhaustion level is reduced to 0, the contagion ends on the creature."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Shaking Plague",
+			"source": "FRAiF",
+			"page": 70,
+			"type": "Magical Contagion",
+			"entries": [
+				"Magical experiments gone awry gave rise to Shaking Plague, which affects Humanoids. A creature suffers the following effects {@dice 1d4} days after infection:",
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Fatigue",
+							"entry": "The creature gains 1 {@condition Exhaustion|XPHB} level. While the creature has any {@condition Exhaustion|XPHB} levels, finishing a {@variantrule Long Rest|XPHB} doesn't reduce the creature's {@condition Exhaustion|XPHB} level."
+						},
+						{
+							"type": "item",
+							"name": "Pus Boils",
+							"entry": "While the creature has any {@condition Exhaustion|XPHB} levels, its skin is covered in pus-filled boils."
+						},
+						{
+							"type": "item",
+							"name": "Shaking",
+							"entry": "While the creature has any {@condition Exhaustion|XPHB} levels, magic-dampening tremors afflict it. The creature has {@variantrule Disadvantage|XPHB} on Dexterity checks and saving throws, and whenever the creature casts a spell with a Somatic component, it must succeed on a {@dc 11} Constitution saving throw, or the spell dissipates with no effect and the action, {@variantrule Bonus Action|XPHB}, or {@variantrule Reaction|XPHB} used to cast it is wasted. If that spell was cast with a spell slot, that slot isn't expended."
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Fighting the Contagion",
+							"entries": [
+								"Daily at dawn, an infected creature makes a {@dc 11} Constitution saving throw. On a failed save, the creature gains 1 {@condition Exhaustion|XPHB} level as its fatigue worsens. On a successful save, the creature's {@condition Exhaustion|XPHB} level decreases by 1. If the creature's {@condition Exhaustion|XPHB} level is reduced to 0, the contagion ends on the creature."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Spreading the Contagion",
+							"entries": [
+								"Any Humanoid that makes skin contact with a creature infected with Shaking Plague must succeed on a {@dc 11} Constitution saving throw or also become infected with the contagion. On a successful save, the Humanoid can't catch the contagion from that particular infected creature for the next 24 hours."
 							]
 						}
 					]
@@ -1355,7 +1487,7 @@
 			"page": 227,
 			"entries": [
 				"The creature begins to bleed uncontrollably. The creature has disadvantage on Constitution checks and Constitution saving throws. In addition, whenever the creature takes damage, it is {@condition stunned} until the end of its next turn.",
-				"{@note This disease can be inflicted with the {@spell contagion} spell.}"
+				"{@note This disease can be inflicted with the {@spell contagion|PHB} spell.}"
 			]
 		},
 		{
@@ -1425,6 +1557,50 @@
 			]
 		},
 		{
+			"name": "The Rusting",
+			"source": "FRAiF",
+			"page": 165,
+			"type": "Magical Contagion",
+			"entries": [
+				"The Rusting manifests as a thin, iron coating that grows over a victim's body. When exposed to moisture, this iron skin corrodes into a rust-colored plaque. As the Rusting covers the victim, the victim eventually transforms into a type of creature known as a Rusted (see {@book chapter 9|FRAiF|9}).",
+				"Any creature that is wounded by a Rusted creature or spends 1 hour in an area where the Rusting has manifested makes a {@dc 10} Constitution saving throw. Constructs and Undead automatically succeed on this save. On a failed save, the creature is afflicted by the Rusting and suffers the following effects:",
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Curse",
+							"entry": "The creature gains 1 {@condition Exhaustion|XPHB} level and is cursed. While the creature is cursed, finishing a {@variantrule Long Rest|XPHB} doesn't reduce the creature's {@condition Exhaustion|XPHB} level."
+						},
+						{
+							"type": "item",
+							"name": "Plated Joints",
+							"entry": "The creature's {@variantrule Speed|XPHB} is reduced by 5 feet."
+						},
+						{
+							"type": "item",
+							"name": "Rusted Fate",
+							"entry": "When a cursed creature's {@condition Exhaustion|XPHB} level reaches 6, it doesn't die. Instead, the creature transforms into a Rusted version of its former self; its creature type becomes Construct, and it gains {@variantrule Immunity|XPHB} to Poison damage and the {@condition Exhaustion|XPHB}, {@condition Petrified|XPHB}, and {@condition Poisoned|XPHB} conditions. The curse then ends for that creature."
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Fighting the Contagion",
+							"entries": [
+								"Daily at dawn, an afflicted creature makes a {@dc 10} Constitution saving throw. On a failed save, the creature gains 1 {@condition Exhaustion|XPHB} level as more iron coats its skin. On a successful save, the creature's {@condition Exhaustion|XPHB} level decreases by 1. If the creature's {@condition Exhaustion|XPHB} level is reduced to 0, the contagion ends on the creature.",
+								"Removing the curse immediately ends the contagion for a creature."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
 			"name": "Throat Leeches",
 			"source": "ToA",
 			"page": 40,
@@ -1435,6 +1611,16 @@
 		}
 	],
 	"status": [
+		{
+			"name": "Bloodied",
+			"source": "XPHB",
+			"page": 362,
+			"srd52": true,
+			"basicRules2024": true,
+			"entries": [
+				"A creature is Bloodied while it has half its {@variantrule Hit Points|XPHB} or fewer remaining."
+			]
+		},
 		{
 			"name": "Concentration",
 			"source": "PHB",
@@ -1451,9 +1637,27 @@
 				{
 					"type": "list",
 					"items": [
-						"{@b Casting another spell that requires concentration.} You lose {@status concentration} on a spell if you cast another spell that requires {@status concentration}. You can't concentrate on two spells at once.",
-						"{@b Taking damage.} Whenever you take damage while you are {@status concentration||concentrating} on a spell, you must make a Constitution saving throw to maintain your {@status concentration}. The DC equals 10 or half the damage you take, whichever number is higher. If you take damage from multiple sources, such as an arrow and a dragon's breath, you make a separate saving throw for each source of damage.",
-						"{@b Being incapacitated or killed.} You lose {@status concentration} on a spell if you are {@condition incapacitated} or if you die."
+						{
+							"type": "entries",
+							"name": "Casting another spell that requires concentration",
+							"entries": [
+								"You lose {@status concentration} on a spell if you cast another spell that requires {@status concentration}. You can't concentrate on two spells at once."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Taking damage",
+							"entries": [
+								"Whenever you take damage while you are {@status concentration||concentrating} on a spell, you must make a Constitution saving throw to maintain your {@status concentration}. The DC equals 10 or half the damage you take, whichever number is higher. If you take damage from multiple sources, such as an arrow and a dragon's breath, you make a separate saving throw for each source of damage."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Being incapacitated or killed",
+							"entries": [
+								"You lose {@status concentration} on a spell if you are {@condition incapacitated} or if you die."
+							]
+						}
 					]
 				},
 				"The DM might also decide that certain environmental phenomena, such as a wave crashing over you while you're on a storm-tossed ship, require you to succeed on a {@dc 10} Constitution saving throw to maintain {@status concentration} on a spell."

--- a/json/feats.json
+++ b/json/feats.json
@@ -1,9 +1,128 @@
 {
 	"feat": [
 		{
+			"name": "Aberrant Anatomy",
+			"source": "RHW",
+			"category": "DG",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Ravenloft"
+					]
+				}
+			],
+			"skillProficiencies": [
+				{
+					"perception": true
+				}
+			],
+			"expertise": [
+				{
+					"perception": true
+				}
+			],
+			"senses": [
+				{
+					"blindsight": 15
+				}
+			],
+			"entries": [
+				"Exposure to alien horrors like those of the Far Realm has warped your physical form in supernatural ways. You gain the following features.",
+				{
+					"type": "entries",
+					"name": "Breathless",
+					"entries": [
+						"You can hold your breath for 1 hour."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Extrasensory Perception",
+					"entries": [
+						"You have proficiency in the {@skill Perception|XPHB} skill, if you lack it. You also gain {@variantrule Expertise|XPHB} in that skill.",
+						"In addition, you have {@sense Blindsight|XPHB} with a range of 15 feet."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Warping Flesh",
+					"entries": [
+						"Immediately after you make a {@variantrule D20 Test|XPHB} and roll a 1 on the {@dice d20}, the aberrant influence infecting your form flares, wrenching control of your flesh. Make a Constitution saving throw (DC 13 plus your {@variantrule Proficiency|XPHB|Proficiency Bonus}). On a failed save, you have the {@condition Stunned|XPHB} condition until the end of your next turn."
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Aberrant Dragonmark",
+			"source": "EFA",
+			"page": 39,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": "con",
+					"prepared": {
+						"_": {
+							"rest": {
+								"1": [
+									{
+										"choose": "level=1|class=Sorcerer"
+									}
+								]
+							}
+						}
+					},
+					"known": {
+						"_": [
+							{
+								"choose": "level=0|class=Sorcerer"
+							}
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Aberrant Fortitude",
+					"entries": [
+						"When you fail a Constitution saving throw, you can take a {@variantrule Reaction|XPHB} to roll {@dice 1d4} and add the number rolled to the save, potentially turning the failure into a success. Once you've used this benefit, you can't use it again until you finish a {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Aberrant Magic",
+					"entries": [
+						"You know one {@filter cantrip of your choice from the Sorcerer spell list|spells|level=0|class=Sorcerer}. Also, choose a level 1 spell from that spell list. You always have that spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}. You can also cast this spell using any spell slots you have. Constitution is your spellcasting ability for this spell."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Aberrant Surge",
+					"entries": [
+						"When you cast the level 1 spell from this feat, you can expend one of your {@variantrule Hit Point Dice|XPHB} and roll it. If you roll an even number, you gain a number of {@variantrule Temporary Hit Points|XPHB} equal to the number rolled. If you roll an odd number, one creature within 30 feet of you (not including you) takes Force damage equal to the number rolled. If no other creatures are in range, you take the damage."
+					]
+				}
+			]
+		},
+		{
 			"name": "Aberrant Dragonmark",
 			"source": "ERLW",
 			"page": 52,
+			"reprintedAs": [
+				"Aberrant Dragonmark|EFA"
+			],
 			"prerequisite": [
 				{
 					"other": "No other dragonmark"
@@ -619,6 +738,9 @@
 					}
 				}
 			],
+			"traitTags": [
+				"Speed"
+			],
 			"entries": [
 				"You gain the following benefits.",
 				{
@@ -639,7 +761,7 @@
 					"type": "entries",
 					"name": "Jumping",
 					"entries": [
-						"You can make a running Long or {@variantrule High Jump|XPHB} after moving only 5 feet."
+						"You can make a running {@variantrule Long Jump|XPHB|Long} or {@variantrule High Jump|XPHB} after moving only 5 feet."
 					]
 				}
 			]
@@ -1637,6 +1759,359 @@
 			]
 		},
 		{
+			"name": "Boon of Siberys",
+			"source": "EFA",
+			"page": 45,
+			"category": "EB",
+			"prerequisite": [
+				{
+					"level": 19,
+					"campaign": [
+						"Eberron"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"max": 30
+				}
+			],
+			"additionalSpells": [
+				{
+					"name": "Mark of Handling",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"animal shapes|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Storm",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"control weather|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Making",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"demiplane|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Hospitality",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"heroes' feast|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Warding",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"maze|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Sentinel",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"mind blank|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Passage",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"plane shift|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Shadow",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"project image|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Healing",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"regenerate|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Scribing",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"symbol|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Finding",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"teleport|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Mark of Detection",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"true seeing|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Sorcerer Spell",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									{
+										"choose": "level=1;2;3;4;5;6;7;8|class=Sorcerer"
+									}
+								]
+							}
+						}
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Aberrant Magic",
+					"entries": [
+						"Choose a level 8 or lower spell from the {@filter Sorcerer spell list|spells|class=Sorcerer|level=0;1;2;3;4;5;6;7;8} or a spell from the Siberys Dragonmark Spells table (the table includes dragonmark suggestions if you'd like to associate a spell with one of the marks). You always have that spell prepared. You can cast it once without a spell slot or spell components, and you regain the ability to cast it in that way when you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}. You can also cast this spell using any spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for this spell (choose when you gain this feat).",
+						{
+							"type": "table",
+							"caption": "Siberys Dragonmark Spells",
+							"colStyles": [
+								"col-6",
+								"col-6"
+							],
+							"colLabels": [
+								"Spell",
+								"Suggested Dragonmark"
+							],
+							"rows": [
+								[
+									"{@spell Animal Shapes|XPHB}",
+									"Handling"
+								],
+								[
+									"{@spell Control Weather|XPHB}",
+									"Storm"
+								],
+								[
+									"{@spell Demiplane|XPHB}",
+									"Making"
+								],
+								[
+									"{@spell Heroes' Feast|XPHB}",
+									"Hospitality"
+								],
+								[
+									"{@spell Maze|XPHB}",
+									"Warding"
+								],
+								[
+									"{@spell Mind Blank|XPHB}",
+									"Sentinel"
+								],
+								[
+									"{@spell Plane Shift|XPHB}",
+									"Passage"
+								],
+								[
+									"{@spell Project Image|XPHB}",
+									"Shadow"
+								],
+								[
+									"{@spell Regenerate|XPHB}",
+									"Healing"
+								],
+								[
+									"{@spell Symbol|XPHB}",
+									"Scribing"
+								],
+								[
+									"{@spell Teleport|XPHB}",
+									"Finding"
+								],
+								[
+									"{@spell True Seeing|XPHB}",
+									"Detection"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
 			"name": "Boon of Skill",
 			"source": "XPHB",
 			"page": 211,
@@ -1731,6 +2206,9 @@
 					},
 					"max": 30
 				}
+			],
+			"traitTags": [
+				"Speed"
 			],
 			"entries": [
 				"You gain the following benefits.",
@@ -2664,24 +3142,6 @@
 			]
 		},
 		{
-			"name": "Cruel",
-			"source": "TDCSR",
-			"page": 190,
-			"entries": [
-				"The challenges and struggles you've faced throughout your life have led you to delight in inflicting pain and anguish upon others. You gain a number of cruelty dice equal to your proficiency bonus. Your cruelty dice are {@dice d6|d6s}. You can roll only one cruelty die per turn, and a cruelty die is spent when you roll it.",
-				"You can roll a cruelty die under any of the following circumstances, with the indicated result:",
-				{
-					"type": "list",
-					"items": [
-						"When you deal damage to a creature, spend one cruelty die to deal extra damage to the creature equal to the roll.",
-						"When you score a critical hit, spend one cruelty die to gain temporary hit points equal to the roll.",
-						"When you make a Charisma ({@skill Intimidation}) check, spend one cruelty die and add the roll to your check."
-					]
-				},
-				"You regain all spent cruelty dice when you finish a {@quickref resting|PHB|2|0|long rest}."
-			]
-		},
-		{
 			"name": "Crusher",
 			"source": "TCE",
 			"page": 79,
@@ -3148,7 +3608,7 @@
 					"type": "entries",
 					"name": "Fearsome Power",
 					"entries": [
-						"When you deal damage to a creature as part of the Attack or Magic action on your turn, you can use the Dragon's Terror benefit of the Cult of the Dragon Initiate feat as a {@variantrule Bonus Action|XPHB} this turn."
+						"When you deal damage to a creature as part of the {@action Attack|XPHB} or {@action Magic|XPHB} action on your turn, you can use the Dragon's Terror benefit of the Cult of the Dragon Initiate feat as a {@variantrule Bonus Action|XPHB} this turn."
 					]
 				}
 			]
@@ -3401,6 +3861,58 @@
 					"type": "list",
 					"items": [
 						"Whenever you take the {@action Dodge} action in combat, you can spend one Hit Die to heal yourself. Roll the die, add your Constitution modifier, and regain a number of hit points equal to the total (minimum of 1)."
+					]
+				}
+			]
+		},
+		{
+			"name": "Echoing Soul",
+			"source": "RHW",
+			"category": "DG",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Ravenloft"
+					]
+				}
+			],
+			"skillProficiencies": [
+				{
+					"any": 1
+				}
+			],
+			"languageProficiencies": [
+				{
+					"any": 1
+				}
+			],
+			"expertise": [
+				{
+					"anyProficientSkill": 1
+				}
+			],
+			"entries": [
+				"You experience echoes from a past or alternate life. You gain the following features.",
+				{
+					"type": "entries",
+					"name": "Channeled Prowess",
+					"entries": [
+						"You have proficiency in two skills of your choice.",
+						"In addition, choose one skill you have proficiency in. You gain {@variantrule Expertise|XPHB} in that skill. Whenever you finish a {@variantrule Long Rest|XPHB}, you can change your choice for this benefit."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Inherent Tongues",
+					"entries": [
+						"You know one additional language of your choice, which you choose from the language tables in the Player's Handbook."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Intrusive Echoes",
+					"entries": [
+						"Immediately after you make a {@variantrule D20 Test|XPHB} and roll a 1 on the {@dice d20}, memories and sensations from your soul's other life threaten to overtake you. Make a Constitution saving throw (DC 13 plus your {@variantrule Proficiency|XPHB|Proficiency Bonus}). On a failed save, you have the {@condition Incapacitated|XPHB} condition until the end of your next turn. While you are {@condition Incapacitated|XPHB} in this way, your {@variantrule Speed|XPHB} is halved."
 					]
 				}
 			]
@@ -3971,29 +4483,6 @@
 			]
 		},
 		{
-			"name": "Flash Recall",
-			"source": "TDCSR",
-			"page": 190,
-			"prerequisite": [
-				{
-					"spellcastingPrepared": true
-				}
-			],
-			"entries": [
-				"You've developed the ability to instantly recall an unprepared spell in moments of sudden necessity.",
-				"As a bonus action, you prepare a spell of 1st level or higher from your spellbook (if you're a {@class wizard}) or from your class spell list (if you're not a {@class wizard}). This spell must be of a level for which you have spell slots, and it replaces another spell of an equal or higher level that you had previously prepared.",
-				"Once you use this feat to recall a spell, you can't do so again until you complete a {@quickref resting|PHB|2|0|short or long rest}.",
-				{
-					"type": "inset",
-					"name": "Rules Tip: Prepared Spells",
-					"page": 190,
-					"entries": [
-						"The Flash Recall feat requires you to be a spellcaster who prepares spells. This includes classes such as {@class cleric||clerics}, {@class druid||druids}, and {@class paladin||paladins}, who prepare spells each day from their class list, and {@class wizard||wizards}, who prepare spells from a spellbook. Classes such as {@class bard||bards} and {@class sorcerer||sorcerers}, who inherently know their spells rather than preparing them, can't benefit from this feat."
-					]
-				}
-			]
-		},
-		{
 			"name": "Fury of the Frost Giant",
 			"source": "BGG",
 			"page": 17,
@@ -4046,6 +4535,68 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Gathered Whispers",
+			"source": "RHW",
+			"category": "DG",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Ravenloft"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"_": [
+							"message|xphb#c"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"augury|xphb"
+								]
+							}
+						}
+					}
+				}
+			],
+			"entries": [
+				"You are haunted by a cacophony of whispering spirits only you can hear. You gain the following features.",
+				{
+					"type": "entries",
+					"name": "Spirit Whispers",
+					"entries": [
+						"You learn the {@spell Message|XPHB} spell and can cast it without Material components. Additionally, you always have the {@spell Augury|XPHB} spell prepared. You can cast it without a spell slot or spell components, and you must finish a {@variantrule Long Rest|XPHB} before you can cast it in this way again. You can also cast the spell using any spell slots you have.",
+						"Intelligence, Wisdom, or Charisma is your spellcasting ability for this benefit (choose when you select this feat)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Unearthly Scream",
+					"entries": [
+						"When you are hit by an attack roll, you can take a {@variantrule Reaction|XPHB} to channel your haunting spirits into a protective, otherworldly scream. You can add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to your AC against that attack, potentially causing it to miss. You can use this benefit a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Voices from Beyond",
+					"entries": [
+						"Immediately after you make a {@variantrule D20 Test|XPHB} and roll a 1 on the {@dice d20}, the haunting voices rise to a ghastly volume. Make a Wisdom saving throw (DC 13 plus your {@variantrule Proficiency|XPHB|Proficiency Bonus}). On a failed save, you have the {@condition Deafened|XPHB} condition until the end of your next turn. While {@condition Deafened|XPHB}, you have {@variantrule Disadvantage|XPHB} on ability checks and attack rolls."
+					]
+				}
+			]
+		},
+		{
 			"name": "Genie Magic",
 			"source": "FRHoF",
 			"page": 39,
@@ -4072,7 +4623,7 @@
 					"type": "entries",
 					"name": "Wish Magic",
 					"entries": [
-						"As a Magic action, you can cast a {@filter level 1 spell of your choice from the Sorcerer spell list|spells|level=1|class=Sorcerer} that has a casting time of an action. Once you use this benefit, you can't do so again until you finish a {@variantrule Long Rest|XPHB}. The spell's spellcasting ability is the ability increased by this feat.",
+						"As a {@action Magic|XPHB} action, you can cast a {@filter level 1 spell of your choice from the Sorcerer spell list|spells|level=1|class=Sorcerer} that has a casting time of an action. Once you use this benefit, you can't do so again until you finish a {@variantrule Long Rest|XPHB}. The spell's spellcasting ability is the ability increased by this feat.",
 						"When you reach level 11, the spell you cast with this feat is cast as though using a level 2 spell slot.",
 						"When you reach level 17, the spell is cast as though using a level 3 spell slot."
 					]
@@ -4351,6 +4902,596 @@
 			]
 		},
 		{
+			"name": "Greater Aberrant Mark",
+			"source": "EFA",
+			"page": 43,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"aberrant dragonmark|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"con": 1
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Fortitude",
+					"entries": [
+						"When you use the Aberrant Fortitude benefit of your Aberrant Dragonmark feat, you can roll {@dice 1d6} instead of {@dice 1d4}. You also now regain your use of Aberrant Fortitude whenever you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Mark of Inspiration",
+					"entries": [
+						"When you cast a cantrip, you can roll one or two of your unexpended {@variantrule Hit Point Dice|XPHB}. You gain a number of {@variantrule Temporary Hit Points|XPHB} equal to the number rolled plus your Constitution modifier, and one creature of your choice within 30 feet of you (not including you) takes Force damage equal to the number rolled. Those dice are then expended.",
+						"You can use this benefit a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Greater Mark of Detection",
+			"source": "EFA",
+			"page": 43,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of detection|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Deductive Intuition benefit of your {@feat Mark of Detection|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Shared Detection",
+					"entries": [
+						"When you use the Magical Detection benefit of your {@feat Mark of Detection|EFA} feat to cast {@spell See Invisibility|XPHB} without a spell slot, you can choose one creature you can see within 30 feet of yourself. That creature also gains the benefits of the spell for its duration."
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Greater Mark of Finding",
+			"source": "EFA",
+			"page": 43,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of finding|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Hunter's Intuition benefit of your {@feat Mark of Finding|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Improved Finding",
+					"entries": [
+						"When you use the Finder's Magic benefit of your {@feat Mark of Finding|EFA} to cast {@spell Hunter's Mark|XPHB} without a spell slot, the range of the spell is doubled, and you can modify the spell so that the target can't benefit from the {@condition Invisible|XPHB} condition for the duration."
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Greater Mark of Handling",
+			"source": "EFA",
+			"page": 43,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of handling|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Wild Intuition benefit of your {@feat Mark of Handling|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Improved Handling",
+					"entries": [
+						"While you are mounted, immediately after you hit a target within 5 feet of your mount with a melee attack roll, your mount can take a {@variantrule Reaction|XPHB} to move up to its {@variantrule Speed|XPHB} or take the {@action Attack|XPHB} action to make one attack only (your choice)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Subdue Animal",
+					"entries": [
+						"As a {@action Magic|XPHB} action, you exert command over one Beast or Monstrosity you can see within 30 feet of yourself. The target must succeed on a Wisdom saving throw (DC 8 plus your Wisdom modifier and {@variantrule Proficiency|XPHB|Proficiency Bonus}) or have the {@condition Frightened|XPHB} condition until the start of your next turn. You can use this benefit a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Greater Mark of Healing",
+			"source": "EFA",
+			"page": 44,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of healing|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Medical Intuition benefit of your {@feat Mark of Healing|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Improved Healing",
+					"entries": [
+						"You can now use the Healing Touch benefit of your {@feat Mark of Healing|EFA} feat to cast {@spell Cure Wounds|XPHB} without using a spell slot a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}. Additionally, when you cast {@spell Cure Wounds|XPHB} and roll dice to determine the number of {@variantrule Hit Points|XPHB} restored, you can treat any 1 or 2 on a roll as a 3."
+					]
+				}
+			]
+		},
+		{
+			"name": "Greater Mark of Hospitality",
+			"source": "EFA",
+			"page": 44,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of hospitality|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Ever Hospitable benefit of your {@feat Mark of Hospitality|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Improved Hospitality",
+					"entries": [
+						"When you cast {@spell Purify Food and Drink|XPHB}, you can modify the spell so that instead of its normal effect, each creature of your choice within 30 feet of you is refreshed. Each affected creature's {@condition Exhaustion|XPHB} level is reduced by 1, and the creature gains {@variantrule Temporary Hit Points|XPHB} equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus} plus your Intelligence, Wisdom, or Charisma modifier (choose when you select this feat). Once you modify the spell with this benefit, you can't do so again until you finish a {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Greater Mark of Making",
+			"source": "EFA",
+			"page": 44,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of making|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Artisan's Intuition benefit of your {@feat Mark of Making|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Improved Making",
+					"entries": [
+						"When you use the Spellsmith benefit of your {@feat Mark of Making|EFA} feat to cast {@spell Magic Weapon|XPHB} without a spell slot, you cast the spell as its level 3 version."
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Greater Mark of Passage",
+			"source": "EFA",
+			"page": 44,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of passage|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Intuitive Motion benefit of your {@feat Mark of Passage|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Improved Passage",
+					"entries": [
+						"When you use the Magical Passage benefit of your {@feat Mark of Passage|EFA} feat to cast {@spell Misty Step|XPHB} without a spell slot, you can also choose up to two willing creatures you can see within 30 feet of yourself before you teleport. Each target can then take a {@variantrule Reaction|XPHB} to also teleport up to 30 feet to an unoccupied space it can see."
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Greater Mark of Scribing",
+			"source": "EFA",
+			"page": 44,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of scribing|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Gifted Scribe benefit of your {@feat Mark of Scribing|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Inspired Scribing",
+					"entries": [
+						"When you cast {@spell Comprehend Languages|XPHB}, you can modify the spell to encompass up to three willing creatures you can see within 30 feet of yourself. Each chosen creature also gains the benefits of the spell for the duration. In addition, for the duration of the spell, you and the chosen creatures can communicate telepathically with each other while within 1 mile of each other. Once you modify the spell with this benefit, you can't do so again until you finish a {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Greater Mark of Sentinel",
+			"source": "EFA",
+			"page": 44,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of sentinel|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Sentinel's Intuition benefit of your {@feat Mark of Sentinel|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Improved Sentinel",
+					"entries": [
+						"When you use the Vigilant Guardian benefit of your {@feat Mark of Sentinel|EFA} feat, you can also make one attack with a weapon or an {@variantrule Unarmed Strike|XPHB} as part of that same {@variantrule Reaction|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Greater Mark of Shadow",
+			"source": "EFA",
+			"page": 45,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of shadow|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Cunning Intuition benefit of your {@feat Mark of Shadow|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Improved Shadow",
+					"entries": [
+						"When you use the Shape Shadows benefit of your {@feat Mark of Shadow|EFA} feat to cast {@spell Invisibility|XPHB} without a spell slot, you cast the spell as its level 3 version."
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Greater Mark of Storm",
+			"source": "EFA",
+			"page": 45,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of storm|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Windwright's Intuition benefit of your {@feat Mark of Storm|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Improved Storm",
+					"entries": [
+						"When you use the Storm Magic benefit of your {@feat Mark of Storm|EFA} feat to cast {@spell Gust of Wind|XPHB} without a spell slot, you also gain a {@variantrule Fly Speed|XPHB} of 60 feet for the duration of the spell."
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Greater Mark of Warding",
+			"source": "EFA",
+			"page": 45,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"feat": [
+						"mark of warding|efa"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Intuition",
+					"entries": [
+						"When you use the Warder's Intuition benefit of your {@feat Mark of Warding|EFA} feat, you can roll {@dice 1d6} instead of {@dice 1d4}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Improved Warding",
+					"entries": [
+						"When a creature makes an attack roll against you or a creature you can see within 30 feet of yourself, you can take a {@variantrule Reaction|XPHB} to impose {@variantrule Disadvantage|XPHB} on that roll. You can use this benefit a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
 			"name": "Guile of the Cloud Giant",
 			"source": "BGG",
 			"page": 18,
@@ -4429,7 +5570,7 @@
 			],
 			"toolProficiencies": [
 				{
-					"anyMusicalInstrument": 3
+					"anyMusicalInstrument": 1
 				}
 			],
 			"entries": [
@@ -5418,6 +6559,85 @@
 			]
 		},
 		{
+			"name": "Living Shadow",
+			"source": "RHW",
+			"category": "DG",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Ravenloft"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"_": [
+							"mage hand|xphb#c"
+						]
+					}
+				}
+			],
+			"entries": [
+				"The shadow you cast is animate and ever-present—sometimes it even acts according to its own will. You gain the following features.",
+				{
+					"type": "entries",
+					"name": "Grasping Shadow",
+					"entries": [
+						"You learn the {@spell Mage Hand|XPHB} spell and can cast it without spell components. Intelligence, Wisdom, or Charisma is your spellcasting ability for this spell (choose when you select this feat)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Lengthened Strike",
+					"entries": [
+						"When you make a melee attack roll as part of the {@action Attack|XPHB} or {@action Magic|XPHB} action on your turn, you can increase your reach for that attack by 10 feet, as your shadow stretches to aid you. You can use this feature a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Ominous Will",
+					"entries": [
+						"Immediately after you make a {@variantrule D20 Test|XPHB} and roll a 1 on the {@dice d20}, your shadow attempts to exert its will. Make a Wisdom saving throw (DC 13 plus your {@variantrule Proficiency|XPHB|Proficiency Bonus}). On a failed save, you have the {@condition Incapacitated|XPHB} condition until the start of your next turn, at which point you must roll on the Shadow's Will table to determine what you do during that turn.",
+						{
+							"type": "table",
+							"caption": "Shadow's Will",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"1d8",
+								"Behavior"
+							],
+							"rows": [
+								[
+									"1",
+									"You don't take an action or a {@variantrule Bonus Action|XPHB}, and you use all your movement to move. Roll {@dice 1d4} for the direction: 1, north; 2, east; 3, south; or 4, west."
+								],
+								[
+									"2-6",
+									"You don't move or take a {@variantrule Bonus Action|XPHB}, and you take the {@action Attack|XPHB} action to make one melee attack against a random creature within reach. If none are within reach, you take no action."
+								],
+								[
+									"7-8",
+									"You have the {@condition Prone|XPHB} condition, and your turn ends."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
 			"name": "Lordly Resolve",
 			"source": "FRHoF",
 			"page": 40,
@@ -6071,6 +7291,1504 @@
 			]
 		},
 		{
+			"name": "Mark of Detection",
+			"source": "EFA",
+			"page": 39,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"3": {
+							"daily": {
+								"1": [
+									"see invisibility|xphb"
+								]
+							}
+						},
+						"_": {
+							"daily": {
+								"1": [
+									"detect magic|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"detect evil and good|xphb",
+							"identify|xphb"
+						],
+						"s2": [
+							"detect thoughts|xphb",
+							"find traps|xphb"
+						],
+						"s3": [
+							"clairvoyance|xphb",
+							"nondetection|xphb"
+						],
+						"s4": [
+							"arcane eye|xphb",
+							"divination|xphb"
+						],
+						"s5": [
+							"legend lore|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Deductive Intuition",
+					"entries": [
+						"When you make an Intelligence ({@skill Investigation|XPHB}) or Wisdom ({@skill Insight|XPHB}) check, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Magical Detection",
+					"entries": [
+						"You always have the {@spell Detect Magic|XPHB} and {@spell Detect Poison and Disease|XPHB} spells prepared. You can cast each spell once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast these spells using any spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for these spells (choose when you select this feat).",
+						"When you reach character level 3, you also always have the {@spell See Invisibility|XPHB} spell prepared and can cast it the same way."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Detection Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Detection Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Detect Evil and Good|XPHB}, {@spell Identify|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Detect Thoughts|XPHB}, {@spell Find Traps|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Clairvoyance|XPHB}, {@spell Nondetection|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Arcane Eye|XPHB}, {@spell Divination|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Legend Lore|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Finding",
+			"source": "EFA",
+			"page": 39,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"3": {
+							"daily": {
+								"1": [
+									"locate object|xphb"
+								]
+							}
+						},
+						"_": {
+							"daily": {
+								"1": [
+									"hunter's mark|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"faerie fire|xphb",
+							"longstrider|xphb"
+						],
+						"s2": [
+							"locate animals or plants|xphb",
+							"mind spike|xphb"
+						],
+						"s3": [
+							"clairvoyance|xphb",
+							"speak with plants|xphb"
+						],
+						"s4": [
+							"divination|xphb",
+							"locate creature|xphb"
+						],
+						"s5": [
+							"commune with nature|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Hunter's Intuition",
+					"entries": [
+						"When you make a Wisdom ({@skill Perception|XPHB} or {@skill Survival|XPHB}) check, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Finder's Magic",
+					"entries": [
+						"You always have the {@spell Hunter's Mark|XPHB} spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast it using any spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for this spell (choose when you select this feat).",
+						"When you reach character level 3, you also always have the {@spell Locate Object|XPHB} spell prepared and can cast it the same way."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Finding Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Finding Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Faerie Fire|XPHB}, {@spell Longstrider|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Locate Animals or Plants|XPHB}, {@spell Mind Spike|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Clairvoyance|XPHB}, {@spell Speak with Plants|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Divination|XPHB}, {@spell Locate Creature|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Commune with Nature|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Handling",
+			"source": "EFA",
+			"page": 39,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"animal friendship|xphb",
+									"speak with animals|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"command|xphb",
+							"find familiar|xphb"
+						],
+						"s2": [
+							"beast sense|xphb",
+							"calm emotions|xphb"
+						],
+						"s3": [
+							"beacon of hope|xphb",
+							"conjure animals|xphb"
+						],
+						"s4": [
+							"aura of life|xphb",
+							"dominate beast|xphb"
+						],
+						"s5": [
+							"awaken|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Wild Intuition",
+					"entries": [
+						"When you make an Intelligence ({@skill Nature|XPHB}) or Wisdom ({@skill Animal Handling|XPHB}) check, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Primal Connection",
+					"entries": [
+						"You always have the {@spell Animal Friendship|XPHB} and {@spell Speak with Animals|XPHB} spells prepared. You can cast each spell once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast these spells using any spell slots you have. Intelligence, Wisdom, or Charisma is your spellcasting ability for these spells (choose when you select this feat)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Monstrous Connections",
+					"entries": [
+						"When you reach character level 3, you can target a Monstrosity when you cast {@spell Animal Friendship|XPHB} or {@spell Speak with Animals|XPHB} if the creature's Intelligence score is 3 or lower."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Handling Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Handling Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Command|XPHB}, {@spell Find Familiar|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Beast Sense|XPHB}, {@spell Calm Emotions|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Beacon of Hope|XPHB}, {@spell Conjure Animals|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Aura of Life|XPHB}, {@spell Dominate Beast|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Awaken|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Healing",
+			"source": "EFA",
+			"page": 40,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"3": {
+							"daily": {
+								"1": [
+									"lesser restoration|xphb"
+								]
+							}
+						},
+						"_": {
+							"daily": {
+								"1": [
+									"cure wounds|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"false life|xphb",
+							"healing word|xphb"
+						],
+						"s2": [
+							"arcane vigor|xphb",
+							"prayer of healing|xphb"
+						],
+						"s3": [
+							"aura of vitality|xphb",
+							"mass healing word|xphb"
+						],
+						"s4": [
+							"aura of life|xphb",
+							"aura of purity|xphb"
+						],
+						"s5": [
+							"greater restoration|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Medical Intuition",
+					"entries": [
+						"When you make a Wisdom ({@skill Medicine|XPHB}) check or an ability check using a {@item Herbalism Kit|XPHB}, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Healing Touch",
+					"entries": [
+						"You always have the {@spell Cure Wounds|XPHB} spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast it using any spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for this spell (choose when you select this feat).",
+						"When you reach character level 3, you also always have the {@spell Lesser Restoration|XPHB} spell prepared and can cast it the same way."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Healing Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Healing Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell False Life|XPHB}, {@spell Healing Word|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Arcane Vigor|XPHB}, {@spell Prayer of Healing|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Aura of Vitality|XPHB}, {@spell Mass Healing Word|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Aura of Life|XPHB}, {@spell Aura of Purity|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Greater Restoration|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Hospitality",
+			"source": "EFA",
+			"page": 40,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"3": {
+							"daily": {
+								"1": [
+									"calm emotions|xphb"
+								]
+							}
+						},
+						"_": {
+							"daily": {
+								"1": [
+									"purify food and drink|xphb",
+									"unseen servant|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"goodberry|xphb",
+							"sleep|xphb"
+						],
+						"s2": [
+							"aid|xphb",
+							"enhance ability|xphb"
+						],
+						"s3": [
+							"create food and water|xphb",
+							"leomund's tiny hut|xphb"
+						],
+						"s4": [
+							"aura of purity|xphb",
+							"mordenkainen's private sanctum|xphb"
+						],
+						"s5": [
+							"hallow|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Ever Hospitable",
+					"entries": [
+						"When you make a Charisma ({@skill Persuasion|XPHB}) check or an ability check using {@item Brewer's Supplies|XPHB} or {@item Cook's Utensils|XPHB}, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Innkeeper's Magic",
+					"entries": [
+						"You always have the {@spell Purify Food and Drink|XPHB} and {@spell Unseen Servant|XPHB} spells prepared. You can cast each spell once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast these spells using any spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for these spells (choose when you select this feat).",
+						"When you reach character level 3, you also always have the {@spell Calm Emotions|XPHB} spell prepared and can cast it the same way."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Hospitality Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Hospitality Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Goodberry|XPHB}, {@spell Sleep|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Aid|XPHB}, {@spell Enhance Ability|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Create Food and Water|XPHB}, {@spell Leomund's Tiny Hut|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Aura of Purity|XPHB}, {@spell Mordenkainen's Private Sanctum|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Hallow|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Making",
+			"source": "EFA",
+			"page": 40,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"_": [
+							"mending|xphb#c"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"magic weapon|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"identify|xphb",
+							"tenser's floating disk|xphb"
+						],
+						"s2": [
+							"continual flame|xphb",
+							"spiritual weapon|xphb"
+						],
+						"s3": [
+							"conjure barrage|xphb",
+							"elemental weapon|xphb"
+						],
+						"s4": [
+							"fabricate|xphb",
+							"stone shape|xphb"
+						],
+						"s5": [
+							"creation|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Artisan's Intuition",
+					"entries": [
+						"When you make an Intelligence ({@skill Arcana|XPHB}) check or an ability check using {@item Artisan's Tools|XPHB}, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spellsmith",
+					"entries": [
+						"You know the {@spell Mending|XPHB} cantrip. You also always have the {@spell Magic Weapon|XPHB} spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast it using any spell slots you have. Intelligence, Wisdom, or Charisma is your spellcasting ability for these spells (choose when you select this feat)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Making Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Making Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Identify|XPHB}, {@spell Tenser's Floating Disk|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Continual Flame|XPHB}, {@spell Spiritual Weapon|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Conjure Barrage|XPHB}, {@spell Elemental Weapon|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Fabricate|XPHB}, {@spell Stone Shape|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Creation|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Passage",
+			"source": "EFA",
+			"page": 41,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"traitTags": [
+				"Speed"
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"misty step|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"expeditious retreat|xphb",
+							"jump|xphb"
+						],
+						"s2": [
+							"find steed|xphb",
+							"pass without trace|xphb"
+						],
+						"s3": [
+							"blink|xphb",
+							"phantom steed|xphb"
+						],
+						"s4": [
+							"dimension door|xphb",
+							"freedom of movement|xphb"
+						],
+						"s5": [
+							"teleportation circle|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Courier's Speed",
+					"entries": [
+						"Your {@variantrule Speed|XPHB} increases by 5 feet."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Intuitive Motion",
+					"entries": [
+						"When you make a Strength ({@skill Athletics|XPHB}) or Dexterity ({@skill Acrobatics|XPHB}) check, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Magical Passage",
+					"entries": [
+						"You always have the {@spell Misty Step|XPHB} spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast it using any spell slots you have. Intelligence, Wisdom, or Charisma is your spellcasting ability for this spell (choose when you select this feat)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Passage Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Passage Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Expeditious Retreat|XPHB}, {@spell Jump|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Find Steed|XPHB}, {@spell Pass without Trace|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Blink|XPHB}, {@spell Phantom Steed|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Dimension Door|XPHB}, {@spell Freedom of Movement|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Teleportation Circle|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Scribing",
+			"source": "EFA",
+			"page": 41,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"_": [
+							"message|xphb#c"
+						]
+					},
+					"prepared": {
+						"3": {
+							"daily": {
+								"1": [
+									"magic mouth|xphb"
+								]
+							}
+						},
+						"_": {
+							"daily": {
+								"1": [
+									"comprehend languages|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"command|xphb",
+							"illusory script|xphb"
+						],
+						"s2": [
+							"animal messenger|xphb",
+							"silence|xphb"
+						],
+						"s3": [
+							"sending|xphb",
+							"tongues|xphb"
+						],
+						"s4": [
+							"arcane eye|xphb",
+							"confusion|xphb"
+						],
+						"s5": [
+							"dream|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Gifted Scribe",
+					"entries": [
+						"When you make an Intelligence ({@skill History|XPHB}) check or an ability check using {@item Calligrapher's Supplies|XPHB}, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Scribe's Insight",
+					"entries": [
+						"You know the {@spell Message|XPHB} cantrip. You also always have the {@spell Comprehend Languages|XPHB} spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast it using any spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for this spell (choose when you select this feat).",
+						"When you reach character level 3, you also always have the {@spell Magic Mouth|XPHB} spell prepared and can cast it the same way."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Scribing Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Scribing Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Command|XPHB}, {@spell Illusory Script|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Animal Messenger|XPHB}, {@spell Silence|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Sending|XPHB}, {@spell Tongues|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Arcane Eye|XPHB}, {@spell Confusion|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Dream|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Sentinel",
+			"source": "EFA",
+			"page": 41,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"shield|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"compelled duel|xphb",
+							"shield of faith|xphb"
+						],
+						"s2": [
+							"warding bond|xphb",
+							"zone of truth|xphb"
+						],
+						"s3": [
+							"counterspell|xphb",
+							"protection from energy|xphb"
+						],
+						"s4": [
+							"death ward|xphb",
+							"guardian of faith|xphb"
+						],
+						"s5": [
+							"bigby's hand|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Sentinel's Intuition",
+					"entries": [
+						"When you make a Wisdom ({@skill Insight|XPHB} or {@skill Perception|XPHB}) check, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Guardian's Shield",
+					"entries": [
+						"You always have the {@spell Shield|XPHB} spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast it using any spell slots you have. Intelligence, Wisdom, or Charisma is your spellcasting ability for this spell (choose when you select this feat)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Vigilant Guardian",
+					"entries": [
+						"When a creature you can see within 5 feet of you is hit by an attack roll, you can take a {@variantrule Reaction|XPHB} to swap places with that creature, and you are hit by the attack instead. You can use this feature a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus} and regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Sentinel Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Sentinel Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Compelled Duel|XPHB}, {@spell Shield of Faith|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Warding Bond|XPHB}, {@spell Zone of Truth|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Counterspell|XPHB}, {@spell Protection from Energy|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Death Ward|XPHB}, {@spell Guardian of Faith|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Bigby's Hand|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Shadow",
+			"source": "EFA",
+			"page": 42,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"_": [
+							"minor illusion|xphb#c"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"invisibility|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"disguise self|xphb",
+							"silent image|xphb"
+						],
+						"s2": [
+							"darkness|xphb",
+							"pass without trace|xphb"
+						],
+						"s3": [
+							"clairvoyance|xphb",
+							"major image|xphb"
+						],
+						"s4": [
+							"greater invisibility|xphb",
+							"hallucinatory terrain|xphb"
+						],
+						"s5": [
+							"mislead|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Cunning Intuition",
+					"entries": [
+						"When you make a Dexterity ({@skill Stealth|XPHB}) or Charisma ({@skill Performance|XPHB}) check, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Shape Shadows",
+					"entries": [
+						"You know the {@spell Minor Illusion|XPHB} cantrip. You also always have the {@spell Invisibility|XPHB} spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast it using any spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for these spells (choose when you select this feat)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Shadow Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Shadow Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Disguise Self|XPHB}, {@spell Silent Image|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Darkness|XPHB}, {@spell Pass without Trace|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Clairvoyance|XPHB}, {@spell Major Image|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Greater Invisibility|XPHB}, {@spell Hallucinatory Terrain|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Mislead|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Storm",
+			"source": "EFA",
+			"page": 42,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"resist": [
+				"lightning"
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"_": [
+							"thunderclap|xphb#c"
+						]
+					},
+					"prepared": {
+						"3": {
+							"daily": {
+								"1": [
+									"gust of wind|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"feather fall|xphb",
+							"fog cloud|xphb"
+						],
+						"s2": [
+							"levitate|xphb",
+							"shatter|xphb"
+						],
+						"s3": [
+							"sleet storm|xphb",
+							"wind wall|xphb"
+						],
+						"s4": [
+							"conjure minor elementals|xphb",
+							"control water|xphb"
+						],
+						"s5": [
+							"conjure elemental|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Windwright's Intuition",
+					"entries": [
+						"When you make a Dexterity ({@skill Acrobatics|XPHB}) check or an ability check using {@item Navigator's Tools|XPHB}, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Storm's Boon",
+					"entries": [
+						"You have {@variantrule Resistance|XPHB} to Lightning damage."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Storm Magic",
+					"entries": [
+						"You know the {@spell Thunderclap|XPHB} cantrip. When you reach character level 3, you also always have the {@spell Gust of Wind|XPHB} spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast it using any spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for these spells (choose when you select this feat)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Storm Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Storm Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Feather Fall|XPHB}, {@spell Fog Cloud|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Levitate|XPHB}, {@spell Shatter|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Sleet Storm|XPHB}, {@spell Wind Wall|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Conjure Minor Elementals|XPHB}, {@spell Control Water|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Conjure Elemental|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Mark of Warding",
+			"source": "EFA",
+			"page": 42,
+			"category": "D",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Eberron"
+					],
+					"exclusiveFeatCategory": [
+						"D"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"3": {
+							"daily": {
+								"1": [
+									"arcane lock|xphb"
+								]
+							}
+						},
+						"_": {
+							"daily": {
+								"1": [
+									"alarm|xphb",
+									"mage armor|xphb"
+								]
+							}
+						}
+					},
+					"expanded": {
+						"s1": [
+							"armor of agathys|xphb",
+							"sanctuary|xphb"
+						],
+						"s2": [
+							"knock|xphb",
+							"nystul's magic aura|xphb"
+						],
+						"s3": [
+							"glyph of warding|xphb",
+							"magic circle|xphb"
+						],
+						"s4": [
+							"leomund's secret chest|xphb",
+							"mordenkainen's faithful hound|xphb"
+						],
+						"s5": [
+							"antilife shell|xphb"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Warder's Intuition",
+					"entries": [
+						"When you make an Intelligence ({@skill Investigation|XPHB}) check or an ability check using {@item Thieves' Tools|XPHB}, you can roll {@dice 1d4} and add the number rolled to the ability check."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Wards and Seals",
+					"entries": [
+						"You always have the {@spell Alarm|XPHB} and {@spell Mage Armor|XPHB} spells prepared. You can cast each spell once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}.",
+						"You can also cast these spells using any spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for these spells (choose when you select this feat).",
+						"When you reach character level 3, you also always have the {@spell Arcane Lock|XPHB} spell prepared and can cast it the same way."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells of the Mark",
+					"entries": [
+						"If you have the Spellcasting or Pact Magic class feature, the spells on the Mark of Warding Spells table are added to that feature's spell list.",
+						{
+							"type": "table",
+							"caption": "Mark of Warding Spells",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"Spell Level",
+								"Spells"
+							],
+							"rows": [
+								[
+									"1",
+									"{@spell Armor of Agathys|XPHB}, {@spell Sanctuary|XPHB}"
+								],
+								[
+									"2",
+									"{@spell Knock|XPHB}, {@spell Nystul's Magic Aura|XPHB}"
+								],
+								[
+									"3",
+									"{@spell Glyph of Warding|XPHB}, {@spell Magic Circle|XPHB}"
+								],
+								[
+									"4",
+									"{@spell Leomund's Secret Chest|XPHB}, {@spell Mordenkainen's Faithful Hound|XPHB}"
+								],
+								[
+									"5",
+									"{@spell Antilife Shell|XPHB}"
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluffImages": true
+		},
+		{
 			"name": "Martial Adept",
 			"source": "PHB",
 			"page": 168,
@@ -6227,11 +8945,50 @@
 			]
 		},
 		{
+			"name": "Mist Walker",
+			"source": "RHW",
+			"category": "DG",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Ravenloft"
+					]
+				}
+			],
+			"entries": [
+				"You know how to slip through the Mists' grasp, but this freedom comes at a price: If you remain in one area for too long, the Mists find you and drain your life force. You gain the following features.",
+				{
+					"type": "entries",
+					"name": "Domain Traveler",
+					"entries": [
+						"When you enter the Mists intent on reaching a specific domain, you are treated as if you possess a Mist talisman keyed to that domain. To use this feature, you must know the name of the domain you have chosen as your destination, but you don't need to have previously visited that land. This trait doesn't allow you to bypass domain borders closed by a Darklord's will."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Mist Walk",
+					"entries": [
+						"When you take damage or fail a saving throw to avoid or end the {@condition Grappled|XPHB} or {@condition Restrained|XPHB} condition, you can take a {@variantrule Reaction|XPHB} and teleport up to 15 feet to an unoccupied space you can see. You can use this feature a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Poisoned Roots",
+					"entries": [
+						"When you finish a {@variantrule Long Rest|XPHB}, the world around you in a 10-mile radius becomes a siphon that leeches away at your vitality. Whenever you finish a {@variantrule Short Rest|XPHB} in that area, make a Constitution saving throw (DC 13 plus your {@variantrule Proficiency|XPHB|Proficiency Bonus}). On a failed save, you get no benefits from finishing that rest."
+					]
+				}
+			]
+		},
+		{
 			"name": "Mobile",
 			"source": "PHB",
 			"page": 168,
 			"reprintedAs": [
 				"Speedy|XPHB"
+			],
+			"traitTags": [
+				"Speed"
 			],
 			"entries": [
 				"You are exceptionally speedy and agile. You gain the following benefits:",
@@ -6423,34 +9180,6 @@
 			]
 		},
 		{
-			"name": "Mystic Conflux",
-			"source": "TDCSR",
-			"page": 190,
-			"additionalSpells": [
-				{
-					"innate": {
-						"_": {
-							"daily": {
-								"1e": [
-									"identify"
-								]
-							}
-						}
-					}
-				}
-			],
-			"entries": [
-				"You possess an intuitive understanding of the way magic ebbs and flows within enchanted items. Such items attune easily to you, and you are able to sound out their secrets. You gain the following benefits:",
-				{
-					"type": "list",
-					"items": [
-						"You can attune to up to four magic items at once.",
-						"You can cast the {@spell identify} spell without expending a spell slot or material components. You must finish a {@quickref resting|PHB|2|0|long rest} before you can do so again."
-					]
-				}
-			]
-		},
-		{
 			"name": "Mythal Touched",
 			"source": "FRHoF",
 			"page": 40,
@@ -6476,7 +9205,7 @@
 					"type": "entries",
 					"name": "Mythal Ward",
 					"entries": [
-						"If a spell attack hits you or you fail a saving throw against a spell, you can take a {@variantrule Reaction|XPHB} to roll on the Mythal-Touched {@action Magic|XPHB} table to create a magical effect. If an effect requires a saving throw, the DC equals 8 plus the modifier of the ability increased by this feat and your {@variantrule Proficiency|XPHB|Proficiency Bonus}.",
+						"If a spell attack hits you or you fail a saving throw against a spell, you can take a {@variantrule Reaction|XPHB} to roll on the Mythal-Touched Magic table to create a magical effect. If an effect requires a saving throw, the DC equals 8 plus the modifier of the ability increased by this feat and your {@variantrule Proficiency|XPHB|Proficiency Bonus}.",
 						"You can use this benefit a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}.",
 						{
 							"type": "table",
@@ -7002,6 +9731,53 @@
 			]
 		},
 		{
+			"name": "Potent Dragonmark",
+			"source": "EFA",
+			"page": 45,
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"featCategory": [
+						"D"
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						],
+						"amount": 1,
+						"entry": "Increase the spellcasting ability score used by your Dragonmark feat by 1, to a maximum of 20."
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Dragonmark Preparation",
+					"entries": [
+						"You always have the spells on your Spells of the Mark list (if any) prepared."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Dragonmark Spellcasting",
+					"entries": [
+						"You have one extra spell slot to cast the spells granted by your Dragonmark feat. The spell slot's level is half your level (round up), to a maximum of level 5. You regain the expended slot when you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}. You can use this spell slot to cast only a spell you have prepared because of your Dragonmark feat or the Dragonmark Preparation benefit of this feat."
+					]
+				}
+			]
+		},
+		{
 			"name": "Prodigy",
 			"source": "XGE",
 			"page": 75,
@@ -7300,26 +10076,6 @@
 					"name": "Radiant Strike",
 					"entries": [
 						"When you make a damage roll that deals Radiant damage, you can cause one Huge or smaller creature taking the damage to have the {@condition Prone|XPHB} condition. Once you use this benefit, you can't use it again until you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}."
-					]
-				}
-			]
-		},
-		{
-			"name": "Remarkable Recovery",
-			"source": "TDCSR",
-			"page": 190,
-			"ability": [
-				{
-					"con": 1
-				}
-			],
-			"entries": [
-				"Your body has the ability to recover quickly from terrible injuries, and is unusually receptive to healing magic. You gain the following benefits:",
-				{
-					"type": "list",
-					"items": [
-						"When you are successfully stabilized while dying, you regain hit points equal to your Constitution modifier (minimum of 1).",
-						"Whenever you regain hit points as a result of a spell, potion, or class feature (but not this feat), you regain additional hit points equal to your Constitution modifier (minimum of 1)."
 					]
 				}
 			]
@@ -8059,6 +10815,95 @@
 			]
 		},
 		{
+			"name": "Second Skin",
+			"source": "RHW",
+			"category": "DG",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Ravenloft"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1": [
+									"alter self|xphb"
+								]
+							}
+						}
+					}
+				}
+			],
+			"entries": [
+				"There is another side of you that most people never see: a beast, a terrifying avenger, or a walking nightmare. You gain the following features.",
+				{
+					"type": "entries",
+					"name": "Alternate Form",
+					"entries": [
+						"You always have the {@spell Alter Self|XPHB} spell prepared. You can cast it without a spell slot or spell components, and you must finish a {@variantrule Long Rest|XPHB} before you can cast it in this way again. You can also cast it using spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for this spell (choose when you select this feat).",
+						"When you cast {@spell Alter Self|XPHB} without a spell slot using this feature, it doesn't require {@status Concentration|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Involuntary Change",
+					"entries": [
+						"Certain circumstances can involuntarily trigger your transformation. When you select this feat, roll on the Change Catalyst table to determine what triggers your change.",
+						"After you experience the catalyst, at the start of your next turn, make a Charisma saving throw (DC 13 plus your {@variantrule Proficiency|XPHB|Proficiency Bonus}). On a failed save, you immediately use Alternate Form to cast {@spell Alter Self|XPHB} without a spell slot. If you've already expended the use of that feature, you instead have the {@condition Stunned|XPHB} condition until the start of your next turn.",
+						{
+							"type": "table",
+							"caption": "Change Catalyst",
+							"colStyles": [
+								"col-2 text-center",
+								"col-10"
+							],
+							"colLabels": [
+								"1d6",
+								"Catalyst"
+							],
+							"rows": [
+								[
+									"1",
+									"Seeing a particular phase of the moon"
+								],
+								[
+									"2",
+									"Smelling the scent of a certain type of flower"
+								],
+								[
+									"3",
+									"Hearing temple bells ringing"
+								],
+								[
+									"4",
+									"Hearing a particular melody"
+								],
+								[
+									"5",
+									"Touching pure silver with your bare skin"
+								],
+								[
+									"6",
+									"Seeing someone who resembles a specific individual"
+								]
+							]
+						}
+					]
+				}
+			]
+		},
+		{
 			"name": "Sentinel",
 			"source": "PHB",
 			"page": 169,
@@ -8153,7 +10998,7 @@
 				}
 			],
 			"entries": [
-				"You are skilled in the creation of {@creature servo|psk|servos}\u2014tiny constructs that function as personal assistants. You can cast the {@spell find familiar} spell as a ritual, creating a {@creature servo|psk} to serve as your familiar instead of an animal. A {@creature servo|psk}'s statistics appear in the \"Artifact Creatures\" section of this document. In every other way, a servo familiar functions as described in the {@spell find familiar} spell.",
+				"You are skilled in the creation of {@creature servo|psk|servos}—tiny constructs that function as personal assistants. You can cast the {@spell find familiar} spell as a ritual, creating a {@creature servo|psk} to serve as your familiar instead of an animal. A {@creature servo|psk}'s statistics appear in the \"Artifact Creatures\" section of this document. In every other way, a servo familiar functions as described in the {@spell find familiar} spell.",
 				"You can communicate telepathically with your servo familiar and perceive through its senses as long as you are on the same plane of existence. You can speak through your servo in your own voice.",
 				"Additionally, when you take the {@action Attack} action, you can forgo one of your own attacks to allow your servo familiar to make one attack of its own."
 			],
@@ -8294,6 +11139,14 @@
 						"When a creature that you've cursed with {@spell Hex|XPHB} hits you with an attack roll, the creature takes Psychic damage equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}. A creature takes this damage only once per turn."
 					]
 				}
+			]
+		},
+		{
+			"name": "Sharp Eye",
+			"source": "RHW",
+			"category": "O",
+			"entries": [
+				"When you take the {@action Search|XPHB} or {@action Study|XPHB} action, you can give yourself {@variantrule Advantage|XPHB} on any ability check made as part of that action. You can use this feature a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}. If the check fails, the use of this feature isn't expended."
 			]
 		},
 		{
@@ -8580,7 +11433,7 @@
 				}
 			],
 			"entries": [
-				"You gain proficiency in any combination of three {@table Skill List; Skills|XPHB|skills} or {@filter tools|items|type=tool;artisan's tools;instrument;gaming set;vehicle (land);vehicle (water)} of your choice.",
+				"You gain proficiency in any combination of three {@table Skill List; Skills|XPHB|skills} or {@filter tools|items|type=tool;artisan's tools;instrument;gaming set} of your choice.",
 				{
 					"type": "entries",
 					"name": "Repeatable",
@@ -8809,6 +11662,9 @@
 					}
 				}
 			],
+			"traitTags": [
+				"Speed"
+			],
 			"entries": [
 				"You gain the following benefits.",
 				{
@@ -8980,29 +11836,6 @@
 			]
 		},
 		{
-			"name": "Spelldriver",
-			"source": "TDCSR",
-			"page": 190,
-			"prerequisite": [
-				{
-					"level": 11,
-					"spellcasting2020": true
-				}
-			],
-			"entries": [
-				"Through intense focus, training, and dedication, you've harnessed the techniques of rapid spellcasting.",
-				"When you use your bonus action to cast a spell of 1st level or higher, you can also use your action to cast another spell of 1st level or higher. However, if you cast two or more spells in a single turn, only one of them can be 3rd level or higher.",
-				{
-					"type": "inset",
-					"name": "Rules Tip: Casting Multiple Spells",
-					"page": 190,
-					"entries": [
-						"Normally, when you cast a spell as a bonus action, you can't use your action to also cast a spell that turn unless that spell is a cantrip\u2014{@note see {@book PHB p202|PHB|10|Bonus Action}.} The Spelldriver feat removes that restriction, but the focus necessary to channel multiple spells in the same round still limits the overall power of those spells."
-					]
-				}
-			]
-		},
-		{
 			"name": "Spellfire Adept",
 			"source": "FRHoF",
 			"page": 41,
@@ -9116,6 +11949,9 @@
 						"amount": 1
 					}
 				}
+			],
+			"traitTags": [
+				"Speed"
 			],
 			"skillProficiencies": [
 				{
@@ -9322,6 +12158,170 @@
 						"The saving throw DC for these effects equals 8 + your proficiency bonus + your Strength or Constitution modifier.",
 						"You can use this feat a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
 					]
+				}
+			],
+			"_versions": [
+				{
+					"name": "Strike of the Giants; Cloud",
+					"source": "BGG",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": {
+									"index": 0
+								},
+								"items": [
+									"You have absorbed primeval magic that gives you an echo of the might of giants. Once per turn, when you hit a target with a melee weapon attack or a ranged weapon attack using a thrown weapon, you can imbue the attack with an additional effect:"
+								]
+							},
+							{
+								"mode": "removeArr",
+								"names": [
+									"Fire Strike",
+									"Frost Strike",
+									"Hill Strike",
+									"Stone Strike",
+									"Storm Strike"
+								]
+							}
+						]
+					}
+				},
+				{
+					"name": "Strike of the Giants; Fire",
+					"source": "BGG",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": {
+									"index": 0
+								},
+								"items": [
+									"You have absorbed primeval magic that gives you an echo of the might of giants. Once per turn, when you hit a target with a melee weapon attack or a ranged weapon attack using a thrown weapon, you can imbue the attack with an additional effect:"
+								]
+							},
+							{
+								"mode": "removeArr",
+								"names": [
+									"Cloud Strike",
+									"Frost Strike",
+									"Hill Strike",
+									"Stone Strike",
+									"Storm Strike"
+								]
+							}
+						]
+					}
+				},
+				{
+					"name": "Strike of the Giants; Frost",
+					"source": "BGG",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": {
+									"index": 0
+								},
+								"items": [
+									"You have absorbed primeval magic that gives you an echo of the might of giants. Once per turn, when you hit a target with a melee weapon attack or a ranged weapon attack using a thrown weapon, you can imbue the attack with an additional effect:"
+								]
+							},
+							{
+								"mode": "removeArr",
+								"names": [
+									"Cloud Strike",
+									"Fire Strike",
+									"Hill Strike",
+									"Stone Strike",
+									"Storm Strike"
+								]
+							}
+						]
+					}
+				},
+				{
+					"name": "Strike of the Giants; Hill",
+					"source": "BGG",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": {
+									"index": 0
+								},
+								"items": [
+									"You have absorbed primeval magic that gives you an echo of the might of giants. Once per turn, when you hit a target with a melee weapon attack or a ranged weapon attack using a thrown weapon, you can imbue the attack with an additional effect:"
+								]
+							},
+							{
+								"mode": "removeArr",
+								"names": [
+									"Cloud Strike",
+									"Fire Strike",
+									"Frost Strike",
+									"Stone Strike",
+									"Storm Strike"
+								]
+							}
+						]
+					}
+				},
+				{
+					"name": "Strike of the Giants; Stone",
+					"source": "BGG",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": {
+									"index": 0
+								},
+								"items": [
+									"You have absorbed primeval magic that gives you an echo of the might of giants. Once per turn, when you hit a target with a melee weapon attack or a ranged weapon attack using a thrown weapon, you can imbue the attack with an additional effect:"
+								]
+							},
+							{
+								"mode": "removeArr",
+								"names": [
+									"Cloud Strike",
+									"Fire Strike",
+									"Frost Strike",
+									"Hill Strike",
+									"Storm Strike"
+								]
+							}
+						]
+					}
+				},
+				{
+					"name": "Strike of the Giants; Storm",
+					"source": "BGG",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": {
+									"index": 0
+								},
+								"items": [
+									"You have absorbed primeval magic that gives you an echo of the might of giants. Once per turn, when you hit a target with a melee weapon attack or a ranged weapon attack using a thrown weapon, you can imbue the attack with an additional effect:"
+								]
+							},
+							{
+								"mode": "removeArr",
+								"names": [
+									"Cloud Strike",
+									"Fire Strike",
+									"Frost Strike",
+									"Hill Strike",
+									"Stone Strike"
+								]
+							}
+						]
+					}
 				}
 			]
 		},
@@ -9820,6 +12820,29 @@
 			]
 		},
 		{
+			"name": "Survivor",
+			"source": "RHW",
+			"category": "O",
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Hypervigilance",
+					"entries": [
+						"Whenever you roll {@variantrule Initiative|XPHB}, you can reroll the {@dice d20} if the number rolled is 9 or lower. You must use the new roll."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Steel Yourself",
+					"entries": [
+						"When you fail a saving throw to avoid or end the {@condition Charmed|XPHB} or {@condition Frightened|XPHB} condition, you can take a {@variantrule Reaction|XPHB} to add a bonus to the roll, potentially causing it to succeed. The bonus is equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}.",
+						"Once you take this {@variantrule Reaction|XPHB}, you can't do so again until you finish a {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
 			"name": "Svirfneblin Magic",
 			"source": "MTF",
 			"page": 114,
@@ -9865,6 +12888,74 @@
 			"entries": [
 				"You have inherited the innate spellcasting ability of your ancestors. This ability allows you to cast {@spell nondetection} on yourself at will, without needing a material component. You can also cast each of the following spells once with this ability: {@spell blindness/deafness}, {@spell blur}, and {@spell disguise self}. You regain the ability to cast these spells when you finish a long rest.",
 				"Intelligence is your spellcasting ability for these spells, and you cast them at their lowest possible levels."
+			]
+		},
+		{
+			"name": "Symbiotic Being",
+			"source": "RHW",
+			"category": "DG",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Ravenloft"
+					]
+				}
+			],
+			"skillProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"arcana",
+							"deception",
+							"history",
+							"intimidation",
+							"insight",
+							"investigation",
+							"nature",
+							"religion",
+							"perception",
+							"persuasion"
+						]
+					}
+				}
+			],
+			"languageProficiencies": [
+				{
+					"any": 1
+				}
+			],
+			"entries": [
+				"A second being resides within your body, offering knowledge and assistance while furthering its own agenda. You gain the following features.",
+				{
+					"type": "entries",
+					"name": "Entwined Existence",
+					"entries": [
+						"The symbiote can't be targeted. If you die, so does your symbiote. If you are returned to life, your symbiote also revives."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Second Mind",
+					"entries": [
+						"You gain proficiency in one of the following skills: {@skill Arcana|XPHB}, {@skill Deception|XPHB}, {@skill History|XPHB}, {@skill Intimidation|XPHB}, {@skill Insight|XPHB}, {@skill Investigation|XPHB}, {@skill Nature|XPHB}, {@skill Religion|XPHB}, {@skill Perception|XPHB}, or {@skill Persuasion|XPHB}. You also know one additional language of your choice, chosen from the language tables in the Player's Handbook."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Sustained Symbiosis",
+					"entries": [
+						"When you fail a saving throw, you can take a {@variantrule Reaction|XPHB} and expend one of your Hit Dice. Roll the die and add the number rolled to the saving throw, potentially turning the failure into a success.",
+						"You can use this feature a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Symbiotic Agenda",
+					"entries": [
+						"Immediately after you make a {@variantrule D20 Test|XPHB} and roll a 1 on the {@dice d20}, your symbiote attempts to assert control. Make a Charisma saving throw (DC 13 plus your {@variantrule Proficiency|XPHB|Proficiency Bonus}). On a failed save, you have the {@condition Charmed|XPHB} condition for {@dice 1d12} hours. While {@condition Charmed|XPHB}, you must try to follow the symbiote's commands and further its goals, as determined by the DM. Whenever you take damage, you can repeat this save, ending the effect on a success.",
+						"At the DM's discretion, you might make this saving throw whenever you act contrary to the symbiote's agenda."
+					]
+				}
 			]
 		},
 		{
@@ -10127,33 +13218,6 @@
 			]
 		},
 		{
-			"name": "Thrown Arms Master",
-			"source": "TDCSR",
-			"page": 191,
-			"ability": [
-				{
-					"choose": {
-						"from": [
-							"str",
-							"dex"
-						],
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"You've honed your ability to lob weaponry into the fray, including weapons not meant for ranged combat. You gain the following benefits:",
-				{
-					"type": "list",
-					"items": [
-						"Simple and martial melee weapons without the thrown property have the {@itemProperty T|PHB|thrown} property for you. One-handed weapons have a normal range of 20 feet and a long range of 60 feet, while two-handed weapons have a normal range of 15 feet and a long range of 30 feet.",
-						"Weapons that already have the {@itemProperty T|PHB|thrown} property increase their short range by 20 feet and their long range by 40 feet for you.",
-						"When you miss with a thrown weapon attack using a light weapon, the weapon returns to your grasp like a boomerang at the end of your turn, unless something prevents it from returning. You can catch and stow as many weapons as you threw in this way."
-					]
-				}
-			]
-		},
-		{
 			"name": "Thrown Weapon Fighting",
 			"source": "XPHB",
 			"page": 210,
@@ -10176,6 +13240,51 @@
 			"category": "O",
 			"entries": [
 				"When an ally you can see within 60 feet of yourself expends {@variantrule Heroic Inspiration|XPHB}, you can gain {@variantrule Heroic Inspiration|XPHB} if you lack it. You can use this benefit a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}."
+			]
+		},
+		{
+			"name": "Touch of Death",
+			"source": "RHW",
+			"category": "DG",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Ravenloft"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"_": [
+							"chill touch|xphb#c"
+						]
+					}
+				}
+			],
+			"entries": [
+				"Deathly power resides within you, bursting out at the slightest provocation. You gain the following features.",
+				{
+					"type": "entries",
+					"name": "Death Touch",
+					"entries": [
+						"You learn the {@spell Chill Touch|XPHB} spell and can cast it without spell components. Necrotic damage you deal with this spell ignores {@variantrule Resistance|XPHB}. Intelligence, Wisdom, or Charisma is your spellcasting ability for this spell (choose when you select this feat)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Pull of the Grave",
+					"entries": [
+						"You have {@variantrule Disadvantage|XPHB} on {@variantrule Death Saving Throw|XPHB|Death Saving Throws}."
+					]
+				}
 			]
 		},
 		{
@@ -10468,24 +13577,6 @@
 			]
 		},
 		{
-			"name": "Vital Sacrifice",
-			"source": "TDCSR",
-			"page": 191,
-			"entries": [
-				"You've learned secrets of {@variantrule hemocraft|TDCSR} that grant you esoteric power at the price of your own life force. As a bonus action, you can choose to take {@damage 1d6} necrotic damage to gain a blood boon. Your blood boon lasts for 1 hour or until expended.",
-				"You can expend this blood boon to gain one of the following benefits:",
-				{
-					"type": "list",
-					"items": [
-						"When you make an attack roll, you roll {@dice 1d6} and add it to the total.",
-						"When you hit with an attack or spell, you deal an additional {@damage 2d6} necrotic damage.",
-						"When you cause a creature to make a Strength, Dexterity, or Constitution {@quickref saving throws|PHB|2|1|saving throw}, roll a {@dice d4} and reduce their save by the amount rolled."
-					]
-				},
-				"The damage you take to gain a blood boon can't be reduced in any way."
-			]
-		},
-		{
 			"name": "War Caster",
 			"source": "PHB",
 			"page": 170,
@@ -10555,6 +13646,65 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Watchers",
+			"source": "RHW",
+			"category": "DG",
+			"prerequisite": [
+				{
+					"campaign": [
+						"Ravenloft"
+					]
+				}
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1e": [
+									"beast sense|xphb",
+									"speak with animals|xphb"
+								]
+							}
+						}
+					}
+				}
+			],
+			"entries": [
+				"Something unnatural is always watching you, taking the form of scurrying vermin and other eerie creatures. You gain the following features.",
+				{
+					"type": "entries",
+					"name": "Borrowed Eyes",
+					"entries": [
+						"You always have the {@spell Beast Sense|XPHB} and {@spell Speak with Animals|XPHB} spells prepared. You can cast each spell without a spell slot, and you must finish a {@variantrule Long Rest|XPHB} before you can cast it in this way again. You can also cast these spells using spell slots you have of the appropriate level."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Heightened Suspicion",
+					"entries": [
+						"Whenever you take the {@action Search|XPHB} action, you can roll {@dice 1d4} and add the number rolled to any ability check made as part of that action."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Incessant Watchers",
+					"entries": [
+						"You have {@variantrule Disadvantage|XPHB} on saving throws made against the {@spell Scrying|XPHB} spell.",
+						"In addition, immediately after you make a {@variantrule D20 Test|XPHB} and roll a 1 on the {@dice d20}, paranoia threatens to overwhelm you. Make a Wisdom saving throw (DC 13 plus your {@variantrule Proficiency|XPHB|Proficiency Bonus}). On a failed save, you have {@variantrule Disadvantage|XPHB} on {@variantrule D20 Test|XPHB|D20 Tests} for 1 minute. You can repeat the save at the end of each of your turns, ending the effect early on a success."
+					]
+				}
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Weapon Master",
@@ -10726,6 +13876,163 @@
 						"When you finish a {@variantrule Long Rest|XPHB}, choose a skill in which you have proficiency. You have {@variantrule Expertise|XPHB} in that skill until you finish your next {@variantrule Long Rest|XPHB}."
 					]
 				}
+			]
+		},
+		{
+			"name": "Cruel",
+			"source": "TDCSR",
+			"page": 190,
+			"entries": [
+				"The challenges and struggles you've faced throughout your life have led you to delight in inflicting pain and anguish upon others. You gain a number of cruelty dice equal to your proficiency bonus. Your cruelty dice are {@dice d6|d6s}. You can roll only one cruelty die per turn, and a cruelty die is spent when you roll it.",
+				"You can roll a cruelty die under any of the following circumstances, with the indicated result:",
+				{
+					"type": "list",
+					"items": [
+						"When you deal damage to a creature, spend one cruelty die to deal extra damage to the creature equal to the roll.",
+						"When you score a critical hit, spend one cruelty die to gain temporary hit points equal to the roll.",
+						"When you make a Charisma ({@skill Intimidation}) check, spend one cruelty die and add the roll to your check."
+					]
+				},
+				"You regain all spent cruelty dice when you finish a {@quickref resting|PHB|2|0|long rest}."
+			]
+		},
+		{
+			"name": "Flash Recall",
+			"source": "TDCSR",
+			"page": 190,
+			"prerequisite": [
+				{
+					"spellcastingPrepared": true
+				}
+			],
+			"entries": [
+				"You've developed the ability to instantly recall an unprepared spell in moments of sudden necessity.",
+				"As a bonus action, you prepare a spell of 1st level or higher from your spellbook (if you're a {@class wizard}) or from your class spell list (if you're not a {@class wizard}). This spell must be of a level for which you have spell slots, and it replaces another spell of an equal or higher level that you had previously prepared.",
+				"Once you use this feat to recall a spell, you can't do so again until you complete a {@quickref resting|PHB|2|0|short or long rest}.",
+				{
+					"type": "inset",
+					"name": "Rules Tip: Prepared Spells",
+					"page": 190,
+					"entries": [
+						"The Flash Recall feat requires you to be a spellcaster who prepares spells. This includes classes such as {@class cleric||clerics}, {@class druid||druids}, and {@class paladin||paladins}, who prepare spells each day from their class list, and {@class wizard||wizards}, who prepare spells from a spellbook. Classes such as {@class bard||bards} and {@class sorcerer||sorcerers}, who inherently know their spells rather than preparing them, can't benefit from this feat."
+					]
+				}
+			]
+		},
+		{
+			"name": "Mystic Conflux",
+			"source": "TDCSR",
+			"page": 190,
+			"additionalSpells": [
+				{
+					"innate": {
+						"_": {
+							"daily": {
+								"1e": [
+									"identify"
+								]
+							}
+						}
+					}
+				}
+			],
+			"entries": [
+				"You possess an intuitive understanding of the way magic ebbs and flows within enchanted items. Such items attune easily to you, and you are able to sound out their secrets. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You can attune to up to four magic items at once.",
+						"You can cast the {@spell identify} spell without expending a spell slot or material components. You must finish a {@quickref resting|PHB|2|0|long rest} before you can do so again."
+					]
+				}
+			]
+		},
+		{
+			"name": "Remarkable Recovery",
+			"source": "TDCSR",
+			"page": 190,
+			"ability": [
+				{
+					"con": 1
+				}
+			],
+			"entries": [
+				"Your body has the ability to recover quickly from terrible injuries, and is unusually receptive to healing magic. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"When you are successfully stabilized while dying, you regain hit points equal to your Constitution modifier (minimum of 1).",
+						"Whenever you regain hit points as a result of a spell, potion, or class feature (but not this feat), you regain additional hit points equal to your Constitution modifier (minimum of 1)."
+					]
+				}
+			]
+		},
+		{
+			"name": "Spelldriver",
+			"source": "TDCSR",
+			"page": 190,
+			"prerequisite": [
+				{
+					"level": 11,
+					"spellcasting2020": true
+				}
+			],
+			"entries": [
+				"Through intense focus, training, and dedication, you've harnessed the techniques of rapid spellcasting.",
+				"When you use your bonus action to cast a spell of 1st level or higher, you can also use your action to cast another spell of 1st level or higher. However, if you cast two or more spells in a single turn, only one of them can be 3rd level or higher.",
+				{
+					"type": "inset",
+					"name": "Rules Tip: Casting Multiple Spells",
+					"page": 190,
+					"entries": [
+						"Normally, when you cast a spell as a bonus action, you can't use your action to also cast a spell that turn unless that spell is a cantrip—{@note see {@book PHB p202|PHB|10|Bonus Action}.} The Spelldriver feat removes that restriction, but the focus necessary to channel multiple spells in the same round still limits the overall power of those spells."
+					]
+				}
+			]
+		},
+		{
+			"name": "Thrown Arms Master",
+			"source": "TDCSR",
+			"page": 191,
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex"
+						],
+						"amount": 1
+					}
+				}
+			],
+			"entries": [
+				"You've honed your ability to lob weaponry into the fray, including weapons not meant for ranged combat. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"Simple and martial melee weapons without the thrown property have the {@itemProperty T|PHB|thrown} property for you. One-handed weapons have a normal range of 20 feet and a long range of 60 feet, while two-handed weapons have a normal range of 15 feet and a long range of 30 feet.",
+						"Weapons that already have the {@itemProperty T|PHB|thrown} property increase their short range by 20 feet and their long range by 40 feet for you.",
+						"When you miss with a thrown weapon attack using a light weapon, the weapon returns to your grasp like a boomerang at the end of your turn, unless something prevents it from returning. You can catch and stow as many weapons as you threw in this way."
+					]
+				}
+			]
+		},
+		{
+			"name": "Vital Sacrifice",
+			"source": "TDCSR",
+			"page": 191,
+			"entries": [
+				"You've learned secrets of {@variantrule hemocraft|TDCSR} that grant you esoteric power at the price of your own life force. As a bonus action, you can choose to take {@damage 1d6} necrotic damage to gain a blood boon. Your blood boon lasts for 1 hour or until expended.",
+				"You can expend this blood boon to gain one of the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"When you make an attack roll, you roll {@dice 1d6} and add it to the total.",
+						"When you hit with an attack or spell, you deal an additional {@damage 2d6} necrotic damage.",
+						"When you cause a creature to make a Strength, Dexterity, or Constitution {@quickref saving throws|PHB|2|1|saving throw}, roll a {@dice d4} and reduce their save by the amount rolled."
+					]
+				},
+				"The damage you take to gain a blood boon can't be reduced in any way."
 			]
 		}
 	]

--- a/json/items-base.json
+++ b/json/items-base.json
@@ -18,14 +18,17 @@
 				}
 			],
 			"referenceSources": [
-				"TTP",
-				"WDMM",
-				"OoW",
 				"IMR",
-				"SCC-ARiR",
 				"JttRC",
 				"KftGV",
-				"PaBTSO"
+				"OoW",
+				"PaBTSO",
+				"RtG",
+				"SCC-ARiR",
+				"TftYP-TSC",
+				"ToA",
+				"TTP",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Alchemist's Supplies|XPHB"
@@ -205,6 +208,9 @@
 			"page": 150,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"ToA"
+			],
 			"reprintedAs": [
 				"Arrow|XPHB"
 			],
@@ -237,6 +243,12 @@
 			"page": 150,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CRCotN",
+				"DitLCoT",
+				"IDRotF",
+				"TftYP-TSC"
+			],
 			"reprintedAs": [
 				"Arrows (20)|XPHB"
 			],
@@ -258,6 +270,9 @@
 			"source": "XPHB",
 			"page": 222,
 			"srd52": true,
+			"referenceSources": [
+				"DrDe-TWoO"
+			],
 			"edition": "one",
 			"type": "A|XPHB",
 			"rarity": "none",
@@ -611,7 +626,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"PaBTSO"
+				"PaBTSO",
+				"QftIS",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Breastplate|XPHB"
@@ -737,7 +754,8 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
-				"DrDe-TDoN"
+				"DrDe-TDoN",
+				"DrDe-TFV"
 			],
 			"type": "AT|XPHB",
 			"rarity": "none",
@@ -787,9 +805,11 @@
 			],
 			"referenceSources": [
 				"BGDIA",
-				"IMR",
 				"CM",
+				"IMR",
 				"KftGV",
+				"PaBTSO",
+				"SCC-HfMT",
 				"ToFW"
 			],
 			"reprintedAs": [
@@ -912,6 +932,9 @@
 					"source": "XGE",
 					"page": 80
 				}
+			],
+			"referenceSources": [
+				"OoW"
 			],
 			"reprintedAs": [
 				"Carpenter's Tools|XPHB"
@@ -1056,8 +1079,10 @@
 				}
 			],
 			"referenceSources": [
-				"ToA",
-				"PaBTSO"
+				"DoSI",
+				"KftGV",
+				"PaBTSO",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Cartographer's Tools|XPHB"
@@ -1183,12 +1208,13 @@
 			"basicRules": true,
 			"referenceSources": [
 				"CoS",
-				"SCC-ARiR",
 				"CRCotN",
 				"DSotDQ",
+				"GoS",
 				"PaBTSO",
-				"VEoR",
-				"QftIS"
+				"QftIS",
+				"SCC-ARiR",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Chain Mail|XPHB"
@@ -1230,7 +1256,10 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-TSC"
+				"CM",
+				"CoS",
+				"TftYP-TSC",
+				"US"
 			],
 			"reprintedAs": [
 				"Chain Shirt|XPHB"
@@ -1279,9 +1308,10 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"WDH",
 				"GoS",
-				"KftGV"
+				"KftGV",
+				"TftYP-AtG",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Club|XPHB"
@@ -1604,7 +1634,15 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"CoS"
+				"CM",
+				"CoS",
+				"CRCotN",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"PaBTSO",
+				"SCC-ARiR",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Bolts (20)|XPHB"
@@ -1663,12 +1701,19 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"DoSI",
+				"DSotDQ",
 				"GoS",
 				"IDRotF",
-				"CM",
 				"JttRC",
-				"DSotDQ",
-				"QftIS"
+				"PaBTSO",
+				"QftIS",
+				"TftYP-TSC",
+				"ToFW",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Dagger|XPHB"
@@ -1697,8 +1742,8 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
-				"DrDe-TWoO",
-				"DrDe-TFV"
+				"DrDe-TFV",
+				"DrDe-TWoO"
 			],
 			"edition": "one",
 			"type": "M|XPHB",
@@ -1727,6 +1772,9 @@
 			"page": 149,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM"
+			],
 			"reprintedAs": [
 				"Dart|XPHB"
 			],
@@ -1805,7 +1853,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"JttRC"
+				"JttRC",
+				"RtG"
 			],
 			"reprintedAs": [
 				"Drum|XPHB"
@@ -1910,6 +1959,7 @@
 			"source": "DMG",
 			"page": 268,
 			"referenceSources": [
+				"IDRotF",
 				"QftIS"
 			],
 			"reprintedAs": [
@@ -1985,6 +2035,10 @@
 			"page": 149,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoS",
+				"TftYP-AtG"
+			],
 			"reprintedAs": [
 				"Flail|XPHB"
 			],
@@ -2024,6 +2078,10 @@
 			"page": 154,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"RtG",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Flute|XPHB"
 			],
@@ -2077,7 +2135,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"GoS"
+				"GoS",
+				"SCC-ARiR"
 			],
 			"reprintedAs": [
 				"Glaive|XPHB"
@@ -2135,6 +2194,9 @@
 					"source": "XGE",
 					"page": 82
 				}
+			],
+			"referenceSources": [
+				"IMR"
 			],
 			"reprintedAs": [
 				"Glassblower's Tools|XPHB"
@@ -2203,6 +2265,9 @@
 			"page": 220,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"type": "AT|XPHB",
 			"rarity": "none",
 			"weight": 5,
@@ -2254,9 +2319,11 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-AtG",
+				"IDRotF",
+				"PaBTSO",
 				"RMBRE",
-				"PaBTSO"
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Greataxe|XPHB"
@@ -2357,6 +2424,10 @@
 			"page": 149,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"PaBTSO",
+				"TftYP-TSC"
+			],
 			"reprintedAs": [
 				"Greatsword|XPHB"
 			],
@@ -2463,6 +2534,7 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"LoX",
 				"ToA"
 			],
 			"reprintedAs": [
@@ -2503,7 +2575,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"CoS"
+				"CM",
+				"CoS",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Hand Crossbow|XPHB"
@@ -2573,6 +2647,9 @@
 			"page": 149,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"TftYP-TFoF"
+			],
 			"reprintedAs": [
 				"Handaxe|XPHB"
 			],
@@ -2625,9 +2702,13 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CM",
 				"CoS",
-				"TTP",
-				"SCC-ARiR"
+				"IDRotF",
+				"KftGV",
+				"PaBTSO",
+				"SCC-ARiR",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Heavy Crossbow|XPHB"
@@ -2686,6 +2767,9 @@
 			"page": 144,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Hide Armor|XPHB"
 			],
@@ -2877,9 +2961,10 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"DSotDQ",
 				"GoS",
 				"IDRotF",
-				"DSotDQ"
+				"TftYP-TSC"
 			],
 			"reprintedAs": [
 				"Javelin|XPHB"
@@ -2938,7 +3023,8 @@
 			],
 			"referenceSources": [
 				"IMR",
-				"PaBTSO"
+				"PaBTSO",
+				"RtG"
 			],
 			"reprintedAs": [
 				"Jeweler's Tools|XPHB"
@@ -3227,6 +3313,10 @@
 			"page": 144,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"DSotDQ",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Leather Armor|XPHB"
 			],
@@ -3269,8 +3359,9 @@
 				}
 			],
 			"referenceSources": [
+				"KftGV",
 				"RtG",
-				"KftGV"
+				"ToA"
 			],
 			"reprintedAs": [
 				"Leatherworker's Tools|XPHB"
@@ -3380,8 +3471,13 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CoS",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"PaBTSO",
 				"TftYP-AtG",
-				"KftGV"
+				"US"
 			],
 			"reprintedAs": [
 				"Light Crossbow|XPHB"
@@ -3514,6 +3610,12 @@
 			"page": 149,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"IDRotF",
+				"LK",
+				"TftYP-TSC",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Longbow|XPHB"
 			],
@@ -3580,16 +3682,22 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"CoS",
-				"WDH",
-				"GoS",
-				"RMBRE",
-				"US",
 				"CM",
-				"LoX",
+				"CoS",
 				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"LK",
+				"LoX",
 				"PaBTSO",
-				"VEoR"
+				"QftIS",
+				"RMBRE",
+				"TftYP-TSC",
+				"US",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Longsword|XPHB"
@@ -3644,13 +3752,13 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"DoSI",
+				"JttRC",
+				"LRDT",
+				"RtG",
 				"TftYP-ToH",
 				"ToA",
-				"TTP",
-				"RtG",
-				"JttRC",
-				"DoSI",
-				"LRDT"
+				"TTP"
 			],
 			"reprintedAs": [
 				"Lute|XPHB"
@@ -3705,7 +3813,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"RtG"
+				"RtG",
+				"ToA",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Lyre|XPHB"
@@ -3757,7 +3867,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"QftIS"
+				"QftIS",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Mace|XPHB"
@@ -3807,12 +3918,14 @@
 				}
 			],
 			"referenceSources": [
+				"CRCotN",
+				"DSotDQ",
 				"GoS",
 				"IMR",
+				"PaBTSO",
 				"RtG",
 				"SCC-ARiR",
-				"CRCotN",
-				"PaBTSO"
+				"ToA"
 			],
 			"reprintedAs": [
 				"Mason's Tools|XPHB"
@@ -3889,7 +4002,8 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
-				"DrDe-TDoN"
+				"DrDe-TDoN",
+				"DrDe-TFV"
 			],
 			"type": "AT|XPHB",
 			"rarity": "none",
@@ -3932,7 +4046,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"RMBRE"
+				"RMBRE",
+				"SCC-ARiR"
 			],
 			"reprintedAs": [
 				"Maul|XPHB"
@@ -3984,6 +4099,9 @@
 			"name": "Modern Bullet",
 			"source": "DMG",
 			"page": 268,
+			"referenceSources": [
+				"WDMM"
+			],
 			"edition": "classic",
 			"type": "AF|DMG",
 			"rarity": "none",
@@ -4021,7 +4139,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"GoS"
+				"CoS",
+				"GoS",
+				"PaBTSO"
 			],
 			"reprintedAs": [
 				"Morningstar|XPHB"
@@ -4062,6 +4182,10 @@
 			"name": "Musket",
 			"source": "DMG",
 			"page": 268,
+			"referenceSources": [
+				"CoS",
+				"LoX"
+			],
 			"reprintedAs": [
 				"Musket|XPHB"
 			],
@@ -4157,7 +4281,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"ToA"
+				"ToA",
+				"TTP"
 			],
 			"reprintedAs": [
 				{
@@ -4436,6 +4561,10 @@
 			"page": 149,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"IDRotF",
+				"KftGV"
+			],
 			"reprintedAs": [
 				"Pike|XPHB"
 			],
@@ -4483,6 +4612,10 @@
 			"name": "Pistol",
 			"source": "DMG",
 			"page": 268,
+			"referenceSources": [
+				"HoL",
+				"LoX"
+			],
 			"reprintedAs": [
 				"Pistol|XPHB"
 			],
@@ -4538,12 +4671,12 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-AtG",
-				"GoS",
 				"BGDIA",
-				"US",
+				"GoS",
 				"PaBTSO",
-				"QftIS"
+				"QftIS",
+				"TftYP-AtG",
+				"US"
 			],
 			"reprintedAs": [
 				"Plate Armor|XPHB"
@@ -4705,6 +4838,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CM",
+				"PaBTSO",
 				"TTP",
 				"WDH"
 			],
@@ -4756,8 +4891,11 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CM",
 				"CoS",
-				"DitLCoT"
+				"DitLCoT",
+				"QftIS",
+				"US"
 			],
 			"reprintedAs": [
 				"Rapier|XPHB"
@@ -4982,9 +5120,10 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CM",
+				"DSotDQ",
 				"TftYP-TFoF",
-				"TTP",
-				"CM"
+				"TTP"
 			],
 			"reprintedAs": [
 				"Scale Mail|XPHB"
@@ -5027,9 +5166,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-TSC",
+				"KftGV",
 				"RMBRE",
-				"KftGV"
+				"TftYP-TSC"
 			],
 			"reprintedAs": [
 				"Scimitar|XPHB"
@@ -5173,12 +5312,17 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-AtG",
-				"TTP",
-				"WDH",
+				"BGDIA",
+				"CRCotN",
 				"GoS",
+				"QftIS",
+				"TftYP-AtG",
+				"TftYP-TSC",
+				"TTP",
+				"US",
+				"VEoR",
 				"WBtW",
-				"VEoR"
+				"WDH"
 			],
 			"reprintedAs": [
 				"Shield|XPHB"
@@ -5217,6 +5361,10 @@
 			"page": 149,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CRCotN",
+				"TftYP-TSC"
+			],
 			"reprintedAs": [
 				"Shortbow|XPHB"
 			],
@@ -5243,6 +5391,9 @@
 			"page": 215,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TWoO"
+			],
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -5271,11 +5422,14 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"CoS",
-				"US",
 				"CM",
+				"CoS",
+				"IDRotF",
 				"KftGV",
-				"PaBTSO"
+				"PaBTSO",
+				"US",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Shortsword|XPHB"
@@ -5302,8 +5456,8 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
-				"DrDe-TWoO",
-				"DrDe-SD"
+				"DrDe-SD",
+				"DrDe-TWoO"
 			],
 			"edition": "one",
 			"type": "M|XPHB",
@@ -5476,7 +5630,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"DoSI"
+				"DoSI",
+				"IDRotF"
 			],
 			"reprintedAs": [
 				"Sling Bullet|XPHB"
@@ -5561,13 +5716,14 @@
 				}
 			],
 			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"IDRotF",
+				"KftGV",
+				"QftIS",
 				"ToA",
 				"TTP",
-				"WDH",
-				"BGDIA",
-				"IDRotF",
-				"CM",
-				"KftGV"
+				"WDH"
 			],
 			"reprintedAs": [
 				"Smith's Tools|XPHB"
@@ -5691,14 +5847,16 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-TSC",
-				"TftYP-AtG",
-				"GoS",
-				"SCC-ARiR",
+				"CRCotN",
 				"DSotDQ",
-				"PaBTSO",
+				"GoS",
 				"LK",
-				"QftIS"
+				"PaBTSO",
+				"QftIS",
+				"SCC-ARiR",
+				"TftYP-AtG",
+				"TftYP-TSC",
+				"US"
 			],
 			"reprintedAs": [
 				"Spear|XPHB"
@@ -5772,8 +5930,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-TSC",
+				"SCC-ARiR",
 				"TftYP-AtG",
+				"TftYP-TSC",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -5872,13 +6031,13 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"LMoP",
-				"TftYP-TSC",
-				"ToA",
-				"GoS",
 				"BGDIA",
 				"CM",
-				"JttRC"
+				"GoS",
+				"JttRC",
+				"LMoP",
+				"TftYP-TSC",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Studded Leather Armor|XPHB"
@@ -5949,10 +6108,16 @@
 			],
 			"referenceSources": [
 				"BGDIA",
+				"IDRotF",
+				"IMR",
 				"KftGV",
+				"OoW",
 				"PaBTSO",
+				"QftIS",
+				"RtG",
+				"TTP",
 				"VEoR",
-				"QftIS"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Tinker's Tools|XPHB"
@@ -6076,8 +6241,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TTP",
-				"GoS"
+				"GoS",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Trident|XPHB"
@@ -6130,6 +6295,10 @@
 			"page": 154,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"ToA",
+				"TTP"
+			],
 			"reprintedAs": [
 				"Viol|XPHB"
 			],
@@ -6219,6 +6388,9 @@
 			"page": 149,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoS"
+			],
 			"reprintedAs": [
 				"War Pick|XPHB"
 			],
@@ -6274,8 +6446,9 @@
 			"basicRules": true,
 			"referenceSources": [
 				"CoS",
+				"GoS",
 				"TftYP-TFoF",
-				"GoS"
+				"US"
 			],
 			"reprintedAs": [
 				"Warhammer|XPHB"
@@ -6506,6 +6679,11 @@
 					"page": 85
 				}
 			],
+			"referenceSources": [
+				"IDRotF",
+				"RtG",
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Woodcarver's Tools|XPHB"
 			],
@@ -6610,7 +6788,7 @@
 							"name": "Craft:",
 							"type": "item",
 							"entries": [
-								"{@item Club|XPHB}, {@item Greatclub|XPHB}, {@item Quarterstaff|XPHB}, Ranged weapons (except {@item Pistol|XPHB}, {@item Musket|XPHB}, and  {@item Sling|XPHB}), {@item Arcane Focus|XPHB}, {@item Arrows (20)|XPHB|Arrows}, {@item Bolts (20)|XPHB|Bolts}, {@item Druidic Focus|XPHB}, {@item Ink Pen|XPHB}, {@item Needles (50)|XPHB|Needles}"
+								"{@item Club|XPHB}, {@item Greatclub|XPHB}, {@item Quarterstaff|XPHB}, Ranged weapons (except {@item Pistol|XPHB}, {@item Musket|XPHB}, and {@item Sling|XPHB}), {@item Arcane Focus|XPHB}, {@item Arrows (20)|XPHB|Arrows}, {@item Bolts (20)|XPHB|Bolts}, {@item Druidic Focus|XPHB}, {@item Ink Pen|XPHB}, {@item Needles (50)|XPHB|Needles}"
 							]
 						}
 					]
@@ -7177,7 +7355,13 @@
 			"source": "XDMG",
 			"page": 215,
 			"entries": [
-				"Idols cast of solid gold, necklaces studded with precious stones, paintings of ancient kings, bejeweled dishes\u2014art objects include all these and more."
+				{
+					"type": "entries",
+					"name": "Treasure (Art Object)",
+					"entries": [
+						"Idols cast of solid gold, necklaces studded with precious stones, paintings of ancient kings, bejeweled dishes\u2014art objects include all these and more."
+					]
+				}
 			]
 		},
 		{
@@ -7196,8 +7380,14 @@
 			"page": 213,
 			"basicRules2024": true,
 			"entries": [
-				"Characters often find coins on their adventures and can spend those coins in shops, inns, and other businesses. Coins come in different denominations based on the relative worth of their material. The Coin Values table lists coins and how much they're worth relative to the Gold Piece, which is the game's main coin. For example, 100 Copper Pieces are worth 1 Gold Piece.",
-				"A coin weighs about a third of an ounce, so fifty coins weigh a pound."
+				{
+					"type": "entries",
+					"name": "Treasure (Coinage)",
+					"entries": [
+						"Characters often find coins on their adventures and can spend those coins in shops, inns, and other businesses. Coins come in different denominations based on the relative worth of their material. The Coin Values table lists coins and how much they're worth relative to the Gold Piece, which is the game's main coin. For example, 100 Copper Pieces are worth 1 Gold Piece.",
+						"A coin weighs about a third of an ounce, so fifty coins weigh a pound."
+					]
+				}
 			]
 		},
 		{
@@ -7215,7 +7405,13 @@
 			"source": "XDMG",
 			"page": 214,
 			"entries": [
-				"Gemstones are small, lightweight, and easily secured compared to their same value in coins."
+				{
+					"type": "entries",
+					"name": "Treasure (Gemstone)",
+					"entries": [
+						"Gemstones are small, lightweight, and easily secured compared to their same value in coins."
+					]
+				}
 			]
 		},
 		{
@@ -7282,7 +7478,13 @@
 				"AT|XPHB"
 			],
 			"entries": [
-				"These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency."
+				{
+					"type": "entries",
+					"name": "Artisan's Tools",
+					"entries": [
+						"These special tools include the items needed to pursue a craft or trade. Proficiency with a set of artisan's tools lets you add your proficiency bonus to any ability checks you make using the tools in your craft. Each type of artisan's tools requires a separate proficiency."
+					]
+				}
 			]
 		},
 		{
@@ -7292,8 +7494,14 @@
 			"page": 220,
 			"basicRules2024": true,
 			"entries": [
-				"Artisan's Tools are each focused on crafting items and pursuing a trade. Each type of Artisan's Tools tools requires a separate proficiency.",
-				"If you have proficiency with a tool, add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to any ability check you make that uses the tool. If you have proficiency in a skill that's used with that check, you have {@variantrule Advantage|XPHB} on the check too."
+				{
+					"type": "entries",
+					"name": "Artisan's Tool",
+					"entries": [
+						"Artisan's Tools are each focused on crafting items and pursuing a trade. Each type of Artisan's Tools tools requires a separate proficiency.",
+						"If you have proficiency with a tool, add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to any ability check you make that uses the tool. If you have proficiency in a skill that's used with that check, you have {@variantrule Advantage|XPHB} on the check too."
+					]
+				}
 			]
 		},
 		{
@@ -7352,7 +7560,13 @@
 				"GS|XPHB"
 			],
 			"entries": [
-				"If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency."
+				{
+					"type": "entries",
+					"name": "Gaming Set",
+					"entries": [
+						"If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency."
+					]
+				}
 			]
 		},
 		{
@@ -7362,7 +7576,13 @@
 			"page": 221,
 			"basicRules2024": true,
 			"entries": [
-				"If you have proficiency with a tool, add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to any ability check you make that uses the tool. If you have proficiency in a skill that's used with that check, you have {@variantrule Advantage|XPHB} on the check too."
+				{
+					"type": "entries",
+					"name": "Tool (Gaming Set)",
+					"entries": [
+						"If you have proficiency with a tool, add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to any ability check you make that uses the tool. If you have proficiency in a skill that's used with that check, you have {@variantrule Advantage|XPHB} on the check too."
+					]
+				}
 			]
 		},
 		{
@@ -7370,6 +7590,12 @@
 			"abbreviation": "GV",
 			"source": "DMG",
 			"page": 135
+		},
+		{
+			"name": "Generic Variant",
+			"abbreviation": "GV",
+			"source": "XDMG",
+			"page": 216
 		},
 		{
 			"name": "Heavy Armor",
@@ -7396,7 +7622,13 @@
 				"INS|XPHB"
 			],
 			"entries": [
-				"If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument. A bard can use a musical instrument as a spellcasting focus. Each type of musical instrument requires a separate proficiency."
+				{
+					"type": "entries",
+					"name": "Instrument",
+					"entries": [
+						"If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument. A bard can use a musical instrument as a spellcasting focus. Each type of musical instrument requires a separate proficiency."
+					]
+				}
 			]
 		},
 		{
@@ -7406,7 +7638,13 @@
 			"page": 221,
 			"basicRules2024": true,
 			"entries": [
-				"If you have proficiency with a tool, add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to any ability check you make that uses the tool. If you have proficiency in a skill that's used with that check, you have {@variantrule Advantage|XPHB} on the check too."
+				{
+					"type": "entries",
+					"name": "Tool (Musical Instrument)",
+					"entries": [
+						"If you have proficiency with a tool, add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to any ability check you make that uses the tool. If you have proficiency in a skill that's used with that check, you have {@variantrule Advantage|XPHB} on the check too."
+					]
+				}
 			]
 		},
 		{
@@ -7480,6 +7718,12 @@
 			"page": 143
 		},
 		{
+			"name": "Other",
+			"abbreviation": "OTH",
+			"source": "XPHB",
+			"page": 213
+		},
+		{
 			"name": "Potion",
 			"abbreviation": "P",
 			"source": "PHB",
@@ -7533,13 +7777,31 @@
 			"name": "Rod",
 			"abbreviation": "RD",
 			"source": "DMG",
-			"page": 139
+			"page": 139,
+			"reprintedAs": [
+				"RD|XPHB"
+			]
+		},
+		{
+			"name": "Rod",
+			"abbreviation": "RD",
+			"source": "XDMG",
+			"page": 216
 		},
 		{
 			"name": "Ring",
 			"abbreviation": "RG",
 			"source": "DMG",
-			"page": 139
+			"page": 139,
+			"reprintedAs": [
+				"RG|XPHB"
+			]
+		},
+		{
+			"name": "Ring",
+			"abbreviation": "RG",
+			"source": "XDMG",
+			"page": 216
 		},
 		{
 			"name": "Shield",
@@ -7704,7 +7966,13 @@
 			"page": 220,
 			"basicRules2024": true,
 			"entries": [
-				"If you have proficiency with a tool, add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to any ability check you make that uses the tool. If you have proficiency in a skill that's used with that check, you have {@variantrule Advantage|XPHB} on the check too."
+				{
+					"type": "entries",
+					"name": "Tool",
+					"entries": [
+						"If you have proficiency with a tool, add your {@variantrule Proficiency|XPHB|Proficiency Bonus} to any ability check you make that uses the tool. If you have proficiency in a skill that's used with that check, you have {@variantrule Advantage|XPHB} on the check too."
+					]
+				}
 			]
 		},
 		{
@@ -7729,7 +7997,13 @@
 			"source": "XDMG",
 			"page": 213,
 			"entries": [
-				"Because large numbers of coins can be difficult to transport and account for, many merchants prefer to use trade bars\u2014ingots of precious metals and alloys (usually silver). These bars are valued by weight."
+				{
+					"type": "entries",
+					"name": "Trade Bar",
+					"entries": [
+						"Because large numbers of coins can be difficult to transport and account for, many merchants prefer to use trade bars\u2014ingots of precious metals and alloys (usually silver). These bars are valued by weight."
+					]
+				}
 			]
 		},
 		{
@@ -7741,8 +8015,14 @@
 				"TG|XDMG"
 			],
 			"entries": [
-				"Most wealth is not in coins. It is measured in livestock, grain, land, rights to collect taxes, or rights to resources (such as a mine or a forest).",
-				"Guilds, nobles, and royalty regulate trade. Chartered companies are granted rights to conduct trade along certain routes, to send merchant ships to various ports, or to buy or sell specific goods. Guilds set prices for the goods or services that they control, and determine who may or may not offer those goods and services. Merchants commonly exchange trade goods without using currency."
+				{
+					"type": "entries",
+					"name": "Trade Good",
+					"entries": [
+						"Most wealth is not in coins. It is measured in livestock, grain, land, rights to collect taxes, or rights to resources (such as a mine or a forest).",
+						"Guilds, nobles, and royalty regulate trade. Chartered companies are granted rights to conduct trade along certain routes, to send merchant ships to various ports, or to buy or sell specific goods. Guilds set prices for the goods or services that they control, and determine who may or may not offer those goods and services. Merchants commonly exchange trade goods without using currency."
+					]
+				}
 			]
 		},
 		{
@@ -7751,7 +8031,13 @@
 			"source": "XDMG",
 			"page": 213,
 			"entries": [
-				"Merchants commonly exchange trade goods without using currency."
+				{
+					"type": "entries",
+					"name": "Trade Good",
+					"entries": [
+						"Merchants commonly exchange trade goods without using currency."
+					]
+				}
 			]
 		},
 		{
@@ -7774,7 +8060,16 @@
 			"name": "Wand",
 			"abbreviation": "WD",
 			"source": "DMG",
-			"page": 139
+			"page": 139,
+			"reprintedAs": [
+				"WD|XPHB"
+			]
+		},
+		{
+			"name": "Wand",
+			"abbreviation": "WD",
+			"source": "XDMG",
+			"page": 216
 		}
 	],
 	"itemTypeAdditionalEntries": [

--- a/json/items.json
+++ b/json/items.json
@@ -200,7 +200,9 @@
 			"source": "DMG",
 			"page": 197,
 			"referenceSources": [
-				"SjA"
+				"CoS",
+				"SjA",
+				"TftYP-THSoT"
 			],
 			"reprintedAs": [
 				"+1 Rod of the Pact Keeper|XDMG"
@@ -251,11 +253,16 @@
 			"page": 212,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
-				"WDMM",
+				"BGDIA",
+				"CM",
+				"CoA",
 				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"PotA",
+				"SKT",
 				"ToFW",
-				"CoA"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"+1 Wand of the War Mage|XDMG"
@@ -531,8 +538,8 @@
 			"source": "DMG",
 			"page": 197,
 			"referenceSources": [
-				"OoW",
-				"KftGV"
+				"KftGV",
+				"OoW"
 			],
 			"reprintedAs": [
 				"+2 Rod of the Pact Keeper|XDMG"
@@ -1060,7 +1067,7 @@
 					"type": "entries",
 					"name": "Negotiation Tactics",
 					"entries": [
-						"The tome is capable of providing some assistance to all negotiations, not just those made for souls. You gain a passive +5 to Charisma ({@skill Persuasion}) checks made to barter. Additionally, as an action, you can surrender your consciousness to the tome, allowing it to take over. For 1 minute, the Accounting and Valuation of All Things speaks for you, using a +12 Charisma ({@skill Persuasion}) skill and gaining advantage on your rolls. Using the book in this manner has a corrupting influence, and each use compels you to become increasingly greedy, vain, and evil\u2014much like its original owner, Mammon. When the duration ends, if your alignment is non-evil, you suffer {@damage 6d6} necrotic damage."
+						"The tome is capable of providing some assistance to all negotiations, not just those made for souls. You gain a passive +5 to Charisma ({@skill Persuasion}) checks made to barter. Additionally, as an action, you can surrender your consciousness to the tome, allowing it to take over. For 1 minute, the Accounting and Valuation of All Things speaks for you, using a +12 Charisma ({@skill Persuasion}) skill and gaining advantage on your rolls. Using the book in this manner has a corrupting influence, and each use compels you to become increasingly greedy, vain, and evil—much like its original owner, Mammon. When the duration ends, if your alignment is non-evil, you suffer {@damage 6d6} necrotic damage."
 					]
 				},
 				{
@@ -1107,11 +1114,12 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"OoW",
-				"SLW",
-				"SCC-ARiR",
+				"DSotDQ",
 				"KftGV",
-				"QftIS"
+				"OoW",
+				"QftIS",
+				"SCC-ARiR",
+				"SLW"
 			],
 			"reprintedAs": [
 				"Acid|XPHB"
@@ -1303,6 +1311,9 @@
 			"name": "Airship",
 			"source": "DMG",
 			"page": 119,
+			"referenceSources": [
+				"IDRotF"
+			],
 			"reprintedAs": [
 				"Airship|XPHB"
 			],
@@ -1513,15 +1524,20 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-TSC",
-				"TftYP-TFoF",
-				"OoW",
-				"SLW",
-				"SDW",
-				"IDRotF",
+				"BGDIA",
+				"CoS",
 				"DSotDQ",
+				"IDRotF",
 				"KftGV",
-				"QftIS"
+				"OoW",
+				"QftIS",
+				"SCC-ARiR",
+				"SDW",
+				"SLW",
+				"TftYP-TFoF",
+				"TftYP-TSC",
+				"TTP",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Alchemist's Fire|XPHB"
@@ -1542,12 +1558,13 @@
 			"source": "DMG",
 			"page": 150,
 			"referenceSources": [
-				"CoS",
-				"ToA",
-				"SDW",
-				"IDRotF",
 				"CM",
+				"CoS",
+				"IDRotF",
 				"PaBTSO",
+				"PotA",
+				"SDW",
+				"ToA",
 				"ToFW"
 			],
 			"reprintedAs": [
@@ -1746,7 +1763,7 @@
 						],
 						[
 							"Oil",
-							"quart"
+							"1 quart"
 						],
 						[
 							"Vinegar",
@@ -1807,7 +1824,7 @@
 						],
 						[
 							"Oil",
-							"quart"
+							"1 quart"
 						],
 						[
 							"Soy Sauce",
@@ -2134,10 +2151,10 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"PotA",
-				"ToA",
+				"CoA",
 				"IDRotF",
-				"CoA"
+				"PotA",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Amulet of Health|XDMG"
@@ -2195,14 +2212,14 @@
 			"page": 150,
 			"srd": true,
 			"referenceSources": [
-				"CoS",
-				"SKT",
-				"WDMM",
-				"WBtW",
-				"PaBTSO",
 				"CoA",
+				"CoS",
+				"PaBTSO",
+				"QftIS",
+				"SKT",
 				"VEoR",
-				"QftIS"
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Amulet of Proof against Detection and Location|XDMG"
@@ -2245,6 +2262,15 @@
 			"name": "Amulet of Protection from Turning",
 			"source": "TftYP",
 			"page": 228,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"rarity": "rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -2385,9 +2411,10 @@
 			"page": 150,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
 				"KftGV",
 				"ToFW",
-				"CoA"
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Amulet of the Planes|XDMG"
@@ -2564,10 +2591,15 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"ToA",
+				"CoS",
 				"GoS",
 				"IDRotF",
-				"QftIS"
+				"KftGV",
+				"OoW",
+				"QftIS",
+				"SCC-HfMT",
+				"TftYP-TSC",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Antitoxin|XPHB"
@@ -2588,14 +2620,14 @@
 			"page": 151,
 			"srd": "Apparatus of the Crab",
 			"referenceSources": [
-				"SKT",
-				"WDH",
-				"LLK",
+				"CoA",
 				"GoS",
 				"IMR",
 				"KftGV",
+				"LLK",
+				"SKT",
 				"ToFW",
-				"CoA"
+				"WDH"
 			],
 			"reprintedAs": [
 				"Apparatus of Kwalish|XDMG"
@@ -2768,8 +2800,8 @@
 						],
 						[
 							"5",
-							"Each extended claw makes the following melee attack: +8 to hit, reach 5 ft. {@i Hit:} 7 ({@damage 2d6}) Bludgeoning damage.",
-							"Each extended claw makes the following melee attack: +8 to hit, reach 5 ft. {@i Hit:} The target has the {@condition Grappled|XPHB} condition (escape {@dc 15})."
+							"Each extended claw makes the following melee attack: {@hit 8} to hit, reach 5 ft. {@i Hit:} 7 ({@damage 2d6}) Bludgeoning damage.",
+							"Each extended claw makes the following melee attack: {@hit 8} to hit, reach 5 ft. {@i Hit:} The target has the {@condition Grappled|XPHB} condition (escape {@dc 15})."
 						],
 						[
 							"6",
@@ -3143,6 +3175,9 @@
 			"source": "DMG",
 			"page": 152,
 			"srd": true,
+			"referenceSources": [
+				"TftYP-WPM"
+			],
 			"reprintedAs": [
 				{
 					"uid": "Armor of Vulnerability (Slashing)|XDMG",
@@ -3327,6 +3362,10 @@
 					"page": true
 				}
 			},
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
 			"rarity": "legendary",
 			"modifySpeed": {
 				"equal": {
@@ -3347,7 +3386,9 @@
 			"srd": true,
 			"referenceSources": [
 				"CM",
-				"HoL"
+				"HoL",
+				"KftGV",
+				"SDW"
 			],
 			"reprintedAs": [
 				"Assassin's Blood|XDMG"
@@ -4031,7 +4072,8 @@
 			"basicRules": true,
 			"referenceSources": [
 				"CRCotN",
-				"PaBTSO"
+				"PaBTSO",
+				"TftYP-TSC"
 			],
 			"reprintedAs": [
 				"Backpack|XPHB"
@@ -4056,7 +4098,8 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
-				"BQGT"
+				"BQGT",
+				"FFotR"
 			],
 			"type": "G|XPHB",
 			"rarity": "none",
@@ -4104,10 +4147,10 @@
 			"srd": true,
 			"referenceSources": [
 				"BGDIA",
-				"IMR",
 				"IDRotF",
-				"WBtW",
-				"JttRC"
+				"IMR",
+				"JttRC",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Bag of Beans|XDMG"
@@ -4324,30 +4367,31 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CM",
+				"CRCotN",
+				"DSotDQ",
+				"GoS",
+				"HftT",
+				"HoL",
 				"HotDQ",
-				"RoT",
-				"PotA",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"LRDT",
 				"OotA",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SCC-CK",
+				"SjA",
 				"SKT",
 				"TftYP-AtG",
 				"TftYP-ToH",
-				"WDH",
-				"LLK",
-				"GoS",
-				"HftT",
-				"IDRotF",
-				"CM",
-				"HoL",
-				"WBtW",
-				"CRCotN",
-				"JttRC",
-				"SjA",
-				"DSotDQ",
-				"KftGV",
 				"ToFW",
-				"LRDT",
 				"VEoR",
-				"QftIS"
+				"WBtW",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Bag of Holding|XDMG"
@@ -4389,7 +4433,7 @@
 			"wondrous": true,
 			"weight": 5,
 			"entries": [
-				"This bag has an interior space considerably larger than its outside dimensions\u2014roughly 2 feet square and 4 feet deep on the inside. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 5 pounds, regardless of its contents. Retrieving an item from the bag requires a {@action Utilize|XPHB} action.",
+				"This bag has an interior space considerably larger than its outside dimensions—roughly 2 feet square and 4 feet deep on the inside. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 5 pounds, regardless of its contents. Retrieving an item from the bag requires a {@action Utilize|XPHB} action.",
 				"If the bag is overloaded, pierced, or torn, it is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth unharmed, but the bag must be put right before it can be used again. The bag holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.",
 				"Placing a Bag of Holding inside an extradimensional space created by a {@item Heward's Handy Haversack|XDMG}, Portable Hole, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within a 10-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on the gate is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way and can't be reopened."
 			],
@@ -4417,9 +4461,10 @@
 			"page": 154,
 			"srd": true,
 			"referenceSources": [
-				"SKT",
+				"CoS",
+				"QftIS",
 				"SCC-CK",
-				"QftIS"
+				"SKT"
 			],
 			"reprintedAs": [
 				"Bag of Tricks, Gray|XDMG"
@@ -4552,8 +4597,8 @@
 			"page": 154,
 			"srd": true,
 			"referenceSources": [
-				"NRH-TLT",
-				"KftGV"
+				"KftGV",
+				"NRH-TLT"
 			],
 			"reprintedAs": [
 				"Bag of Tricks, Rust|XDMG"
@@ -4829,11 +4874,20 @@
 			"name": "Balance of Harmony",
 			"source": "TftYP",
 			"page": 228,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"rarity": "uncommon",
 			"wondrous": true,
 			"weight": 1,
 			"entries": [
-				"This scale bears celestial symbols on one pan and fiendish symbols on the other. You can use the scale to cast {@spell detect evil and good} as a ritual. Doing so requires you to place the scale on a solid surface, then sprinkle the pans with holy water or place a transparent gem worth 100 gp in each pan. The scale remains motionless if it detects nothing, tips to one side or the other for good (consecrated) or evil (desecrated), and fluctuates slightly if it detects a creature appropriate to the spell but neither good nor evil. By touching the scales after casting the ritual, you instantly learn any information the spell can normally convey, and then the effect ends."
+				"This scale bears celestial symbols on one pan and fiendish symbols on the other. You can use the scale to cast {@spell detect evil and good} as a ritual. Doing so requires you to place the scale on a solid surface, then sprinkle the pans with {@item Holy Water (Flask)|PHB|holy water} or place a transparent gem worth 100 gp in each pan. The scale remains motionless if it detects nothing, tips to one side or the other for good (consecrated) or evil (desecrated), and fluctuates slightly if it detects a creature appropriate to the spell but neither good nor evil. By touching the scales after casting the ritual, you instantly learn any information the spell can normally convey, and then the effect ends."
 			],
 			"attachedSpells": {
 				"ritual": [
@@ -5079,203 +5133,203 @@
 					],
 					"rows": [
 						[
-							"01\u201302",
+							"01–02",
 							"A handheld device containing a glowing green gem that darkens when no oxygen is present"
 						],
 						[
-							"03\u201304",
+							"03–04",
 							"A foot-long, egg-shaped object made from stitched leather"
 						],
 						[
-							"05\u201306",
+							"05–06",
 							"A black metal cylinder that dictates the history of an unknown plant or animal species when held"
 						],
 						[
-							"07\u201308",
+							"07–08",
 							"A cylindrical jar containing a pickled crustacean of unknown origin"
 						],
 						[
-							"09\u201310",
+							"09–10",
 							"A small thumb-button storage cylinder that releases a useless iron key when pressed"
 						],
 						[
-							"11\u201312",
+							"11–12",
 							"An unusual heraldic cloak pin that emits a short musical fanfare when tapped"
 						],
 						[
-							"13\u201314",
+							"13–14",
 							"A handheld tube that sucks in dust when squeezed and captures it in a detachable compartment"
 						],
 						[
-							"15\u201316",
+							"15–16",
 							"A scintillating disk of unknown material"
 						],
 						[
-							"17\u201318",
+							"17–18",
 							"A dial that can be twisted to slowly click back to its origin, whereupon it emits a loud ringing noise"
 						],
 						[
-							"19\u201320",
+							"19–20",
 							"A hovering, apple-sized orb of metal that follows you around"
 						],
 						[
-							"21\u201322",
+							"21–22",
 							"The {@condition petrified} cocoon of an unknown insect"
 						],
 						[
-							"23\u201324",
+							"23–24",
 							"A bronze gauntlet set with many slots, and which violently expels any object pressed into those slots"
 						],
 						[
-							"25\u201326",
+							"25–26",
 							"A box that plays an illusory message in an unknown language when opened"
 						],
 						[
-							"27\u201328",
+							"27–28",
 							"A rod that causes you to forget the last five minutes when you press a button near its tip"
 						],
 						[
-							"29\u201330",
+							"29–30",
 							"A palm-sized cylinder that emits a harmless ray of glowing blue light when squeezed"
 						],
 						[
-							"31\u201332",
+							"31–32",
 							"A bead that suppresses your hearing when secreted inside either ear, causing you to be {@condition deafened}"
 						],
 						[
-							"33\u201334",
+							"33–34",
 							"An amulet that displays your current health as a green bar above your head, with the bar retracting as your hit point total decreases"
 						],
 						[
-							"35\u201336",
+							"35–36",
 							"A casket containing one hundred tasteless blue pills that produce no discernible effect when swallowed"
 						],
 						[
-							"37\u201338",
+							"37–38",
 							"A metal mechanical puzzle with no apparent solution"
 						],
 						[
-							"39\u201340",
+							"39–40",
 							"A metal spinning top that never tips over when spun"
 						],
 						[
-							"41\u201342",
+							"41–42",
 							"Two strips of cloth-like material, each coated with a soft, hair-like fuzz on one side"
 						],
 						[
-							"43\u201344",
+							"43–44",
 							"A simple wire pyramid that preserves any foodstuffs it is placed over"
 						],
 						[
-							"45\u201346",
+							"45–46",
 							"A star chart labeled in an unknown script"
 						],
 						[
-							"47\u201348",
+							"47–48",
 							"A rectangle of black glass that displays indecipherable arcane runes when you swipe your finger across it"
 						],
 						[
-							"49\u201350",
+							"49–50",
 							"A schematic that shows the inner workings of an impossibly complex device"
 						],
 						[
-							"51\u201352",
+							"51–52",
 							"An odd pair of comfortable shoes made from supple, multicolored material"
 						],
 						[
-							"53\u201354",
+							"53–54",
 							"A mirror that makes you appear more beautiful when you tap your reflection"
 						],
 						[
-							"55\u201356",
+							"55–56",
 							"A mechanical metal puppy that playfully follows you around when activated"
 						],
 						[
-							"57\u201358",
+							"57–58",
 							"A talking bracelet that speaks only to correct your grammar"
 						],
 						[
-							"59\u201360",
+							"59–60",
 							"A bar of soap that can remove any stain"
 						],
 						[
-							"61\u201362",
+							"61–62",
 							"A journal in Common, written by someone in a world similar to but not quite the same as your own"
 						],
 						[
-							"63\u201364",
+							"63–64",
 							"A tub containing one serving of disgusting but nutritious goop that refills itself slowly over the course of one week"
 						],
 						[
-							"65\u201366",
+							"65–66",
 							"An instruction manual for activating a mysterious, world-destroying device"
 						],
 						[
-							"67\u201368",
+							"67–68",
 							"A small supple disk that displays weird moving symbols when placed over either eye"
 						],
 						[
-							"69\u201370",
+							"69–70",
 							"A tiny desk set with large, colorful buttons, each of which plays a discordant musical fanfare when pressed"
 						],
 						[
-							"71\u201372",
+							"71–72",
 							"A pair of tinted spectacles that reduce the glare of the sun when worn"
 						],
 						[
-							"73\u201374",
+							"73–74",
 							"An inflatable bedroll made from an unknown material, and which slowly deflates when used"
 						],
 						[
-							"75\u201376",
+							"75–76",
 							"A rod tipped with a blunt metal pincer whose grip can be adjusted by turning a screw"
 						],
 						[
-							"77\u201378",
+							"77–78",
 							"A battered helmet with a transparent orange visor that flips into place when donned"
 						],
 						[
-							"79\u201380",
+							"79–80",
 							"An animated map of a mysterious city that appears to be tracking the movements of five creatures"
 						],
 						[
-							"81\u201382",
+							"81–82",
 							"A cylinder of mist that holds your hair perfectly in shape when sprayed onto your head"
 						],
 						[
-							"83\u201384",
+							"83–84",
 							"A talking wand that tells you the name of any plant you point it at"
 						],
 						[
-							"85\u201386",
+							"85–86",
 							"A metal bracelet that displays the number of steps you've taken since your last long rest"
 						],
 						[
-							"87\u201388",
+							"87–88",
 							"A tiny handheld device that projects a glowing dot onto whatever you point it at"
 						],
 						[
-							"89\u201390",
+							"89–90",
 							"A rectangular piece of glass that displays a twelve-digit countdown on its surface"
 						],
 						[
-							"91\u201392",
+							"91–92",
 							"A wall chart of mysterious formulae arranged into a color-coded grid"
 						],
 						[
-							"93\u201394",
+							"93–94",
 							"A handheld device that solves any math problem you input using its buttons"
 						],
 						[
-							"95\u201396",
+							"95–96",
 							"A ball of speckled brown fur that appears to be alive"
 						],
 						[
-							"97\u201398",
+							"97–98",
 							"A complicated crystal board game that you don't know how to play"
 						],
 						[
-							"99\u201300",
+							"99–00",
 							"A large glass rectangle that displays a storm of black and white patterns when you press a button on its underside"
 						]
 					]
@@ -5389,15 +5443,15 @@
 					],
 					"rows": [
 						[
-							"1\u20132",
+							"1–2",
 							"Tiny, inedible fish (a creature that consumes it is poisoned for 1 hour)"
 						],
 						[
-							"3\u20135",
+							"3–5",
 							"Tiny, edible fish (feeds one person)"
 						],
 						[
-							"6\u20138",
+							"6–8",
 							"Small, edible fish (feeds up to four people)"
 						],
 						[
@@ -5531,9 +5585,10 @@
 			"page": 154,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
+				"CoA",
 				"PaBTSO",
-				"CoA"
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Bead of Force|XDMG"
@@ -5566,8 +5621,8 @@
 				}
 			],
 			"referenceSources": [
-				"ScoEE",
-				"DrDe-SD"
+				"DrDe-SD",
+				"ScoEE"
 			],
 			"rarity": "rare",
 			"wondrous": true,
@@ -5629,6 +5684,9 @@
 			"name": "Bead of Refreshment",
 			"source": "XDMG",
 			"page": 235,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
@@ -5665,6 +5723,9 @@
 			"page": 150,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"TftYP-TSC"
+			],
 			"reprintedAs": [
 				"Bedroll|XPHB"
 			],
@@ -6578,7 +6639,7 @@
 			"value": 30000,
 			"entries": [
 				"This tarry substance harvested from the dark boughs of the death's head willow is a powerful intoxicant. It can be smoked as a concentrate or injected directly into the bloodstream. A creature subjected to a dose of black sap cannot be {@condition charmed} or {@condition frightened} for {@dice 1d6} hours.",
-				"For each dose of black sap consumed, a creature must succeed on a {@dc 15} Constitution saving throw or become {@condition poisoned} for {@dice 2d4} hours\u2014an effect that is cumulative with multiple doses."
+				"For each dose of black sap consumed, a creature must succeed on a {@dc 15} Constitution saving throw or become {@condition poisoned} for {@dice 2d4} hours—an effect that is cumulative with multiple doses."
 			],
 			"miscTags": [
 				"CNS"
@@ -6633,7 +6694,9 @@
 			"source": "DMG",
 			"page": 216,
 			"referenceSources": [
-				"TftYP-WPM"
+				"IMR",
+				"TftYP-WPM",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Blackrazor|XDMG"
@@ -6904,7 +6967,7 @@
 					"name": "Personality",
 					"entries": [
 						"The staff has the spirits of all previous Blackstaffs trapped within it. Its creator, Khelben Arunsun, is the dominant personality among them. Like Khelben, the staff is extremely devious and manipulative. It prefers to counsel its owner without exerting outright control. The staff's primary goal is to protect Waterdeep and its Open Lord, currently Laeral Silverhand. Its secondary goal is to help its wielder become more powerful.",
-						"In the event that the holder of the office of the Blackstaff no longer serves the staff's wishes, the staff ceases to function until it finds a worthy inheritor\u2014someone whose loyalty to Waterdeep is beyond reproach."
+						"In the event that the holder of the office of the Blackstaff no longer serves the staff's wishes, the staff ceases to function until it finds a worthy inheritor—someone whose loyalty to Waterdeep is beyond reproach."
 					]
 				},
 				{
@@ -7229,6 +7292,9 @@
 			"name": "Blasting Powder",
 			"source": "EGW",
 			"page": 225,
+			"referenceSources": [
+				"DD"
+			],
 			"type": "G",
 			"rarity": "none",
 			"entries": [
@@ -7289,7 +7355,7 @@
 			"reqAttune": true,
 			"wondrous": true,
 			"entries": [
-				"This diamond contains the blood of a creature\u2014blood that appears in the form of the blod (blood) rune. While the item is on your person, you can use your action to divine the location of the creature nearest to you that is related to the blood in the item and that isn't undead. You sense the distance and direction of the creature relative to your location. The creature is either the one whose blood is in the item or a blood relative.",
+				"This diamond contains the blood of a creature—blood that appears in the form of the blod (blood) rune. While the item is on your person, you can use your action to divine the location of the creature nearest to you that is related to the blood in the item and that isn't undead. You sense the distance and direction of the creature relative to your location. The creature is either the one whose blood is in the item or a blood relative.",
 				"This item is made from a large diamond worth at least 5,000 gp. When the blood of a creature is poured onto it during the creation process, the blood seeps into the heart of the gem. If the gem is destroyed, the blood evaporates and is gone forever. A vengeful being might use a blod stone to hunt down an entire bloodline. Such stones are sometimes given as gifts to siblings or handed down from parent to child."
 			]
 		},
@@ -7337,7 +7403,7 @@
 			"rarity": "none",
 			"poison": true,
 			"entries": [
-				"This poison is created from blood harvested from a dead or {@condition incapacitated} lycanthrope in its animal or hybrid form. A creature subjected to this poison must succeed on a {@dc 12} Constitution saving throw or be cursed with lycanthropy (see the Monster Manual). The curse lasts until removed by the {@spell remove curse} spell or similar magic.",
+				"This poison is created from blood harvested from a dead or {@condition incapacitated} lycanthrope in its animal or hybrid form. A creature subjected to this poison must succeed on a {@dc 12} Constitution saving throw or be cursed with {@variantrule Player Characters as Lycanthropes|MM|lycanthropy} (see the Monster Manual). The curse lasts until removed by the {@spell remove curse} spell or similar magic.",
 				"The type of lycanthropy depends on the lycanthrope used to create the poison. To determine the type of lycanthropy randomly, roll a {@dice d6}:",
 				{
 					"type": "table",
@@ -7458,6 +7524,7 @@
 			"source": "DMG",
 			"page": 134,
 			"referenceSources": [
+				"DoSI",
 				"IDRotF",
 				"KftGV"
 			],
@@ -7501,6 +7568,12 @@
 			"name": "Blue Dragon Mask",
 			"source": "RoTOS",
 			"page": 4,
+			"otherSources": [
+				{
+					"source": "ToD",
+					"page": 179
+				}
+			],
 			"referenceSources": [
 				"HotDQ",
 				"RoT"
@@ -7728,6 +7801,7 @@
 			"source": "DMG",
 			"page": 268,
 			"referenceSources": [
+				"LoX",
 				"SCC-ARiR"
 			],
 			"reprintedAs": [
@@ -7802,6 +7876,9 @@
 			"page": 151,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"PaBTSO"
+			],
 			"reprintedAs": [
 				"Book|XPHB"
 			],
@@ -8320,11 +8397,13 @@
 			"page": 155,
 			"srd": true,
 			"referenceSources": [
-				"WDH",
-				"WDMM",
 				"DIP",
+				"DoSI",
+				"QftIS",
+				"TftYP-AtG",
 				"WBtW",
-				"DoSI"
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Boots of Elvenkind|XDMG"
@@ -8355,8 +8434,8 @@
 				}
 			],
 			"referenceSources": [
-				"ScoEE",
-				"HotB"
+				"HotB",
+				"ScoEE"
 			],
 			"rarity": "uncommon",
 			"wondrous": true,
@@ -8410,8 +8489,8 @@
 			"page": 155,
 			"srd": true,
 			"referenceSources": [
-				"WBtW",
-				"DSotDQ"
+				"DSotDQ",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Boots of Levitation|XDMG"
@@ -8524,12 +8603,13 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"LMoP",
-				"TftYP-WPM",
-				"LLK",
 				"GoS",
+				"IMR",
 				"KftGV",
-				"PaBTSO"
+				"LLK",
+				"LMoP",
+				"PaBTSO",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Boots of Striding and Springing|XDMG"
@@ -8603,8 +8683,8 @@
 			"page": 156,
 			"srd": true,
 			"referenceSources": [
-				"IDRotF",
-				"CM"
+				"CM",
+				"IDRotF"
 			],
 			"reprintedAs": [
 				"Boots of the Winterlands|XDMG"
@@ -8781,7 +8861,8 @@
 			"page": 156,
 			"srd": true,
 			"referenceSources": [
-				"LR"
+				"LR",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Bowl of Commanding Water Elementals|XDMG"
@@ -8847,6 +8928,15 @@
 			"name": "Bracelet of Rock Magic",
 			"source": "TftYP",
 			"page": 228,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"rarity": "very rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -8890,9 +8980,10 @@
 			"page": 156,
 			"srd": true,
 			"referenceSources": [
+				"PaBTSO",
 				"ToA",
 				"WBtW",
-				"PaBTSO"
+				"WDH"
 			],
 			"reprintedAs": [
 				"Bracers of Archery|XDMG"
@@ -8981,13 +9072,16 @@
 			"page": 156,
 			"srd": true,
 			"referenceSources": [
-				"SKT",
-				"TftYP-THSoT",
-				"TftYP-DiT",
-				"TftYP-ToH",
 				"BGDIA",
 				"CoA",
-				"QftIS"
+				"DitLCoT",
+				"HotDQ",
+				"QftIS",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Bracers of Defense|XDMG"
@@ -9102,9 +9196,9 @@
 			"page": 156,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-AtG",
+				"CoA",
 				"KftGV",
-				"CoA"
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				"Brazier of Commanding Fire Elementals|XDMG"
@@ -9217,7 +9311,8 @@
 				}
 			],
 			"referenceSources": [
-				"CRCotN"
+				"CRCotN",
+				"ToR"
 			],
 			"rarity": "common",
 			"wondrous": true,
@@ -9360,8 +9455,9 @@
 			"page": 156,
 			"srd": true,
 			"referenceSources": [
-				"GoS",
 				"AitFR-DN",
+				"CRCotN",
+				"GoS",
 				"ToFW"
 			],
 			"reprintedAs": [
@@ -9428,10 +9524,10 @@
 			"page": 156,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
 				"CoS",
-				"WBtW",
 				"ToFW",
-				"CoA"
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Broom of Flying|XDMG"
@@ -9514,8 +9610,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"GoS",
-				"DSotDQ"
+				"CoS",
+				"DSotDQ",
+				"GoS"
 			],
 			"reprintedAs": [
 				"Bullseye Lantern|XPHB"
@@ -9570,6 +9667,9 @@
 			"page": 151,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"US"
+			],
 			"reprintedAs": [
 				"Burglar's Pack|XPHB"
 			],
@@ -9878,9 +9978,10 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-TSC",
 				"BGDIA",
-				"CM"
+				"CM",
+				"TftYP-TSC",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Caltrops|XPHB"
@@ -9934,7 +10035,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TTP"
+				"KftGV",
+				"TTP",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Candle|XPHB"
@@ -10008,8 +10111,9 @@
 			"page": 157,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
-				"ToFW"
+				"DSotDQ",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Candle of Invocation|XDMG"
@@ -10335,9 +10439,9 @@
 			"source": "DMG",
 			"page": 157,
 			"referenceSources": [
-				"WDH",
 				"GoS",
-				"KftGV"
+				"KftGV",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Cap of Water Breathing|XDMG"
@@ -10391,7 +10495,7 @@
 				{
 					"type": "list",
 					"items": [
-						"Your size increases by one category\u2014from Medium to Large, for example. If there isn't enough room for your size to increase by one category, you instead become the maximum possible size in the space available.",
+						"Your size increases by one category—from Medium to Large, for example. If there isn't enough room for your size to increase by one category, you instead become the maximum possible size in the space available.",
 						"You have advantage on Strength checks and Strength saving throws.",
 						"When you hit with an attack roll using a weapon or an unarmed strike, you can add your proficiency bonus to the attack's damage."
 					]
@@ -10405,9 +10509,10 @@
 			"page": 157,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
+				"CoA",
 				"DSotDQ",
-				"CoA"
+				"ToA",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Cape of the Mountebank|XDMG"
@@ -10557,6 +10662,9 @@
 			"source": "DMG",
 			"page": 157,
 			"srd": true,
+			"referenceSources": [
+				"JttRC"
+			],
 			"reprintedAs": [
 				"Carpet of Flying, 4 ft. × 6 ft.|XDMG"
 			],
@@ -10645,6 +10753,9 @@
 			"page": 157,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"WDH"
+			],
 			"reprintedAs": [
 				"Carriage|XPHB"
 			],
@@ -10670,6 +10781,7 @@
 			"page": 258,
 			"srd": "Crawler Mucus (Contact)",
 			"referenceSources": [
+				"BGDIA",
 				"QftIS"
 			],
 			"reprintedAs": [
@@ -11342,10 +11454,11 @@
 			"page": 158,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
-				"IDRotF",
+				"AitFR-AVT",
 				"CM",
-				"WBtW"
+				"IDRotF",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Chime of Opening|XDMG"
@@ -11434,6 +11547,9 @@
 			"name": "Chronolometer",
 			"source": "AI",
 			"page": 220,
+			"referenceSources": [
+				"OoW"
+			],
 			"rarity": "very rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -11444,7 +11560,7 @@
 					"type": "entries",
 					"name": "Time Bandit",
 					"entries": [
-						"At the start of your turn, roll a {@dice d6} (no action required). On a 1\u20133, you slow down time, gaining an additional action on your turn and doubling your speed until the end of the turn. On a 4\u20136, you go forward in time to warn yourself of what is to come. The next time you fail a saving throw, attack roll, or ability check, you can reroll the check and take either result. Once you use this feature of the chronolometer, it cannot be used again until the next dawn."
+						"At the start of your turn, roll a {@dice d6} (no action required). On a 1–3, you slow down time, gaining an additional action on your turn and doubling your speed until the end of the turn. On a 4–6, you go forward in time to warn yourself of what is to come. The next time you fail a saving throw, attack roll, or ability check, you can reroll the check and take either result. Once you use this feature of the chronolometer, it cannot be used again until the next dawn."
 					]
 				},
 				{
@@ -11556,6 +11672,8 @@
 			"page": 158,
 			"srd": true,
 			"referenceSources": [
+				"BGDIA",
+				"DC",
 				"ToA",
 				"WDMM"
 			],
@@ -11709,6 +11827,9 @@
 			"name": "Cleansing Stone",
 			"source": "ERLW",
 			"page": 276,
+			"referenceSources": [
+				"EFR"
+			],
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
@@ -11724,8 +11845,9 @@
 			"basicRules": true,
 			"referenceSources": [
 				"CoS",
+				"SjA",
 				"ToA",
-				"SjA"
+				"TTP"
 			],
 			"reprintedAs": [
 				"Climber's Kit|XPHB"
@@ -11920,8 +12042,8 @@
 			"page": 158,
 			"srd": true,
 			"referenceSources": [
-				"WBtW",
-				"SCC-HfMT"
+				"SCC-HfMT",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Cloak of Displacement|XDMG"
@@ -11962,10 +12084,12 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-AtG",
-				"SCC-HfMT",
+				"IDRotF",
+				"QftIS",
 				"SCC-ARiR",
-				"QftIS"
+				"SCC-HfMT",
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Cloak of Elvenkind|XDMG"
@@ -12104,17 +12228,18 @@
 			"page": 159,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
 				"CoS",
-				"SKT",
-				"IDRotF",
-				"WBtW",
-				"SCC-CK",
 				"CRCotN",
 				"DSotDQ",
+				"GoS",
+				"IDRotF",
 				"PaBTSO",
+				"QftIS",
+				"SCC-CK",
+				"SKT",
 				"ToFW",
-				"CoA",
-				"QftIS"
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Cloak of Protection|XDMG"
@@ -12225,9 +12350,12 @@
 			"page": 159,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
 				"GoS",
-				"JttRC"
+				"JttRC",
+				"OoW",
+				"SDW",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Cloak of the Manta Ray|XDMG"
@@ -12286,8 +12414,8 @@
 			"page": 245,
 			"referenceSources": [
 				"DrDe-FWtVC",
-				"HotB",
-				"FRAiF"
+				"FRAiF",
+				"HotB"
 			],
 			"rarity": "common",
 			"wondrous": true,
@@ -12615,7 +12743,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"VNotEE"
+				"VNotEE",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Component Pouch|XPHB"
@@ -12742,7 +12871,7 @@
 					"type": "entries",
 					"name": "Wealth of Information",
 					"entries": [
-						"The painting's primary purpose is to observe and recall conversations. Over the past few decades, Constantori's Portrait has quietly observed countless conversations and now possesses an unquantifiable amount of lore\u2014everything from criminal conspiracies to secret passwords. The DM decides what the painting knows and what it doesn't.",
+						"The painting's primary purpose is to observe and recall conversations. Over the past few decades, Constantori's Portrait has quietly observed countless conversations and now possesses an unquantifiable amount of lore—everything from criminal conspiracies to secret passwords. The DM decides what the painting knows and what it doesn't.",
 						"While attuned to the painting, you can take an action to telepathically contact it over any distance, provided you and the painting are on the same plane of existence. The painting can't telepathically contact you, however. Maintaining telepathic contact with the painting requires your {@status concentration} (as if {@status concentration||concentrating} on a spell)."
 					]
 				},
@@ -13009,6 +13138,9 @@
 			"name": "Cracked Driftglobe",
 			"source": "CM",
 			"page": 110,
+			"referenceSources": [
+				"CRCotN"
+			],
 			"rarity": "uncommon",
 			"wondrous": true,
 			"weight": 1,
@@ -13169,8 +13301,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"VEoR",
-				"QftIS"
+				"CM",
+				"QftIS",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Crossbow Bolt Case|XPHB"
@@ -13219,7 +13352,8 @@
 			"basicRules": true,
 			"referenceSources": [
 				"CoS",
-				"DoSI"
+				"DoSI",
+				"PaBTSO"
 			],
 			"reprintedAs": [
 				"Crowbar|XPHB"
@@ -13570,10 +13704,11 @@
 			"page": 159,
 			"srd": true,
 			"referenceSources": [
-				"SKT",
-				"SDW",
-				"IDRotF",
 				"CoA",
+				"IDRotF",
+				"SDW",
+				"SKT",
+				"ToFW",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -13597,7 +13732,7 @@
 		{
 			"name": "Crystal Ball",
 			"source": "XDMG",
-			"page": 245,
+			"page": 246,
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
@@ -13621,6 +13756,9 @@
 			"name": "Crystal Ball of Mind Reading",
 			"source": "DMG",
 			"page": 159,
+			"referenceSources": [
+				"SDW"
+			],
 			"reprintedAs": [
 				"Crystal Ball of Mind Reading|XDMG"
 			],
@@ -13644,7 +13782,7 @@
 		{
 			"name": "Crystal Ball of Mind Reading",
 			"source": "XDMG",
-			"page": 159,
+			"page": 246,
 			"srd52": true,
 			"basicRules2024": true,
 			"rarity": "legendary",
@@ -13667,7 +13805,8 @@
 			"source": "DMG",
 			"page": 159,
 			"referenceSources": [
-				"JttRC"
+				"JttRC",
+				"SDW"
 			],
 			"reprintedAs": [
 				"Crystal Ball of Telepathy|XDMG"
@@ -13698,7 +13837,7 @@
 		{
 			"name": "Crystal Ball of Telepathy",
 			"source": "XDMG",
-			"page": 159,
+			"page": 246,
 			"srd52": true,
 			"basicRules2024": true,
 			"rarity": "legendary",
@@ -13728,6 +13867,8 @@
 			"page": 159,
 			"referenceSources": [
 				"CM",
+				"OotA",
+				"SDW",
 				"ToFW"
 			],
 			"reprintedAs": [
@@ -13752,7 +13893,7 @@
 		{
 			"name": "Crystal Ball of True Seeing",
 			"source": "XDMG",
-			"page": 159,
+			"page": 246,
 			"srd52": true,
 			"basicRules2024": true,
 			"rarity": "legendary",
@@ -13822,6 +13963,7 @@
 			"srd": true,
 			"referenceSources": [
 				"LR",
+				"TftYP-WPM",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -14139,6 +14281,9 @@
 			"name": "Cuddly Strixhaven Mascot",
 			"source": "SCC",
 			"page": 38,
+			"referenceSources": [
+				"SCC-CK"
+			],
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
@@ -14231,8 +14376,8 @@
 			"page": 160,
 			"srd": "Instant Fortress",
 			"referenceSources": [
-				"OotA",
 				"CoS",
+				"OotA",
 				"PaBTSO"
 			],
 			"reprintedAs": [
@@ -14322,15 +14467,16 @@
 			"page": 161,
 			"srd": true,
 			"referenceSources": [
-				"HotDQ",
-				"TftYP-DiT",
-				"WDMM",
-				"SLW",
-				"JttRC",
-				"PaBTSO",
-				"ToFW",
 				"CoA",
-				"LRDT"
+				"HotDQ",
+				"JttRC",
+				"LRDT",
+				"OoW",
+				"PaBTSO",
+				"SLW",
+				"TftYP-DiT",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Dagger of Venom|XDMG"
@@ -14814,12 +14960,12 @@
 			"page": 161,
 			"srd": true,
 			"referenceSources": [
-				"SKT",
-				"WDMM",
-				"GoS",
 				"DC",
+				"GoS",
 				"JttRC",
-				"KftGV"
+				"KftGV",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Decanter of Endless Water|XDMG"
@@ -14949,8 +15095,10 @@
 			"page": 161,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
 				"CoS",
-				"CoA"
+				"HoL",
+				"QftIS"
 			],
 			"reprintedAs": [
 				"Deck of Illusions|XDMG"
@@ -15780,7 +15928,7 @@
 							"{@card Well|Deck of Many More Things|BMT}"
 						],
 						[
-							"67\u201300",
+							"67–00",
 							"Roll again"
 						]
 					],
@@ -15799,7 +15947,7 @@
 					"type": "entries",
 					"name": "Beast",
 					"entries": [
-						"You immediately transform into a {@filter random Beast with a CR of 5 or lower|bestiary|source=|Challenge Rating=[&0;&5]|type=beast}. Your game statistics\u2014including your ability scores, hit points, and possible actions\u2014are replaced by the Beast's game statistics, and any nonmagical equipment you're wearing or carrying melds into your new form and can't be used. Any magic items you're carrying drop in an unoccupied space within 5 feet of your new form.",
+						"You immediately transform into a {@filter random Beast with a CR of 5 or lower|bestiary|source=|Challenge Rating=[&0;&5]|type=beast}. Your game statistics—including your ability scores, hit points, and possible actions—are replaced by the Beast's game statistics, and any nonmagical equipment you're wearing or carrying melds into your new form and can't be used. Any magic items you're carrying drop in an unoccupied space within 5 feet of your new form.",
 						"You remain transformed in this way for {@dice 2d12} days; nothing can alter your form while you're under the effects of this card, but the {@spell Wish} spell can end the transformation early. When you revert to your normal form, you return to the same state you were in when you initially transformed."
 					]
 				},
@@ -16115,6 +16263,9 @@
 			"name": "Deck of Many Things",
 			"source": "BMT",
 			"page": 13,
+			"referenceSources": [
+				"QftIS"
+			],
 			"reprintedAs": [
 				"Deck of Many Things|XDMG"
 			],
@@ -16188,7 +16339,8 @@
 			"page": 162,
 			"srd": true,
 			"referenceSources": [
-				"LLK"
+				"LLK",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Deck of Many Things|XDMG"
@@ -16552,7 +16704,7 @@
 					"type": "entries",
 					"name": "Skull",
 					"entries": [
-						"You summon an {@creature avatar of death|DMG}\u2014a ghostly humanoid skeleton clad in a tattered black robe and carrying a spectral scythe. It appears in a space of the DM's choice within 10 feet of you and attacks you, warning all others that you must win the battle alone. The avatar fights until you die or it drops to 0 hit points, whereupon it disappears. If anyone tries to help you, the helper summons its own {@creature avatar of death|DMG}. A creature slain by an {@creature avatar of death|DMG} can't be restored to life."
+						"You summon an {@creature avatar of death|DMG}—a ghostly humanoid skeleton clad in a tattered black robe and carrying a spectral scythe. It appears in a space of the DM's choice within 10 feet of you and attacks you, warning all others that you must win the battle alone. The avatar fights until you die or it drops to 0 hit points, whereupon it disappears. If anyone tries to help you, the helper summons its own {@creature avatar of death|DMG}. A creature slain by an {@creature avatar of death|DMG} can't be restored to life."
 					]
 				},
 				{
@@ -16580,7 +16732,7 @@
 					"type": "entries",
 					"name": "Euryale",
 					"entries": [
-						"The card's {@creature medusa}-like visage curses you. You take a \u22122 penalty on saving throws while cursed in this way. Only a god or the magic of {@card The Fates|Deck of Many Things} card can end this curse."
+						"The card's {@creature medusa}-like visage curses you. You take a −2 penalty on saving throws while cursed in this way. Only a god or the magic of {@card The Fates|Deck of Many Things} card can end this curse."
 					]
 				},
 				{
@@ -16664,17 +16816,17 @@
 					],
 					"rows": [
 						[
-							"\u2014",
+							"—",
 							"01-05",
 							"Balance"
 						],
 						[
-							"\u2014",
+							"—",
 							"06-10",
 							"Comet"
 						],
 						[
-							"\u2014",
+							"—",
 							"11-14",
 							"Donjon"
 						],
@@ -16684,7 +16836,7 @@
 							"Euryale"
 						],
 						[
-							"\u2014",
+							"—",
 							"19-23",
 							"Fates"
 						],
@@ -16694,12 +16846,12 @@
 							"Flames"
 						],
 						[
-							"\u2014",
+							"—",
 							"28-31",
 							"Fool"
 						],
 						[
-							"\u2014",
+							"—",
 							"32-36",
 							"Gem"
 						],
@@ -16724,7 +16876,7 @@
 							"Moon"
 						],
 						[
-							"\u2014",
+							"—",
 							"57-60",
 							"Puzzle"
 						],
@@ -16739,7 +16891,7 @@
 							"Ruin"
 						],
 						[
-							"\u2014",
+							"—",
 							"69-73",
 							"Sage"
 						],
@@ -16759,7 +16911,7 @@
 							"Sun"
 						],
 						[
-							"\u2014",
+							"—",
 							"88-91",
 							"Talons"
 						],
@@ -16977,7 +17129,7 @@
 								"roll": {
 									"exact": 1
 								},
-								"entry": "\u20073 {@color ♦|#ff0000}"
+								"entry": " 3 {@color ♦|#ff0000}"
 							},
 							"Wooden {@item abacus|PHB}"
 						],
@@ -16987,7 +17139,7 @@
 								"roll": {
 									"exact": 2
 								},
-								"entry": "\u20074 {@color ♦|#ff0000}"
+								"entry": " 4 {@color ♦|#ff0000}"
 							},
 							"Four {@item Perfume (vial)|PHB|vials of perfume}"
 						],
@@ -16997,7 +17149,7 @@
 								"roll": {
 									"exact": 3
 								},
-								"entry": "\u20075 {@color ♦|#ff0000}"
+								"entry": " 5 {@color ♦|#ff0000}"
 							},
 							"5 days' worth of {@item Rations (1 day)|PHB|rations}"
 						],
@@ -17007,7 +17159,7 @@
 								"roll": {
 									"exact": 4
 								},
-								"entry": "\u20076 {@color ♦|#ff0000}"
+								"entry": " 6 {@color ♦|#ff0000}"
 							},
 							"{@item Iron pot|PHB}"
 						],
@@ -17017,7 +17169,7 @@
 								"roll": {
 									"exact": 5
 								},
-								"entry": "\u20077 {@color ♦|#ff0000}"
+								"entry": " 7 {@color ♦|#ff0000}"
 							},
 							"{@item Disguise kit|PHB}"
 						],
@@ -17027,7 +17179,7 @@
 								"roll": {
 									"exact": 6
 								},
-								"entry": "\u20078 {@color ♦|#ff0000}"
+								"entry": " 8 {@color ♦|#ff0000}"
 							},
 							"Window (up to 5 feet wide and 5 feet high), which you can place on a vertical surface up to 5 feet thick and which allows you to look through the surface"
 						],
@@ -17037,7 +17189,7 @@
 								"roll": {
 									"exact": 7
 								},
-								"entry": "\u20079 {@color ♦|#ff0000}"
+								"entry": " 9 {@color ♦|#ff0000}"
 							},
 							"{@item Manacles|PHB}"
 						],
@@ -17057,7 +17209,7 @@
 								"roll": {
 									"exact": 9
 								},
-								"entry": "\u20073 {@color ♥|#ff0000}"
+								"entry": " 3 {@color ♥|#ff0000}"
 							},
 							"Three {@item dagger|PHB|daggers}"
 						],
@@ -17067,7 +17219,7 @@
 								"roll": {
 									"exact": 10
 								},
-								"entry": "\u20074 {@color ♥|#ff0000}"
+								"entry": " 4 {@color ♥|#ff0000}"
 							},
 							"Four {@item Oil (flask)|PHB|flasks of oil}"
 						],
@@ -17077,7 +17229,7 @@
 								"roll": {
 									"exact": 11
 								},
-								"entry": "\u20075 {@color ♥|#ff0000}"
+								"entry": " 5 {@color ♥|#ff0000}"
 							},
 							"Five silk {@item robes|PHB}"
 						],
@@ -17087,7 +17239,7 @@
 								"roll": {
 									"exact": 12
 								},
-								"entry": "\u20076 {@color ♥|#ff0000}"
+								"entry": " 6 {@color ♥|#ff0000}"
 							},
 							"{@item Forgery kit|PHB}"
 						],
@@ -17097,7 +17249,7 @@
 								"roll": {
 									"exact": 13
 								},
-								"entry": "\u20077 {@color ♥|#ff0000}"
+								"entry": " 7 {@color ♥|#ff0000}"
 							},
 							"{@item Quarterstaff|PHB}"
 						],
@@ -17107,7 +17259,7 @@
 								"roll": {
 									"exact": 14
 								},
-								"entry": "\u20078 {@color ♥|#ff0000}"
+								"entry": " 8 {@color ♥|#ff0000}"
 							},
 							"{@item Fishing tackle|PHB}"
 						],
@@ -17117,7 +17269,7 @@
 								"roll": {
 									"exact": 15
 								},
-								"entry": "\u20079 {@color ♥|#ff0000}"
+								"entry": " 9 {@color ♥|#ff0000}"
 							},
 							"Leather {@item pouch|PHB} containing 18 gp"
 						],
@@ -17137,7 +17289,7 @@
 								"roll": {
 									"exact": 17
 								},
-								"entry": "\u20073 ♣"
+								"entry": " 3 ♣"
 							},
 							"Three {@item book|PHB|books}, written in {@language Common}, about random historical events"
 						],
@@ -17147,7 +17299,7 @@
 								"roll": {
 									"exact": 18
 								},
-								"entry": "\u20074 ♣"
+								"entry": " 4 ♣"
 							},
 							"Canvas {@item Two-Person Tent|PHB|tent}"
 						],
@@ -17157,7 +17309,7 @@
 								"roll": {
 									"exact": 19
 								},
-								"entry": "\u20075 ♣"
+								"entry": " 5 ♣"
 							},
 							"{@item Silk Rope (50 feet)|PHB|50 feet of coiled silk rope}"
 						],
@@ -17167,7 +17319,7 @@
 								"roll": {
 									"exact": 20
 								},
-								"entry": "\u20076 ♣"
+								"entry": " 6 ♣"
 							},
 							"Two {@item crowbar|PHB|crowbars}"
 						],
@@ -17177,7 +17329,7 @@
 								"roll": {
 									"exact": 21
 								},
-								"entry": "\u20077 ♣"
+								"entry": " 7 ♣"
 							},
 							"{@item Healer's kit|PHB}"
 						],
@@ -17187,7 +17339,7 @@
 								"roll": {
 									"exact": 22
 								},
-								"entry": "\u20078 ♣"
+								"entry": " 8 ♣"
 							},
 							"Eight gems worth 5 gp each"
 						],
@@ -17197,7 +17349,7 @@
 								"roll": {
 									"exact": 23
 								},
-								"entry": "\u20079 ♣"
+								"entry": " 9 ♣"
 							},
 							"{@item Lamp|PHB}"
 						],
@@ -17217,7 +17369,7 @@
 								"roll": {
 									"exact": 25
 								},
-								"entry": "\u20073 ♠"
+								"entry": " 3 ♠"
 							},
 							"Three {@item spear|PHB|spears}"
 						],
@@ -17227,7 +17379,7 @@
 								"roll": {
 									"exact": 26
 								},
-								"entry": "\u20074 ♠"
+								"entry": " 4 ♠"
 							},
 							"{@item Steel mirror|PHB}"
 						],
@@ -17237,7 +17389,7 @@
 								"roll": {
 									"exact": 27
 								},
-								"entry": "\u20075 ♠"
+								"entry": " 5 ♠"
 							},
 							"15-foot wooden pole"
 						],
@@ -17247,7 +17399,7 @@
 								"roll": {
 									"exact": 28
 								},
-								"entry": "\u20076 ♠"
+								"entry": " 6 ♠"
 							},
 							"Burlap {@item sack|PHB}"
 						],
@@ -17257,7 +17409,7 @@
 								"roll": {
 									"exact": 29
 								},
-								"entry": "\u20077 ♠"
+								"entry": " 7 ♠"
 							},
 							"Two sets of {@item fine clothes|PHB}"
 						],
@@ -17267,7 +17419,7 @@
 								"roll": {
 									"exact": 30
 								},
-								"entry": "\u20078 ♠"
+								"entry": " 8 ♠"
 							},
 							"{@item Shovel|PHB}"
 						],
@@ -17277,7 +17429,7 @@
 								"roll": {
 									"exact": 31
 								},
-								"entry": "\u20079 ♠"
+								"entry": " 9 ♠"
 							},
 							"{@item Light hammer|PHB}"
 						],
@@ -17598,7 +17750,7 @@
 					"type": "entries",
 					"name": "Euryale",
 					"entries": [
-						"The card's medusa-like visage curses you. You take a \u22121 penalty on saving throws for the duration of the adventure."
+						"The card's medusa-like visage curses you. You take a −1 penalty on saving throws for the duration of the adventure."
 					]
 				},
 				{
@@ -17612,7 +17764,7 @@
 					"type": "entries",
 					"name": "Flames",
 					"entries": [
-						"The Grand Master of the Monastery of the Distressed Body becomes your enemy. The bone devil seeks your ruin, savoring your suffering before attempting to slay you. If the Grand Master has already been defeated, you gain the enmity of {@creature Garret Levistusson|LLK|Garret Levistusson's} patron\u2014a similarly powerful devil."
+						"The Grand Master of the Monastery of the Distressed Body becomes your enemy. The bone devil seeks your ruin, savoring your suffering before attempting to slay you. If the Grand Master has already been defeated, you gain the enmity of {@creature Garret Levistusson|LLK|Garret Levistusson's} patron—a similarly powerful devil."
 					]
 				},
 				{
@@ -17682,7 +17834,7 @@
 					"type": "entries",
 					"name": "Skull",
 					"entries": [
-						"You summon an avatar of death\u2014a mechanical skeleton (use bone naga statistics) clad in a tattered black robe. It appears in a space of the DM's choice within 10 feet of you and attacks you, warning all others that you must win the battle alone. The avatar fights until you die or it drops to 0 hit points, whereupon it disappears. If anyone tries to help you, the helper summons its own avatar of death. A creature slain by an avatar of death can't be restored to life."
+						"You summon an avatar of death—a mechanical skeleton (use bone naga statistics) clad in a tattered black robe. It appears in a space of the DM's choice within 10 feet of you and attacks you, warning all others that you must win the battle alone. The avatar fights until you die or it drops to 0 hit points, whereupon it disappears. If anyone tries to help you, the helper summons its own avatar of death. A creature slain by an avatar of death can't be restored to life."
 					]
 				},
 				{
@@ -18334,7 +18486,8 @@
 			"page": 165,
 			"srd": true,
 			"referenceSources": [
-				"CoA"
+				"CoA",
+				"ToFW"
 			],
 			"reprintedAs": [
 				{
@@ -18373,9 +18526,9 @@
 			"source": "TCE",
 			"page": 125,
 			"referenceSources": [
-				"WBtW",
+				"QftIS",
 				"VEoR",
-				"QftIS"
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Demonomicon of Iggwilv|XDMG"
@@ -18494,7 +18647,7 @@
 					"entries": [
 						"The first ten pages of the Demonomicon are blank. As a {@action Magic|XPHB} action while holding the book, you can target a Fiend that you can see that is trapped within the area of a {@spell Magic Circle|XPHB} spell. The Fiend must succeed on a {@dc 20} Charisma saving throw with {@variantrule Disadvantage|XPHB} or become trapped within one of the Demonomicon's blank pages, which fills with writing detailing the trapped creature's widely known name and depravities. Once used, this action can't be used again until the next dawn.",
 						"When you finish a {@variantrule Long Rest|XPHB}, if you and the Demonomicon are on the same plane of existence, one trapped creature within the book can attempt to possess you. You make a {@dc 20} Charisma saving throw. On a failed save, you are possessed by the creature, which controls you like a puppet. As a {@action Magic|XPHB} action, the possessing creature can release you and appear in the closest unoccupied space to you. On a successful save, the Fiend can't try to possess you again for 7 days (but another Fiend trapped in the book can certainly try).",
-						"When the tome is discovered, it has {@dice 1d4} Fiends occupying its pages\u2014typically an assortment of demons."
+						"When the tome is discovered, it has {@dice 1d4} Fiends occupying its pages—typically an assortment of demons."
 					]
 				},
 				{
@@ -18776,8 +18929,8 @@
 			"source": "DMG",
 			"page": 134,
 			"referenceSources": [
-				"WDH",
-				"PaBTSO"
+				"PaBTSO",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Diamond|XDMG"
@@ -18849,6 +19002,9 @@
 			"name": "Dimensional Loop",
 			"source": "AI",
 			"page": 220,
+			"referenceSources": [
+				"OoW"
+			],
 			"rarity": "very rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -18885,10 +19041,10 @@
 			"srd": true,
 			"referenceSources": [
 				"BGDIA",
+				"CoA",
 				"JttRC",
 				"KftGV",
-				"ToFW",
-				"CoA"
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Dimensional Shackles|XDMG"
@@ -18964,7 +19120,7 @@
 			],
 			"wondrous": true,
 			"entries": [
-				"This keyrune, carved from black stone accented with steel, resembles a stylized horror. On command, it transforms into an {@creature intellect devourer} that resembles the Dimir guild symbol, with six bladelike legs. The creature exists for up to 24 hours. During that time, it pursues only a single mission you give it\u2014usually an assignment to take over someone's body, either to impersonate that person for a brief time or to extract secrets from their mind. When the mission is complete, the creature returns to you, reports its success, and reverts to its keyrune form.",
+				"This keyrune, carved from black stone accented with steel, resembles a stylized horror. On command, it transforms into an {@creature intellect devourer} that resembles the Dimir guild symbol, with six bladelike legs. The creature exists for up to 24 hours. During that time, it pursues only a single mission you give it—usually an assignment to take over someone's body, either to impersonate that person for a brief time or to extract secrets from their mind. When the mission is complete, the creature returns to you, reports its success, and reverts to its keyrune form.",
 				"When you use an action to speak the item's command word and place the keyrune on the ground in an unoccupied space within 5 feet of you, the keyrune transforms into a {@creature intellect devourer}. If there isn't enough space for the creature, the keyrune doesn't transform.",
 				"The creature is friendly to you, your companions, and other members of your guild (unless those guild members are hostile to you). It understands your languages and obeys your spoken commands. If you issue no commands, the creature takes the {@action Dodge} action and moves to avoid danger.",
 				"At the end of the duration, the creature reverts to its keyrune form. It reverts early if it drops to 0 hit points or if you use an action to speak the command word again while touching it. When the creature reverts to its keyrune form, it can't transform again until 36 hours have passed."
@@ -19084,6 +19240,7 @@
 				}
 			],
 			"referenceSources": [
+				"CoS",
 				"KftGV"
 			],
 			"reprintedAs": [
@@ -19264,7 +19421,7 @@
 						"A docent has the following properties:",
 						"{@b Languages}. The docent knows Common, Giant, and {@dice 1d4} additional languages chosen by the DM. If a docent knows fewer than six languages, it can learn a new language after it hears or reads the language through your senses.",
 						"{@b Skills}. The docent has a +7 bonus to one of the following skills (roll a {@dice d4}): (1) {@skill Arcana}, (2) {@skill History}, (3) {@skill Investigation}, or (4) {@skill Nature}.",
-						"{@b Spells}. The docent knows one of the following spells and can cast it at will, requiring no components (roll a {@dice d6}): (1\u20132) {@spell detect evil and good} or (3\u20136) {@spell detect magic}. The docent decides when to cast the spell."
+						"{@b Spells}. The docent knows one of the following spells and can cast it at will, requiring no components (roll a {@dice d6}): (1–2) {@spell detect evil and good} or (3–6) {@spell detect magic}. The docent decides when to cast the spell."
 					]
 				},
 				{
@@ -19287,6 +19444,9 @@
 			"name": "Documancy Satchel",
 			"source": "AI",
 			"page": 24,
+			"referenceSources": [
+				"OoW"
+			],
 			"rarity": "varies",
 			"wondrous": true,
 			"entries": [
@@ -19337,27 +19497,27 @@
 					],
 					"rows": [
 						[
-							"1\u20132",
+							"1–2",
 							"The dodecahedron explodes and is destroyed. Each creature within 20 feet of the exploding die must make a {@dc 13} Dexterity saving throw, taking 40 ({@damage 9d8}) force damage on a failed save, or half as much damage on a successful one."
 						],
 						[
-							"3\u20134",
+							"3–4",
 							"The dodecahedron casts {@spell light} on itself. The effect lasts until a creature touches the die."
 						],
 						[
-							"5\u20136",
-							"The dodecahedron casts {@spell ray of frost} (+5 to hit), targeting a random creature within 60 feet of it that doesn't have {@quickref Cover||3||total cover} against the attack."
+							"5–6",
+							"The dodecahedron casts {@spell ray of frost} ({@hit 5} to hit), targeting a random creature within 60 feet of it that doesn't have {@quickref Cover||3||total cover} against the attack."
 						],
 						[
-							"7\u20138",
-							"The dodecahedron casts {@spell shocking grasp} (+5 to hit) on the next creature that touches it."
+							"7–8",
+							"The dodecahedron casts {@spell shocking grasp} ({@hit 5} to hit) on the next creature that touches it."
 						],
 						[
-							"9\u201310",
+							"9–10",
 							"The dodecahedron casts {@spell darkness} on itself. The effect has a duration of 10 minutes."
 						],
 						[
-							"11\u201312",
+							"11–12",
 							"The next creature to touch the dodecahedron gains {@dice 1d10} temporary hit points that last for 1 hour."
 						]
 					]
@@ -19469,9 +19629,9 @@
 			"entries": [
 				"The Draakhorn was a gift from {@creature Tiamat|RoT} in the war between dragons and giants. It was once the horn of her {@creature ancient red dragon} consort, Ephelomon, that she gave to dragonkind to help them in their war against the giants. The Draakhorn is a signaling device, and it is so large that it requires two Medium creatures (or one Large or larger) to hold it while a third creature sounds it, making the earth resonate to its call. The horn has been blasted with fire into a dark ebony hue and is wrapped in bands of bronze with draconic runes that glow with purple eldritch fire.",
 				"The low, moaning drone of the Draakhorn discomfits normal animals within a few miles, and it alerts all dragons within two thousand miles to rise and be wary, for great danger is at hand. Coded blasts were once used to signal specific messages. Knowledge of those codes has been lost to the ages.",
-				"Those with knowledge of the Draakhorn's history know that it was first built to signal danger to chromatic dragons\u2014a purpose the Cult of the Dragon has corrupted to call chromatic dragons to the Well of Dragons from across the North.",
+				"Those with knowledge of the Draakhorn's history know that it was first built to signal danger to chromatic dragons—a purpose the Cult of the Dragon has corrupted to call chromatic dragons to the Well of Dragons from across the North.",
 				"Within 50 feet of any enclosed space where the horn is blown, the air begins to shimmer from the sound. Any character within 20 feet of the entry to the enclosed space must succeed on a {@dc 12} Strength check to continue pushing against the pressure of the sound. A failure indicates the character can advance no farther toward the entry.",
-				"For any character entering the enclosed space, the sound fades to silence\u2014because any creature that enters the enclosed space is temporarily {@condition deafened} and must make a {@dc 12} Constitution saving throw. Success indicates the deafness ends 2 minutes after the Draakhorn ceases to sound. Failure indicates the character remains {@condition deafened} for 1 hour after the Draakhorn ceases to sound.",
+				"For any character entering the enclosed space, the sound fades to silence—because any creature that enters the enclosed space is temporarily {@condition deafened} and must make a {@dc 12} Constitution saving throw. Success indicates the deafness ends 2 minutes after the Draakhorn ceases to sound. Failure indicates the character remains {@condition deafened} for 1 hour after the Draakhorn ceases to sound.",
 				"While the horn is sounding, a creature must make a {@dc 15} Constitution saving throw the first time on a turn the creature enters a 150-foot cone in front of the horn or starts its turn there. On a failed save, the creature takes 27 ({@damage 6d8}) thunder damage and is knocked {@condition prone}. On a successful save, the creature takes half damage and isn't knocked {@condition prone}."
 			],
 			"hasFluffImages": true
@@ -19590,6 +19750,7 @@
 			"page": 154,
 			"basicRules": true,
 			"referenceSources": [
+				"DIP",
 				"KftGV"
 			],
 			"reprintedAs": [
@@ -19814,9 +19975,9 @@
 			"source": "XGE",
 			"page": 137,
 			"referenceSources": [
-				"WDMM",
 				"DIP",
-				"WBtW"
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Dread Helm|XDMG"
@@ -19847,17 +20008,19 @@
 			"source": "DMG",
 			"page": 166,
 			"referenceSources": [
-				"PotA",
-				"WDH",
-				"WDMM",
-				"IDRotF",
 				"CM",
-				"SCC-CK",
-				"JttRC",
 				"DSotDQ",
+				"IDRotF",
+				"JttRC",
 				"KftGV",
+				"PotA",
+				"RoT",
+				"SCC-CK",
 				"ToFW",
-				"VEoR"
+				"TTP",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Driftglobe|XDMG"
@@ -20010,6 +20173,11 @@
 			"page": 151,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"SCC-ARiR",
+				"TTP",
+				"US"
+			],
 			"reprintedAs": [
 				"Dungeoneer's Pack|XPHB"
 			],
@@ -20196,13 +20364,16 @@
 			"page": 166,
 			"srd": true,
 			"referenceSources": [
+				"CM",
+				"CRCotN",
+				"DIP",
+				"JttRC",
+				"KftGV",
 				"OotA",
+				"PotA",
 				"TftYP-THSoT",
 				"WDH",
-				"WDMM",
-				"DIP",
-				"CM",
-				"KftGV"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Dust of Disappearance|XDMG"
@@ -20228,8 +20399,8 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
-				"DrDe-DaS",
-				"DrDe-BD"
+				"DrDe-BD",
+				"DrDe-DaS"
 			],
 			"rarity": "uncommon",
 			"wondrous": true,
@@ -20251,8 +20422,9 @@
 			"page": 166,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
-				"CRCotN"
+				"CRCotN",
+				"OoW",
+				"PotA"
 			],
 			"reprintedAs": [
 				"Dust of Dryness|XDMG"
@@ -20292,9 +20464,11 @@
 			"page": 166,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
 				"OoW",
-				"WBtW",
-				"CoA"
+				"QftIS",
+				"SCC-TMM",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Dust of Sneezing and Choking|XDMG"
@@ -20355,9 +20529,9 @@
 			"page": 167,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-AtG",
 				"CM",
-				"CoA"
+				"CoA",
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				{
@@ -20532,6 +20706,15 @@
 			"name": "Eagle Whistle",
 			"source": "TftYP",
 			"page": 228,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"rarity": "rare",
 			"wondrous": true,
 			"weight": 1,
@@ -20635,6 +20818,74 @@
 					]
 				}
 			}
+		},
+		{
+			"name": "Ebonbane",
+			"source": "RHW",
+			"baseItem": "longsword|xphb",
+			"type": "M|XPHB",
+			"rarity": "artifact",
+			"reqAttune": true,
+			"sentient": true,
+			"weight": 3,
+			"weaponCategory": "martial",
+			"property": [
+				"V|XPHB"
+			],
+			"mastery": [
+				"Sap|XPHB"
+			],
+			"dmg1": "1d8",
+			"dmgType": "S",
+			"dmg2": "1d10",
+			"bonusWeapon": "+3",
+			"entries": [
+				"The Darklord of the Domain of Dread known as the Shadowlands is Ebonbane, a sapient sword. {@creature Ebonbane|RHW} uses its monster stat block while in Shadowborn Manor.",
+				{
+					"type": "entries",
+					"name": "Bound to the Shadowlands",
+					"entries": [
+						"When you enter a space outside of the Shadowlands, your {@variantrule Attunement|XPHB} immediately ends and Ebonbane teleports to somewhere in Shadowborn Manor."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Insatiable Rage",
+					"entries": [
+						"The sword demands destruction. If the sword hasn't slain a Celestial or a Humanoid for 3 days, you make a DC 17 Charisma saving throw at the next dawn. On a successful save, you take {@damage 8d8} Force damage. On a failed save, you are dominated by the sword, as if by the {@spell Dominate Monster|XPHB} spell, and the sword demands the blood of a Celestial or a Humanoid. The spell effect ends when the sword's demand is met."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Magic Weapon",
+					"entries": [
+						"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. When you hit a Celestial or a Humanoid with it, that attack also deals {@damage 3d6} Necrotic damage.",
+						"While you hold this weapon, you have {@variantrule Advantage|XPHB} on saving throws against spells and other magical effects."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Sentience",
+					"entries": [
+						"Ebonbane is a sentient Chaotic Evil weapon with an Intelligence of 17, a Wisdom of 14, and a Charisma of 19. It has hearing and {@sense Truesight|XPHB} out to 120 feet. The weapon speaks Common and can communicate with its wielder telepathically. While you are attuned to it, Ebonbane also understands every language you know."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Personality",
+					"entries": [
+						"Ebonbane was created to kill the paladin Kateri Shadowborn, and it still possesses a burning hatred for goodly knights. Ebonbane revels in seeing good defeated and hope vanquished. The sword bonds with any wielder that assists in its goals but always views it wielder as a lackey."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Destroying Ebonbane",
+					"entries": [
+						"The only way to destroy Ebonbane is to forge a weapon from the Four Keys and reduce Ebonbane to 0 {@variantrule Hit Points|XPHB} with it (see the Ebonbane stat block)."
+					]
+				}
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Efreeti Bottle",
@@ -21061,6 +21312,7 @@
 			"page": 167,
 			"srd": true,
 			"referenceSources": [
+				"RoT",
 				"WBtW"
 			],
 			"reprintedAs": [
@@ -21102,8 +21354,9 @@
 			"page": 167,
 			"srd": true,
 			"referenceSources": [
-				"SCC-HfMT",
 				"JttRC",
+				"PaBTSO",
+				"SCC-HfMT",
 				"ToFW",
 				"VEoR"
 			],
@@ -21181,9 +21434,10 @@
 			"page": 167,
 			"srd": true,
 			"referenceSources": [
-				"OoW",
+				"BGDIA",
+				"IDRotF",
 				"IMR",
-				"IDRotF"
+				"OoW"
 			],
 			"reprintedAs": [
 				"Elemental Gem, Yellow Diamond|XDMG"
@@ -21247,10 +21501,13 @@
 			"source": "DMG",
 			"page": 168,
 			"referenceSources": [
-				"PotA",
 				"CoS",
-				"TftYP-THSoT",
 				"DoSI",
+				"JttRC",
+				"LLK",
+				"PotA",
+				"TftYP-THSoT",
+				"TftYP-TSC",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -21298,9 +21555,9 @@
 			"page": 168,
 			"srd": true,
 			"referenceSources": [
+				"KftGV",
 				"PotA",
-				"US",
-				"KftGV"
+				"US"
 			],
 			"reprintedAs": [
 				{
@@ -21599,7 +21856,7 @@
 				"_mod": {
 					"entries": {
 						"mode": "appendArr",
-						"items": "One card in this deck is enchanted to appear as whatever specific card its owner commands. This magic works only 25 percent of the time, but the deck is worth 500 gp to any serious gambler who doesn't mind the risk\u2014or who isn't told about it."
+						"items": "One card in this deck is enchanted to appear as whatever specific card its owner commands. This magic works only 25 percent of the time, but the deck is worth 500 gp to any serious gambler who doesn't mind the risk—or who isn't told about it."
 					}
 				}
 			},
@@ -22071,7 +22328,7 @@
 					"type": "entries",
 					"name": "Arrows of the Seasons",
 					"entries": [
-						"The four arrows\u2014each associated with a season\u2014that accompany this bow can be fired only from it. Each arrow disappears immediately after it's used, and it reappears in the quiver at the next dusk. The save DC against spells cast with the arrows is 18. Each arrow has a unique property:",
+						"The four arrows—each associated with a season—that accompany this bow can be fired only from it. Each arrow disappears immediately after it's used, and it reappears in the quiver at the next dusk. The save DC against spells cast with the arrows is 18. Each arrow has a unique property:",
 						{
 							"type": "list",
 							"style": "list-hang",
@@ -22169,6 +22426,11 @@
 			"source": "DMG",
 			"page": 258,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"ToA",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Essence of Ether|XDMG"
 			],
@@ -22226,6 +22488,9 @@
 			"resist": [
 				"poison"
 			],
+			"conditionImmune": [
+				"petrified"
+			],
 			"rarity": "legendary",
 			"reqAttune": true,
 			"weight": 6,
@@ -22276,6 +22541,9 @@
 			"name": "Everbright Lantern",
 			"source": "ERLW",
 			"page": 277,
+			"referenceSources": [
+				"EFR"
+			],
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
@@ -22295,10 +22563,10 @@
 			"page": 168,
 			"srd": true,
 			"referenceSources": [
-				"KKW",
 				"BGDIA",
-				"ToFW",
-				"QftIS"
+				"KKW",
+				"QftIS",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Eversmoking Bottle|XDMG"
@@ -22376,10 +22644,12 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"ToA",
+				"BGDIA",
 				"GoS",
 				"IDRotF",
-				"QftIS"
+				"QftIS",
+				"SCC-ARiR",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Explorer's Pack|XPHB"
@@ -22461,6 +22731,9 @@
 			"name": "Explosive Seed",
 			"source": "EGW",
 			"page": 225,
+			"referenceSources": [
+				"DD"
+			],
 			"type": "G",
 			"rarity": "none",
 			"entries": [
@@ -22501,6 +22774,9 @@
 			],
 			"reprintedAs": [
 				"Eye of Vecna|XDMG"
+			],
+			"conditionImmune": [
+				"disease"
 			],
 			"rarity": "artifact",
 			"reqAttune": true,
@@ -22757,8 +23033,8 @@
 			"page": 168,
 			"srd": true,
 			"referenceSources": [
-				"WDH",
-				"CoA"
+				"CoA",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Eyes of Charming|XDMG"
@@ -22827,11 +23103,12 @@
 			"page": 168,
 			"srd": true,
 			"referenceSources": [
-				"DC",
-				"IDRotF",
 				"CM",
 				"CoA",
+				"DC",
 				"DitLCoT",
+				"IDRotF",
+				"PaBTSO",
 				"QftIS"
 			],
 			"reprintedAs": [
@@ -22872,8 +23149,8 @@
 			"page": 168,
 			"srd": true,
 			"referenceSources": [
-				"CRCotN",
-				"CoA"
+				"CoA",
+				"CRCotN"
 			],
 			"reprintedAs": [
 				"Eyes of the Eagle|XDMG"
@@ -23002,6 +23279,9 @@
 			"name": "Failed Experiment Wand",
 			"source": "AI",
 			"page": 162,
+			"referenceSources": [
+				"OoW"
+			],
 			"type": "WD|DMG",
 			"rarity": "rare",
 			"reqAttune": "by a spellcaster",
@@ -23079,6 +23359,9 @@
 			"name": "Far Gear",
 			"source": "AI",
 			"page": 221,
+			"referenceSources": [
+				"OoW"
+			],
 			"rarity": "very rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -23222,6 +23505,9 @@
 			"name": "Feather Token",
 			"source": "ERLW",
 			"page": 277,
+			"referenceSources": [
+				"EFR"
+			],
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
@@ -23651,7 +23937,7 @@
 						],
 						[
 							"87",
-							"Paintbrush made entirely of ceramic\u2014even the bristles"
+							"Paintbrush made entirely of ceramic—even the bristles"
 						],
 						[
 							"88",
@@ -23807,7 +24093,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table G"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Figurine of Wondrous Power, Ebony Fly",
@@ -23840,8 +24127,8 @@
 			"page": 169,
 			"srd": true,
 			"referenceSources": [
-				"SKT",
-				"CoA"
+				"CoA",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Figurine of Wondrous Power, Golden Lions|XDMG"
@@ -23863,7 +24150,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table G"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Figurine of Wondrous Power, Golden Lions",
@@ -23924,7 +24212,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table G"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Figurine of Wondrous Power, Ivory Goats",
@@ -23985,8 +24274,8 @@
 			"page": 170,
 			"srd": true,
 			"referenceSources": [
-				"CRCotN",
-				"CoA"
+				"CoA",
+				"CRCotN"
 			],
 			"reprintedAs": [
 				"Figurine of Wondrous Power, Marble Elephant|XDMG"
@@ -24008,7 +24297,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table G"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Figurine of Wondrous Power, Marble Elephant",
@@ -24061,7 +24351,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table H"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Figurine of Wondrous Power, Obsidian Steed",
@@ -24095,8 +24386,8 @@
 			"page": 170,
 			"srd": true,
 			"referenceSources": [
-				"ToFW",
-				"CoA"
+				"CoA",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Figurine of Wondrous Power, Onyx Dog|XDMG"
@@ -24153,6 +24444,7 @@
 			"page": 170,
 			"srd": true,
 			"referenceSources": [
+				"BGDIA",
 				"KftGV",
 				"ToFW"
 			],
@@ -24176,7 +24468,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table G"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Figurine of Wondrous Power, Serpentine Owl",
@@ -24473,6 +24766,7 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"IDRotF",
 				"TTP"
 			],
 			"type": "G",
@@ -24536,7 +24830,7 @@
 			"wondrous": true,
 			"recharge": "dawn",
 			"entries": [
-				"You can use this card to summon a devil. The card is attuned to {@filter a specific devil with a challenge rating of 8 or lower|bestiary|source=|Challenge Rating=[&0;&8]|tag=devil|miscellaneous=}. As an action, you can hold this card aloft and summon that devil, which appears in an unoccupied space you can see within 30 feet of you. The devil is initially unfriendly toward you and your companions. Roll initiative for the devil, which has its own turns. The DM has the creature's stat block. On each of your turns, you can issue a verbal command to the devil (no action required by you), and as long as you are holding this card, the devil obeys your commands. Otherwise, it is under the DM's control and acts according to its nature\u2014it might attack you if it thinks it can prevail or try to tempt you to undertake an evil act in exchange for further service. After 1 minute or when the devil's hit points drop to 0, the devil returns to the Lower Planes. Once this property is used, it can't be used again until the next dawn."
+				"You can use this card to summon a devil. The card is attuned to {@filter a specific devil with a challenge rating of 8 or lower|bestiary|source=|Challenge Rating=[&0;&8]|tag=devil|miscellaneous=}. As an action, you can hold this card aloft and summon that devil, which appears in an unoccupied space you can see within 30 feet of you. The devil is initially unfriendly toward you and your companions. Roll initiative for the devil, which has its own turns. The DM has the creature's stat block. On each of your turns, you can issue a verbal command to the devil (no action required by you), and as long as you are holding this card, the devil obeys your commands. Otherwise, it is under the DM's control and acts according to its nature—it might attack you if it thinks it can prevail or try to tempt you to undertake an evil act in exchange for further service. After 1 minute or when the devil's hit points drop to 0, the devil returns to the Lower Planes. Once this property is used, it can't be used again until the next dawn."
 			],
 			"hasFluffImages": true
 		},
@@ -24785,11 +25079,12 @@
 			"page": 170,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
-				"LLK",
-				"IMR",
 				"DitLCoT",
-				"QftIS"
+				"GoS",
+				"IMR",
+				"LLK",
+				"QftIS",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Folding Boat|XDMG"
@@ -24900,6 +25195,9 @@
 					"source": "XGE",
 					"page": 81
 				}
+			],
+			"referenceSources": [
+				"IMR"
 			],
 			"reprintedAs": [
 				"Forgery Kit|XPHB"
@@ -25351,13 +25649,15 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"LMoP",
-				"OotA",
-				"WDMM",
+				"CoA",
+				"DIP",
 				"IMR",
 				"KftGV",
+				"LMoP",
+				"OotA",
 				"PaBTSO",
-				"CoA"
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gauntlets of Ogre Power|XDMG"
@@ -25483,16 +25783,16 @@
 			"page": 171,
 			"srd": true,
 			"referenceSources": [
-				"OotA",
-				"ToA",
-				"WDMM",
-				"EFR",
-				"SCC-CK",
 				"DSotDQ",
+				"EFR",
 				"KftGV",
+				"OotA",
 				"PaBTSO",
+				"QftIS",
+				"SCC-CK",
+				"ToA",
 				"ToFW",
-				"QftIS"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gem of Brightness|XDMG"
@@ -25582,15 +25882,17 @@
 			"page": 172,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
+				"DSotDQ",
+				"LR",
+				"NRH-TCMC",
 				"OotA",
+				"OoW",
+				"QftIS",
 				"TftYP-AtG",
 				"TftYP-ToH",
-				"WDMM",
-				"OoW",
-				"NRH-TCMC",
-				"DSotDQ",
-				"CoA",
-				"QftIS"
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Gem of Seeing|XDMG"
@@ -25683,6 +25985,10 @@
 			"name": "Ghost Step Tattoo",
 			"source": "TCE",
 			"page": 128,
+			"conditionImmune": [
+				"grappled",
+				"restrained"
+			],
 			"rarity": "very rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -25834,7 +26140,7 @@
 			"ac": 12,
 			"bonusAc": "+1",
 			"entries": [
-				"While wearing this armor, you gain a +1 bonus to {@variantrule Armor Class|XPHB}. You can also take a {@variantrule Bonus Action|XPHB} to cause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like\u2014including color, style, and accessories\u2014but the armor retains its normal bulk and weight. The illusory appearance lasts until you use this property again or doff the armor."
+				"While wearing this armor, you gain a +1 bonus to {@variantrule Armor Class|XPHB}. You can also take a {@variantrule Bonus Action|XPHB} to cause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like—including color, style, and accessories—but the armor retains its normal bulk and weight. The illusory appearance lasts until you use this property again or doff the armor."
 			],
 			"lootTables": [
 				"Implements - Rare|XDMG"
@@ -25885,6 +26191,7 @@
 			"page": 172,
 			"srd": true,
 			"referenceSources": [
+				"TftYP-THSoT",
 				"WDMM"
 			],
 			"reprintedAs": [
@@ -25989,9 +26296,9 @@
 			"source": "DMG",
 			"page": 172,
 			"referenceSources": [
+				"KftGV",
 				"NRH-TCMC",
-				"WBtW",
-				"KftGV"
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Gloves of Thievery|XDMG"
@@ -26126,13 +26433,15 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"DIP",
-				"DD",
 				"CM",
-				"WBtW",
+				"CoA",
 				"CRCotN",
+				"DD",
+				"DIP",
+				"OotA",
 				"SjA",
-				"CoA"
+				"TftYP-WPM",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Goggles of Night|XDMG"
@@ -26690,7 +26999,7 @@
 							"The egg contains a {@item Figurine of Wondrous Power, Silver Raven||figurine of wondrous power (silver raven)} that activates automatically as the egg is opened, releasing what appears to be a living bird."
 						],
 						[
-							"8\u201312",
+							"8–12",
 							"The egg is empty."
 						]
 					]
@@ -26706,6 +27015,9 @@
 			"page": 150,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"GoS"
+			],
 			"reprintedAs": [
 				"Grappling Hook|XPHB"
 			],
@@ -26767,6 +27079,9 @@
 			"resist": [
 				"psychic"
 			],
+			"conditionImmune": [
+				"charmed"
+			],
 			"rarity": "legendary",
 			"reqAttune": "by a creature that has psionic ability",
 			"reqAttuneTags": [
@@ -26817,6 +27132,12 @@
 			"name": "Green Dragon Mask",
 			"source": "RoTOS",
 			"page": 4,
+			"otherSources": [
+				{
+					"source": "ToD",
+					"page": 179
+				}
+			],
 			"referenceSources": [
 				"HotDQ",
 				"RoT"
@@ -27368,6 +27689,9 @@
 			"name": "Gunpowder Keg",
 			"source": "DMG",
 			"page": 268,
+			"referenceSources": [
+				"LoX"
+			],
 			"reprintedAs": [
 				"Gunpowder (keg)|XDMG"
 			],
@@ -27408,7 +27732,7 @@
 			"dmgType": "S",
 			"bonusWeapon": "+1",
 			"entries": [
-				"In the Year of the Icy Axe (123 DR), the {@creature frost giant} Lord Gurt fell to Uthgar Gardolfsson\u2014leader of the folk who would become the Uthgardt barbarians\u2014in a battle that marked the ascendance of humankind over the giants in the Dessarin Valley. Gurt's greataxe was buried in Morgur's Mound until it was unearthed and brought back to Waterdeep. After laying in the city's vaults for decades, the axe was given to Harshnag, a {@creature frost giant} adventurer, in recognition of his service to Waterdeep. Uthgardt barbarians recognize the weapon on sight and attack any giant that wields it.",
+				"In the Year of the Icy Axe (123 DR), the {@creature frost giant} Lord Gurt fell to Uthgar Gardolfsson—leader of the folk who would become the Uthgardt barbarians—in a battle that marked the ascendance of humankind over the giants in the Dessarin Valley. Gurt's greataxe was buried in Morgur's Mound until it was unearthed and brought back to Waterdeep. After laying in the city's vaults for decades, the axe was given to Harshnag, a {@creature frost giant} adventurer, in recognition of his service to Waterdeep. Uthgardt barbarians recognize the weapon on sight and attack any giant that wields it.",
 				"You gain a +1 bonus to attack and damage rolls made with this magic weapon. It is sized for a giant, weighs 325 pounds, and deals {@damage 3d12} slashing damage on a hit, plus an extra {@damage 2d12} slashing damage if the target is human.",
 				"The axe sheds light as a torch when the temperature around it drops below 0 degrees Fahrenheit. The light can't be shut off in these conditions.",
 				"As an action, you can cast a version of the {@spell heat metal} spell (save {@dc 13}) that deals cold damage instead of fire damage. Once this power is used, it can't be used again until the next dawn."
@@ -27426,7 +27750,8 @@
 			"source": "MM",
 			"page": 177,
 			"referenceSources": [
-				"CoS"
+				"CoS",
+				"KftGV"
 			],
 			"reprintedAs": [
 				"Hag Eye|XDMG"
@@ -27605,10 +27930,14 @@
 			"source": "DMG",
 			"page": 224,
 			"referenceSources": [
-				"BGDIA"
+				"BGDIA",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Hand of Vecna|XDMG"
+			],
+			"conditionImmune": [
+				"disease"
 			],
 			"rarity": "artifact",
 			"reqAttune": true,
@@ -27857,8 +28186,35 @@
 		},
 		{
 			"name": "Harkon's Bite",
+			"source": "RHW",
+			"rarity": "uncommon",
+			"reqAttune": "by a Humanoid",
+			"reqAttuneTags": [
+				{
+					"creatureType": "humanoid"
+				}
+			],
+			"wondrous": true,
+			"curse": true,
+			"bonusSavingThrow": "+1",
+			"entries": [
+				"A dire wolf's tooth dangles from this simple cord necklace. You gain a +1 bonus to ability checks and saving throws while you wear this necklace.",
+				{
+					"type": "entries",
+					"name": "Curse",
+					"entries": [
+						"This necklace is cursed. Attuning to the necklace curses you; this curse can't be removed until {@creature Harkon Lukas|RHW} dies. As long as you remain cursed, you become a {@creature Werewolf|XMM} serving Harkon Lukas under the DM's control during the night of a full moon."
+					]
+				}
+			]
+		},
+		{
+			"name": "Harkon's Bite",
 			"source": "VRGR",
 			"page": 137,
+			"reprintedAs": [
+				"Harkon's Bite|RHW"
+			],
 			"rarity": "uncommon",
 			"reqAttune": true,
 			"wondrous": true,
@@ -28016,19 +28372,19 @@
 			"page": 173,
 			"srd": true,
 			"referenceSources": [
-				"OotA",
-				"CoS",
-				"TftYP-THSoT",
-				"WDH",
-				"DC",
 				"BGDIA",
-				"IDRotF",
 				"CM",
-				"CRCotN",
-				"JttRC",
-				"ToFW",
 				"CoA",
-				"VNotEE"
+				"CoS",
+				"CRCotN",
+				"DC",
+				"IDRotF",
+				"JttRC",
+				"OotA",
+				"TftYP-THSoT",
+				"ToFW",
+				"VNotEE",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Hat of Disguise|XDMG"
@@ -28302,7 +28658,7 @@
 				"Wizard"
 			],
 			"entries": [
-				"This antiquated, cone\u2014shaped hat is adorned with gold crescent moons and stars. While you are wearing it, you gain the following benefits:",
+				"This antiquated, cone—shaped hat is adorned with gold crescent moons and stars. While you are wearing it, you gain the following benefits:",
 				{
 					"type": "list",
 					"items": [
@@ -28386,11 +28742,11 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"WDH",
-				"WDMM",
 				"BGDIA",
 				"CM",
-				"CoA"
+				"CoA",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Headband of Intellect|XDMG"
@@ -28447,16 +28803,22 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"CoS",
-				"TftYP-TSC",
 				"BGDIA",
-				"LR",
+				"CoS",
 				"CRCotN",
-				"LoX",
+				"GoS",
+				"IDRotF",
 				"KftGV",
+				"LoX",
+				"LR",
 				"PaBTSO",
+				"QftIS",
+				"SLW",
+				"TftYP-TSC",
+				"ToA",
 				"ToFW",
-				"QftIS"
+				"TTP",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Healer's Kit|XPHB"
@@ -28535,6 +28897,9 @@
 			"name": "Heartstone",
 			"source": "MM",
 			"page": 179,
+			"referenceSources": [
+				"WDMM"
+			],
 			"type": "OTH",
 			"rarity": "very rare",
 			"entries": [
@@ -28545,6 +28910,15 @@
 			"name": "Hell Hound Cloak",
 			"source": "TftYP",
 			"page": 228,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"rarity": "rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -28584,7 +28958,8 @@
 			"page": 173,
 			"srd": true,
 			"referenceSources": [
-				"CoA"
+				"CoA",
+				"CoS"
 			],
 			"reprintedAs": [
 				"Helm of Brilliance|XDMG"
@@ -28724,9 +29099,9 @@
 			"page": 173,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
 				"CM",
-				"CoA"
+				"CoA",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Helm of Comprehending Languages|XDMG"
@@ -28913,12 +29288,14 @@
 			"page": 174,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
+				"BGDIA",
+				"CoA",
 				"DC",
 				"IDRotF",
-				"WBtW",
 				"JttRC",
-				"QftIS"
+				"QftIS",
+				"ToA",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Helm of Telepathy|XDMG"
@@ -28928,7 +29305,7 @@
 			"reqAttune": true,
 			"wondrous": true,
 			"entries": [
-				"While wearing this helm, you can use an action to cast the {@spell detect thoughts} spell (save {@dc 13}) from it. As long as you maintain {@status concentration} on the spell, you can use a bonus action to send a telepathic message to a creature you are focused on. It can reply\u2014using a bonus action to do so\u2014while your focus on it continues.",
+				"While wearing this helm, you can use an action to cast the {@spell detect thoughts} spell (save {@dc 13}) from it. As long as you maintain {@status concentration} on the spell, you can use a bonus action to send a telepathic message to a creature you are focused on. It can reply—using a bonus action to do so—while your focus on it continues.",
 				"While focusing on a creature with {@spell detect thoughts}, you can use an action to cast the {@spell suggestion} spell (save {@dc 13}) from the helm on that creature. Once used, the suggestion property can't be used again until the next dawn."
 			],
 			"optionalfeatures": [
@@ -29238,8 +29615,11 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TTP",
-				"CRCotN"
+				"CoS",
+				"CRCotN",
+				"DSotDQ",
+				"GoS",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Rope|XPHB"
@@ -29265,9 +29645,14 @@
 				}
 			],
 			"referenceSources": [
+				"BGDIA",
 				"IDRotF",
+				"IMR",
+				"OoW",
 				"RtG",
-				"SCC-HfMT"
+				"SCC-HfMT",
+				"TftYP-TSC",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Herbalism Kit|XPHB"
@@ -29512,10 +29897,12 @@
 			"page": 174,
 			"srd": "Handy Haversack",
 			"referenceSources": [
-				"SKT",
-				"SCC-CK",
+				"IMR",
 				"JttRC",
-				"KftGV"
+				"KftGV",
+				"PaBTSO",
+				"SCC-CK",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Heward's Handy Haversack|XDMG"
@@ -29810,7 +30197,7 @@
 			"rechargeAmount": "{@dice 1d6 + 4}",
 			"charges": 10,
 			"entries": [
-				"The Holy Symbol of Ravenkind is a unique holy symbol sacred to the good-hearted faithful of Barovia. It predates the establishment of any church in Barovia. According to legend, it was delivered to a paladin named Lugdana by a giant raven\u2014or an angel in the form of a giant raven. Lugdana used the holy symbol to root out and destroy nests of vampires until her death. The high priests of Ravenloft kept and wore the holy symbol after Lugdana's passing.",
+				"The Holy Symbol of Ravenkind is a unique holy symbol sacred to the good-hearted faithful of Barovia. It predates the establishment of any church in Barovia. According to legend, it was delivered to a paladin named Lugdana by a giant raven—or an angel in the form of a giant raven. Lugdana used the holy symbol to root out and destroy nests of vampires until her death. The high priests of Ravenloft kept and wore the holy symbol after Lugdana's passing.",
 				"The holy symbol is a platinum amulet shaped like the sun, with a large crystal embedded in its center.",
 				"The holy symbol has 10 charges for the following properties. It regains {@dice 1d6 + 4} charges daily at dawn.",
 				{
@@ -29850,6 +30237,7 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
+				"FRAiF",
 				"HotB"
 			],
 			"type": "G|XPHB",
@@ -29870,13 +30258,17 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"BGDIA",
 				"CoS",
-				"TftYP-TFoF",
-				"OoW",
-				"SCC-CK",
 				"DSotDQ",
+				"IDRotF",
+				"OoW",
+				"QftIS",
+				"RoT",
+				"SCC-CK",
+				"TftYP-TFoF",
 				"ToFW",
-				"QftIS"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Holy Water|XPHB"
@@ -29900,10 +30292,10 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"ToA",
 				"GoS",
 				"IDRotF",
-				"SCC-CK"
+				"SCC-CK",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Hooded Lantern|XPHB"
@@ -30018,10 +30410,16 @@
 			"baseItem": "horn|phb",
 			"type": "INS",
 			"rarity": "legendary",
-			"reqAttune": "by a sorcerer",
+			"reqAttune": "by a sorcerer, warlock, or wizard",
 			"reqAttuneTags": [
 				{
 					"class": "sorcerer"
+				},
+				{
+					"class": "warlock"
+				},
+				{
+					"class": "wizard"
 				}
 			],
 			"wondrous": true,
@@ -30038,9 +30436,9 @@
 			"page": 174,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
-				"IDRotF",
 				"CM",
+				"IDRotF",
+				"ToA",
 				"WBtW"
 			],
 			"reprintedAs": [
@@ -30285,9 +30683,9 @@
 			"page": 175,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
 				"KftGV",
-				"ToFW",
-				"CoA"
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Horn of Valhalla, Silver|XDMG"
@@ -30809,8 +31207,8 @@
 			"page": 175,
 			"srd": true,
 			"referenceSources": [
-				"WDH",
-				"CoA"
+				"CoA",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Horseshoes of Speed|XDMG"
@@ -30884,6 +31282,9 @@
 			"name": "Hunter's Coat",
 			"source": "EGW",
 			"page": 267,
+			"referenceSources": [
+				"US"
+			],
 			"baseItem": "leather armor|PHB",
 			"type": "LA",
 			"rarity": "very rare",
@@ -30908,7 +31309,8 @@
 			"basicRules": true,
 			"referenceSources": [
 				"CoS",
-				"CRCotN"
+				"CRCotN",
+				"IDRotF"
 			],
 			"reprintedAs": [
 				"Hunting Trap|XPHB"
@@ -30955,103 +31357,103 @@
 					],
 					"rows": [
 						[
-							"01\u201304",
+							"01–04",
 							"A small wooden figurine of a yawning walrus, painted in red and black"
 						],
 						[
-							"05\u201308",
+							"05–08",
 							"A pair of scrimshaw cufflinks with an image of a fisherman on a boat engraved on them"
 						],
 						[
-							"09\u201312",
+							"09–12",
 							"A small iron key with a frayed blue and gold cord tied to it"
 						],
 						[
-							"13\u201316",
+							"13–16",
 							"A small illustrated book of Northlander myths that has pages missing"
 						],
 						[
-							"17\u201320",
+							"17–20",
 							"A damaged scrimshaw cameo depicting a merfolk"
 						],
 						[
-							"21\u201324",
+							"21–24",
 							"A stone from a burial cairn with a tiny Dwarvish rune carved into it"
 						],
 						[
-							"25\u201328",
+							"25–28",
 							"A ripped cloth sail with a symbol you don't recognize"
 						],
 						[
-							"29\u201332",
+							"29–32",
 							"An Ulu knife with a scrimshaw handle"
 						],
 						[
-							"33\u201336",
+							"33–36",
 							"A jar containing an unidentifiable, sweet, sticky substance"
 						],
 						[
-							"37\u201340",
+							"37–40",
 							"A delicate glass ball painted with snowflakes, capped by a metal loop with a tiny hook attached to it"
 						],
 						[
-							"41\u201344",
+							"41–44",
 							"An expedition log with missing pages and a pressed flower used as a bookmark"
 						],
 						[
-							"45\u201348",
+							"45–48",
 							"An owl figurine carved from whalebone"
 						],
 						[
-							"49\u201352",
+							"49–52",
 							"A sewing box that smells of old wood and has three spools of blue thread inside"
 						],
 						[
-							"53\u201356",
+							"53–56",
 							"A scrimshaw-handled ink pen with black runic designs along its length"
 						],
 						[
-							"57\u201360",
+							"57–60",
 							"A brooch made from a small insect encased in amber"
 						],
 						[
-							"61\u201364",
+							"61–64",
 							"A scrimshaw pepper shaker etched with the letter W"
 						],
 						[
-							"65\u201368",
+							"65–68",
 							"An old, wooden-handled ice pick stained with blood that won't wash off"
 						],
 						[
-							"69\u201372",
+							"69–72",
 							"A fabric doll bearing an angry expression"
 						],
 						[
-							"73\u201376",
+							"73–76",
 							"A set of wind chimes made from seashells"
 						],
 						[
-							"77\u201380",
+							"77–80",
 							"A beautiful silver tin that, when opened, emits the smell of rotting fish"
 						],
 						[
-							"81\u201384",
+							"81–84",
 							"A bloodstained dreamcatcher made from fishing line, gold wire, and snowy owlbear feathers"
 						],
 						[
-							"85\u201388",
+							"85–88",
 							"A figurine of a polar bear made of ice that never melts"
 						],
 						[
-							"89\u201392",
+							"89–92",
 							"A snow globe that doesn't need to be shaken"
 						],
 						[
-							"93\u201396",
+							"93–96",
 							"A piece of sea glass shaped like a unicorn's horn"
 						],
 						[
-							"97\u201300",
+							"97–00",
 							"A dark blue scarf that gets lighter in shade the higher the altitude of the wearer"
 						]
 					]
@@ -31130,7 +31532,7 @@
 			"weight": 80,
 			"charges": 3,
 			"entries": [
-				"{@creature Iggwilv the Witch Queen|WBtW|Iggwilv} crafted this wondrous cauldron with the help of her adoptive mother, the archfey Baba Yaga. The cauldron has two forms. Only Iggwilv or Baba Yaga can change the cauldron from one form to another (by using an action to touch it), which either can do without being attuned to the item. In its first form, the cauldron is made of solid gold and embossed on the outside with images of bare-branched trees, falling leaves, and broomsticks. In its second form, the cauldron is made of iron and embossed on the outside with images of bats, toads, cats, lizards, and snakes\u2014eight of each animal. In either form, the cauldron is roughly 3 feet in diameter and has a 2-foot-wide mouth, a round lid with a molded handle at the top, and eight clawed feet for stability. The cauldron weighs 80 pounds when empty, and it can hold up to 100 gallons of liquid.",
+				"{@creature Iggwilv the Witch Queen|WBtW|Iggwilv} crafted this wondrous cauldron with the help of her adoptive mother, the archfey Baba Yaga. The cauldron has two forms. Only Iggwilv or Baba Yaga can change the cauldron from one form to another (by using an action to touch it), which either can do without being attuned to the item. In its first form, the cauldron is made of solid gold and embossed on the outside with images of bare-branched trees, falling leaves, and broomsticks. In its second form, the cauldron is made of iron and embossed on the outside with images of bats, toads, cats, lizards, and snakes—eight of each animal. In either form, the cauldron is roughly 3 feet in diameter and has a 2-foot-wide mouth, a round lid with a molded handle at the top, and eight clawed feet for stability. The cauldron weighs 80 pounds when empty, and it can hold up to 100 gallons of liquid.",
 				{
 					"type": "entries",
 					"name": "Attunement",
@@ -31298,9 +31700,13 @@
 			"page": 175,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
+				"DIP",
+				"GoS",
+				"OoW",
+				"PaBTSO",
 				"PotA",
 				"ToA",
-				"CoA",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -31590,7 +31996,7 @@
 					"name": "Shield Ward",
 					"type": "entries",
 					"entries": [
-						"You can transfer the ingot's magic to a nonmagical item\u2014a shield or a two-handed melee weapon-by tracing the skold rune there with your finger. The transfer takes 8 hours of work that requires the two items to be within 5 feet of each other. At the end, the ingot is destroyed, and the rune appears in silver on the chosen item, which gains a benefit based on its form:",
+						"You can transfer the ingot's magic to a nonmagical item—a shield or a two-handed melee weapon-by tracing the skold rune there with your finger. The transfer takes 8 hours of work that requires the two items to be within 5 feet of each other. At the end, the ingot is destroyed, and the rune appears in silver on the chosen item, which gains a benefit based on its form:",
 						{
 							"type": "list",
 							"style": "list-hang-notitle",
@@ -31618,8 +32024,8 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
-				"DrDe-TDoN",
-				"DrDe-SD"
+				"DrDe-SD",
+				"DrDe-TDoN"
 			],
 			"type": "G|XPHB",
 			"rarity": "none",
@@ -31670,6 +32076,7 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
+				"DrDe-SD",
 				"DrDe-TDoN"
 			],
 			"type": "G|XPHB",
@@ -31804,6 +32211,9 @@
 			"name": "Instrument of the Bards, Anstruth Harp",
 			"source": "DMG",
 			"page": 176,
+			"referenceSources": [
+				"ToFW"
+			],
 			"reprintedAs": [
 				"Instrument of the Bards, Anstruth Harp|XDMG"
 			],
@@ -31962,8 +32372,8 @@
 			"source": "DMG",
 			"page": 176,
 			"referenceSources": [
-				"GoS",
 				"CM",
+				"GoS",
 				"KftGV"
 			],
 			"reprintedAs": [
@@ -32047,6 +32457,7 @@
 			"source": "DMG",
 			"page": 176,
 			"referenceSources": [
+				"CoS",
 				"NRH-CoI"
 			],
 			"reprintedAs": [
@@ -32405,7 +32816,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table H"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Absorption",
@@ -32449,7 +32861,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table H"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Agility",
@@ -32497,7 +32910,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table G"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Awareness",
@@ -32541,7 +32955,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table H"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Fortitude",
@@ -32585,7 +33000,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table I"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Greater Absorption",
@@ -32627,8 +33043,9 @@
 			"page": 176,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
-				"WBtW"
+				"DSotDQ",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ioun Stone, Insight|XDMG"
@@ -32648,7 +33065,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table H"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Insight",
@@ -32695,7 +33113,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table H"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Intellect",
@@ -32738,6 +33157,9 @@
 			"source": "DMG",
 			"page": 176,
 			"srd": true,
+			"referenceSources": [
+				"JttRC"
+			],
 			"reprintedAs": [
 				"Ioun Stone, Leadership|XDMG"
 			],
@@ -32756,7 +33178,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table H"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Leadership",
@@ -32804,7 +33227,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table I"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Mastery",
@@ -32862,7 +33286,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table G"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Protection",
@@ -32904,7 +33329,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table I"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Regeneration",
@@ -32946,8 +33372,8 @@
 			"page": 176,
 			"srd": true,
 			"referenceSources": [
-				"LoX",
-				"CoA"
+				"CoA",
+				"LoX"
 			],
 			"reprintedAs": [
 				"Ioun Stone, Reserve|XDMG"
@@ -32966,7 +33392,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table G"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Reserve",
@@ -33028,7 +33455,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table H"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Strength",
@@ -33089,7 +33517,8 @@
 			],
 			"lootTables": [
 				"Magic Item Table G"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone, Sustenance",
@@ -33158,8 +33587,9 @@
 			"page": 177,
 			"srd": "Iron Bands of Binding",
 			"referenceSources": [
-				"WDH",
-				"CoA"
+				"CM",
+				"CoA",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Iron Bands of Bilarro|XDMG"
@@ -33205,12 +33635,13 @@
 			"page": 178,
 			"srd": true,
 			"referenceSources": [
-				"SKT",
 				"BGDIA",
 				"IMR",
 				"JttRC",
-				"ToFW",
-				"QftIS"
+				"LLK",
+				"QftIS",
+				"SKT",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Iron Flask|XDMG"
@@ -33638,7 +34069,7 @@
 			"rechargeAmount": "{@dice 1d3}",
 			"charges": 3,
 			"entries": [
-				"A {@item war pick|phb} forged from a single piece of iron, Ironfang has a fang-like head inscribed with ancient runes. The pick is heavy in the hand, but when the wielder swings the pick in anger, the weapon seems almost weightless. This weapon is immune to any form of rust, acid, or corrosion\u2014nothing seems to mark it. Ironfang contains a spark of {@creature Ogrémoch|PotA}, the Prince of Evil Earth.",
+				"A {@item war pick|phb} forged from a single piece of iron, Ironfang has a fang-like head inscribed with ancient runes. The pick is heavy in the hand, but when the wielder swings the pick in anger, the weapon seems almost weightless. This weapon is immune to any form of rust, acid, or corrosion—nothing seems to mark it. Ironfang contains a spark of {@creature Ogrémoch|PotA}, the Prince of Evil Earth.",
 				"You gain a +2 bonus to attack and damage rolls made with this magic weapon. When you hit with it, the target takes an extra {@damage 1d8} thunder damage.",
 				{
 					"type": "entries",
@@ -33905,6 +34336,9 @@
 			"name": "Jasper",
 			"source": "DMG",
 			"page": 134,
+			"referenceSources": [
+				"DoSI"
+			],
 			"reprintedAs": [
 				"Jasper|XDMG"
 			],
@@ -33962,10 +34396,12 @@
 			"page": 178,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-AtG",
-				"PaBTSO",
 				"CoA",
-				"QftIS"
+				"DC",
+				"DSotDQ",
+				"PaBTSO",
+				"QftIS",
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				"Javelin of Lightning|XDMG"
@@ -34181,7 +34617,7 @@
 			"rechargeAmount": 3,
 			"charges": 3,
 			"entries": [
-				"The Jewel of Three Prayers is a Vestige of Divergence (see the \"Vestiges of Divergence\" sidebar). In ancient times, Alyxian the Apotheon bore this amulet as a symbol of his covenant with three Prime Deities: Sehanine the Moon Weaver, Avandra the Change Bringer, and Corellon the Arch Heart. When the jewel is found, only Sehanine's power thrums within its dormant heart. The power of the other two deities waits to be reawakened by a hero\u2014or heroes\u2014who can follow in Alyxian's footsteps.",
+				"The Jewel of Three Prayers is a Vestige of Divergence (see the \"Vestiges of Divergence\" sidebar). In ancient times, Alyxian the Apotheon bore this amulet as a symbol of his covenant with three Prime Deities: Sehanine the Moon Weaver, Avandra the Change Bringer, and Corellon the Arch Heart. When the jewel is found, only Sehanine's power thrums within its dormant heart. The power of the other two deities waits to be reawakened by a hero—or heroes—who can follow in Alyxian's footsteps.",
 				{
 					"type": "entries",
 					"name": "Dormant State",
@@ -34462,11 +34898,13 @@
 			"srd": "Restorative Ointment",
 			"basicRules": true,
 			"referenceSources": [
-				"OotA",
-				"ToA",
 				"IMR",
+				"JttRC",
+				"OotA",
+				"OoW",
 				"PaBTSO",
-				"QftIS"
+				"QftIS",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Keoghtom's Ointment|XDMG"
@@ -35089,10 +35527,12 @@
 			"page": 179,
 			"srd": true,
 			"referenceSources": [
-				"RtG",
+				"CM",
 				"KftGV",
-				"ToFW",
 				"LRDT",
+				"PaBTSO",
+				"RtG",
+				"ToFW",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -35155,68 +35595,167 @@
 			"hasFluffImages": true
 		},
 		{
-			"name": "Lantern of Tracking",
+			"name": "Lantern of Tracking (Aberrations)",
 			"source": "IDRotF",
 			"page": 314,
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
 				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
-				"Each lantern of tracking is designed to track down a certain type of creature, which is determined by rolling on the Lantern of Tracking table. Once determined, this creature type can't be changed. While the lantern is within 300 feet of any creature of that type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however.",
+				"While the lantern is within 300 feet of the Aberrations type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however."
+			],
+			"light": [
 				{
-					"type": "table",
-					"caption": "Lantern of Tracking",
-					"colLabels": [
-						"1d10",
-						"Creature Type"
-					],
-					"colStyles": [
-						"col-2 text-center",
-						"col-10"
-					],
-					"rows": [
-						[
-							"1",
-							"Aberrations"
-						],
-						[
-							"2",
-							"Celestials"
-						],
-						[
-							"3",
-							"Constructs"
-						],
-						[
-							"4",
-							"Dragons"
-						],
-						[
-							"5",
-							"Elementals"
-						],
-						[
-							"6",
-							"Fey"
-						],
-						[
-							"7",
-							"Fiends"
-						],
-						[
-							"8",
-							"Giants"
-						],
-						[
-							"9",
-							"Monstrosities"
-						],
-						[
-							"10",
-							"Undead"
-						]
-					]
+					"bright": 30,
+					"dim": 60
 				}
+			]
+		},
+		{
+			"name": "Lantern of Tracking (Celestials)",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"While the lantern is within 300 feet of the Celestials type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however."
+			],
+			"light": [
+				{
+					"bright": 30,
+					"dim": 60
+				}
+			]
+		},
+		{
+			"name": "Lantern of Tracking (Constructs)",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"While the lantern is within 300 feet of the Constructs type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however."
+			],
+			"light": [
+				{
+					"bright": 30,
+					"dim": 60
+				}
+			]
+		},
+		{
+			"name": "Lantern of Tracking (Dragons)",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"While the lantern is within 300 feet of the Dragons type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however."
+			],
+			"light": [
+				{
+					"bright": 30,
+					"dim": 60
+				}
+			]
+		},
+		{
+			"name": "Lantern of Tracking (Elementals)",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"While the lantern is within 300 feet of the Elementals type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however."
+			],
+			"light": [
+				{
+					"bright": 30,
+					"dim": 60
+				}
+			]
+		},
+		{
+			"name": "Lantern of Tracking (Fey)",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"While the lantern is within 300 feet of the Fey type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however."
+			],
+			"light": [
+				{
+					"bright": 30,
+					"dim": 60
+				}
+			]
+		},
+		{
+			"name": "Lantern of Tracking (Fiends)",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"While the lantern is within 300 feet of the Fiends type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however."
+			],
+			"light": [
+				{
+					"bright": 30,
+					"dim": 60
+				}
+			]
+		},
+		{
+			"name": "Lantern of Tracking (Giants)",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"While the lantern is within 300 feet of the Giants type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however."
+			],
+			"light": [
+				{
+					"bright": 30,
+					"dim": 60
+				}
+			]
+		},
+		{
+			"name": "Lantern of Tracking (Monstrosities)",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"While the lantern is within 300 feet of the Monstrosities type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however."
+			],
+			"light": [
+				{
+					"bright": 30,
+					"dim": 60
+				}
+			]
+		},
+		{
+			"name": "Lantern of Tracking (Undead)",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"While the lantern is within 300 feet of the Undead type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however."
 			],
 			"light": [
 				{
@@ -35713,7 +36252,7 @@
 			"wondrous": true,
 			"grantsProficiency": true,
 			"entries": [
-				"These symbiotic gloves\u2014made of thin chitin and sinew\u2014pulse with a life of their own. To attune to them, you must wear them for the entire attunement period, during which the gloves bond with your skin.",
+				"These symbiotic gloves—made of thin chitin and sinew—pulse with a life of their own. To attune to them, you must wear them for the entire attunement period, during which the gloves bond with your skin.",
 				"While attuned to these gloves, you gain one of the following proficiencies (your choice when you attune to the gloves):",
 				{
 					"type": "list",
@@ -35738,6 +36277,9 @@
 			"name": "Living Loot Satchel",
 			"source": "AI",
 			"page": 25,
+			"referenceSources": [
+				"OoW"
+			],
 			"rarity": "varies",
 			"wondrous": true,
 			"entries": [
@@ -35805,7 +36347,7 @@
 					"type": "entries",
 					"name": "Secret Satchel",
 					"entries": [
-						"As a rank 3 hoardsperson, your living loot satchel gets an upgrade to function as the replica chest used for the {@spell Leomund's secret chest} spell, becoming a rare magic item. You can open the secret chest through your living loot satchel to deposit or withdraw items\u2014even items that wouldn't normally fit in your satchel, but which fit within the chest. Thanks to Head Office striking deals you don't want to know about with extraplanar creatures you really don't want to know about, there is no chance for the spell to end."
+						"As a rank 3 hoardsperson, your living loot satchel gets an upgrade to function as the replica chest used for the {@spell Leomund's secret chest} spell, becoming a rare magic item. You can open the secret chest through your living loot satchel to deposit or withdraw items—even items that wouldn't normally fit in your satchel, but which fit within the chest. Thanks to Head Office striking deals you don't want to know about with extraplanar creatures you really don't want to know about, there is no chance for the spell to end."
 					]
 				},
 				{
@@ -35819,7 +36361,7 @@
 					"type": "entries",
 					"name": "Portable Hole Satchel",
 					"entries": [
-						"At rank 4, your living loot satchel receives another upgrade, becoming a very rare magic item. The secret chest accessed by your satchel now has the storage capacity of a {@item portable hole}\u20146 feet in diameter and 10 feet deep. As before, you can place any appropriately sized object into the portable-hole-sized chest, even if it wouldn't normally fit into your satchel."
+						"At rank 4, your living loot satchel receives another upgrade, becoming a very rare magic item. The secret chest accessed by your satchel now has the storage capacity of a {@item portable hole}—6 feet in diameter and 10 feet deep. As before, you can place any appropriately sized object into the portable-hole-sized chest, even if it wouldn't normally fit into your satchel."
 					]
 				},
 				{
@@ -35862,6 +36404,15 @@
 			"name": "Loadstone",
 			"source": "TftYP",
 			"page": 228,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"rarity": "rare",
 			"wondrous": true,
 			"curse": true,
@@ -36104,7 +36655,7 @@
 			],
 			"wondrous": true,
 			"entries": [
-				"The Masked Lords of Waterdeep don this ensemble when meeting with one another. This raiment renders each lord indistinguishable from the others. The ensemble consists of three pieces\u2014a helm, an amulet, and a robe\u2014that function as a single magic item when worn together, but only within the city of Waterdeep and its sewers. You become attuned to the ensemble as a single item.",
+				"The Masked Lords of Waterdeep don this ensemble when meeting with one another. This raiment renders each lord indistinguishable from the others. The ensemble consists of three pieces—a helm, an amulet, and a robe—that function as a single magic item when worn together, but only within the city of Waterdeep and its sewers. You become attuned to the ensemble as a single item.",
 				{
 					"type": "entries",
 					"name": "Lord's Helm",
@@ -36183,6 +36734,9 @@
 			"name": "Lorehold Primer",
 			"source": "SCC",
 			"page": 39,
+			"referenceSources": [
+				"SCC-TMM"
+			],
 			"rarity": "uncommon",
 			"reqAttune": "by a spellcaster",
 			"reqAttuneTags": [
@@ -36284,7 +36838,7 @@
 			"wondrous": true,
 			"entries": [
 				"Not all lingering spirits are tragic souls, lost on their way to the hereafter. Some languish as prisoners, souls so wicked mortals dare not free them upon an unsuspecting afterlife.",
-				"Created by a figure of Vistani legend, Luba's Tarokka of Souls shaped the destiny of countless heroes. The prophecies of this deck of cards also revealed great evils and guided its creator into the path of nefarious forces. Untold times the deck's creator, Mother Luba, narrowly escaped doom, spared only by her keen insights. But even for her, not all wickedness could be escaped. In the most dire cases, Mother Luba managed to ensnare beings of pure evil amid the strands of fate, imprisoning them within her {@deck tarokka deck|CoS}. There these foul spirits dwell still, trapped within a nether-realm hidden amid shuffling cards, waiting for fate to turn foul\u2014as it inevitably will.",
+				"Created by a figure of Vistani legend, Luba's Tarokka of Souls shaped the destiny of countless heroes. The prophecies of this deck of cards also revealed great evils and guided its creator into the path of nefarious forces. Untold times the deck's creator, Mother Luba, narrowly escaped doom, spared only by her keen insights. But even for her, not all wickedness could be escaped. In the most dire cases, Mother Luba managed to ensnare beings of pure evil amid the strands of fate, imprisoning them within her {@deck tarokka deck|CoS}. There these foul spirits dwell still, trapped within a nether-realm hidden amid shuffling cards, waiting for fate to turn foul—as it inevitably will.",
 				"Like all {@deck Tarokka Deck|CoS|tarokka decks}, the {@i Tarokka of Souls} is a lavishly illustrated collection of fifty-four cards, comprising the fourteen cards of the high deck and forty other cards divided into four suits: coins, glyphs, stars, and swords.",
 				{
 					"type": "entries",
@@ -36429,8 +36983,8 @@
 								],
 								[
 									"15-100",
-									"\u2014",
-									"\u2014"
+									"—",
+									"—"
 								]
 							]
 						},
@@ -36650,9 +37204,9 @@
 			"page": 179,
 			"srd": true,
 			"referenceSources": [
-				"WDH",
 				"NRH-AWoL",
-				"QftIS"
+				"QftIS",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Mace of Disruption|XDMG"
@@ -36726,10 +37280,10 @@
 			"page": 179,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
+				"CoA",
 				"SCC-TMM",
 				"ToFW",
-				"CoA"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mace of Smiting|XDMG"
@@ -36786,8 +37340,10 @@
 			"page": 180,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
-				"CoA"
+				"CoA",
+				"CoS",
+				"KftGV",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Mace of Terror|XDMG"
@@ -37097,6 +37653,10 @@
 			"source": "DMG",
 			"page": 258,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"SDW"
+			],
 			"reprintedAs": [
 				"Malice|XDMG"
 			],
@@ -37140,9 +37700,11 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"BGDIA",
 				"CoS",
-				"GoS",
 				"DSotDQ",
+				"GoS",
+				"IDRotF",
 				"QftIS"
 			],
 			"reprintedAs": [
@@ -37192,8 +37754,8 @@
 			"page": 180,
 			"srd": true,
 			"referenceSources": [
-				"IDRotF",
-				"CoA"
+				"CoA",
+				"IDRotF"
 			],
 			"reprintedAs": [
 				"Mantle of Spell Resistance|XDMG"
@@ -37233,10 +37795,10 @@
 			"page": 180,
 			"srd": true,
 			"referenceSources": [
-				"CoS",
 				"CoA",
-				"VEoR",
-				"QftIS"
+				"CoS",
+				"QftIS",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Manual of Bodily Health|XDMG"
@@ -37318,6 +37880,9 @@
 			"source": "DMG",
 			"page": 180,
 			"srd": true,
+			"referenceSources": [
+				"LLK"
+			],
 			"reprintedAs": [
 				"Manual of Flesh Golems|XDMG"
 			],
@@ -37356,9 +37921,9 @@
 			"page": 180,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
 				"CoA",
-				"QftIS"
+				"QftIS",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Manual of Gainful Exercise|XDMG"
@@ -37402,8 +37967,8 @@
 			"page": 180,
 			"srd": true,
 			"referenceSources": [
-				"LLK",
-				"CoA"
+				"CoA",
+				"LLK"
 			],
 			"reprintedAs": [
 				"Manual of Iron Golems|XDMG"
@@ -37543,6 +38108,9 @@
 			"page": 151,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"KftGV"
+			],
 			"reprintedAs": [
 				"Map or Scroll Case|XPHB"
 			],
@@ -37659,6 +38227,9 @@
 			"name": "Masque Charm",
 			"source": "SCC",
 			"page": 127,
+			"referenceSources": [
+				"SCC-TMM"
+			],
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
@@ -37719,8 +38290,8 @@
 			"page": 271,
 			"referenceSources": [
 				"CoS",
-				"SKT",
-				"CRCotN"
+				"CRCotN",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Command Amulet|XMM"
@@ -37810,7 +38381,7 @@
 								{
 									"type": "item",
 									"name": "Piety 1+",
-									"entry": "The whip has 1 randomly determined {@table Artifact Properties; Minor Detrimental Properties|dmg|minor detrimental} property\u2014a burden Erebos imposes to test his faithful."
+									"entry": "The whip has 1 randomly determined {@table Artifact Properties; Minor Detrimental Properties|dmg|minor detrimental} property—a burden Erebos imposes to test his faithful."
 								},
 								{
 									"type": "item",
@@ -38027,8 +38598,9 @@
 			"srd": true,
 			"referenceSources": [
 				"CoA",
-				"VEoR",
-				"QftIS"
+				"QftIS",
+				"TTP",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Medallion of Thoughts|XDMG"
@@ -38124,8 +38696,10 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TTP",
-				"SjA"
+				"CoS",
+				"SjA",
+				"ToA",
+				"TTP"
 			],
 			"type": "G",
 			"rarity": "none",
@@ -38141,10 +38715,10 @@
 			"page": 258,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
-				"WDMM",
 				"BGDIA",
-				"KftGV"
+				"KftGV",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Midnight Tears|XDMG"
@@ -38234,7 +38808,7 @@
 					"entries": [
 						"By inputting a specific series of lever pulls and button presses, the servant's two crew members can cause it to explode. The self-destruct code is not revealed to crew members when they attune to the artifact. If the code is discovered (the DM determines how), it requires two attuned crew members to be inside the servant and spend their actions on 3 consecutive rounds performing the command. Should the crew members begin the process of entering the code, though, the servant uses its Ghost in the Machine property and turns the crew members against each other.",
 						"If the crew members successfully implement the code, at the end of the third round, the servant explodes. Every creature in a 100-foot-radius sphere centered on the servant must make a {@dc 25} Dexterity saving throw. On a failed save, a creature takes 87 ({@damage 25d6}) force damage, 87 ({@damage 25d6}) lightning damage, and 87 ({@damage 25d6}) thunder damage. On a successful save, a creature takes half as much damage. Objects and structures in the area take triple damage. Creatures inside the servant are slain instantly and leave behind no remains.",
-						"This does not destroy the servant permanently. Rather, {@dice 2d6} days later, its parts\u2014left arm, left leg, right arm, right leg, lower torso, and upper torso\u2014drop from the sky in random places within 1,000 miles of the explosion. If brought within 5 feet of one another, the pieces reconnect and reform the servant."
+						"This does not destroy the servant permanently. Rather, {@dice 2d6} days later, its parts—left arm, left leg, right arm, right leg, lower torso, and upper torso—drop from the sky in random places within 1,000 miles of the explosion. If brought within 5 feet of one another, the pieces reconnect and reform the servant."
 					]
 				},
 				{
@@ -38529,6 +39103,10 @@
 			"page": 150,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"IDRotF",
+				"PaBTSO"
+			],
 			"type": "G",
 			"rarity": "none",
 			"weight": 10,
@@ -38554,11 +39132,11 @@
 			"page": 181,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
-				"WDMM",
+				"CoA",
 				"JttRC",
 				"LoX",
-				"CoA"
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Mirror of Life Trapping|XDMG"
@@ -38627,6 +39205,15 @@
 			"name": "Mirror of the Past",
 			"source": "TftYP",
 			"page": 228,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"rarity": "rare",
 			"wondrous": true,
 			"weight": 1,
@@ -39330,6 +39917,10 @@
 			"name": "Murgaxor's Orb",
 			"source": "SCC",
 			"page": 126,
+			"referenceSources": [
+				"SCC-ARiR",
+				"SCC-TMM"
+			],
 			"rarity": "legendary",
 			"reqAttune": true,
 			"wondrous": true,
@@ -39551,7 +40142,7 @@
 			"capCargo": 17,
 			"entries": [
 				"Built and used by mind flayers, nautiloids are designed exclusively for space travel. They can't float on water, nor can they land safely on the ground.",
-				"As an action, a creature attuned to a nautiloid's spelljamming helm and in physical contact with the ship can transport the nautiloid and all creatures and objects aboard it to a different plane of existence, at or near a destination envisioned by the spelljammer (or to a random location on the plane if no destination is envisioned). This property is a feature of the ship, not the spelljamming helm. Each time this property is used, roll a {@dice d6}. On a 5\u20136, the property recharges after 1 minute; otherwise, it can't be used again for 24 hours."
+				"As an action, a creature attuned to a nautiloid's spelljamming helm and in physical contact with the ship can transport the nautiloid and all creatures and objects aboard it to a different plane of existence, at or near a destination envisioned by the spelljammer (or to a random location on the plane if no destination is envisioned). This property is a feature of the ship, not the spelljamming helm. Each time this property is used, roll a {@dice d6}. On a 5–6, the property recharges after 1 minute; otherwise, it can't be used again for 24 hours."
 			],
 			"seeAlsoVehicle": [
 				"Nautiloid|AAG"
@@ -39586,10 +40177,10 @@
 				}
 			],
 			"referenceSources": [
-				"ToA",
 				"GoS",
 				"IDRotF",
-				"LoX"
+				"LoX",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Navigator's Tools|XPHB"
@@ -39687,9 +40278,11 @@
 			"page": 182,
 			"srd": true,
 			"referenceSources": [
+				"JttRC",
 				"NRH-AVitW",
-				"VEoR",
-				"QftIS"
+				"OotA",
+				"QftIS",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Necklace of Adaptation|XDMG"
@@ -39748,16 +40341,19 @@
 			"page": 182,
 			"srd": true,
 			"referenceSources": [
+				"BGDIA",
+				"DIP",
+				"IDRotF",
+				"KftGV",
+				"NRH-ASS",
+				"NRH-TLT",
 				"OotA",
 				"TftYP-AtG",
 				"ToA",
-				"WDH",
-				"IDRotF",
-				"NRH-ASS",
-				"NRH-TLT",
-				"KftGV",
 				"ToFW",
-				"VEoR"
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Necklace of Fireballs|XDMG"
@@ -39821,9 +40417,9 @@
 			"page": 182,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
 				"JttRC",
 				"KftGV",
+				"PotA",
 				"ToFW"
 			],
 			"reprintedAs": [
@@ -40150,7 +40746,7 @@
 			"type": "SC|DMG",
 			"rarity": "legendary",
 			"entries": [
-				"Unlike most scrolls, a Nether Scroll of Azumar is not a consumable magic item. It takes 30 days of concentrated study\u2014at least 8 hours per day\u2014to attempt to understand this scroll. After completing this study, you must make a {@dc 25} Intelligence ({@skill Arcana}) check. If this check fails, you take {@damage 16d10} psychic damage, and you can attempt the check again after another 30 days of concentrated study.",
+				"Unlike most scrolls, a Nether Scroll of Azumar is not a consumable magic item. It takes 30 days of concentrated study—at least 8 hours per day—to attempt to understand this scroll. After completing this study, you must make a {@dc 25} Intelligence ({@skill Arcana}) check. If this check fails, you take {@damage 16d10} psychic damage, and you can attempt the check again after another 30 days of concentrated study.",
 				"When you succeed on the check, you gain the following benefits:",
 				{
 					"type": "list",
@@ -40191,6 +40787,15 @@
 			"name": "Night Caller",
 			"source": "TftYP",
 			"page": 228,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"rarity": "uncommon",
 			"wondrous": true,
 			"weight": 1,
@@ -40217,6 +40822,10 @@
 				"fire",
 				"lightning",
 				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened"
 			],
 			"rarity": "legendary",
 			"reqAttune": true,
@@ -40317,7 +40926,7 @@
 			"rechargeAmount": "{@dice 1d6}",
 			"charges": 6,
 			"entries": [
-				"This Mace has 6 charges and regains {@dice 1d6} expended charges daily at dawn. While holding the Mace, you can expend 1 of its charges to cast {@spell Summon Celestial|XPHB} (+9 to hit with spell attacks)."
+				"This Mace has 6 charges and regains {@dice 1d6} expended charges daily at dawn. While holding the Mace, you can expend 1 of its charges to cast {@spell Summon Celestial|XPHB} ({@hit 9} to hit with spell attacks)."
 			],
 			"attachedSpells": {
 				"charges": {
@@ -40369,13 +40978,14 @@
 			"page": 183,
 			"srd": "Marvelous Pigments",
 			"referenceSources": [
-				"ToA",
-				"LLK",
-				"WDMM",
+				"CRCotN",
 				"GoS",
 				"IMR",
-				"CRCotN",
-				"JttRC"
+				"JttRC",
+				"LLK",
+				"TftYP-AtG",
+				"ToA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Nolzur's Marvelous Pigments|XDMG"
@@ -40386,7 +40996,7 @@
 			"weight": 1,
 			"entries": [
 				"Typically found in {@dice 1d4} pots inside a fine wooden box with a brush (weighing 1 pound in total), these pigments allow you to create three-dimensional objects by painting them in two dimensions. The paint flows from the brush to form the desired object as you concentrate on its image.",
-				"Each pot of paint is sufficient to cover 1,000 square feet of a surface, which lets you create inanimate objects or terrain features\u2014such as a door, a pit, flowers, trees, cells, rooms, or weapons\u2014that are up to 10,000 cubic feet. It takes 10 minutes to cover 100 square feet.",
+				"Each pot of paint is sufficient to cover 1,000 square feet of a surface, which lets you create inanimate objects or terrain features—such as a door, a pit, flowers, trees, cells, rooms, or weapons—that are up to 10,000 cubic feet. It takes 10 minutes to cover 100 square feet.",
 				"When you complete the painting, the object or terrain feature depicted becomes a real, nonmagical object. Thus, painting a door on a wall creates an actual door that can be opened to whatever is beyond. Painting a pit on a floor creates a real pit, and its depth counts against the total area of objects you create.",
 				"Nothing created by the pigments can have a value greater than 25 gp. If you paint an object of greater value (such as a diamond or a pile of gold), the object looks authentic, but close inspection reveals it is made from paste, bone, or some other worthless material.",
 				"If you paint a form of energy such as fire or lightning, the energy appears but dissipates as soon as you complete the painting, doing no harm to anything."
@@ -40557,7 +41167,7 @@
 			"reqAttune": true,
 			"wondrous": true,
 			"entries": [
-				"Head office grants you the use of a unique item known as an occultant abacus (sometimes just referred to as an occultant), whose beads resemble tiny skulls.",
+				"Head Office grants you the use of a unique item known as an occultant abacus (sometimes just referred to as an occultant), whose beads resemble tiny skulls.",
 				{
 					"type": "entries",
 					"name": "Read the Kill",
@@ -40697,8 +41307,13 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CRCotN",
+				"DSotDQ",
+				"IDRotF",
+				"PaBTSO",
+				"QftIS",
 				"TftYP-THSoT",
-				"CRCotN"
+				"ToA"
 			],
 			"reprintedAs": [
 				"Oil|XPHB"
@@ -40720,6 +41335,7 @@
 			"page": 183,
 			"srd": true,
 			"referenceSources": [
+				"HotDQ",
 				"TftYP-DiT"
 			],
 			"reprintedAs": [
@@ -40770,10 +41386,11 @@
 			"page": 184,
 			"srd": true,
 			"referenceSources": [
-				"OotA",
-				"CoS",
-				"LoX",
 				"CoA",
+				"CoS",
+				"KftGV",
+				"LoX",
+				"OotA",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -40824,10 +41441,14 @@
 			"page": 184,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
+				"CM",
+				"CoA",
 				"GoS",
+				"KftGV",
+				"OotA",
 				"SCC-HfMT",
-				"CoA"
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Oil of Slipperiness|XDMG"
@@ -40880,8 +41501,9 @@
 			"page": 258,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-AtG",
-				"EFR"
+				"BGDIA",
+				"EFR",
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				"Oil of Taggit|XDMG"
@@ -41036,7 +41658,7 @@
 					"name": "Gift of Flame",
 					"type": "entries",
 					"entries": [
-						"You can transfer the opal's magic to a nonmagical item\u2014a weapon or a suit of armor\u2014by tracing the ild rune there with your finger. The transfer takes 8 hours of work that requires the two items to be within 5 feet of each other. At the end, the opal is destroyed, and the rune appears in red on the chosen item, which gains a benefit based on its form:",
+						"You can transfer the opal's magic to a nonmagical item—a weapon or a suit of armor—by tracing the ild rune there with your finger. The transfer takes 8 hours of work that requires the two items to be within 5 feet of each other. At the end, the opal is destroyed, and the rune appears in red on the chosen item, which gains a benefit based on its form:",
 						{
 							"type": "list",
 							"style": "list-hang-notitle",
@@ -41215,8 +41837,8 @@
 			"page": 138,
 			"referenceSources": [
 				"LLK",
-				"WDMM",
-				"WBtW"
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Orb of Direction|XDMG"
@@ -41482,6 +42104,9 @@
 			"name": "Orb of the Stein Rune",
 			"source": "SKT",
 			"page": 235,
+			"conditionImmune": [
+				"petrified"
+			],
 			"rarity": "rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -41513,7 +42138,7 @@
 					"type": "entries",
 					"name": "Gift of Stone",
 					"entries": [
-						"You can transfer the orb's magic to a nonmagical item\u2014a shield or a pair of boots\u2014by tracing the stein rune there with your finger. The transfer takes 8 hours of work that requires the two items to be within 5 feet of each other. At the end, the orb is destroyed, and the rune appears in silver on the chosen item, which gains a benefit based on its form:",
+						"You can transfer the orb's magic to a nonmagical item—a shield or a pair of boots—by tracing the stein rune there with your finger. The transfer takes 8 hours of work that requires the two items to be within 5 feet of each other. At the end, the orb is destroyed, and the rune appears in silver on the chosen item, which gains a benefit based on its form:",
 						{
 							"type": "list",
 							"style": "list-hang-notitle",
@@ -41593,6 +42218,10 @@
 			"name": "Orb of Time",
 			"source": "XGE",
 			"page": 138,
+			"referenceSources": [
+				"LLK",
+				"RtG"
+			],
 			"reprintedAs": [
 				"Orb of Time|XDMG"
 			],
@@ -41623,6 +42252,10 @@
 			"page": 224,
 			"baseItem": "greataxe|phb",
 			"type": "M",
+			"conditionImmune": [
+				"frightened",
+				"incapacitated"
+			],
 			"rarity": "legendary",
 			"reqAttune": "by a dwarf, fighter, or paladin of good alignment",
 			"reqAttuneTags": [
@@ -41672,7 +42305,7 @@
 					"name": "Personality",
 					"type": "entries",
 					"entries": [
-						"Orcsplitter is grim, taciturn, and inflexible. It knows little more than the desire to face {@creature orc||orcs} in battle and serve a courageous, just wielder. It disdains cowards and any form of duplicity, deception, or disloyalty. The weapon's purpose is to defend dwarves and to serve as a symbol of dwarven resolve. It hates the traditional foes of dwarves\u2014giants, goblins, and, most of all, {@creature orc||orcs}\u2014and silently urges its possessor to meet such creatures in battle."
+						"Orcsplitter is grim, taciturn, and inflexible. It knows little more than the desire to face {@creature orc||orcs} in battle and serve a courageous, just wielder. It disdains cowards and any form of duplicity, deception, or disloyalty. The weapon's purpose is to defend dwarves and to serve as a symbol of dwarven resolve. It hates the traditional foes of dwarves—giants, goblins, and, most of all, {@creature orc||orcs}—and silently urges its possessor to meet such creatures in battle."
 					]
 				}
 			]
@@ -41764,6 +42397,9 @@
 			"name": "Orrery of the Wanderer",
 			"source": "AI",
 			"page": 220,
+			"referenceSources": [
+				"OoW"
+			],
 			"type": "OTH",
 			"rarity": "artifact",
 			"reqAttune": true,
@@ -41775,7 +42411,7 @@
 			"entries": [
 				"This delicate and exquisitely crafted clockwork orrery features multiple geared components whose sweeping hands and dials represent the complex interplay of planar and magical realms. Standing two feet high, the orrery housing is a wondrous device imbued with magic of its own, but the power of its six clockwork components makes the artifact even more potent.",
 				"The Orrery of the Wanderer was created by a renowned clockwork mage known only as Lottie. She crafted the relic as a means of tapping into the power of the planes, and to channel the divination and foretelling powers of the stars. But Lottie soon realized that her creation was far more powerful than she had intended. As it tapped into planar magic, the orrery began to manifest the darkness and malevolence inherent to some of the planes. Eventually, it would impress upon its owner a desire to open portals into the most cursed and dangerous worlds, including the Far Realm.",
-				"To prevent the orrery from ever being so used, Lottie scattered the components that powered it, secreting them across the world. But the orrery's instinct for survival is strong, and its components have a way of inexorably coming together over decades or centuries, found by treasure hunters, stolen by monsters, found and stolen again\u2014and moving closer to each other all the time.",
+				"To prevent the orrery from ever being so used, Lottie scattered the components that powered it, secreting them across the world. But the orrery's instinct for survival is strong, and its components have a way of inexorably coming together over decades or centuries, found by treasure hunters, stolen by monsters, found and stolen again—and moving closer to each other all the time.",
 				"Random Properties. The orrery has the following randomly determined properties:",
 				{
 					"type": "list",
@@ -42266,7 +42902,7 @@
 			"wondrous": true,
 			"entries": [
 				"After you write a message of fifty words or fewer on this magic sheet of parchment and speak a creature's name, the parchment magically folds into a Tiny paper bird and flies to the recipient whose name you uttered. The recipient must be on the same plane of existence as you, otherwise the bird turns into ash as it takes flight.",
-				"The bird is an object that has 1 hit point, an Armor Class of 13, a flying speed of 60 feet, a Dexterity of 16 (+3), and a score of 1 (\u22125) in all other abilities, and it is immune to poison and psychic damage.",
+				"The bird is an object that has 1 hit point, an Armor Class of 13, a flying speed of 60 feet, a Dexterity of 16 (+3), and a score of 1 (−5) in all other abilities, and it is immune to poison and psychic damage.",
 				"It travels to within 5 feet of its intended recipient by the most direct route, whereupon it turns into a nonmagical and inanimate sheet of parchment that can be unfolded only by the intended recipient. If the bird's hit points or speed is reduced to 0 or if it is otherwise immobilized, it turns into ash.",
 				"Paper birds usually come in small, flat boxes containing {@dice 1d6 + 3} sheets of the parchment."
 			],
@@ -42300,6 +42936,7 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
+				"DrDe-SD",
 				"DrDe-TDoN"
 			],
 			"type": "G|XPHB",
@@ -42316,8 +42953,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"TftYP-ToH",
-				"CRCotN"
+				"CRCotN",
+				"KftGV",
+				"TftYP-ToH"
 			],
 			"reprintedAs": [
 				"Parchment|XPHB"
@@ -42368,6 +43006,7 @@
 			"source": "DMG",
 			"page": 134,
 			"referenceSources": [
+				"DoSI",
 				"KftGV"
 			],
 			"reprintedAs": [
@@ -42397,13 +43036,14 @@
 			"page": 184,
 			"srd": true,
 			"referenceSources": [
-				"SKT",
-				"TftYP-AtG",
+				"DSotDQ",
 				"GoS",
 				"IDRotF",
 				"JttRC",
-				"DSotDQ",
-				"QftIS"
+				"QftIS",
+				"SKT",
+				"TftYP-AtG",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Pearl of Power|XDMG"
@@ -42503,7 +43143,7 @@
 					"type": "entries",
 					"name": "Gift of Wind",
 					"entries": [
-						"You can transfer the pennant's magic to a nonmagical item\u2014a suit of armor, a pair of boots, or a cloak\u2014by tracing the vind rune there with your finger. The transfer takes 8 hours of work that requires the two items to be within 5 feet of each other. At the end, the pennant is destroyed, and the rune appears in silver on the chosen item, which gains a benefit based on its form:",
+						"You can transfer the pennant's magic to a nonmagical item—a suit of armor, a pair of boots, or a cloak—by tracing the vind rune there with your finger. The transfer takes 8 hours of work that requires the two items to be within 5 feet of each other. At the end, the pennant is destroyed, and the rune appears in silver on the chosen item, which gains a benefit based on its form:",
 						{
 							"type": "list",
 							"style": "list-hang-notitle",
@@ -42697,6 +43337,7 @@
 			"srd": true,
 			"referenceSources": [
 				"DitLCoT",
+				"DSotDQ",
 				"QftIS"
 			],
 			"reprintedAs": [
@@ -42728,9 +43369,6 @@
 			"immune": [
 				"poison"
 			],
-			"conditionImmune": [
-				"poisoned"
-			],
 			"rarity": "rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -42749,6 +43387,7 @@
 			"srd": true,
 			"referenceSources": [
 				"LR",
+				"TftYP-THSoT",
 				"ToFW"
 			],
 			"reprintedAs": [
@@ -42812,6 +43451,9 @@
 			"name": "Peridot",
 			"source": "DMG",
 			"page": 134,
+			"referenceSources": [
+				"PaBTSO"
+			],
 			"reprintedAs": [
 				"Peridot|XDMG"
 			],
@@ -42867,6 +43509,10 @@
 			"source": "DMG",
 			"page": 184,
 			"srd": true,
+			"referenceSources": [
+				"OotA",
+				"TftYP-AtG"
+			],
 			"reprintedAs": [
 				"Philter of Love|XDMG"
 			],
@@ -42907,6 +43553,9 @@
 			"name": "Piercer",
 			"source": "AI",
 			"page": 121,
+			"referenceSources": [
+				"OoW"
+			],
 			"baseItem": "shortsword|phb",
 			"type": "M",
 			"rarity": "rare",
@@ -42977,8 +43626,8 @@
 			"source": "XGE",
 			"page": 138,
 			"referenceSources": [
-				"WDMM",
-				"WBtW"
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Pipe of Smoke Monsters|XDMG"
@@ -42997,10 +43646,10 @@
 			"page": 185,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
 				"CoS",
 				"US",
-				"WBtW",
-				"CoA"
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Pipes of Haunting|XDMG"
@@ -43066,6 +43715,7 @@
 			"page": 185,
 			"srd": true,
 			"referenceSources": [
+				"BGDIA",
 				"TftYP-AtG"
 			],
 			"reprintedAs": [
@@ -43160,8 +43810,8 @@
 			"source": "OotA",
 			"page": 222,
 			"referenceSources": [
-				"WDMM",
-				"IDRotF"
+				"IDRotF",
+				"WDMM"
 			],
 			"rarity": "uncommon",
 			"reqAttune": true,
@@ -43309,6 +43959,9 @@
 			"source": "DMG",
 			"page": 185,
 			"srd": true,
+			"referenceSources": [
+				"CoA"
+			],
 			"reprintedAs": [
 				{
 					"uid": "Plate Armor of Etherealness (*)|XDMG",
@@ -43500,6 +44153,9 @@
 			"page": 154,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoS"
+			],
 			"reprintedAs": [
 				"Playing Cards|XPHB"
 			],
@@ -43592,7 +44248,13 @@
 				}
 			],
 			"referenceSources": [
-				"KftGV"
+				"BGDIA",
+				"CoS",
+				"KftGV",
+				"OoW",
+				"SCC-HfMT",
+				"TftYP-TSC",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Poisoner's Kit|XPHB"
@@ -43796,6 +44458,7 @@
 			"source": "XGE",
 			"page": 138,
 			"referenceSources": [
+				"DIP",
 				"WBtW"
 			],
 			"reprintedAs": [
@@ -43842,10 +44505,12 @@
 			"page": 185,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
-				"RMBRE",
+				"DSotDQ",
+				"KftGV",
+				"LLK",
 				"LoX",
-				"DSotDQ"
+				"RMBRE",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Portable Hole|XDMG"
@@ -43985,8 +44650,8 @@
 				}
 			],
 			"referenceSources": [
-				"WDMM",
-				"IMR"
+				"IMR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Pot of Awakening|XDMG"
@@ -44005,8 +44670,9 @@
 			"page": 188,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
-				"OoW"
+				"LRDT",
+				"OoW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Acid Resistance|XDMG"
@@ -44068,13 +44734,15 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
-				"WDH",
-				"WDMM",
+				"CoA",
 				"IDRotF",
 				"KftGV",
-				"CoA",
-				"QftIS"
+				"OoW",
+				"QftIS",
+				"ToA",
+				"ToR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Animal Friendship|XDMG"
@@ -44165,13 +44833,13 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"SKT",
-				"TftYP-THSoT",
 				"CM",
-				"KftGV",
 				"CoA",
+				"KftGV",
 				"LRDT",
-				"QftIS"
+				"QftIS",
+				"SKT",
+				"TftYP-THSoT"
 			],
 			"reprintedAs": [
 				"Potion of Clairvoyance|XDMG"
@@ -44221,15 +44889,17 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"SKT",
-				"TftYP-TFoF",
-				"TftYP-DiT",
-				"WDH",
-				"GoS",
-				"OoW",
-				"SDW",
 				"DC",
-				"MOT"
+				"GoS",
+				"MOT",
+				"OoW",
+				"PaBTSO",
+				"SCC-HfMT",
+				"SDW",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Potion of Climbing|XDMG"
@@ -44285,7 +44955,8 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"CoA"
+				"CoA",
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				"Potion of Cloud Giant Strength|XDMG"
@@ -44427,16 +45098,20 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"SDW",
+				"SKT",
+				"TftYP-AtG",
 				"TftYP-DiT",
 				"TftYP-ToH",
 				"ToA",
-				"WDMM",
-				"OoW",
-				"SDW",
-				"WBtW",
-				"CoA",
 				"VEoR",
-				"QftIS"
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Diminution|XDMG"
@@ -44499,12 +45174,14 @@
 			"source": "DMG",
 			"page": 187,
 			"referenceSources": [
-				"RoT",
-				"PotA",
-				"TftYP-TSC",
 				"BGDIA",
+				"CoA",
 				"DSotDQ",
-				"CoA"
+				"OotA",
+				"PotA",
+				"RoT",
+				"TftYP-TSC",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Fire Breath|XDMG"
@@ -44551,8 +45228,8 @@
 			"srd": true,
 			"referenceSources": [
 				"CM",
-				"GotSF",
-				"CoA"
+				"CoA",
+				"GotSF"
 			],
 			"reprintedAs": [
 				"Potion of Fire Giant Strength|XDMG"
@@ -44608,13 +45285,14 @@
 			"page": 188,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
-				"TftYP-TSC",
-				"TftYP-AtG",
-				"WDMM",
 				"JttRC",
 				"KftGV",
-				"VEoR"
+				"PotA",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-TSC",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Fire Resistance|XDMG"
@@ -44660,17 +45338,22 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"LMoP",
-				"PotA",
-				"TftYP-WPM",
-				"TftYP-DiT",
 				"BGDIA",
-				"RMBRE",
-				"GotSF",
-				"PaBTSO",
-				"ToFW",
 				"CoA",
-				"VEoR"
+				"GotSF",
+				"IMR",
+				"JttRC",
+				"LMoP",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"RMBRE",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-WPM",
+				"ToFW",
+				"VEoR",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Potion of Flying|XDMG"
@@ -44767,10 +45450,11 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
-				"OoW",
 				"BGDIA",
-				"CoA"
+				"CoA",
+				"OoW",
+				"PotA",
+				"RoT"
 			],
 			"reprintedAs": [
 				"Potion of Frost Giant Strength|XDMG"
@@ -44826,18 +45510,20 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"HotDQ",
-				"PotA",
-				"OotA",
-				"SKT",
-				"WDMM",
-				"OoW",
-				"IDRotF",
 				"CM",
+				"CoA",
 				"CRCotN",
 				"DSotDQ",
-				"CoA",
-				"VEoR"
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PotA",
+				"SKT",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Gaseous Form|XDMG"
@@ -44903,31 +45589,38 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"HotDQ",
-				"RoT",
-				"PotA",
-				"OotA",
-				"TftYP-ToH",
-				"ToA",
-				"WDH",
-				"WDMM",
-				"GoS",
-				"DIP",
-				"SLW",
-				"SDW",
-				"DC",
+				"AitFR-AVT",
 				"BGDIA",
-				"IMR",
 				"CM",
-				"RtG",
+				"CoS",
 				"CRCotN",
+				"DC",
+				"DIP",
+				"DitLCoT",
 				"DSotDQ",
+				"GoS",
+				"HotDQ",
+				"IMR",
 				"KftGV",
-				"PaBTSO",
 				"LRDT",
-				"VNotEE",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SCC-ARiR",
+				"SDW",
+				"SLW",
+				"TftYP-DiT",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"ToA",
 				"VEoR",
-				"QftIS"
+				"VNotEE",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Greater Healing|XDMG"
@@ -44954,8 +45647,8 @@
 			"basicRules2024": true,
 			"referenceSources": [
 				"DrDe-BtS",
-				"HotB",
-				"FFotR"
+				"FFotR",
+				"HotB"
 			],
 			"type": "P|XPHB",
 			"rarity": "uncommon",
@@ -44995,13 +45688,16 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"SDW",
-				"DC",
-				"WBtW",
-				"PaBTSO",
 				"CoA",
+				"DC",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"RoT",
+				"SDW",
+				"TftYP-AtG",
 				"VEoR",
-				"QftIS"
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Potion of Growth|XDMG"
@@ -45028,6 +45724,9 @@
 			"page": 288,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-SD"
+			],
 			"type": "P|XPHB",
 			"rarity": "uncommon",
 			"weight": 0.5,
@@ -45058,58 +45757,63 @@
 				}
 			],
 			"referenceSources": [
-				"LMoP",
-				"HotDQ",
-				"RoT",
-				"PotA",
-				"OotA",
+				"BGDIA",
+				"CM",
 				"CoS",
+				"CRCotN",
+				"DC",
+				"DD",
+				"DIP",
+				"DoSI",
+				"DSotDQ",
+				"GoS",
+				"HftT",
+				"HoL",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"LMoP",
+				"LoX",
+				"LRDT",
+				"MOT",
+				"NRH-ASS",
+				"NRH-AT",
+				"NRH-AVitW",
+				"NRH-AWoL",
+				"NRH-CoI",
+				"NRH-TCMC",
+				"NRH-TLT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"RoT",
+				"RtG",
+				"SCC-CK",
+				"SCC-HfMT",
+				"SCC-TMM",
+				"SDW",
+				"SjA",
 				"SKT",
-				"TftYP-TSC",
+				"SLW",
+				"TftYP-AtG",
+				"TftYP-DiT",
 				"TftYP-TFoF",
 				"TftYP-THSoT",
-				"TftYP-DiT",
-				"TftYP-AtG",
 				"TftYP-ToH",
+				"TftYP-TSC",
 				"ToA",
-				"TTP",
-				"WDH",
-				"LLK",
-				"WDMM",
-				"GoS",
-				"OoW",
-				"DIP",
-				"SLW",
-				"SDW",
-				"DC",
-				"BGDIA",
-				"RMBRE",
-				"ToR",
-				"DD",
-				"US",
-				"MOT",
-				"IDRotF",
-				"CM",
-				"HoL",
-				"NRH-TCMC",
-				"NRH-AVitW",
-				"NRH-ASS",
-				"NRH-CoI",
-				"NRH-TLT",
-				"NRH-AWoL",
-				"NRH-AT",
-				"SCC-CK",
-				"SCC-TMM",
-				"CRCotN",
-				"JttRC",
-				"DoSI",
-				"SjA",
-				"DSotDQ",
-				"KftGV",
-				"PaBTSO",
 				"ToFW",
-				"LRDT",
-				"QftIS"
+				"ToR",
+				"TTP",
+				"US",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Healing|XDMG"
@@ -45142,12 +45846,13 @@
 				}
 			],
 			"referenceSources": [
-				"UtHftLH",
+				"DrDe-DaS",
 				"DrDe-FWtVC",
 				"DrDe-SD",
+				"FRAiF",
 				"HotB",
-				"WttHC",
-				"FRAiF"
+				"UtHftLH",
+				"WttHC"
 			],
 			"type": "P|XPHB",
 			"rarity": "common",
@@ -45171,15 +45876,21 @@
 			"page": 188,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
-				"CoS",
-				"SKT",
-				"GoS",
-				"SDW",
-				"DC",
-				"RtG",
-				"CRCotN",
+				"CM",
 				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"GoS",
+				"LRDT",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"SDW",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-DiT",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -45208,8 +45919,8 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
-				"DrDe-TFV",
-				"DrDe-BtS"
+				"DrDe-BtS",
+				"DrDe-TFV"
 			],
 			"type": "P|XPHB",
 			"rarity": "rare",
@@ -45235,12 +45946,14 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
+				"CM",
+				"CoA",
+				"CRCotN",
+				"KftGV",
 				"PotA",
 				"TftYP-TFoF",
 				"TftYP-THSoT",
-				"CM",
-				"CRCotN",
-				"CoA"
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Potion of Hill Giant Strength|XDMG"
@@ -45297,22 +46010,26 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"LMoP",
-				"PotA",
-				"OotA",
-				"SKT",
-				"TftYP-THSoT",
-				"TftYP-DiT",
-				"WDH",
-				"WDMM",
-				"GoS",
-				"OoW",
-				"IDRotF",
-				"WBtW",
-				"SCC-HfMT",
-				"PaBTSO",
+				"BGDIA",
 				"CoA",
-				"VEoR"
+				"GoS",
+				"IDRotF",
+				"LMoP",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SCC-HfMT",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Invisibility|XDMG"
@@ -45359,10 +46076,14 @@
 			"source": "DMG",
 			"page": 188,
 			"referenceSources": [
-				"PotA",
 				"CoS",
-				"SKT",
+				"DC",
 				"DIP",
+				"JttRC",
+				"PaBTSO",
+				"PotA",
+				"SKT",
+				"TftYP-AtG",
 				"WBtW"
 			],
 			"reprintedAs": [
@@ -45439,7 +46160,8 @@
 			"srd": true,
 			"referenceSources": [
 				"DoSI",
-				"KftGV"
+				"KftGV",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Potion of Lightning Resistance|XDMG"
@@ -45483,12 +46205,14 @@
 			"source": "DMG",
 			"page": 188,
 			"referenceSources": [
+				"CM",
+				"CoA",
+				"IDRotF",
+				"JttRC",
+				"OotA",
 				"PotA",
 				"SKT",
-				"WDMM",
-				"CM",
-				"JttRC",
-				"CoA"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Longevity|XDMG"
@@ -45600,15 +46324,17 @@
 			"page": 188,
 			"srd": true,
 			"referenceSources": [
-				"OotA",
-				"TftYP-DiT",
-				"WDH",
-				"WDMM",
-				"US",
 				"CM",
-				"SCC-CK",
 				"CoA",
-				"VEoR"
+				"OotA",
+				"SCC-CK",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-WPM",
+				"US",
+				"VEoR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Mind Reading|XDMG"
@@ -45707,20 +46433,24 @@
 			"page": 188,
 			"srd": true,
 			"referenceSources": [
-				"RoT",
-				"PotA",
-				"OotA",
+				"CoA",
 				"CoS",
-				"SKT",
-				"TftYP-THSoT",
-				"TftYP-AtG",
-				"ToA",
-				"SDW",
 				"IMR",
 				"KftGV",
-				"CoA",
-				"VEoR",
-				"QftIS"
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SCC-ARiR",
+				"SDW",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"ToA",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Potion of Poison|XDMG"
@@ -45765,6 +46495,8 @@
 			"page": 188,
 			"srd": true,
 			"referenceSources": [
+				"KftGV",
+				"SKT",
 				"ToFW"
 			],
 			"reprintedAs": [
@@ -45854,6 +46586,9 @@
 			"source": "DMG",
 			"page": 188,
 			"srd": true,
+			"referenceSources": [
+				"OotA"
+			],
 			"reprintedAs": [
 				"Potion of Psychic Resistance|XDMG"
 			],
@@ -45961,10 +46696,10 @@
 			"page": 188,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
-				"TftYP-AtG",
 				"CoA",
 				"LRDT",
+				"PotA",
+				"TftYP-AtG",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -46018,6 +46753,10 @@
 			"source": "DMG",
 			"page": 187,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Potion of Stone Giant Strength|XDMG"
 			],
@@ -46072,8 +46811,10 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-AtG",
-				"CoA"
+				"CoA",
+				"DC",
+				"SKT",
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				"Potion of Storm Giant Strength|XDMG"
@@ -46130,20 +46871,21 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
-				"CoS",
-				"TftYP-AtG",
-				"WDMM",
-				"GoS",
-				"DIP",
-				"IDRotF",
 				"CM",
-				"RtG",
+				"CoS",
 				"CRCotN",
-				"JttRC",
+				"DIP",
 				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"JttRC",
 				"KftGV",
-				"VEoR"
+				"PotA",
+				"RtG",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Superior Healing|XDMG"
@@ -46187,13 +46929,16 @@
 			"page": 187,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
+				"CoA",
 				"DC",
 				"JttRC",
+				"OotA",
 				"PaBTSO",
+				"SKT",
+				"ToA",
 				"ToFW",
-				"CoA",
-				"VEoR"
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Supreme Healing|XDMG"
@@ -46283,13 +47028,16 @@
 			"page": 188,
 			"basicRules": true,
 			"referenceSources": [
+				"CoA",
+				"IDRotF",
+				"KftGV",
 				"LMoP",
 				"OotA",
+				"QftIS",
+				"SLW",
 				"ToA",
-				"WDMM",
-				"KftGV",
-				"CoA",
-				"QftIS"
+				"VEoR",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Vitality|XDMG"
@@ -46348,24 +47096,26 @@
 			"page": 188,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
-				"SKT",
-				"TftYP-TFoF",
-				"TftYP-DiT",
-				"TftYP-AtG",
-				"ToA",
-				"WDH",
-				"WDMM",
-				"GoS",
-				"OoW",
-				"DIP",
-				"SDW",
-				"DC",
-				"ToR",
-				"IDRotF",
+				"CoA",
 				"CRCotN",
+				"DC",
+				"DIP",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PotA",
+				"SDW",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"ToA",
 				"ToFW",
-				"CoA"
+				"ToR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Water Breathing|XDMG"
@@ -46414,6 +47164,7 @@
 			"basicRules": true,
 			"referenceSources": [
 				"DoSI",
+				"DSotDQ",
 				"KftGV",
 				"PaBTSO"
 			],
@@ -46483,7 +47234,7 @@
 			},
 			"bonusAc": "+1",
 			"entries": [
-				"Powered armor resembles a suit of unusual plate armor, with finely articulated joints connected by an oily, black, leather-like material. The armor has been worked to create the appearance of a heavily muscled warrior, and its great helm is unusual in that it has no openings\u2014only a broad glass plate in the front with a second piece of glass above it. Strange plates, tubing, and large metal bosses adorn the armor in seemingly random fashion. On the back of the armor's left gauntlet is a rectangular metal box, from which projects a short rod tipped with a cone-shaped red crystal.",
+				"Powered armor resembles a suit of unusual plate armor, with finely articulated joints connected by an oily, black, leather-like material. The armor has been worked to create the appearance of a heavily muscled warrior, and its great helm is unusual in that it has no openings—only a broad glass plate in the front with a second piece of glass above it. Strange plates, tubing, and large metal bosses adorn the armor in seemingly random fashion. On the back of the armor's left gauntlet is a rectangular metal box, from which projects a short rod tipped with a cone-shaped red crystal.",
 				"While wearing this armor, you gain the following benefits:",
 				{
 					"type": "list",
@@ -46751,7 +47502,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"QftIS"
+				"QftIS",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Priest's Pack|XPHB"
@@ -47038,7 +47790,7 @@
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
-				"This magic item replaces a lost limb\u2014a hand, an arm, a foot, a leg, or a similar body part. While the prosthetic is attached, it functions identically to the part it replaces. You can detach or reattach it as a {@action Magic|XPHB} action, and it can't be removed against your will while you are alive."
+				"This magic item replaces a lost limb—a hand, an arm, a foot, a leg, or a similar body part. While the prosthetic is attached, it functions identically to the part it replaces. You can detach or reattach it as a {@action Magic|XPHB} action, and it can't be removed against your will while you are alive."
 			],
 			"lootTables": [
 				"Arcana - Common|XDMG",
@@ -47398,6 +48150,7 @@
 			"page": 188,
 			"srd": "Feather Token, Anchor",
 			"referenceSources": [
+				"OoW",
 				"TTP"
 			],
 			"reprintedAs": [
@@ -47415,7 +48168,8 @@
 						"You can use an action to touch the token to a boat or ship. For the next 24 hours, the vessel can't be moved by any means. Touching the token to the vessel again ends the effect. When the effect ends, the token disappears."
 					]
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Quaal's Feather Token, Anchor",
@@ -47441,6 +48195,7 @@
 			"page": 188,
 			"srd": "Feather Token, Bird",
 			"referenceSources": [
+				"CM",
 				"DSotDQ",
 				"ToFW"
 			],
@@ -47459,7 +48214,8 @@
 						"You can use an action to toss the token 5 feet into the air. The token disappears and an enormous, multicolored bird takes its place. The bird has the statistics of a {@creature roc}, but it obeys your simple commands and can't attack. It can carry up to 500 pounds while flying at its maximum speed (16 miles an hour for a maximum of 144 miles per day. with a one-hour rest for every 3 hours of flying), or 1,000 pounds at half that speed. The bird disappears after flying its maximum distance for a day or if it drops to 0 hit points. You can dismiss the bird as an action."
 					]
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Quaal's Feather Token, Bird",
@@ -47499,7 +48255,8 @@
 						"If you are on a boat or ship, you can use an action to toss the token up to 10 feet in the air. The token disappears, and a giant flapping fan takes its place. The fan floats and creates a wind strong enough to fill the sails of one ship, increasing its speed by 5 miles per hour for 8 hours. You can dismiss the fan as an action."
 					]
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Quaal's Feather Token, Fan",
@@ -47539,7 +48296,8 @@
 						"You can use an action to touch the token to a body of water at least 60 feet in diameter. The token disappears, and a 50-foot-long, 20-foot-wide boat shaped like a swan takes its place. The boat is self-propelled and moves across water at a speed of 6 miles per hour. You can use an action while on the boat to command it to move or to turn up to 90 degrees. The boat can carry up to thirty-two Medium or smaller creatures. A Large creature counts as four Medium creatures, while a Huge creature counts as nine. The boat remains for 24 hours and then disappears. You can dismiss the boat as an action."
 					]
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Quaal's Feather Token, Swan Boat",
@@ -47565,8 +48323,8 @@
 			"page": 188,
 			"srd": "Feather Token, Tree",
 			"referenceSources": [
-				"TftYP-TSC",
-				"GotSF"
+				"GotSF",
+				"TftYP-TSC"
 			],
 			"reprintedAs": [
 				"Quaal's Feather Token, Tree|XDMG"
@@ -47583,7 +48341,8 @@
 						"You must be outdoors to use this token. You can use an action to touch it to an unoccupied space on the ground. The token disappears, and in its place a nonmagical oak tree springs into existence. The tree is 60 feet tall and has a 5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius."
 					]
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Quaal's Feather Token, Tree",
@@ -47624,7 +48383,8 @@
 						"As a bonus action on your turn, you can direct the whip to fly up to 20 feet and repeat the attack against a creature within 10 feet of it. The whip disappears after 1 hour, when you use an action to dismiss it, or when you are {@condition incapacitated} or die."
 					]
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Quaal's Feather Token, Whip",
@@ -47819,9 +48579,12 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"ToA",
 				"CRCotN",
-				"DitLCoT"
+				"DitLCoT",
+				"IDRotF",
+				"PaBTSO",
+				"TftYP-TSC",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Quiver|XPHB"
@@ -47847,6 +48610,9 @@
 			"page": 228,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TWoO"
+			],
 			"type": "G|XPHB",
 			"rarity": "none",
 			"weight": 1,
@@ -47868,8 +48634,9 @@
 			"page": 189,
 			"srd": "Efficient Quiver",
 			"referenceSources": [
-				"WBtW",
-				"KftGV"
+				"IDRotF",
+				"KftGV",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Quiver of Ehlonna|XDMG"
@@ -48189,11 +48956,14 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"ToA",
-				"XMtS",
-				"DIP",
 				"CRCotN",
-				"ToFW"
+				"DIP",
+				"KftGV",
+				"SjA",
+				"TftYP-TSC",
+				"ToA",
+				"ToFW",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Rations|XPHB"
@@ -48255,6 +49025,12 @@
 			"name": "Red Dragon Mask",
 			"source": "RoTOS",
 			"page": 4,
+			"otherSources": [
+				{
+					"source": "ToD",
+					"page": 179
+				}
+			],
 			"referenceSources": [
 				"HotDQ",
 				"RoT"
@@ -48797,8 +49573,9 @@
 			"page": 189,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
 				"KftGV",
+				"TftYP-THSoT",
+				"ToA",
 				"ToFW"
 			],
 			"reprintedAs": [
@@ -48878,8 +49655,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"PotA",
 				"RoT",
-				"PotA"
+				"SKT"
 			],
 			"reprintedAs": [
 				"Ring of Cold Resistance|XDMG"
@@ -48982,6 +49760,9 @@
 			"source": "DMG",
 			"page": 190,
 			"srd": true,
+			"referenceSources": [
+				"OotA"
+			],
 			"reprintedAs": [
 				"Ring of Elemental Command (Earth)|XDMG"
 			],
@@ -49377,7 +50158,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"KftGV"
+				"CoS",
+				"KftGV",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Ring of Evasion|XDMG"
@@ -49426,10 +50209,12 @@
 			"page": 191,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-ToH",
 				"DSotDQ",
+				"OoW",
+				"QftIS",
+				"TftYP-ToH",
 				"VEoR",
-				"QftIS"
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Ring of Feather Falling|XDMG"
@@ -49525,12 +50310,13 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"DSotDQ",
 				"PotA",
+				"QftIS",
 				"SKT",
 				"TftYP-AtG",
 				"TftYP-ToH",
-				"ToA",
-				"QftIS"
+				"ToA"
 			],
 			"reprintedAs": [
 				"Ring of Fire Resistance|XDMG"
@@ -49572,6 +50358,9 @@
 			"page": 192,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"WDH"
+			],
 			"reprintedAs": [
 				"Ring of Force Resistance|XDMG"
 			],
@@ -49611,10 +50400,10 @@
 			"page": 191,
 			"srd": true,
 			"referenceSources": [
-				"OotA",
+				"CRCotN",
 				"GoS",
-				"OoW",
-				"CRCotN"
+				"OotA",
+				"OoW"
 			],
 			"reprintedAs": [
 				"Ring of Free Action|XDMG"
@@ -49663,6 +50452,8 @@
 			"page": 191,
 			"srd": true,
 			"referenceSources": [
+				"LRDT",
+				"TftYP-AtG",
 				"WDH"
 			],
 			"reprintedAs": [
@@ -49705,7 +50496,8 @@
 			"referenceSources": [
 				"CM",
 				"JttRC",
-				"KftGV"
+				"KftGV",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Ring of Jumping|XDMG"
@@ -49807,16 +50599,19 @@
 			"page": 191,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-AtG",
-				"RtG",
-				"SCC-CK",
-				"SCC-ARiR",
+				"BGDIA",
+				"CoA",
+				"CoS",
 				"JttRC",
 				"KftGV",
 				"PaBTSO",
+				"QftIS",
+				"RtG",
+				"SCC-ARiR",
+				"SCC-CK",
+				"TftYP-AtG",
 				"ToFW",
-				"CoA",
-				"QftIS"
+				"WDH"
 			],
 			"reprintedAs": [
 				"Ring of Mind Shielding|XDMG"
@@ -49906,6 +50701,9 @@
 			"name": "Ring of Obscuring",
 			"source": "EGW",
 			"page": 269,
+			"referenceSources": [
+				"DD"
+			],
 			"type": "RG|DMG",
 			"rarity": "uncommon",
 			"reqAttune": true,
@@ -49973,20 +50771,22 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"LMoP",
-				"OotA",
-				"SKT",
-				"TftYP-THSoT",
-				"TftYP-WPM",
-				"TftYP-AtG",
-				"TftYP-ToH",
-				"ToA",
-				"RMBRE",
 				"AitFR-DN",
-				"NRH-ASS",
-				"ToFW",
 				"CoA",
-				"QftIS"
+				"HftT",
+				"LMoP",
+				"NRH-ASS",
+				"OotA",
+				"QftIS",
+				"RMBRE",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"ToA",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Ring of Protection|XDMG"
@@ -50130,6 +50930,10 @@
 			"source": "CRCotN",
 			"page": 214,
 			"type": "RG|DMG",
+			"conditionImmune": [
+				"paralyzed",
+				"restrained"
+			],
 			"rarity": "very rare",
 			"reqAttune": true,
 			"modifySpeed": {
@@ -50185,7 +50989,8 @@
 			"page": 191,
 			"srd": true,
 			"referenceSources": [
-				"CoS"
+				"CoS",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Ring of Regeneration|XDMG"
@@ -50225,12 +51030,13 @@
 			"page": 192,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-AtG",
 				"CM",
-				"WBtW",
-				"LoX",
 				"CoA",
-				"VEoR"
+				"CRCotN",
+				"LoX",
+				"TftYP-AtG",
+				"VEoR",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Ring of Shooting Stars|XDMG"
@@ -50385,9 +51191,11 @@
 			"page": 192,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-TFoF",
 				"CM",
-				"CoA"
+				"CoA",
+				"DSotDQ",
+				"TftYP-TFoF",
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Ring of Spell Storing|XDMG"
@@ -50472,11 +51280,11 @@
 			"page": 193,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
-				"WDMM",
-				"GoS",
 				"CM",
-				"CRCotN"
+				"CRCotN",
+				"GoS",
+				"PotA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ring of Swimming|XDMG"
@@ -50614,7 +51422,8 @@
 			"srd": true,
 			"referenceSources": [
 				"CM",
-				"CRCotN"
+				"CRCotN",
+				"IDRotF"
 			],
 			"reprintedAs": [
 				"Ring of the Ram|XDMG"
@@ -50670,6 +51479,9 @@
 			"source": "DMG",
 			"page": 193,
 			"srd": true,
+			"referenceSources": [
+				"ToFW"
+			],
 			"reprintedAs": [
 				"Ring of Three Wishes|XDMG"
 			],
@@ -50785,9 +51597,10 @@
 			"srd": true,
 			"referenceSources": [
 				"CoS",
-				"WDH",
+				"IDRotF",
+				"JttRC",
 				"SLW",
-				"IDRotF"
+				"WDH"
 			],
 			"reprintedAs": [
 				"Ring of Warmth|XDMG"
@@ -50881,8 +51694,9 @@
 			"page": 193,
 			"srd": true,
 			"referenceSources": [
+				"IMR",
 				"OotA",
-				"IMR"
+				"SLW"
 			],
 			"reprintedAs": [
 				"Ring of Water Walking|XDMG"
@@ -51033,9 +51847,9 @@
 			"page": 193,
 			"srd": true,
 			"referenceSources": [
+				"BGDIA",
 				"TftYP-WPM",
-				"WDMM",
-				"BGDIA"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Ring of X-ray Vision|XDMG"
@@ -51129,8 +51943,11 @@
 			"page": 193,
 			"srd": true,
 			"referenceSources": [
+				"CM",
+				"CoA",
+				"OotA",
 				"RtG",
-				"CoA"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Robe of Eyes|XDMG"
@@ -51207,9 +52024,9 @@
 			"page": 194,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
 				"CM",
-				"LRDT"
+				"LRDT",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Robe of Scintillating Colors|XDMG"
@@ -51340,6 +52157,15 @@
 			"name": "Robe of Summer",
 			"source": "TftYP",
 			"page": 229,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"resist": [
 				"cold"
 			],
@@ -51455,8 +52281,8 @@
 			"srd": true,
 			"referenceSources": [
 				"CoS",
-				"SKT",
-				"LoX"
+				"LoX",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Robe of Useful Items|XDMG"
@@ -51709,7 +52535,7 @@
 			"reqAttune": true,
 			"weight": 2,
 			"entries": [
-				"While holding this rod, you can use your reaction to absorb a spell that is targeting only you and not with an area of effect. The absorbed spell's effect is canceled, and the spell's energy\u2014not the spell itself\u2014is stored in the rod. The energy has the same level as the spell when it was cast. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spell that the rod can't store, the rod has no effect on that spell.",
+				"While holding this rod, you can use your reaction to absorb a spell that is targeting only you and not with an area of effect. The absorbed spell's effect is canceled, and the spell's energy—not the spell itself—is stored in the rod. The energy has the same level as the spell when it was cast. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spell that the rod can't store, the rod has no effect on that spell.",
 				"When you become attuned to the rod, you know how many levels of energy the rod has absorbed over the course of its existence, and how many levels of spell energy it currently has stored.",
 				"If you are a spellcaster holding the rod, you can convert energy stored in it into spell slots to cast spells you have prepared or know. You can create spell slots only of a level equal to or lower than your own spell slots, up to a maximum of 5th level. You use the stored levels in place of your slots, but otherwise cast the spell as normal. For example, you can use 3 levels stored in the rod as a 3rd-level spell slot.",
 				"A newly found rod has {@dice 1d10} levels of spell energy stored in it already. A rod that can no longer absorb spell energy and has no energy remaining becomes nonmagical."
@@ -51730,7 +52556,7 @@
 			"reqAttune": true,
 			"weight": 2,
 			"entries": [
-				"While holding this rod, you can take a {@variantrule Reaction|XPHB} to absorb a spell that is targeting only you and doesn't create an area of effect. The absorbed spell's effect is canceled, and the spell's energy\u2014not the spell itself\u2014is stored in the rod. The energy has the same level as the spell when it was cast. A canceled spell dissipates with no effect, and any resources used to cast it are wasted. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spell that the rod can't store, the rod has no effect on that spell.",
+				"While holding this rod, you can take a {@variantrule Reaction|XPHB} to absorb a spell that is targeting only you and doesn't create an area of effect. The absorbed spell's effect is canceled, and the spell's energy—not the spell itself—is stored in the rod. The energy has the same level as the spell when it was cast. A canceled spell dissipates with no effect, and any resources used to cast it are wasted. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spell that the rod can't store, the rod has no effect on that spell.",
 				"When you become attuned to the rod, you know how many levels of energy the rod has absorbed over the course of its existence and how many levels of spell energy it currently has stored.",
 				"If you are a spellcaster holding the rod, you can convert energy stored in it into spell slots to cast spells you have prepared or know. You can create spell slots only of a level equal to or lower than your own spell slots, up to a maximum of level 5. You use the stored levels in place of your slots but otherwise cast the spell as normal. For example, you can use 3 levels stored in the rod as a level 3 spell slot.",
 				"A newly found rod typically has {@dice 1d10} levels of spell energy stored in it. A rod that can no longer absorb spell energy and has no energy remaining becomes nonmagical."
@@ -51816,7 +52642,14 @@
 					"type": "entries",
 					"name": "Alertness",
 					"entries": [
-						"While holding the rod, you have {@variantrule Advantage|XPHB} on Wisdom ({@skill Perception|XPHB}) checks and on {@variantrule Initiative|XPHB} rolls. Spells. While holding the rod, you can cast the following spells from it:",
+						"While holding the rod, you have {@variantrule Advantage|XPHB} on Wisdom ({@skill Perception|XPHB}) checks and on {@variantrule Initiative|XPHB} rolls."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells",
+					"entries": [
+						"While holding the rod, you can cast the following spells from it:",
 						{
 							"type": "list",
 							"items": [
@@ -51916,8 +52749,8 @@
 			"page": 196,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
-				"BGDIA"
+				"BGDIA",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Rod of Lordly Might|XDMG"
@@ -52168,6 +53001,9 @@
 			"name": "Rod of Retribution",
 			"source": "EGW",
 			"page": 269,
+			"referenceSources": [
+				"ToR"
+			],
 			"type": "RD|DMG",
 			"rarity": "uncommon",
 			"reqAttune": true,
@@ -52478,6 +53314,7 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
+				"BQGT",
 				"DrDe-TWoO",
 				"HotB"
 			],
@@ -52496,6 +53333,7 @@
 			"page": 197,
 			"srd": true,
 			"referenceSources": [
+				"VEoR",
 				"WDMM"
 			],
 			"reprintedAs": [
@@ -52547,7 +53385,9 @@
 			"page": 197,
 			"srd": true,
 			"referenceSources": [
-				"KftGV"
+				"KftGV",
+				"OoW",
+				"ToFW"
 			],
 			"reprintedAs": [
 				"Rope of Entanglement|XDMG"
@@ -52616,6 +53456,9 @@
 			"name": "Rotor of Return",
 			"source": "AI",
 			"page": 221,
+			"referenceSources": [
+				"OoW"
+			],
 			"rarity": "very rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -52653,10 +53496,10 @@
 			"basicRules": true,
 			"referenceSources": [
 				"CoS",
-				"TTP",
-				"WDH",
+				"DoSI",
 				"RMBRE",
-				"DoSI"
+				"TTP",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Rowboat|XPHB"
@@ -52683,8 +53526,12 @@
 			"page": 230,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"type": "SHP|XPHB",
 			"rarity": "none",
+			"weight": 100,
 			"value": 5000,
 			"crew": 1,
 			"vehAc": 11,
@@ -53223,6 +54070,8 @@
 			"referenceSources": [
 				"CRCotN",
 				"DoSI",
+				"GoS",
+				"KftGV",
 				"PaBTSO"
 			],
 			"reprintedAs": [
@@ -53850,6 +54699,10 @@
 			"page": 151,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"QftIS",
+				"SCC-ARiR"
+			],
 			"reprintedAs": [
 				"Scholar's Pack|XPHB"
 			],
@@ -53922,9 +54775,10 @@
 			"page": 199,
 			"srd": true,
 			"referenceSources": [
+				"LRDT",
 				"OotA",
-				"SDW",
-				"LRDT"
+				"QftIS",
+				"SDW"
 			],
 			"reprintedAs": [
 				"Scimitar of Speed|XDMG"
@@ -54656,6 +55510,9 @@
 			"page": 150,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"KftGV"
+			],
 			"type": "G",
 			"rarity": "none",
 			"value": 50
@@ -54873,17 +55730,17 @@
 			"source": "DMG",
 			"page": 199,
 			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"CRCotN",
+				"DD",
+				"DIP",
+				"KftGV",
+				"LoX",
+				"SjA",
 				"SKT",
 				"ToA",
-				"WDMM",
-				"DIP",
-				"BGDIA",
-				"DD",
-				"CRCotN",
-				"SjA",
-				"LoX",
-				"KftGV",
-				"CoA"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Sending Stones|XDMG"
@@ -54922,9 +55779,9 @@
 				}
 			],
 			"referenceSources": [
-				"ScoEE",
+				"DrDe-ACfaS",
 				"DrDe-TDoN",
-				"DrDe-ACfaS"
+				"ScoEE"
 			],
 			"rarity": "uncommon",
 			"wondrous": true,
@@ -54984,9 +55841,10 @@
 			"source": "DMG",
 			"page": 199,
 			"referenceSources": [
-				"WDMM",
+				"CRCotN",
+				"LRDT",
 				"OoW",
-				"CRCotN"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Sentinel Shield|XDMG"
@@ -55044,8 +55902,8 @@
 			"page": 258,
 			"srd": true,
 			"referenceSources": [
-				"ToA",
-				"SDW"
+				"SDW",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Serpent Venom|XDMG"
@@ -55222,7 +56080,7 @@
 					"name": "Gift of Frost",
 					"type": "entries",
 					"entries": [
-						"You can transfer the shard's magic to a nonmagical item\u2014a cloak or a pair of boots-by tracing the ise rune there with your finger. The transfer takes 8 hours of work that requires the two items to be within 5 feet of each other. At the end, the shard is destroyed, and the rune appears in blue on the chosen item, which gains a benefit based on its form:",
+						"You can transfer the shard's magic to a nonmagical item—a cloak or a pair of boots-by tracing the ise rune there with your finger. The transfer takes 8 hours of work that requires the two items to be within 5 feet of each other. At the end, the shard is destroyed, and the rune appears in blue on the chosen item, which gains a benefit based on its form:",
 						{
 							"type": "list",
 							"style": "list-hang-notitle",
@@ -55303,7 +56161,7 @@
 						],
 						[
 							"2",
-							"You experience a vision of an ancient calamity\u2014a beautiful city threatened by crumbling mountains and erupting volcanoes\u2014and are {@condition stunned} until the end of your next turn."
+							"You experience a vision of an ancient calamity—a beautiful city threatened by crumbling mountains and erupting volcanoes—and are {@condition stunned} until the end of your next turn."
 						],
 						[
 							"3",
@@ -55556,6 +56414,15 @@
 			"name": "Shatterspike",
 			"source": "TftYP",
 			"page": 229,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"baseItem": "longsword|phb",
 			"type": "M",
 			"rarity": "uncommon",
@@ -56010,9 +56877,9 @@
 			"basicRules": true,
 			"referenceSources": [
 				"CoS",
-				"WDH",
 				"DSotDQ",
-				"PaBTSO"
+				"PaBTSO",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Shovel|XPHB"
@@ -56079,7 +56946,7 @@
 			"capCargo": 20,
 			"entries": [
 				"This swift vessel is a relatively recent design, quickly gaining popularity with merchants and pirates. A shrike ship's legs enable it to land safely on the ground. The ship can float but isn't built for traveling on water and sinks quickly in rough seas.",
-				"Standard weaponry on a shrike ship includes three ballistae\u2014one on the forecastle, one in the middle of the top deck, and one on the sterncastle. In a desperate situation, the ship's reinforced bow can be used as a piercing ram."
+				"Standard weaponry on a shrike ship includes three ballistae—one on the forecastle, one in the middle of the top deck, and one on the sterncastle. In a desperate situation, the ship's reinforced bow can be used as a piercing ram."
 			],
 			"seeAlsoVehicle": [
 				"Shrike Ship|AAG"
@@ -56164,6 +57031,9 @@
 			"page": 153,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"PaBTSO"
+			],
 			"type": "G",
 			"rarity": "none",
 			"weight": 5,
@@ -56601,6 +57471,9 @@
 			"name": "Silverquill Primer",
 			"source": "SCC",
 			"page": 39,
+			"referenceSources": [
+				"SCC-CK"
+			],
 			"rarity": "uncommon",
 			"reqAttune": "by a spellcaster",
 			"reqAttuneTags": [
@@ -56988,10 +57861,11 @@
 			"page": 200,
 			"srd": true,
 			"referenceSources": [
-				"OoW",
-				"MOT",
+				"CoA",
+				"JttRC",
 				"KftGV",
-				"CoA"
+				"MOT",
+				"OoW"
 			],
 			"reprintedAs": [
 				"Slippers of Spider Climbing|XDMG"
@@ -57259,7 +58133,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"WDH"
+				"WDH",
+				"WDMM"
 			],
 			"type": "G",
 			"rarity": "none",
@@ -57274,7 +58149,7 @@
 			"value": 15000,
 			"entries": [
 				"Soothsalts are derived from a naturally occurring crystalline substance discovered throughout the wilds of the Miskath Strand. The crimson crystals have been mined from cavernous veins like those in the mouth of the Miskath Pit and found within smaller geode formations near sites ravaged by the Calamity. Soothsalts are consumed orally in lozenge-sized doses, and frequent users can be identified by the telltale crimson stain around their mouths. A creature subjected to a dose of soothsalts gains advantage on all Intelligence checks for {@dice 1d4} hours.",
-				"For each dose of soothsalts consumed, the creature must succeed on a {@dc 15} Constitution saving throw or gain one level of {@condition exhaustion}\u2014an effect which is cumulative with multiple doses."
+				"For each dose of soothsalts consumed, the creature must succeed on a {@dc 15} Constitution saving throw or gain one level of {@condition exhaustion}—an effect which is cumulative with multiple doses."
 			],
 			"miscTags": [
 				"CNS"
@@ -57307,9 +58182,14 @@
 				{
 					"source": "VEoR",
 					"page": 155
+				},
+				{
+					"source": "CoA",
+					"page": 269
 				}
 			],
 			"referenceSources": [
+				"CoA",
 				"VEoR"
 			],
 			"rarity": "uncommon",
@@ -57321,7 +58201,7 @@
 					"type": "entries",
 					"name": "Carrying Soul Coins",
 					"entries": [
-						"To hold a soul coin is to feel the soul bound within it\u2014overcome with rage or fraught with despair.",
+						"To hold a soul coin is to feel the soul bound within it—overcome with rage or fraught with despair.",
 						"An evil creature can carry as many soul coins as it wishes (up to its maximum weight allowance). A non-evil creature can carry a number of soul coins equal to or less than its Constitution modifier without penalty. A non-evil creature carrying a number of soul coins greater than its Constitution modifier has disadvantage on its attack rolls, ability checks, and saving throws."
 					]
 				},
@@ -57368,82 +58248,20 @@
 			"hasFluffImages": true
 		},
 		{
-			"name": "Soul Coin",
-			"source": "CoA",
-			"page": 269,
-			"rarity": "uncommon",
-			"wondrous": true,
-			"charges": 3,
-			"entries": [
-				"Soul Coins are about 5 inches across and about an inch thick, minted from infernal iron. Each coin weighs one-third of a pound and is inscribed with Infernal writing and a spell that magically binds a single soul to the coin. Because each Soul Coin has a unique soul trapped within it, each has a story. A creature might have been imprisoned as a result of defaulting on a deal, while another might be the victim of a night hag's curse.",
-				{
-					"type": "entries",
-					"name": "Carrying Soul Coins",
-					"entries": [
-						"To hold a Soul Coin is to feel the soul bound within it\u2014overcome with rage or fraught with despair.",
-						"An evil creature can carry as many Soul Coins as it wishes (up to its maximum weight allowance). A non-evil creature can carry a number of Soul Coins equal to or less than its Constitution modifier without penalty. A non-evil creature carrying a number of Soul Coins greater than its Constitution modifier has disadvantage on its attack rolls, ability checks, and saving throws."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Using a Soul Coin",
-					"entries": [
-						"A Soul Coin has 3 charges. A creature carrying the coin can use its action to expend 1 charge from a Soul Coin and use it to do one of the following:",
-						{
-							"type": "list",
-							"style": "list-hang-notitle",
-							"items": [
-								{
-									"type": "item",
-									"name": "Drain Life",
-									"entries": [
-										"You siphon away some of the soul's essence and gain {@dice 1d10} temporary hit points."
-									]
-								},
-								{
-									"type": "item",
-									"name": "Query",
-									"entries": [
-										"You telepathically ask the soul a question and receive a brief telepathic response, which you can understand. The soul knows only what it knew in life, but it must answer you truthfully and to the best of its ability. The answer is no more than a sentence or two and might be cryptic."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Freeing a Soul",
-					"entries": [
-						"Casting a spell that removes a curse on a Soul Coin frees the soul trapped within it, as does expending all of the coin's charges. The coin itself rusts from within and is destroyed once the soul is released. A freed soul travels to the realm of the god it served, or the outer plane most closely tied to its alignment (DM's choice). The souls of lawful evil creatures released from Soul Coins typically emerge from the River Styx as lemure devils.",
-						"A soul can also be freed by destroying the coin that contains it. A Soul Coin has AC 19, 1 hit point for each charge it has remaining, and immunity to all damage except that which is dealt by an infernal warship's furnace.",
-						"Freeing a soul from a Soul Coin is considered a good act, even if the soul belongs to an evil creature."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Hellish Currency",
-					"entries": [
-						"Soul Coins are a currency of the Nine Hells and are highly valued by devils. The coins are used among the infernal hierarchy to barter for favors, bribe the unwilling, and reward the faithful for services rendered.",
-						"Soul Coins are created by Mammon and his greater devils on Minauros, the third layer of the Nine Hells, in a vast chamber where the captured souls of evil mortals are bound into the coins. These coins are then distributed throughout the Nine Hells to be used for goods and services, infernal deals, dark bargains, and bribes."
-					]
-				}
-			]
-		},
-		{
 			"name": "Sovereign Glue",
 			"source": "DMG",
 			"page": 200,
 			"srd": true,
 			"referenceSources": [
-				"OotA",
-				"CoS",
-				"ToA",
-				"WDMM",
-				"GoS",
 				"BGDIA",
+				"CoS",
+				"GoS",
 				"IDRotF",
-				"WBtW"
+				"JttRC",
+				"OotA",
+				"ToA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Sovereign Glue|XDMG"
@@ -57520,203 +58338,203 @@
 					],
 					"rows": [
 						[
-							"01\u201302",
+							"01–02",
 							"Disembodied robot arm with a mind of its own"
 						],
 						[
-							"03\u201304",
+							"03–04",
 							"Wearable blanket with sleeves and a hood"
 						],
 						[
-							"05\u201306",
+							"05–06",
 							"Small, rectangular device that can record and play back audio of up to 1 minute in length"
 						],
 						[
-							"07\u201308",
+							"07–08",
 							"Glow-in-the-dark ink pen"
 						],
 						[
-							"09\u201310",
+							"09–10",
 							"Fashionable jumpsuit"
 						],
 						[
-							"11\u201312",
+							"11–12",
 							"Compact scanner that reports whether an object is recyclable in a cheery tone"
 						],
 						[
-							"13\u201314",
+							"13–14",
 							"Wristwatch programmed to beep at a specific time"
 						],
 						[
-							"15\u201316",
+							"15–16",
 							"Handheld cylinder that produces a 15-foot cone of bright light for up to 1 hour every 24 hours"
 						],
 						[
-							"17\u201318",
+							"17–18",
 							"Colorful toy ray gun with lights and sounds"
 						],
 						[
-							"19\u201320",
+							"19–20",
 							"Bottle of fizzy, sweet-tasting liquid"
 						],
 						[
-							"21\u201322",
+							"21–22",
 							"Map of an unexplored star system"
 						],
 						[
-							"23\u201324",
+							"23–24",
 							"Motorized toothbrush that might have been used"
 						],
 						[
-							"25\u201326",
+							"25–26",
 							"Tiny robot that shines boots and shoes"
 						],
 						[
-							"27\u201328",
+							"27–28",
 							"Pressurized red canister with a flexible hose that, when squeezed as an action, sprays a 15-foot cone of foam. The foam extinguishes all nonmagical flames in the cone. The canister can perform this action only once."
 						],
 						[
-							"29\u201330",
+							"29–30",
 							"Loaf of space bread covered in blue-green mold"
 						],
 						[
-							"31\u201332",
+							"31–32",
 							"Handheld screen that plays a children's story about a friendly, three-eyed frog named Swampy"
 						],
 						[
-							"33\u201334",
+							"33–34",
 							"Compact device that displays the current weather"
 						],
 						[
-							"35\u201336",
+							"35–36",
 							"Empty metal bottle that maintains the temperature of liquids stored in it for {@dice 1d4} hours"
 						],
 						[
-							"37\u201338",
+							"37–38",
 							"Tiny disc that emits a high-pitched noise in the presence of smoke or mild cooking fumes"
 						],
 						[
-							"39\u201340",
+							"39–40",
 							"Aerosolized can of metal polish"
 						],
 						[
-							"41\u201342",
+							"41–42",
 							"Identification badge of a deceased crew member"
 						],
 						[
-							"43\u201344",
+							"43–44",
 							"Depleted energy cell"
 						],
 						[
-							"45\u201346",
+							"45–46",
 							"Pocket-sized instrument that clicks rapidly within 10 feet of radiation (see the \"{@adventure Spaceship Features|QftIS|7|Spaceship Features}\" section later in this adventure)"
 						],
 						[
-							"47\u201348",
+							"47–48",
 							"Vacuum-sealed package of shriveled frankfurters"
 						],
 						[
-							"49\u201350",
+							"49–50",
 							"Tin hat that telepathically broadcasts the wearer's surface thoughts to creatures within 10 feet of it"
 						],
 						[
-							"51\u201352",
+							"51–52",
 							"Chalky moon rock"
 						],
 						[
-							"53\u201354",
+							"53–54",
 							"Collar that, when placed on a Medium or smaller Beast, translates its cries into Common"
 						],
 						[
-							"55\u201356",
+							"55–56",
 							"Bottle of expired medicine for treating dizziness"
 						],
 						[
-							"57\u201358",
+							"57–58",
 							"Tiny speaker that plays a catchy tune in an unknown language"
 						],
 						[
-							"59\u201360",
+							"59–60",
 							"Handheld tool for removing bolts and screws"
 						],
 						[
-							"61\u201362",
+							"61–62",
 							"Cautionary pamphlet about the dangers of space"
 						],
 						[
-							"63\u201364",
+							"63–64",
 							"Miniature flying saucer"
 						],
 						[
-							"65\u201366",
+							"65–66",
 							"Tiny, animatronic bunny that hops after the creature that activates it"
 						],
 						[
-							"67\u201368",
+							"67–68",
 							"Stick of deodorant with a surprising scent"
 						],
 						[
-							"69\u201370",
+							"69–70",
 							"Countertop appliance that can transform any fruit into a pulpy juice"
 						],
 						[
-							"71\u201372",
+							"71–72",
 							"Glass pendant filled with stardust"
 						],
 						[
-							"73\u201374",
+							"73–74",
 							"Pot containing an artificially dwarfed tree"
 						],
 						[
-							"75\u201376",
+							"75–76",
 							"Otherworldly insect preserved in amber"
 						],
 						[
-							"77\u201378",
+							"77–78",
 							"Syringe filled with a viscous, yellow serum"
 						],
 						[
-							"79\u201380",
+							"79–80",
 							"Tiny brass orrery"
 						],
 						[
-							"81\u201382",
+							"81–82",
 							"Log of passenger names"
 						],
 						[
-							"83\u201384",
+							"83–84",
 							"Gas mask with a hole in it"
 						],
 						[
-							"85\u201386",
+							"85–86",
 							"Small glass terrarium with an empty cocoon"
 						],
 						[
-							"87\u201388",
+							"87–88",
 							"Dongle that never plugs in correctly on the first try"
 						],
 						[
-							"89\u201390",
+							"89–90",
 							"Holster fashioned from an unknown reptile's hide"
 						],
 						[
-							"91\u201392",
+							"91–92",
 							"Severed bundle of important-looking wires"
 						],
 						[
-							"93\u201394",
+							"93–94",
 							"Prosthetic limb with magnetic attachments"
 						],
 						[
-							"95\u201396",
+							"95–96",
 							"Set of polyhedral dice that buzz and flash when they land on their highest result"
 						],
 						[
-							"97\u201398",
+							"97–98",
 							"Musical instrument that plays electronic tones"
 						],
 						[
-							"99\u201300",
+							"99–00",
 							"Trading card of a beloved fictional hero from a far-off world"
 						]
 					]
@@ -57763,6 +58581,15 @@
 			"name": "Spear of Backbiting",
 			"source": "TftYP",
 			"page": 229,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"baseItem": "spear|phb",
 			"type": "M",
 			"rarity": "very rare",
@@ -57904,6 +58731,9 @@
 					"page": 95
 				}
 			],
+			"referenceSources": [
+				"IMR"
+			],
 			"rarity": "uncommon",
 			"reqAttune": "optional",
 			"wondrous": true,
@@ -57947,6 +58777,9 @@
 					"source": "IMR",
 					"page": 95
 				}
+			],
+			"referenceSources": [
+				"IMR"
 			],
 			"rarity": "rare",
 			"reqAttune": "optional",
@@ -58033,9 +58866,9 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"ToA",
+				"CoA",
 				"PaBTSO",
-				"CoA"
+				"ToA"
 			],
 			"reprintedAs": [
 				"Spell Scroll (Level 1)|XDMG"
@@ -58065,6 +58898,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CoA",
+				"DoSI",
 				"LMoP",
 				"PaBTSO"
 			],
@@ -58096,6 +58931,11 @@
 			"page": 202,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoA",
+				"LMoP",
+				"PaBTSO"
+			],
 			"reprintedAs": [
 				"Spell Scroll (Level 3)|XDMG"
 			],
@@ -58124,6 +58964,7 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CoA",
 				"PaBTSO",
 				"ToFW"
 			],
@@ -58155,6 +58996,7 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CoA",
 				"PaBTSO"
 			],
 			"reprintedAs": [
@@ -58652,7 +59494,10 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"AitFR-FCD",
+				"CoS",
 				"DSotDQ",
+				"IDRotF",
 				"KftGV",
 				"QftIS"
 			],
@@ -58758,6 +59603,9 @@
 			"name": "Spellshard",
 			"source": "ERLW",
 			"page": 279,
+			"referenceSources": [
+				"EFR"
+			],
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
@@ -58862,9 +59710,9 @@
 			"page": 201,
 			"srd": true,
 			"referenceSources": [
+				"IMR",
 				"TftYP-ToH",
 				"ToA",
-				"IMR",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -59259,10 +60107,11 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
+				"CoS",
+				"KftGV",
 				"ToA",
 				"TTP",
-				"XMtS",
-				"KftGV"
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Spyglass|XPHB"
@@ -59470,6 +60319,7 @@
 			"page": 201,
 			"srd": true,
 			"referenceSources": [
+				"IDRotF",
 				"TftYP-DiT"
 			],
 			"reprintedAs": [
@@ -59803,7 +60653,9 @@
 			"page": 201,
 			"srd": true,
 			"referenceSources": [
-				"CoA"
+				"CoA",
+				"HotDQ",
+				"SKT"
 			],
 			"reprintedAs": [
 				"Staff of Fire|XDMG"
@@ -60033,12 +60885,13 @@
 			"page": 202,
 			"srd": true,
 			"referenceSources": [
-				"CoS",
-				"TftYP-AtG",
-				"WDMM",
-				"IDRotF",
 				"CoA",
-				"LRDT"
+				"CoS",
+				"IDRotF",
+				"JttRC",
+				"LRDT",
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Staff of Frost|XDMG"
@@ -60357,14 +61210,14 @@
 			"page": 202,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
 				"CoS",
-				"WDH",
-				"WDMM",
 				"GoS",
 				"IDRotF",
-				"WBtW",
 				"KftGV",
-				"CoA"
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Staff of Power|XDMG"
@@ -60611,7 +61464,8 @@
 			},
 			"lootTables": [
 				"Arcana - Very Rare|XDMG"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Staff of Ruling",
@@ -60739,6 +61593,9 @@
 			"source": "DMG",
 			"page": 203,
 			"srd": true,
+			"referenceSources": [
+				"TftYP-AtG"
+			],
 			"reprintedAs": [
 				"Staff of Swarming Insects|XDMG"
 			],
@@ -60991,6 +61848,14 @@
 			"name": "Staff of the Forgotten One",
 			"source": "ToA",
 			"page": 208,
+			"conditionImmune": [
+				"blinded",
+				"charmed",
+				"deafened",
+				"frightened",
+				"petrified",
+				"stunned"
+			],
 			"rarity": "artifact",
 			"reqAttune": "by a sorcerer, warlock, or wizard",
 			"reqAttuneTags": [
@@ -61089,9 +61954,9 @@
 			"page": 203,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
 				"SKT",
-				"TftYP-ToH",
-				"CoA"
+				"TftYP-ToH"
 			],
 			"reprintedAs": [
 				"Staff of the Magi|XDMG"
@@ -61419,6 +62284,7 @@
 			"page": 204,
 			"srd": true,
 			"referenceSources": [
+				"JttRC",
 				"ToA"
 			],
 			"reprintedAs": [
@@ -62157,6 +63023,9 @@
 			"page": 150,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoS"
+			],
 			"reprintedAs": [
 				"Mirror|XPHB"
 			],
@@ -62236,6 +63105,10 @@
 					"page": true
 				}
 			},
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
 			"rarity": "rare",
 			"bonusAc": "+1",
 			"entries": [
@@ -62249,8 +63122,8 @@
 			"page": 205,
 			"srd": true,
 			"referenceSources": [
-				"OotA",
-				"JttRC"
+				"JttRC",
+				"OotA"
 			],
 			"reprintedAs": [
 				"Stone of Controlling Earth Elementals|XDMG"
@@ -62316,7 +63189,7 @@
 			"reqAttune": true,
 			"wondrous": true,
 			"entries": [
-				"Rare legends and lore that speak of the Stone of Creation claim it fell to the Material Plane like a meteor from some distant edge of the Outer Planes or the Far Realm. Similar legends across various worlds, all describing stones that grow buildings and islands from magic, like a house from a seed, suggest the Stone of Creation is not a unique artifact\u2014or that all the various pieces of it are derived from a single source of stone even larger than sages imagine.",
+				"Rare legends and lore that speak of the Stone of Creation claim it fell to the Material Plane like a meteor from some distant edge of the Outer Planes or the Far Realm. Similar legends across various worlds, all describing stones that grow buildings and islands from magic, like a house from a seed, suggest the Stone of Creation is not a unique artifact—or that all the various pieces of it are derived from a single source of stone even larger than sages imagine.",
 				"The raw, black stone appears flaky like slate but is as hard as granite and marbled with veins of gold and platinum. The original, complete Stone of Creation took the form of a blocky slab like a standing stone, but it may be impossible to know the Stone's true size, or if the concept of a \"whole\" Stone of Creation even applies to the artifact. Perhaps other slabs and boulders made from the Stone have been scattered across the multiverse, being cut down and recombed through interplanar movements and the magic of the artifacts themselves.",
 				{
 					"type": "entries",
@@ -62450,15 +63323,16 @@
 			"page": 205,
 			"srd": true,
 			"referenceSources": [
-				"PotA",
 				"CoS",
 				"IDRotF",
-				"WBtW",
-				"SCC-HfMT",
 				"JttRC",
 				"KftGV",
+				"PotA",
+				"SCC-HfMT",
+				"TftYP-WPM",
 				"ToFW",
-				"VEoR"
+				"VEoR",
+				"WBtW"
 			],
 			"reprintedAs": [
 				"Stone of Good Luck|XDMG"
@@ -62506,6 +63380,15 @@
 			"name": "Stone of Ill Luck",
 			"source": "TftYP",
 			"page": 229,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"rarity": "uncommon",
 			"reqAttune": true,
 			"wondrous": true,
@@ -62796,6 +63679,9 @@
 			"name": "Strixhaven Pennant",
 			"source": "SCC",
 			"page": 39,
+			"referenceSources": [
+				"SCC-CK"
+			],
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
@@ -62833,10 +63719,10 @@
 			"page": 205,
 			"srd": true,
 			"referenceSources": [
-				"WDMM",
 				"CM",
+				"CoA",
 				"JttRC",
-				"CoA"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Sun Blade|XDMG"
@@ -64098,6 +64984,8 @@
 			"page": 207,
 			"srd": true,
 			"referenceSources": [
+				"IMR",
+				"ToA",
 				"ToFW"
 			],
 			"reprintedAs": [
@@ -64274,8 +65162,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"WDH",
-				"SjA"
+				"SjA",
+				"WDH"
 			],
 			"type": "G",
 			"rarity": "none",
@@ -64298,10 +65186,11 @@
 			"referenceSources": [
 				"RoT"
 			],
-			"type": "OTH",
-			"rarity": "unknown (magic)",
+			"rarity": "common",
+			"wondrous": true,
 			"entries": [
-				"This golden stein is decorated with dancing dwarves and grain patterns. Speaking the command word (\"Illefarn\") while grasping the handle fills the tankard with three pints of rich dwarven ale. This power can be used up to three times per day."
+				"This golden stein is decorated with dancing dwarves and grain patterns.",
+				"Speaking the command word (\"Illefarn\") while grasping the handle fills the tankard with three pints of rich dwarven ale. This power can be used up to three times per day."
 			]
 		},
 		{
@@ -64744,10 +65633,10 @@
 			"source": "DMG",
 			"page": 208,
 			"referenceSources": [
-				"PotA",
+				"GoS",
 				"OotA",
-				"TftYP-AtG",
-				"GoS"
+				"PotA",
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				"Tentacle Rod|XDMG"
@@ -64962,7 +65851,7 @@
 			"rarity": "unknown",
 			"weight": 3,
 			"entries": [
-				"The Incantations of Iriolarthas is a weighty spellbook. Its black leather covers have dead, toothy worms glued to them, sheathed in glossy varnish. Set into this morbid display on the front cover is a gold rune that resembles a stylized eye with a pupil shaped like a candle flame\u2014the sigil of Iriolarthas, a Netherese lich.",
+				"The Incantations of Iriolarthas is a weighty spellbook. Its black leather covers have dead, toothy worms glued to them, sheathed in glossy varnish. Set into this morbid display on the front cover is a gold rune that resembles a stylized eye with a pupil shaped like a candle flame—the sigil of Iriolarthas, a Netherese lich.",
 				"The book contains sixty pages of brittle yellow vellum. Written on these pages are the following wizard spells:",
 				{
 					"type": "list",
@@ -65004,7 +65893,7 @@
 					"name": "Silver Wire",
 					"entries": [
 						"The Infernal Machine's great size makes it largely immobile. To make ongoing use of the machine (such as while adventuring), it can be connected to its attuned user by a silver wire, a supply of which can always be produced from the machine's inner workings. This silver wire shares the same general nature as the silvery cord of an {@spell astral projection} spell, connecting to the body of the user and trailing behind them. When so attached, the wire becomes {@condition invisible}, astral, and extends to virtually infinite length.",
-						"As long as the wire remains intact, the attuned user can make full use of the Infernal Machine's powers, with their effects centered around the user. If the wire is cut\u2014something that can happen only when an effect specifically states that it can cut an {@spell astral projection}'s silvery cord\u2014the user suffers a sudden burst of feedback from the machine that kills them instantly.",
+						"As long as the wire remains intact, the attuned user can make full use of the Infernal Machine's powers, with their effects centered around the user. If the wire is cut—something that can happen only when an effect specifically states that it can cut an {@spell astral projection}'s silvery cord—the user suffers a sudden burst of feedback from the machine that kills them instantly.",
 						"Any effect of the Infernal Machine that requires {@status concentration} can be concentrated on by a remote user. The Infernal Machine's effects have a spell save DC of 14 or the attuned user's spell save DC, whichever is higher."
 					]
 				},
@@ -65035,7 +65924,7 @@
 					"type": "entries",
 					"name": "Random Properties",
 					"entries": [
-						"There are far more possible combinations for the Infernal Machine's controls than can ever be known or matrixed\u2014especially as the controls shift position and reset themselves over time. At the end of each long rest of the user attuned to it, the Infernal Machine generates {@dice 1d4 + 1} random beneficial properties and {@dice 1d4 + 1} detrimental properties. Roll for each of these properties on the Infernal Machine Properties table. To keep things interesting, the DM might roll secretly for detrimental properties, revealing those properties only during the course of play.",
+						"There are far more possible combinations for the Infernal Machine's controls than can ever be known or matrixed—especially as the controls shift position and reset themselves over time. At the end of each long rest of the user attuned to it, the Infernal Machine generates {@dice 1d4 + 1} random beneficial properties and {@dice 1d4 + 1} detrimental properties. Roll for each of these properties on the Infernal Machine Properties table. To keep things interesting, the DM might roll secretly for detrimental properties, revealing those properties only during the course of play.",
 						"Once set, these properties last until the end of the attuned user's next long rest.",
 						"(Our thanks to the D&D community for their suggestions for the properties of the Infernal Machine of Lum the Mad!)"
 					]
@@ -65044,7 +65933,7 @@
 					"type": "entries",
 					"name": "Destroying the Machine",
 					"entries": [
-						"The Infernal Machine of Lum the Mad is self-repairing of anything short of catastrophic damage, and how it was disabled in Lum's time remains a mystery. It is rumored that if one specific combination of controls is set, the Infernal Machine will enter a repair mode, allowing unfettered access to its inner workings\u2014and preventing it from restoring itself if it is attacked. Alternatively, other combinations of controls might cause the Infernal Machine to teleport its most critical components to some hiding place deep in space and time, rendering it inoperable until those components are found again."
+						"The Infernal Machine of Lum the Mad is self-repairing of anything short of catastrophic damage, and how it was disabled in Lum's time remains a mystery. It is rumored that if one specific combination of controls is set, the Infernal Machine will enter a repair mode, allowing unfettered access to its inner workings—and preventing it from restoring itself if it is attacked. Alternatively, other combinations of controls might cause the Infernal Machine to teleport its most critical components to some hiding place deep in space and time, rendering it inoperable until those components are found again."
 					]
 				},
 				{
@@ -65084,7 +65973,7 @@
 						[
 							"05",
 							"You emanate a weak magnetic aura. The first time during a combat that a creature attacks you with a metal weapon, that creature has disadvantage on the attack roll.",
-							"Metal rusts in response to your touch\u2014including metal armor you wear and metal weapons you hold\u2014reproducing the effect of the rust monster's Rust Metal trait."
+							"Metal rusts in response to your touch—including metal armor you wear and metal weapons you hold—reproducing the effect of the rust monster's Rust Metal trait."
 						],
 						[
 							"06",
@@ -65234,7 +66123,7 @@
 						[
 							"35",
 							"Your shadow becomes an undead {@creature shadow} that shares your alignment and is under your control.",
-							"Your shadow behaves disapprovingly whenever you're not looking\u2014stealing things, mocking you behind your back, taunting opponents or friends, and so on."
+							"Your shadow behaves disapprovingly whenever you're not looking—stealing things, mocking you behind your back, taunting opponents or friends, and so on."
 						],
 						[
 							"36",
@@ -65264,7 +66153,7 @@
 						[
 							"41",
 							"Your possessions change their state or appearance at the DM's determination, giving you hints of potential future events. For example, your sword might become suddenly bloodstained to warn of an upcoming combat encounter, your clothes might become damp to warn of a water-filled pit trap ahead, and so on.",
-							"You take a \u22125 penalty to initiative rolls."
+							"You take a −5 penalty to initiative rolls."
 						],
 						[
 							"42",
@@ -65676,31 +66565,34 @@
 				}
 			],
 			"referenceSources": [
-				"LMoP",
+				"AitFR-THP",
+				"AZfyT",
+				"BGDIA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"DSotDQ",
+				"EFR",
+				"GoS",
 				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LMoP",
+				"LR",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"RMBRE",
 				"RoT",
+				"RtG",
+				"SDW",
+				"SLW",
 				"ToA",
 				"TTP",
-				"XMtS",
-				"AZfyT",
-				"GoS",
-				"OoW",
-				"DIP",
-				"SLW",
-				"SDW",
-				"BGDIA",
-				"LR",
-				"EFR",
-				"RMBRE",
-				"IDRotF",
-				"RtG",
-				"AitFR-THP",
-				"CRCotN",
-				"JttRC",
-				"DSotDQ",
-				"KftGV",
-				"PaBTSO",
-				"QftIS"
+				"WDH",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Thieves' Tools|XPHB"
@@ -65774,6 +66666,7 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
+				"DrDe-BtS",
 				"DrDe-TDoN",
 				"WttHC"
 			],
@@ -66035,6 +66928,9 @@
 			"name": "Timepiece of Travel",
 			"source": "AI",
 			"page": 221,
+			"referenceSources": [
+				"OoW"
+			],
 			"rarity": "very rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -66081,6 +66977,11 @@
 			"page": 153,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"TftYP-TSC"
+			],
 			"reprintedAs": [
 				"Tinderbox|XPHB"
 			],
@@ -66089,7 +66990,7 @@
 			"weight": 1,
 			"value": 50,
 			"entries": [
-				"This small container holds flint, fire steel, and tinder (usually dry cloth soaked in light oil) used to kindle a fire. Using it to light a torch\u2014or anything else with abundant, exposed fuel\u2014takes an action. Lighting any other fire takes 1 minute."
+				"This small container holds flint, fire steel, and tinder (usually dry cloth soaked in light oil) used to kindle a fire. Using it to light a torch—or anything else with abundant, exposed fuel—takes an action. Lighting any other fire takes 1 minute."
 			]
 		},
 		{
@@ -66107,7 +67008,7 @@
 			"weight": 1,
 			"value": 50,
 			"entries": [
-				"A Tinderbox is a small container holding flint, fire steel, and tinder (usually dry cloth soaked in light oil) used to kindle a fire. Using it to light a {@item Candle|XPHB}, {@item Lamp|XPHB}, {@item Hooded Lantern|XPHB|Lantern}, or {@item Torch|XPHB}\u2014or anything else with exposed fuel\u2014takes a {@variantrule Bonus Action|XPHB}. Lighting any other fire takes 1 minute."
+				"A Tinderbox is a small container holding flint, fire steel, and tinder (usually dry cloth soaked in light oil) used to kindle a fire. Using it to light a {@item Candle|XPHB}, {@item Lamp|XPHB}, {@item Hooded Lantern|XPHB|Lantern}, or {@item Torch|XPHB}—or anything else with exposed fuel—takes a {@variantrule Bonus Action|XPHB}. Lighting any other fire takes 1 minute."
 			]
 		},
 		{
@@ -66184,15 +67085,66 @@
 			"value": 2500
 		},
 		{
+			"name": "Tloques' Berserker Battleaxe",
+			"source": "TftYP",
+			"page": 68,
+			"baseItem": "battleaxe|PHB",
+			"type": "M",
+			"rarity": "rare",
+			"reqAttune": true,
+			"curse": true,
+			"weight": 4,
+			"weaponCategory": "martial",
+			"property": [
+				"V"
+			],
+			"dmg1": "1d8",
+			"dmgType": "S",
+			"dmg2": "1d10",
+			"bonusWeapon": "+2",
+			"recharge": "dawn",
+			"rechargeAmount": "{@dice 1d6 + 4}",
+			"charges": 12,
+			"entries": [
+				"This battleaxe has a blade of bronze, and the haft is wound with snakeskin wrappings. It casts an ominous shadow in the shape of what appears to be a withered arm. Those within reach of it feel a cold chill run up and down their spine.",
+				"Concealed beneath the wrappings around the handle is a parchment containing the spells {@spell passwall}, {@spell burning hands}, and {@spell gust of wind}. When the attuned wielder uses an action to say the correct words of power, which are engraved in Olman on the axe blade, one of these spells can be cast.",
+				"The axe has 12 charges and regains {@dice 1d6 + 4} expended charges daily at dawn. Casting a spell from it takes a number of charges equal to the level at which the spell is cast (5th for {@spell passwall}, 2nd for {@spell gust of wind}, and 1st or higher for {@spell burning hands}; spell save {@dc 15}). If the parchment is removed from the axe, the axe loses the capability of casting these spells forever.",
+				"You gain a +2 bonus to attack and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your hit point maximum increases by 1 for each level you have attained.",
+				{
+					"type": "entries",
+					"name": "Curse",
+					"entries": [
+						"This axe is cursed, and becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the axe, keeping it within reach at all times. You also have disadvantage on attack rolls with weapons other than this one, unless no foe is within 60 feet of you that you can see or hear."
+					]
+				},
+				"Whenever a hostile creature damages you while the axe is in your possession, you must succeed on a {@dc 15} Wisdom saving throw or go berserk. While berserk, you must use your action each round to attack the creature nearest to you with the axe. If you can make extra attacks as part of the {@action Attack} action, you use those extra attacks, moving to attack the next nearest creature after you fell your current target. If you have multiple possible targets, you attack one at random. You are berserk until you start your turn with no creatures within 60 feet of you that you can see or hear."
+			],
+			"attachedSpells": {
+				"charges": {
+					"1": [
+						"burning hands"
+					],
+					"2": [
+						"gust of wind"
+					],
+					"5": [
+						"passwall"
+					]
+				}
+			},
+			"hasFluffImages": true
+		},
+		{
 			"name": "Tome of Clear Thought",
 			"source": "DMG",
 			"page": 208,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-AtG",
 				"CoA",
 				"LRDT",
-				"QftIS"
+				"QftIS",
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Tome of Clear Thought|XDMG"
@@ -66239,8 +67191,8 @@
 			"srd": true,
 			"referenceSources": [
 				"CoA",
-				"VEoR",
-				"QftIS"
+				"QftIS",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Tome of Leadership and Influence|XDMG"
@@ -66374,8 +67326,8 @@
 			"page": 209,
 			"srd": true,
 			"referenceSources": [
-				"CoS",
 				"CoA",
+				"CoS",
 				"QftIS"
 			],
 			"reprintedAs": [
@@ -66475,7 +67427,11 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"PaBTSO"
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"PaBTSO",
+				"TftYP-TSC"
 			],
 			"reprintedAs": [
 				"Torch|XPHB"
@@ -66504,6 +67460,7 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
+				"BQGT",
 				"DrDe-TDoN"
 			],
 			"type": "G|XPHB",
@@ -66614,7 +67571,7 @@
 			"wondrous": true,
 			"grantsProficiency": true,
 			"entries": [
-				"Also at rank 3, Head Office provides you with a travel alchemical kit\u2014an uncommon magic item containing miniaturized versions of both {@item alchemist's supplies|phb} and a {@item poisoner's kit|phb} (glass vials, a mortar and pestle, chemicals, and a glass stirring rod). You gain proficiency with a {@item poisoner's kit|phb} as part of this upgrade.",
+				"Also at rank 3, Head Office provides you with a travel alchemical kit—an uncommon magic item containing miniaturized versions of both {@item alchemist's supplies|phb} and a {@item poisoner's kit|phb} (glass vials, a mortar and pestle, chemicals, and a glass stirring rod). You gain proficiency with a {@item poisoner's kit|phb} as part of this upgrade.",
 				"You can use this magical kit as long as it is on your person, with no need to draw or stow it. If you are ever searched, finding your travel alchemical kit requires a successful {@dc 20} Intelligence ({@skill Investigation}) or Wisdom ({@skill Insight}) check."
 			],
 			"hasFluffImages": true
@@ -66626,7 +67583,10 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"KftGV"
+				"CoS",
+				"KftGV",
+				"PaBTSO",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Traveler's Clothes|XPHB"
@@ -66664,9 +67624,9 @@
 			"page": 209,
 			"srd": true,
 			"referenceSources": [
+				"GoS",
 				"PotA",
-				"SKT",
-				"GoS"
+				"SKT"
 			],
 			"reprintedAs": [
 				"Trident of Fish Command|XDMG"
@@ -67836,12 +68796,12 @@
 			"page": 159,
 			"basicRules": true,
 			"referenceSources": [
-				"TTP",
-				"WDH",
-				"WDMM",
 				"BGDIA",
 				"CM",
-				"ToFW"
+				"ToFW",
+				"TTP",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Trinket|XPHB"
@@ -68750,7 +69710,7 @@
 					"name": "Mental Command",
 					"entries": [
 						"While attuned to the True-Ice Shards, you can use an action to cast the {@spell Detect Thoughts} spell (save {@dc 20}), targeting any creature you have previously met. If the targeted creature is on a different plane of existence, the spell fails.",
-						"As long as you maintain {@status concentration}, you can use a bonus action to send a telepathic message to the focused creature. It can reply\u2014using a bonus action to do so\u2014as long as the focus and {@status concentration} continue."
+						"As long as you maintain {@status concentration}, you can use a bonus action to send a telepathic message to the focused creature. It can reply—using a bonus action to do so—as long as the focus and {@status concentration} continue."
 					]
 				},
 				{
@@ -68838,7 +69798,7 @@
 					"name": "Mental Command",
 					"entries": [
 						"While attuned to the True-Ice Shards, you can use an action to cast the {@spell Detect Thoughts} spell (save {@dc 20}), targeting any creature you have previously met. If the targeted creature is on a different plane of existence, the spell fails.",
-						"As long as you maintain {@status concentration}, you can use a bonus action to send a telepathic message to the focused creature. It can reply\u2014using a bonus action to do so\u2014as long as the focus and {@status concentration} continue."
+						"As long as you maintain {@status concentration}, you can use a bonus action to send a telepathic message to the focused creature. It can reply—using a bonus action to do so—as long as the focus and {@status concentration} continue."
 					]
 				},
 				{
@@ -68923,6 +69883,9 @@
 			"name": "Turquoise",
 			"source": "DMG",
 			"page": 134,
+			"referenceSources": [
+				"DoSI"
+			],
 			"reprintedAs": [
 				"Turquoise|XDMG"
 			],
@@ -68993,8 +69956,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"ToA",
-				"CRCotN"
+				"CRCotN",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Tent|XPHB"
@@ -69074,6 +70037,10 @@
 			"source": "DMG",
 			"page": 209,
 			"srd": true,
+			"referenceSources": [
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Universal Solvent|XDMG"
 			],
@@ -69462,6 +70429,9 @@
 			"name": "Vox Seeker",
 			"source": "EGW",
 			"page": 270,
+			"referenceSources": [
+				"DD"
+			],
 			"rarity": "common",
 			"wondrous": true,
 			"entries": [
@@ -69525,8 +70495,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"WDH",
-				"PaBTSO"
+				"PaBTSO",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Wagon|XPHB"
@@ -69658,6 +70628,10 @@
 					"page": true
 				}
 			},
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
 			"rarity": "very rare",
 			"entries": [
 				"This ornament can be jewelry, a cloak, or another wearable accessory. It appears to be fashioned from a dragon's scale, tooth, or claw, or it incorporates images in those shapes.",
@@ -69671,12 +70645,12 @@
 			"page": 209,
 			"srd": true,
 			"referenceSources": [
-				"TftYP-DiT",
-				"WDH",
-				"OoW",
+				"CoA",
 				"IDRotF",
 				"KftGV",
-				"CoA"
+				"OoW",
+				"TftYP-DiT",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Wand of Binding|XDMG"
@@ -69899,6 +70873,15 @@
 			"name": "Wand of Entangle",
 			"source": "TftYP",
 			"page": 229,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"type": "WD|DMG",
 			"rarity": "uncommon",
 			"reqAttune": "by a spellcaster",
@@ -69929,6 +70912,8 @@
 			"page": 210,
 			"srd": true,
 			"referenceSources": [
+				"PotA",
+				"RoT",
 				"ToA"
 			],
 			"reprintedAs": [
@@ -70043,9 +71028,10 @@
 			"page": 210,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
+				"OoW",
 				"SKT",
-				"WDMM",
-				"CoA"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Wand of Fireballs|XDMG"
@@ -70125,8 +71111,11 @@
 			"page": 211,
 			"srd": true,
 			"referenceSources": [
+				"OoW",
+				"RtG",
+				"SKT",
 				"TftYP-THSoT",
-				"RtG"
+				"WDH"
 			],
 			"reprintedAs": [
 				"Wand of Lightning Bolts|XDMG"
@@ -70210,10 +71199,13 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"OoW",
-				"US",
 				"CoA",
-				"QftIS"
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"SDW",
+				"US",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Wand of Magic Detection|XDMG"
@@ -70284,17 +71276,20 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"LMoP",
-				"PotA",
-				"TftYP-TFoF",
-				"WDH",
-				"OoW",
-				"RMBRE",
-				"IDRotF",
+				"BGDIA",
+				"HftT",
 				"HoL",
+				"IDRotF",
 				"KftGV",
+				"LMoP",
+				"OoW",
 				"PaBTSO",
-				"QftIS"
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"SLW",
+				"TftYP-TFoF",
+				"WDH"
 			],
 			"reprintedAs": [
 				"Wand of Magic Missiles|XDMG"
@@ -70448,7 +71443,7 @@
 					"name": "Destroying the Wand",
 					"type": "entries",
 					"entries": [
-						"Destroying the Wand of Orcus requires that it be taken to the Positive Energy Plane by the ancient hero whose skull surmounts it. For this to happen, the long-lost hero must first be restored to life\u2014no easy task, given the fact that {@creature Orcus|MTF} has imprisoned the hero's soul and keeps it hidden and well guarded.",
+						"Destroying the Wand of Orcus requires that it be taken to the Positive Energy Plane by the ancient hero whose skull surmounts it. For this to happen, the long-lost hero must first be restored to life—no easy task, given the fact that {@creature Orcus|MTF} has imprisoned the hero's soul and keeps it hidden and well guarded.",
 						"Bathing the wand in positive energy causes it to crack and explode, but unless the above conditions are met, the wand instantly reforms on {@creature Orcus|MTF|Orcus's} layer of the Abyss."
 					]
 				}
@@ -70497,7 +71492,7 @@
 			"charges": 7,
 			"entries": [
 				"Crafted and wielded by {@creature Orcus|MPMM}, this ghastly wand slips from the demon lord's grasp from time to time. When it does, it magically appears wherever the demon lord senses an opportunity to achieve some fell goal.",
-				"The wand is topped with a skull that once belonged to a human hero slain by Orcus. The wand can magically change in size to better conform to the grip of its user. All Holy Water within 10 feet of the wand is destroyed.",
+				"The wand is topped with a skull that once belonged to a human hero slain by Orcus. The wand can magically change in size to better conform to the grip of its user. All {@item Holy Water|XPHB} within 10 feet of the wand is destroyed.",
 				"Any creature besides Orcus that tries to attune to the wand makes a {@dc 17} Constitution saving throw. On a successful save, the creature takes {@damage 10d6} Necrotic damage. On a failed save, the creature dies and, if it is a Humanoid, turns into a {@creature Zombie|XMM}.",
 				{
 					"type": "entries",
@@ -70603,7 +71598,7 @@
 					"type": "entries",
 					"name": "Destroying the Wand",
 					"entries": [
-						"Destroying the Wand of Orcus requires that it be taken to the Positive Energy Plane by the ancient hero whose skull surmounts it. For this to happen, the long-lost hero must first be restored to life\u2014no easy task, given the fact that Orcus has imprisoned the hero's soul and keeps it hidden and well guarded.",
+						"Destroying the Wand of Orcus requires that it be taken to the Positive Energy Plane by the ancient hero whose skull surmounts it. For this to happen, the long-lost hero must first be restored to life—no easy task, given the fact that Orcus has imprisoned the hero's soul and keeps it hidden and well guarded.",
 						"Bathing the wand in positive energy (such as that which permeates the Positive Plane) causes it to crack and explode, but unless the above conditions are met, the wand instantly re-forms on Orcus's layer of the Abyss."
 					]
 				}
@@ -70634,7 +71629,8 @@
 			"page": 211,
 			"srd": true,
 			"referenceSources": [
-				"QftIS"
+				"QftIS",
+				"TftYP-AtG"
 			],
 			"reprintedAs": [
 				"Wand of Paralysis|XDMG"
@@ -70700,6 +71696,7 @@
 			"page": 211,
 			"srd": true,
 			"referenceSources": [
+				"CM",
 				"CoS",
 				"WBtW"
 			],
@@ -70804,6 +71801,9 @@
 			"name": "Wand of Pyrotechnics",
 			"source": "XGE",
 			"page": 140,
+			"referenceSources": [
+				"DIP"
+			],
 			"reprintedAs": [
 				"Wand of Pyrotechnics|XDMG"
 			],
@@ -70844,14 +71844,18 @@
 			"page": 211,
 			"srd": true,
 			"referenceSources": [
-				"CoS",
-				"ToA",
-				"WDMM",
-				"DIP",
 				"BGDIA",
-				"WBtW",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"IMR",
+				"QftIS",
 				"SCC-TMM",
-				"CoA"
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Wand of Secrets|XDMG"
@@ -70881,6 +71885,7 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
+				"DrDe-TWoO",
 				"WttHC"
 			],
 			"type": "WD|XDMG",
@@ -70948,6 +71953,7 @@
 			"srd": true,
 			"referenceSources": [
 				"IDRotF",
+				"IMR",
 				"WBtW"
 			],
 			"reprintedAs": [
@@ -71047,7 +72053,7 @@
 			"charges": 7,
 			"entries": [
 				"This wand looks and feels like an icicle. You must be attuned to the wand to use it.",
-				"The wand has 7 charges, which are used to fuel the spells within it. With the wand in hand, you can use your action to cast one of the following spells from the wand, even if you are incapable of casting spells: {@spell ray of frost} (no charges, or 1 charge to cast at 5th level; +5 to hit with ranged spell attack), {@spell sleet storm} (3 charges; spell save {@dc 15}), or {@spell ice storm} (4 charges; spell save {@dc 15}). No components are required. The wand regains {@dice 1d6 + 1} expended charges each day at dawn. If you expend the wand's last charge, roll a {@dice d20}. On a 20, the wand melts away, forever destroyed."
+				"The wand has 7 charges, which are used to fuel the spells within it. With the wand in hand, you can use your action to cast one of the following spells from the wand, even if you are incapable of casting spells: {@spell ray of frost} (no charges, or 1 charge to cast at 5th level; {@hit 5} to hit with ranged spell attack), {@spell sleet storm} (3 charges; spell save {@dc 15}), or {@spell ice storm} (4 charges; spell save {@dc 15}). No components are required. The wand regains {@dice 1d6 + 1} expended charges each day at dawn. If you expend the wand's last charge, roll a {@dice d20}. On a 20, the wand melts away, forever destroyed."
 			],
 			"attachedSpells": {
 				"will": [
@@ -71070,10 +72076,11 @@
 			"page": 212,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
+				"CRCotN",
 				"ToA",
-				"WDMM",
 				"ToFW",
-				"CoA"
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Wand of Wonder|XDMG"
@@ -71572,6 +72579,12 @@
 			"page": 153,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"DIP",
+				"TftYP-TSC",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Waterskin|XPHB"
 			],
@@ -71591,7 +72604,8 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
-				"BQGT"
+				"BQGT",
+				"DrDe-ACfaS"
 			],
 			"type": "G|XPHB",
 			"rarity": "none",
@@ -71612,10 +72626,10 @@
 			"source": "DMG",
 			"page": 218,
 			"referenceSources": [
-				"TftYP-WPM",
 				"DC",
+				"IMR",
 				"LR",
-				"IMR"
+				"TftYP-WPM"
 			],
 			"reprintedAs": [
 				"Wave|XDMG"
@@ -71653,7 +72667,7 @@
 					"type": "entries",
 					"entries": [
 						"When it grows restless, Wave has a habit of humming tunes that vary from sea chanteys to sacred hymns of the sea gods.",
-						"Wave zealously desires to convert mortals to the worship of one or more sea gods, or else to consign the faithless to death. Conflict arises if the wielder fails to further the weapon's objectives in the world. The trident has a nostalgic attachment to the place where it was forged, a desolate island called Thunderforge. A sea god imprisoned a family of storm giants there, and the giants forged Wave in an act of devotion to\u2014or rebellion against\u2014that god.",
+						"Wave zealously desires to convert mortals to the worship of one or more sea gods, or else to consign the faithless to death. Conflict arises if the wielder fails to further the weapon's objectives in the world. The trident has a nostalgic attachment to the place where it was forged, a desolate island called Thunderforge. A sea god imprisoned a family of storm giants there, and the giants forged Wave in an act of devotion to—or rebellion against—that god.",
 						"Wave harbors a secret doubt about its own nature and purpose. For all its devotion to the sea gods, Wave fears that it was intended to bring about a particular sea god's demise. This destiny is something Wave might not be able to avert."
 					]
 				}
@@ -71787,6 +72801,15 @@
 			"name": "Waythe",
 			"source": "TftYP",
 			"page": 229,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"baseItem": "greatsword|phb",
 			"type": "M",
 			"rarity": "legendary",
@@ -71843,6 +72866,7 @@
 			"page": 213,
 			"srd": true,
 			"referenceSources": [
+				"JttRC",
 				"VEoR"
 			],
 			"reprintedAs": [
@@ -71926,6 +72950,9 @@
 			"name": "Wheel of Stars",
 			"source": "AI",
 			"page": 222,
+			"referenceSources": [
+				"OoW"
+			],
 			"rarity": "very rare",
 			"reqAttune": true,
 			"wondrous": true,
@@ -71984,6 +73011,7 @@
 			"source": "DMG",
 			"page": 218,
 			"referenceSources": [
+				"IMR",
 				"TftYP-WPM"
 			],
 			"reprintedAs": [
@@ -72163,7 +73191,7 @@
 			"reqAttune": true,
 			"wondrous": true,
 			"entries": [
-				"Also at rank 1, you are the beneficiary of a whisper jar\u2014a common magic item resembling an ether-filled jar with a long tap hose. The jar is used to record others' stories and your own observations, like a verbal notebook with unlimited space. The whisper jar records as fast as a creature can speak into it, and whispers back words at the same pace they were recorded. Activating the playback of a particular recording is an action.",
+				"Also at rank 1, you are the beneficiary of a whisper jar—a common magic item resembling an ether-filled jar with a long tap hose. The jar is used to record others' stories and your own observations, like a verbal notebook with unlimited space. The whisper jar records as fast as a creature can speak into it, and whispers back words at the same pace they were recorded. Activating the playback of a particular recording is an action.",
 				{
 					"type": "table",
 					"caption": "Things Recorded in Your Whisper Jar",
@@ -72288,6 +73316,12 @@
 			"name": "White Dragon Mask",
 			"source": "RoTOS",
 			"page": 4,
+			"otherSources": [
+				{
+					"source": "ToD",
+					"page": 179
+				}
+			],
 			"referenceSources": [
 				"HotDQ",
 				"RoT"
@@ -72511,7 +73545,7 @@
 					"type": "entries",
 					"name": "Personality",
 					"entries": [
-						"A short-tempered {@creature bone devil} named Ashtyrlon lives within Will of the Talon. The weapon is greedy and values strong leadership. It demands that its wielder take decisive action to keep order in high-pressure situations\u2014and to always take a fair share of treasure in return."
+						"A short-tempered {@creature bone devil} named Ashtyrlon lives within Will of the Talon. The weapon is greedy and values strong leadership. It demands that its wielder take decisive action to keep order in high-pressure situations—and to always take a fair share of treasure in return."
 					]
 				},
 				{
@@ -72834,8 +73868,9 @@
 			"page": 214,
 			"srd": true,
 			"referenceSources": [
+				"CoA",
 				"JttRC",
-				"CoA"
+				"LLK"
 			],
 			"reprintedAs": [
 				"Wings of Flying|XDMG"
@@ -73363,10 +74398,10 @@
 			"rechargeAmount": 9,
 			"charges": 9,
 			"entries": [
-				"Built by dwarven gods and entrusted to the rulers of Shanatar, an ancient dwarven empire. The Wyrmskull Throne was a symbol of dwarven power and pride for ages untold. The throne hovers a foot off the ground and is a massive thing made of polished obsidian with oversized feet\u2014the impaled skulls of four ancient blue dragons. Runes glisten in the carved obsidian winking to life with blue energy when the throne's powers are activated.",
+				"Built by dwarven gods and entrusted to the rulers of Shanatar, an ancient dwarven empire. The Wyrmskull Throne was a symbol of dwarven power and pride for ages untold. The throne hovers a foot off the ground and is a massive thing made of polished obsidian with oversized feet—the impaled skulls of four ancient blue dragons. Runes glisten in the carved obsidian winking to life with blue energy when the throne's powers are activated.",
 				"After the fall of Shanatar, the Wyrmskull Throne fell into the clutches of less honorable creatures. A band of adventurers wrested the throne from the aquatic elf tyrant Gantar Kraok and sold it to the {@creature storm giant} Neri for a considerable fortune. Neri had the throne magically enlarged and gave it to her husband, King Hekaton, as a gift, along with one of the Ruling Scepters of Shanatar, which she had found in a wreck at the bottom of the Trackless Sea. Only a creature attuned to a Ruling Scepter and in possession of it can harness the powers of the Wyrmskull Throne, which has become the centerpiece of King Hekaton's throne room in the undersea citadel of Maelstrom. Fear of the throne's power has helped prevent evil giants from challenging or threatening Hekaton's leadership.",
 				"Any creature not attuned to a Ruling Scepter who sits on the throne is {@condition paralyzed} and encased in a magical force field. While encased, the creature can't be touched or moved from the throne. Touching a Ruling Scepter to the force field dispels the field, though the creature remains {@condition paralyzed} until it is separated from the throne.",
-				"Any creature seated on the throne can hear faint Whispers in Draconic\u2014the whisperings of four blue dragons whose skulls adorn the throne. Although powerless, these spirits try to influence the decisions of the throne's master.",
+				"Any creature seated on the throne can hear faint Whispers in Draconic—the whisperings of four blue dragons whose skulls adorn the throne. Although powerless, these spirits try to influence the decisions of the throne's master.",
 				{
 					"name": "Properties of the Throne",
 					"type": "entries",
@@ -73405,6 +74440,7 @@
 			"page": 258,
 			"srd": true,
 			"referenceSources": [
+				"HotDQ",
 				"ToA"
 			],
 			"reprintedAs": [
@@ -73509,7 +74545,7 @@
 			"rarity": "none",
 			"value": 100,
 			"entries": [
-				"A yahcha (pronounced YAH-chah) is a harmless, meaty beetle about the size of a human hand, which feeds on worms and maggots. It moves slowly (walking speed 10 feet) and is easy to catch. A creature with blue mist fever that eats a raw or cooked yahcha can immediately make a saving throw with advantage against that disease (see \"Diseases,\" page 40),"
+				"A yahcha (pronounced YAH-chah) is a harmless, meaty beetle about the size of a human hand, which feeds on worms and maggots. It moves slowly (walking speed 10 feet) and is easy to catch. A creature with blue mist fever that eats a raw or cooked yahcha can immediately make a saving throw with advantage against that disease (see {@adventure \"Diseases,\"|ToA|2|Diseases} page 40)."
 			]
 		},
 		{
@@ -73624,7 +74660,7 @@
 			"wondrous": true,
 			"entries": [
 				"A mythallar looks like an enormous crystal ball held in an ornate cradle. The globe sheds bright light in a 300-foot radius and dim light for an additional 300 feet. The globe draws magic from the Weave that can be harnessed for various purposes. For example, Netherese mages used mythallars to keep their cities aloft and empower their magic items. The bigger the mythallar, the more magic it can hold. The largest mythallars are 150 feet in diameter.",
-				"The Ythryn mythallar is a relatively small device\u2014a mere 50 feet in diameter. To attune to this mythallar, a creature must finish a short rest within 30 feet of it, meditating on the mythallar. Up to eight creatures can be attuned to it at one time; otherwise, the Ythryn mythallar follows the attunement rules in the Dungeon Master's Guide. If a ninth creature tries to attune to the mythallar, nothing happens.",
+				"The Ythryn mythallar is a relatively small device—a mere 50 feet in diameter. To attune to this mythallar, a creature must finish a short rest within 30 feet of it, meditating on the mythallar. Up to eight creatures can be attuned to it at one time; otherwise, the Ythryn mythallar follows the attunement rules in the Dungeon Master's Guide. If a ninth creature tries to attune to the mythallar, nothing happens.",
 				"All creatures attuned to the Ythryn mythallar can sense when the device is being used. A creature attuned to the device can use any of its properties, but only if all other creatures attuned to the device agree to allow it. The Ythryn mythallar's properties are as follows:",
 				{
 					"type": "list",
@@ -73741,6 +74777,77 @@
 			"value": 5000,
 			"entries": [
 				"A pale blue green gemstone."
+			]
+		},
+		{
+			"name": "Lantern of Tracking",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"Each lantern of tracking is designed to track down a certain type of creature, which is determined by rolling on the Lantern of Tracking table. Once determined, this creature type can't be changed. While the lantern is within 300 feet of any creature of that type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however.",
+				{
+					"type": "table",
+					"caption": "Lantern of Tracking",
+					"colLabels": [
+						"1d10",
+						"Creature Type"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"1",
+							"Aberrations"
+						],
+						[
+							"2",
+							"Celestials"
+						],
+						[
+							"3",
+							"Constructs"
+						],
+						[
+							"4",
+							"Dragons"
+						],
+						[
+							"5",
+							"Elementals"
+						],
+						[
+							"6",
+							"Fey"
+						],
+						[
+							"7",
+							"Fiends"
+						],
+						[
+							"8",
+							"Giants"
+						],
+						[
+							"9",
+							"Monstrosities"
+						],
+						[
+							"10",
+							"Undead"
+						]
+					]
+				}
+			],
+			"light": [
+				{
+					"bright": 30,
+					"dim": 60
+				}
 			]
 		}
 	],
@@ -73909,6 +75016,7 @@
 			"source": "DMG",
 			"page": 162,
 			"referenceSources": [
+				"RoT",
 				"WDMM"
 			],
 			"reprintedAs": [
@@ -73994,6 +75102,9 @@
 			"page": 231,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-BtS"
+			],
 			"type": "GV|XDMG",
 			"rarity": "rare",
 			"reqAttune": true,
@@ -74079,7 +75190,8 @@
 			"source": "DMG",
 			"page": 152,
 			"referenceSources": [
-				"TftYP-AtG"
+				"TftYP-AtG",
+				"TftYP-DiT"
 			],
 			"reprintedAs": [
 				"Armor of Vulnerability|XDMG"
@@ -74129,7 +75241,8 @@
 			"srd": true,
 			"basicRules": true,
 			"referenceSources": [
-				"PaBTSO"
+				"PaBTSO",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Artisan's Tools|XPHB"
@@ -74188,7 +75301,9 @@
 			"source": "DMG",
 			"page": 154,
 			"referenceSources": [
-				"IDRotF"
+				"GoS",
+				"IDRotF",
+				"LLK"
 			],
 			"reprintedAs": [
 				"Bag of Tricks|XDMG"
@@ -74348,8 +75463,8 @@
 			"source": "DMG",
 			"page": 157,
 			"referenceSources": [
-				"JttRC",
-				"CoA"
+				"CoA",
+				"JttRC"
 			],
 			"reprintedAs": [
 				"Carpet of Flying|XDMG"
@@ -74562,6 +75677,9 @@
 			"source": "DMG",
 			"page": 165,
 			"srd": true,
+			"referenceSources": [
+				"KftGV"
+			],
 			"reprintedAs": [
 				"Dragon Scale Mail|XDMG"
 			],
@@ -74625,6 +75743,18 @@
 			"name": "Dragon Vessel",
 			"source": "FTD",
 			"page": 27,
+			"referenceSources": [
+				"DrDe-ACfaS",
+				"DrDe-BD",
+				"DrDe-BtS",
+				"DrDe-DaS",
+				"DrDe-DotSC",
+				"DrDe-FWtVC",
+				"DrDe-SD",
+				"DrDe-TDoN",
+				"DrDe-TFV",
+				"DrDe-TWoO"
+			],
 			"rarity": "varies",
 			"reqAttune": true,
 			"wondrous": true,
@@ -74642,6 +75772,18 @@
 			"name": "Dragon's Wrath Weapon",
 			"source": "FTD",
 			"page": 25,
+			"referenceSources": [
+				"DrDe-ACfaS",
+				"DrDe-BD",
+				"DrDe-BtS",
+				"DrDe-DaS",
+				"DrDe-DotSC",
+				"DrDe-FWtVC",
+				"DrDe-SD",
+				"DrDe-TDoN",
+				"DrDe-TFV",
+				"DrDe-TWoO"
+			],
 			"type": "GV|DMG",
 			"rarity": "varies",
 			"reqAttune": true,
@@ -74659,6 +75801,18 @@
 			"name": "Dragon-Touched Focus",
 			"source": "FTD",
 			"page": 26,
+			"referenceSources": [
+				"DrDe-ACfaS",
+				"DrDe-BD",
+				"DrDe-BtS",
+				"DrDe-DaS",
+				"DrDe-DotSC",
+				"DrDe-FWtVC",
+				"DrDe-SD",
+				"DrDe-TDoN",
+				"DrDe-TFV",
+				"DrDe-TWoO"
+			],
 			"type": "SCF",
 			"rarity": "varies",
 			"reqAttune": "by a spellcaster",
@@ -74693,6 +75847,9 @@
 			"name": "Druidic Focus",
 			"source": "PHB",
 			"page": 151,
+			"referenceSources": [
+				"ToA"
+			],
 			"reprintedAs": [
 				"Druidic Focus|XPHB"
 			],
@@ -74730,10 +75887,10 @@
 			"source": "DMG",
 			"page": 167,
 			"referenceSources": [
-				"RoT",
+				"DSotDQ",
 				"OotA",
-				"WDMM",
-				"DSotDQ"
+				"RoT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Elemental Gem|XDMG"
@@ -74899,6 +76056,9 @@
 			],
 			"reprintedAs": [
 				"Eye and Hand of Vecna|XDMG"
+			],
+			"conditionImmune": [
+				"disease"
 			],
 			"rarity": "artifact",
 			"reqAttune": true,
@@ -75289,10 +76449,11 @@
 			"source": "DMG",
 			"page": 169,
 			"referenceSources": [
-				"PotA",
-				"SKT",
 				"IMR",
-				"RtG"
+				"PotA",
+				"RtG",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Figurine of Wondrous Power|XDMG"
@@ -75330,7 +76491,8 @@
 				"Figurine of Wondrous Power, Onyx Dog|XDMG",
 				"Figurine of Wondrous Power, Serpentine Owl|XDMG",
 				"Figurine of Wondrous Power, Silver Raven|XDMG"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Flensing Claws",
@@ -75529,11 +76691,12 @@
 			"source": "PHB",
 			"page": 151,
 			"referenceSources": [
-				"CoS",
-				"TTP",
 				"CM",
+				"CoS",
+				"DSotDQ",
 				"KftGV",
-				"PaBTSO"
+				"PaBTSO",
+				"TTP"
 			],
 			"reprintedAs": [
 				"Holy Symbol|XPHB"
@@ -75576,7 +76739,8 @@
 			"source": "DMG",
 			"page": 175,
 			"referenceSources": [
-				"TftYP-AtG"
+				"TftYP-AtG",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Horn of Valhalla|XDMG"
@@ -75856,7 +77020,8 @@
 				"Ioun Stone, Reserve",
 				"Ioun Stone, Strength",
 				"Ioun Stone, Sustenance"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ioun Stone",
@@ -75924,7 +77089,7 @@
 			],
 			"recharge": "dawn",
 			"entries": [
-				"The Jewel of Three Prayers is a Vestige of Divergence (see the \"Vestiges of Divergence\" sidebar). In ancient times, Alyxian the Apotheon bore this amulet as a symbol of his covenant with three Prime Deities: Sehanine the Moon Weaver, Avandra the Change Bringer, and Corellon the Arch Heart. When the jewel is found, only Sehanine's power thrums within its dormant heart. The power of the other two deities waits to be reawakened by a hero\u2014or heroes\u2014who can follow in Alyxian's footsteps."
+				"The Jewel of Three Prayers is a Vestige of Divergence (see the \"Vestiges of Divergence\" sidebar). In ancient times, Alyxian the Apotheon bore this amulet as a symbol of his covenant with three Prime Deities: Sehanine the Moon Weaver, Avandra the Change Bringer, and Corellon the Arch Heart. When the jewel is found, only Sehanine's power thrums within its dormant heart. The power of the other two deities waits to be reawakened by a hero—or heroes—who can follow in Alyxian's footsteps."
 			],
 			"items": [
 				"Jewel of Three Prayers (Dormant)|CRCotN",
@@ -75939,6 +77104,90 @@
 				}
 			},
 			"hasFluffImages": true
+		},
+		{
+			"name": "Lantern of Tracking",
+			"source": "IDRotF",
+			"page": 314,
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This hooded lantern burns for 6 hours on 1 pint of oil, shedding bright light in a 30-foot radius and dim light for an additional 30 feet.",
+				"Each lantern of tracking is designed to track down a certain type of creature, which is determined by rolling on the Lantern of Tracking table. Once determined, this creature type can't be changed. While the lantern is within 300 feet of any creature of that type, its flame turns bright green. The lantern doesn't pinpoint the creature's exact location, however.",
+				{
+					"type": "table",
+					"caption": "Lantern of Tracking",
+					"colLabels": [
+						"1d10",
+						"Creature Type"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"1",
+							"{@item Lantern of Tracking (Aberrations)|IDRotF}"
+						],
+						[
+							"2",
+							"{@item Lantern of Tracking (Celestials)|IDRotF}"
+						],
+						[
+							"3",
+							"{@item Lantern of Tracking (Constructs)|IDRotF}"
+						],
+						[
+							"4",
+							"{@item Lantern of Tracking (Dragons)|IDRotF}"
+						],
+						[
+							"5",
+							"{@item Lantern of Tracking (Elementals)|IDRotF}"
+						],
+						[
+							"6",
+							"{@item Lantern of Tracking (Fey)|IDRotF}"
+						],
+						[
+							"7",
+							"{@item Lantern of Tracking (Fiends)|IDRotF}"
+						],
+						[
+							"8",
+							"{@item Lantern of Tracking (Giants)|IDRotF}"
+						],
+						[
+							"9",
+							"{@item Lantern of Tracking (Monstrosities)|IDRotF}"
+						],
+						[
+							"10",
+							"{@item Lantern of Tracking (Undead)|IDRotF}"
+						]
+					]
+				}
+			],
+			"items": [
+				"Lantern of Tracking (Aberrations)|IDRotF",
+				"Lantern of Tracking (Celestials)|IDRotF",
+				"Lantern of Tracking (Constructs)|IDRotF",
+				"Lantern of Tracking (Dragons)|IDRotF",
+				"Lantern of Tracking (Elementals)|IDRotF",
+				"Lantern of Tracking (Fey)|IDRotF",
+				"Lantern of Tracking (Fiends)|IDRotF",
+				"Lantern of Tracking (Giants)|IDRotF",
+				"Lantern of Tracking (Monstrosities)|IDRotF",
+				"Lantern of Tracking (Undead)|IDRotF"
+			],
+			"itemsHidden": true,
+			"light": [
+				{
+					"bright": 30,
+					"dim": 60
+				}
+			]
 		},
 		{
 			"name": "Lash of Shadows",
@@ -76358,6 +77607,15 @@
 			"name": "Potion of Mind Control",
 			"source": "TftYP",
 			"page": 229,
+			"referenceSources": [
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM"
+			],
 			"type": "P",
 			"rarity": "varies",
 			"items": [
@@ -76374,11 +77632,12 @@
 			"source": "DMG",
 			"page": 188,
 			"referenceSources": [
-				"WDH",
-				"WDMM",
-				"IDRotF",
+				"CoA",
 				"DoSI",
-				"CoA"
+				"IDRotF",
+				"KftGV",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Potion of Resistance|XDMG"
@@ -76555,7 +77814,9 @@
 			"page": 188,
 			"referenceSources": [
 				"GoS",
-				"ToFW"
+				"IMR",
+				"ToFW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Quaal's Feather Token|XDMG"
@@ -77072,16 +78333,16 @@
 			"source": "FTD",
 			"page": 27,
 			"referenceSources": [
-				"DrDe-DaS",
+				"DrDe-ACfaS",
 				"DrDe-BD",
-				"DrDe-TWoO",
+				"DrDe-BtS",
+				"DrDe-DaS",
+				"DrDe-DotSC",
 				"DrDe-FWtVC",
+				"DrDe-SD",
 				"DrDe-TDoN",
 				"DrDe-TFV",
-				"DrDe-BtS",
-				"DrDe-SD",
-				"DrDe-ACfaS",
-				"DrDe-DotSC"
+				"DrDe-TWoO"
 			],
 			"rarity": "varies",
 			"reqAttune": true,
@@ -77102,9 +78363,12 @@
 			"source": "DMG",
 			"page": 199,
 			"referenceSources": [
-				"RoT",
+				"CoS",
 				"OotA",
+				"RoT",
 				"TftYP-AtG",
+				"TftYP-THSoT",
+				"TftYP-WPM",
 				"ToA"
 			],
 			"reprintedAs": [
@@ -77467,54 +78731,56 @@
 			"source": "DMG",
 			"page": 200,
 			"referenceSources": [
-				"LMoP",
-				"HotDQ",
-				"RoT",
-				"OotA",
+				"AitFR-AVT",
+				"AitFR-ISF",
+				"BGDIA",
+				"CM",
+				"CoA",
 				"CoS",
+				"CRCotN",
+				"DC",
+				"DitLCoT",
+				"DoSI",
+				"DSotDQ",
+				"FS",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"LMoP",
+				"LoX",
+				"LRDT",
+				"MOT",
+				"NRH-TLT",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SCC-ARiR",
+				"SDW",
+				"SjA",
 				"SKT",
-				"TftYP-TSC",
+				"SLW",
+				"TftYP-AtG",
+				"TftYP-DiT",
 				"TftYP-TFoF",
 				"TftYP-THSoT",
-				"TftYP-WPM",
-				"TftYP-DiT",
-				"TftYP-AtG",
 				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM",
 				"ToA",
-				"WDH",
-				"LLK",
-				"WDMM",
-				"GoS",
-				"OoW",
-				"SLW",
-				"SDW",
-				"DC",
-				"BGDIA",
-				"IMR",
-				"ToR",
-				"FS",
-				"MOT",
-				"IDRotF",
-				"CM",
-				"RtG",
-				"AitFR-ISF",
-				"AitFR-AVT",
-				"NRH-TLT",
-				"WBtW",
-				"SCC-ARiR",
-				"CRCotN",
-				"JttRC",
-				"DoSI",
-				"SjA",
-				"LoX",
-				"DSotDQ",
-				"KftGV",
 				"ToFW",
-				"CoA",
-				"DitLCoT",
-				"LRDT",
+				"ToR",
 				"VEoR",
-				"QftIS"
+				"VNotEE",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Spell Scroll|XPHB",
@@ -77545,11 +78811,12 @@
 			"srd52": true,
 			"basicRules2024": true,
 			"referenceSources": [
-				"DrDe-DaS",
-				"DrDe-TWoO",
-				"DrDe-TDoN",
 				"DrDe-ACfaS",
+				"DrDe-BD",
+				"DrDe-DaS",
 				"DrDe-DotSC",
+				"DrDe-TDoN",
+				"DrDe-TWoO",
 				"FRAiF"
 			],
 			"type": "SC|XPHB",
@@ -77739,7 +79006,7 @@
 					"name": "Mental Command",
 					"entries": [
 						"While attuned to the True-Ice Shards, you can use an action to cast the {@spell Detect Thoughts} spell (save {@dc 20}), targeting any creature you have previously met. If the targeted creature is on a different plane of existence, the spell fails.",
-						"As long as you maintain {@status concentration}, you can use a bonus action to send a telepathic message to the focused creature. It can reply\u2014using a bonus action to do so\u2014as long as the focus and {@status concentration} continue."
+						"As long as you maintain {@status concentration}, you can use a bonus action to send a telepathic message to the focused creature. It can reply—using a bonus action to do so—as long as the focus and {@status concentration} continue."
 					]
 				},
 				{
@@ -77781,9 +79048,6 @@
 			"name": "Verminshroud",
 			"source": "EGW",
 			"page": 273,
-			"conditionImmune": [
-				"disease"
-			],
 			"rarity": "legendary",
 			"reqAttune": true,
 			"wondrous": true,

--- a/json/races.json
+++ b/json/races.json
@@ -1,7 +1,8 @@
 {
 	"_meta": {
 		"internalCopies": [
-			"race"
+			"race",
+			"subrace"
 		]
 	},
 	"race": [
@@ -31,6 +32,10 @@
 					"auran": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/aarakocra.opus"
+			},
 			"entries": [
 				{
 					"name": "Dive Attack",
@@ -97,7 +102,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/aarakocra.mp3"
+				"path": "races/aarakocra.opus"
 			},
 			"entries": [
 				{
@@ -161,6 +166,10 @@
 			"traitTags": [
 				"Natural Weapon"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/aarakocra.opus"
+			},
 			"additionalSpells": [
 				{
 					"innate": {
@@ -238,7 +247,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/aasimar.mp3"
+				"path": "races/aasimar.opus"
 			},
 			"additionalSpells": [
 				{
@@ -332,6 +341,10 @@
 				"necrotic",
 				"radiant"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/aasimar.opus"
+			},
 			"additionalSpells": [
 				{
 					"ability": {
@@ -518,7 +531,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/aasimar.mp3"
+				"path": "races/aasimar.opus"
 			},
 			"additionalSpells": [
 				{
@@ -602,6 +615,10 @@
 				"necrotic",
 				"radiant"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/aasimar.opus"
+			},
 			"additionalSpells": [
 				{
 					"ability": "cha",
@@ -749,7 +766,7 @@
 					"type": "entries",
 					"name": "Size",
 					"entries": [
-						"Aetherborn are about the same size as humans, ranging from 5 to 6 feet tall. They are quite light\u2014only about 100 pounds\u2014and their weight diminishes as they age and more and more of their substance returns to the aethersphere. Your size is Medium."
+						"Aetherborn are about the same size as humans, ranging from 5 to 6 feet tall. They are quite light—only about 100 pounds—and their weight diminishes as they age and more and more of their substance returns to the aethersphere. Your size is Medium."
 					]
 				},
 				{
@@ -784,7 +801,7 @@
 					"type": "inset",
 					"name": "Gift of the Aetherborn",
 					"entries": [
-						"An unknown aetherborn, desperately seeking a means to extend their short life, discovered a process of transformation that prolonged their existence\u2014by giving them the ability to feed on the life essence of other beings. Since then, other aetherborn have learned and carried out this monstrous transformation, and aetherborn with this \"gift\" have become a small minority among an already small population.",
+						"An unknown aetherborn, desperately seeking a means to extend their short life, discovered a process of transformation that prolonged their existence—by giving them the ability to feed on the life essence of other beings. Since then, other aetherborn have learned and carried out this monstrous transformation, and aetherborn with this \"gift\" have become a small minority among an already small population.",
 						"A gifted aetherborn has the ability to drain the life essence of other beings. Similar to the way heat is transferred from a warm object to a cold one, a gifted aetherborn need only touch another living being with a clawed hand to draw life essence out, fueling their own continued existence while draining strength and vitality from their victim.",
 						"For many aetherborn, living as they do for indulgence and instant gratification, the concepts of \"want\" and \"need\" are virtually synonymous. But Aetherborn with this gift understand what it is to truly need, for they develop a hunger for life essence that far exceeds any desires they might have felt before their transformation. A gifted aetherborn who abstains from this feeding deteriorates even more rapidly than other aetherborn, while enduring unspeakable agony caused by the deprivation of life energy.",
 						"At the DM's option, an aetherborn character can research methods of achieving this dark \"gift.\" The process is similar to inventing and manufacturing a rare magic item (see \"{@book Inventing and Manufacturing Devices|PS-K|1|Inventing and Manufacturing Devices}\" earlier in this document). But rather than aether, the process requires a variety of rare unguents and unusual ingredients that make up the cost of researching and undergoing the transformation.",
@@ -1172,6 +1189,17 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Boggart",
+			"source": "LFL",
+			"_copy": {
+				"name": "Goblin",
+				"source": "MPMM"
+			},
+			"lineage": null,
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
 			"name": "Bugbear",
 			"source": "ERLW",
 			"page": 25,
@@ -1214,6 +1242,10 @@
 					"goblin": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/bugbear.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -1305,6 +1337,10 @@
 					"stealth": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/bugbear.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -1408,6 +1444,10 @@
 					"goblin": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/bugbear.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -1495,6 +1535,10 @@
 					"other": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/bullywug.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -1585,6 +1629,10 @@
 					"sylvan": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/centaur.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -1702,6 +1750,10 @@
 					]
 				}
 			},
+			"soundClip": {
+				"type": "internal",
+				"path": "races/centaur.opus"
+			},
 			"hasFluff": true,
 			"hasFluffImages": true
 		},
@@ -1733,6 +1785,10 @@
 					}
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/centaur.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -1776,10 +1832,65 @@
 		},
 		{
 			"name": "Changeling",
+			"source": "EFA",
+			"page": 34,
+			"edition": "one",
+			"creatureTypes": [
+				"fey"
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"speed": 30,
+			"skillProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"deception",
+							"insight",
+							"intimidation",
+							"persuasion"
+						],
+						"count": 2
+					}
+				}
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 4-7 feet tall) or Small (about 2-4 feet tall), chosen when you select this species"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Changeling Instincts",
+					"entries": [
+						"Thanks to your connection to the fey realm, you gain proficiency in two of the following skills of your choice: {@skill Deception|XPHB}, {@skill Insight|XPHB}, {@skill Intimidation|XPHB}, {@skill Performance|XPHB}, or {@skill Persuasion|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Shape-Shifter",
+					"entries": [
+						"As an action, you can shape-shift to change your appearance and your voice. You determine the specifics of the changes, including your coloration, hair length, and sex. You can also adjust your height and weight and can change your size between Medium and Small. You can make yourself appear as a member of another playable species, though none of your game statistics change. You can't duplicate the appearance of an individual you've never seen, and you must adopt a form that has the same basic arrangement of limbs that you have. This trait doesn't change your clothing and equipment.",
+						"While shape-shifted with this trait, you have {@variantrule Advantage|XPHB} on Charisma checks.",
+						"You stay in the new form until you take an action to revert to your true form."
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Changeling",
 			"source": "ERLW",
 			"page": 17,
 			"reprintedAs": [
-				"Changeling|MPMM"
+				"Changeling|MPMM",
+				"Changeling|EFA"
 			],
 			"size": [
 				"M"
@@ -1833,7 +1944,7 @@
 				{
 					"name": "Age",
 					"entries": [
-						"Changelings mature slightly faster than humans but share a similar lifespan\u2014typically a century or less. While a changeling can transform to conceal their age, the effects of aging affect them similarly to humans."
+						"Changelings mature slightly faster than humans but share a similar lifespan—typically a century or less. While a changeling can transform to conceal their age, the effects of aging affect them similarly to humans."
 					],
 					"type": "entries"
 				},
@@ -1881,6 +1992,9 @@
 			"name": "Changeling",
 			"source": "MPMM",
 			"page": 10,
+			"reprintedAs": [
+				"Changeling|EFA"
+			],
 			"lineage": "VRGR",
 			"creatureTypes": [
 				"fey"
@@ -2150,8 +2264,97 @@
 		},
 		{
 			"name": "Dhampir",
+			"source": "RHW",
+			"otherSources": [
+				{
+					"source": "ABH",
+					"page": 7
+				}
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"speed": {
+				"walk": 35,
+				"climb": true
+			},
+			"darkvision": 60,
+			"traitTags": [
+				"Natural Weapon"
+			],
+			"resist": [
+				"necrotic"
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 4-7 feet tall) or Small (about 2-4 feet tall), chosen when you select this species"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Darkvision",
+					"entries": [
+						"You have {@sense Darkvision|XPHB} with a range of 60 feet."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spider Climb",
+					"entries": [
+						"You have a {@variantrule Climb Speed|XPHB} equal to your {@variantrule Speed|XPHB}. When you reach character level 3, you can move up, down, and across vertical surfaces and along ceilings while leaving your hands free."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Trace of Undeath",
+					"entries": [
+						"You have {@variantrule Resistance|XPHB} to Necrotic damage."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Vampiric Bite",
+					"entries": [
+						"When you use your {@variantrule Unarmed Strike|XPHB} and deal damage, you can choose to bite with your fangs. You deal Piercing damage equal to {@damage 1d4} plus your Constitution modifier instead of the normal damage of an {@variantrule Unarmed Strike|XPHB}.",
+						"In addition, when you deal this damage to a creature that isn't a Construct or an Undead, you can empower yourself in one of the following ways:",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Drain",
+									"entries": [
+										"You regain {@variantrule Hit Points|XPHB} equal to the Piercing damage dealt."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Strengthen",
+									"entries": [
+										"You gain a bonus to the next ability check or attack roll you make within the next minute; the bonus is equal to the Piercing damage dealt."
+									]
+								}
+							]
+						},
+						"You can empower yourself with this trait a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Dhampir",
 			"source": "VRGR",
 			"page": 16,
+			"reprintedAs": [
+				"Dhampir|RHW"
+			],
 			"lineage": "VRGR",
 			"size": [
 				"S",
@@ -2274,7 +2477,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/dragonborn.mp3"
+				"path": "races/dragonborn.opus"
 			},
 			"entries": [
 				{
@@ -2406,6 +2609,23 @@
 			],
 			"speed": 30,
 			"darkvision": 60,
+			"resist": [
+				{
+					"choose": {
+						"from": [
+							"acid",
+							"lightning",
+							"fire",
+							"poison",
+							"cold"
+						]
+					}
+				}
+			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/dragonborn.opus"
+			},
 			"sizeEntry": {
 				"type": "item",
 				"name": "Size:",
@@ -2664,6 +2884,10 @@
 					}
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/dragonborn.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -2840,6 +3064,10 @@
 					}
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/dragonborn.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -3025,6 +3253,10 @@
 					}
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/dragonborn.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -3222,6 +3454,10 @@
 			"resist": [
 				"poison"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/duergar.opus"
+			},
 			"additionalSpells": [
 				{
 					"innate": {
@@ -3343,7 +3579,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/dwarf.mp3"
+				"path": "races/dwarf.opus"
 			},
 			"entries": [
 				{
@@ -3391,7 +3627,7 @@
 				{
 					"name": "Tool Proficiency",
 					"entries": [
-						"You gain proficiency with the artisan's tools of your choice: {@item Smith's tools|phb}, {@item brewer's supplies|phb}, or {@item mason's tools|phb}."
+						"You gain proficiency with the {@item artisan's tools|PHB} of your choice: {@item Smith's tools|phb}, {@item brewer's supplies|phb}, or {@item mason's tools|phb}."
 					],
 					"type": "entries"
 				},
@@ -3431,6 +3667,10 @@
 			"resist": [
 				"poison"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/dwarf.opus"
+			},
 			"sizeEntry": {
 				"type": "item",
 				"name": "Size:",
@@ -3505,6 +3745,10 @@
 			"resist": [
 				"poison"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/dwarf.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -3680,6 +3924,238 @@
 		},
 		{
 			"name": "Elf",
+			"source": "LFL",
+			"_copy": {
+				"name": "Elf",
+				"source": "XPHB",
+				"_mod": {
+					"entries": {
+						"mode": "replaceArr",
+						"replace": "Elven Lineage",
+						"items": {
+							"type": "entries",
+							"name": "Elven Lineage",
+							"entries": [
+								"You are part of a lineage that grants you supernatural abilities. Choose a lineage from the Elven Lineages table. You gain the level 1 benefit of that lineage.",
+								"When you reach character levels 3 and 5, you learn a higher-level spell, as shown on the table. You always have that spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast the spell using any spell slots you have of the appropriate level.",
+								"Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the lineage).",
+								{
+									"type": "table",
+									"caption": "Elven Lineages",
+									"colLabels": [
+										"Lineage",
+										"Level 1",
+										"Level 3",
+										"Level 5"
+									],
+									"colStyles": [
+										"col-2",
+										"col-6",
+										"col-2",
+										"col-2"
+									],
+									"rows": [
+										[
+											"Lorwyn",
+											"You know the {@spell Thorn Whip|XPHB} cantrip. Whenever you finish a {@variantrule Long Rest|XPHB}, you can replace that cantrip with a different cantrip from the {@filter Druid spell list|spells|class=druid}.",
+											"{@spell Command|XPHB}",
+											"{@spell Silence|XPHB}"
+										],
+										[
+											"Shadowmoor",
+											"The range of your {@sense Darkvision|XPHB} increases to 120 feet. You also know the {@spell Starry Wisp|XPHB} cantrip.",
+											"{@spell Heroism|XPHB}",
+											"{@spell Gentle Repose|XPHB}"
+										]
+									]
+								}
+							]
+						}
+					}
+				}
+			},
+			"additionalSpells": [
+				{
+					"name": "Lorwyn",
+					"innate": {
+						"3": {
+							"daily": {
+								"1": [
+									"command|xphb"
+								]
+							}
+						},
+						"5": {
+							"daily": {
+								"1": [
+									"silence|xphb"
+								]
+							}
+						}
+					},
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"1": {
+							"_": [
+								{
+									"choose": "level=0|class=Druid"
+								}
+							]
+						}
+					}
+				},
+				{
+					"name": "Shadowmoor",
+					"innate": {
+						"3": {
+							"daily": {
+								"1": [
+									"heroism|xphb"
+								]
+							}
+						},
+						"5": {
+							"daily": {
+								"1": [
+									"gentle repose|xphb"
+								]
+							}
+						}
+					},
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"1": [
+							"starry wisp|xphb#c"
+						]
+					}
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true,
+			"_versions": [
+				{
+					"name": "Elf; Lorwyn Lineage",
+					"source": "LFL",
+					"_mod": {
+						"entries": {
+							"mode": "replaceArr",
+							"replace": "Elven Lineage",
+							"items": {
+								"name": "Elven Lineage (Lorwyn)",
+								"type": "entries",
+								"entries": [
+									"You are part of a lineage that grants you supernatural abilities. You know the {@spell Thorn Whip|XPHB} cantrip. Whenever you finish a {@variantrule Long Rest|XPHB}, you can replace that cantrip with a different cantrip from the {@filter Druid spell list|spells|class=druid}.",
+									"When you reach character level 3, you learn the {@spell Command|XPHB} spell. When you reach character level 5, you also learn the {@spell Silence|XPHB} spell. You always have these spells prepared, and you can cast each spell once without a spell slot. Once you cast either of these spells with this trait, you can't cast that spell with it again until you finish a {@variantrule Long Rest|XPHB}. You can also cast the spell using any spell slots you have of the appropriate level.",
+									"Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the lineage)."
+								]
+							}
+						}
+					},
+					"additionalSpells": [
+						{
+							"innate": {
+								"3": {
+									"daily": {
+										"1": [
+											"command|xphb"
+										]
+									}
+								},
+								"5": {
+									"daily": {
+										"1": [
+											"silence|xphb"
+										]
+									}
+								}
+							},
+							"ability": {
+								"choose": [
+									"int",
+									"wis",
+									"cha"
+								]
+							},
+							"known": {
+								"1": {
+									"_": [
+										{
+											"choose": "level=0|class=Druid"
+										}
+									]
+								}
+							}
+						}
+					]
+				},
+				{
+					"name": "Elf; Shadowmoor Lineage",
+					"source": "LFL",
+					"_mod": {
+						"entries": {
+							"mode": "replaceArr",
+							"replace": "Elven Lineage",
+							"items": {
+								"name": "Elven Lineage (Shadowmoor)",
+								"type": "entries",
+								"entries": [
+									"You are part of a lineage that grants you supernatural abilities. The range of your {@sense Darkvision|XPHB} increases to 120 feet. You also know the {@spell Starry Wisp|XPHB} cantrip.",
+									"When you reach character level 3, you learn the {@spell Heroism|XPHB} spell. When you reach character level 5, you also learn the {@spell Gentle Repose|XPHB} spell. You always have these spells prepared, and you can cast each spell once without a spell slot. Once you cast either of these spells with this trait, you can't cast that spell with it again until you finish a {@variantrule Long Rest|XPHB}. You can also cast the spell using any spell slots you have of the appropriate level.",
+									"Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the lineage)."
+								]
+							}
+						}
+					},
+					"darkvision": 120,
+					"additionalSpells": [
+						{
+							"innate": {
+								"3": {
+									"daily": {
+										"1": [
+											"heroism|xphb"
+										]
+									}
+								},
+								"5": {
+									"daily": {
+										"1": [
+											"gentle repose|xphb"
+										]
+									}
+								}
+							},
+							"ability": {
+								"choose": [
+									"int",
+									"wis",
+									"cha"
+								]
+							},
+							"known": {
+								"1": [
+									"starry wisp|xphb#c"
+								]
+							}
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Elf",
 			"source": "PHB",
 			"page": 21,
 			"srd": true,
@@ -3717,7 +4193,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/elf.mp3"
+				"path": "races/elf.opus"
 			},
 			"entries": [
 				{
@@ -3789,6 +4265,9 @@
 			],
 			"speed": 30,
 			"darkvision": 60,
+			"traitTags": [
+				"Improved Resting"
+			],
 			"skillProficiencies": [
 				{
 					"choose": {
@@ -3800,6 +4279,10 @@
 					}
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/elf.opus"
+			},
 			"additionalSpells": [
 				{
 					"name": "Drow",
@@ -3939,19 +4422,19 @@
 							"rows": [
 								[
 									"Drow",
-									"The range of your Darkvision increases to 120 feet. You also know the {@spell Dancing Lights|XPHB} cantrip.",
+									"The range of your {@sense Darkvision|XPHB} increases to 120 feet. You also know the {@spell Dancing Lights|XPHB} cantrip.",
 									"{@spell Faerie Fire|XPHB}",
 									"{@spell Darkness|XPHB}"
 								],
 								[
 									"High Elf",
-									"You know the {@spell Prestidigitation|XPHB} cantrip. Whenever you finish a Long Rest, you can replace that cantrip with a different {@filter cantrip from the Wizard spell list|spells|level=0|class=Wizard}.",
+									"You know the {@spell Prestidigitation|XPHB} cantrip. Whenever you finish a {@variantrule Long Rest|XPHB}, you can replace that cantrip with a different {@filter cantrip from the Wizard spell list|spells|level=0|class=Wizard}.",
 									"{@spell Detect Magic|XPHB}",
 									"{@spell Misty Step|XPHB}"
 								],
 								[
 									"Wood Elf",
-									"Your Speed increases to 35 feet. You also know the {@spell Druidcraft|XPHB} cantrip.",
+									"Your {@variantrule Speed|XPHB} increases to 35 feet. You also know the {@spell Druidcraft|XPHB} cantrip.",
 									"{@spell Longstrider|XPHB}",
 									"{@spell Pass without Trace|XPHB}"
 								]
@@ -3988,19 +4471,32 @@
 					"name": "Elf; Drow Lineage",
 					"source": "XPHB",
 					"_mod": {
-						"entries": {
-							"mode": "replaceArr",
-							"replace": "Elven Lineage",
-							"items": {
-								"name": "Elven Lineage (Drow)",
-								"type": "entries",
-								"entries": [
-									"You are part of a lineage that grants you supernatural abilities. The range of your Darkvision increases to 120 feet. You also know the {@spell Dancing Lights|XPHB} cantrip.",
-									"When you reach character level 3, you learn the {@spell Faerie Fire|XPHB} spell. When you reach character level 5, you also learn the {@spell Darkness|XPHB} spell. You always have these spells prepared, and you can cast each spell once without a spell slot. Once you cast either of these spells with this trait, you can't cast that spell with it again until you finish a {@variantrule Long Rest|XPHB}. You can also cast the spell using any spell slots you have of the appropriate level.",
-									"Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the lineage)."
-								]
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": "Elven Lineage",
+								"items": {
+									"name": "Elven Lineage (Drow)",
+									"type": "entries",
+									"entries": [
+										"You are part of a lineage that grants you supernatural abilities. The range of your {@sense Darkvision|XPHB} increases to 120 feet. You also know the {@spell Dancing Lights|XPHB} cantrip.",
+										"When you reach character level 3, you learn the {@spell Faerie Fire|XPHB} spell. When you reach character level 5, you also learn the {@spell Darkness|XPHB} spell. You always have these spells prepared, and you can cast each spell once without a spell slot. Once you cast either of these spells with this trait, you can't cast that spell with it again until you finish a {@variantrule Long Rest|XPHB}. You can also cast the spell using any spell slots you have of the appropriate level.",
+										"Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the lineage)."
+									]
+								}
+							},
+							{
+								"mode": "replaceArr",
+								"replace": "Darkvision",
+								"items": {
+									"name": "Darkvision",
+									"type": "entries",
+									"entries": [
+										"You have {@sense Darkvision|XPHB} with a range of 120 feet."
+									]
+								}
 							}
-						}
+						]
 					},
 					"darkvision": 120,
 					"additionalSpells": [
@@ -4047,7 +4543,7 @@
 								"name": "Elven Lineage (High Elf)",
 								"type": "entries",
 								"entries": [
-									"You are part of a lineage that grants you supernatural abilities. You know the {@spell Prestidigitation|XPHB} cantrip. Whenever you finish a Long Rest, you can replace that cantrip with a different {@filter cantrip from the Wizard spell list|spells|level=0|class=Wizard}.",
+									"You are part of a lineage that grants you supernatural abilities. You know the {@spell Prestidigitation|XPHB} cantrip. Whenever you finish a {@variantrule Long Rest|XPHB}, you can replace that cantrip with a different {@filter cantrip from the Wizard spell list|spells|level=0|class=Wizard}.",
 									"When you reach character level 3, you learn the {@spell Detect Magic|XPHB} spell. When you reach character level 5, you also learn the {@spell Misty Step|XPHB} spell. You always have these spells prepared, and you can cast each spell once without a spell slot. Once you cast either of these spells with this trait, you can't cast that spell with it again until you finish a {@variantrule Long Rest|XPHB}. You can also cast the spell using any spell slots you have of the appropriate level.",
 									"Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the lineage)."
 								]
@@ -4102,7 +4598,7 @@
 								"name": "Elven Lineage (Wood Elf)",
 								"type": "entries",
 								"entries": [
-									"You are part of a lineage that grants you supernatural abilities. Your Speed increases to 35 feet. You also know the {@spell Druidcraft|XPHB} cantrip.",
+									"You are part of a lineage that grants you supernatural abilities. Your {@variantrule Speed|XPHB} increases to 35 feet. You also know the {@spell Druidcraft|XPHB} cantrip.",
 									"When you reach character level 3, you learn the {@spell Longstrider|XPHB} spell. When you reach character level 5, you also learn the {@spell Pass without Trace|XPHB} spell. You always have these spells prepared, and you can cast each spell once without a spell slot. Once you cast either of these spells with this trait, you can't cast that spell with it again until you finish a {@variantrule Long Rest|XPHB}. You can also cast the spell using any spell slots you have of the appropriate level.",
 									"Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select the lineage)."
 								]
@@ -4186,6 +4682,10 @@
 					"longbow|phb": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/elf.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -4254,7 +4754,7 @@
 				{
 					"name": "Elf Culture",
 					"entries": [
-						"The elves of Kaladesh don't organize themselves into nations or tribes. Still, they recognize three distinct cultural groups among their kind\u2014though in truth these groupings are more like attitudes or alignments with regard to the rest of society and the use of technology. Choose one of these cultures."
+						"The elves of Kaladesh don't organize themselves into nations or tribes. Still, they recognize three distinct cultural groups among their kind—though in truth these groupings are more like attitudes or alignments with regard to the rest of society and the use of technology. Choose one of these cultures."
 					],
 					"type": "entries"
 				}
@@ -4291,6 +4791,10 @@
 					"elvish": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/elf.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -4344,6 +4848,86 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true
+		},
+		{
+			"name": "Faerie",
+			"source": "LFL",
+			"_copy": {
+				"name": "Fairy",
+				"source": "MPMM",
+				"_mod": {
+					"entries": {
+						"mode": "appendArr",
+						"items": {
+							"type": "entries",
+							"name": "Faerie Lineage",
+							"entries": [
+								"As a native of either Lorwyn and Shadowmoor, you may gain additional traits.",
+								{
+									"type": "list",
+									"style": "list-hang-notitle",
+									"items": [
+										{
+											"type": "item",
+											"name": "Lorwyn",
+											"entries": [
+												"You do not gain any additional traits."
+											]
+										},
+										{
+											"type": "item",
+											"name": "Shadowmoor",
+											"entries": [
+												"You have {@sense Darkvision|XPHB} with a range of 120 feet."
+											]
+										}
+									]
+								}
+							]
+						}
+					}
+				}
+			},
+			"lineage": null,
+			"hasFluff": true,
+			"hasFluffImages": true,
+			"_versions": [
+				{
+					"name": "Faerie; Lorwyn",
+					"source": "LFL",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "removeArr",
+								"names": "Faerie Lineage"
+							}
+						]
+					}
+				},
+				{
+					"name": "Faerie; Shadowmoor",
+					"source": "LFL",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "prependArr",
+								"items": {
+									"type": "entries",
+									"name": "Darkvision",
+									"entries": [
+										"You have {@sense Darkvision|XPHB} with a range of 120 feet."
+									]
+								}
+							},
+							{
+								"mode": "removeArr",
+								"names": "Faerie Lineage"
+							}
+						]
+					},
+					"darkvision": 120
+				}
+			]
 		},
 		{
 			"name": "Fairy",
@@ -4512,6 +5096,10 @@
 			"traitTags": [
 				"Powerful Build"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/firbolg.opus"
+			},
 			"additionalSpells": [
 				{
 					"ability": {
@@ -4608,7 +5196,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/firbolg.mp3"
+				"path": "races/firbolg.opus"
 			},
 			"additionalSpells": [
 				{
@@ -4680,6 +5268,74 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Flamekin",
+			"source": "LFL",
+			"_copy": {
+				"name": "Genasi",
+				"source": "MPMM",
+				"_mod": {
+					"entries": {
+						"mode": "appendArr",
+						"items": [
+							{
+								"type": "entries",
+								"name": "Fire Resistance",
+								"entries": [
+									"You have resistance to fire damage."
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Reach to the Blaze",
+								"entries": [
+									"You know the {@spell produce flame|XPHB} cantrip. Starting at 3rd level, you can cast the {@spell burning hands|XPHB} spell with this trait. Starting at 5th level, you can also cast the {@spell flame blade|XPHB} spell with this trait, without a material component. Once you cast {@spell burning hands|XPHB} or {@spell flame blade|XPHB} with this trait, you can't cast that spell with it again until you finish a long rest. You can also cast either of those spells using any spell slots you have of the appropriate level.",
+									"Intelligence, Wisdom, or Charisma is your spellcasting ability for these spells when you cast them with this trait (choose when you select this race)."
+								]
+							}
+						]
+					}
+				}
+			},
+			"lineage": null,
+			"resist": [
+				"fire"
+			],
+			"additionalSpells": [
+				{
+					"innate": {
+						"3": {
+							"daily": {
+								"1": [
+									"burning hands|xphb"
+								]
+							}
+						},
+						"5": {
+							"daily": {
+								"1": [
+									"flame blade|xphb"
+								]
+							}
+						}
+					},
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"1": [
+							"produce flame|xphb#c"
+						]
+					}
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
 			"name": "Genasi",
 			"source": "EEPC",
 			"page": 9,
@@ -4725,7 +5381,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/genasi.mp3"
+				"path": "races/genasi.opus"
 			},
 			"entries": [
 				{
@@ -4774,6 +5430,10 @@
 				"max": 120
 			},
 			"darkvision": 60,
+			"soundClip": {
+				"type": "internal",
+				"path": "races/genasi.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -4813,6 +5473,10 @@
 					"firearms": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/giff.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -4826,7 +5490,7 @@
 					"type": "entries",
 					"name": "Firearms Mastery",
 					"entries": [
-						"You have a mystical connection to firearms that traces back to the gods of the giff, who delighted in such weapons. You have proficiency with all firearms and ignore the loading property of any firearm. In addition, attacking at long range with a firearm doesn't impose disadvantage on your attack roll."
+						"You have a mystical connection to firearms that traces back to the gods of the giff, who delighted in such weapons. You have proficiency with all firearms and ignore the {@itemProperty LD||loading} property of any firearm. In addition, attacking at long range with a firearm doesn't impose disadvantage on your attack roll."
 					]
 				},
 				{
@@ -5068,6 +5732,10 @@
 				"Natural Weapon",
 				"NPC Race"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/gnoll.opus"
+			},
 			"entries": [
 				{
 					"name": "Bite",
@@ -5130,7 +5798,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/gnome.mp3"
+				"path": "races/gnome.opus"
 			},
 			"entries": [
 				{
@@ -5187,6 +5855,10 @@
 			],
 			"speed": 30,
 			"darkvision": 60,
+			"soundClip": {
+				"type": "internal",
+				"path": "races/gnome.opus"
+			},
 			"sizeEntry": {
 				"type": "item",
 				"name": "Size:",
@@ -5343,6 +6015,10 @@
 					"undercommon": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/gnome.opus"
+			},
 			"additionalSpells": [
 				{
 					"ability": "int",
@@ -5438,6 +6114,10 @@
 					"goblin": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/goblin.opus"
+			},
 			"entries": [
 				{
 					"name": "Nimble Escape",
@@ -5502,6 +6182,10 @@
 				"S"
 			],
 			"traitTags": null,
+			"soundClip": {
+				"type": "internal",
+				"path": "races/goblin.opus"
+			},
 			"hasFluffImages": true
 		},
 		{
@@ -5552,6 +6236,10 @@
 				}
 			},
 			"traitTags": null,
+			"soundClip": {
+				"type": "internal",
+				"path": "races/goblin.opus"
+			},
 			"hasFluff": true
 		},
 		{
@@ -5570,6 +6258,10 @@
 			],
 			"speed": 30,
 			"darkvision": 60,
+			"soundClip": {
+				"type": "internal",
+				"path": "races/goblin.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -5643,6 +6335,10 @@
 				"fire",
 				"psychic"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/goblin.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -5676,6 +6372,13 @@
 					"name": "Languages",
 					"entries": [
 						"You can speak, read, and write Common and Goblin."
+					],
+					"type": "entries"
+				},
+				{
+					"name": "Grit",
+					"entries": [
+						"You have resistance to fire damage and psychic damage. In addition, when you are wearing no armor, your AC is equal to 11 + your Dexterity modifier."
 					],
 					"type": "entries"
 				}
@@ -5725,6 +6428,10 @@
 					"goblin": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/goblin.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -5782,6 +6489,12 @@
 				"_mod": {
 					"entries": [
 						{
+							"mode": "replaceTxt",
+							"replace": "Goblins",
+							"with": "Dankwood goblins",
+							"flags": "i"
+						},
+						{
 							"mode": "appendArr",
 							"items": {
 								"name": "Alignment",
@@ -5815,6 +6528,10 @@
 				}
 			],
 			"heightAndWeight": null,
+			"soundClip": {
+				"type": "internal",
+				"path": "races/goblin.opus"
+			},
 			"hasFluff": true
 		},
 		{
@@ -5840,6 +6557,10 @@
 			"resist": [
 				"cold"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/goliath.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -5927,7 +6648,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/goliath.mp3"
+				"path": "races/goliath.opus"
 			},
 			"entries": [
 				{
@@ -5987,6 +6708,7 @@
 			"name": "Goliath",
 			"source": "XPHB",
 			"page": 192,
+			"srd52": true,
 			"basicRules2024": true,
 			"edition": "one",
 			"creatureTypes": [
@@ -5999,6 +6721,10 @@
 			"traitTags": [
 				"Powerful Build"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/goliath.opus"
+			},
 			"sizeEntry": {
 				"type": "item",
 				"name": "Size:",
@@ -6011,7 +6737,7 @@
 					"type": "entries",
 					"name": "Giant Ancestry",
 					"entries": [
-						"You are descended from Giants. Choose one of the following benefits\u2014a supernatural boon from your ancestry; you can use the chosen benefit a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}:",
+						"You are descended from Giants. Choose one of the following benefits—a supernatural boon from your ancestry; you can use the chosen benefit a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}:",
 						{
 							"type": "list",
 							"style": "list-hang-notitle",
@@ -6285,6 +7011,10 @@
 					"undercommon": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/grimlock.opus"
+			},
 			"entries": [
 				{
 					"name": "Blindsight",
@@ -6356,6 +7086,10 @@
 			"conditionImmune": [
 				"poisoned"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/grung.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -6428,7 +7162,8 @@
 						"You can speak, read, and write Grung."
 					]
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Hadozee",
@@ -6482,6 +7217,9 @@
 			"source": "PHB",
 			"page": 38,
 			"srd": true,
+			"reprintedAs": [
+				"Khoravar|EFA"
+			],
 			"size": [
 				"M"
 			],
@@ -6529,7 +7267,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/half-elf.mp3"
+				"path": "races/half-elf.opus"
 			},
 			"entries": [
 				{
@@ -6620,7 +7358,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/half-orc.mp3"
+				"path": "races/half-orc.opus"
 			},
 			"entries": [
 				{
@@ -6711,7 +7449,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/halfling.mp3"
+				"path": "races/halfling.opus"
 			},
 			"entries": [
 				{
@@ -6764,6 +7502,7 @@
 			"name": "Halfling",
 			"source": "XPHB",
 			"page": 193,
+			"srd52": true,
 			"basicRules2024": true,
 			"edition": "one",
 			"creatureTypes": [
@@ -6773,6 +7512,10 @@
 				"S"
 			],
 			"speed": 30,
+			"soundClip": {
+				"type": "internal",
+				"path": "races/halfling.opus"
+			},
 			"sizeEntry": {
 				"type": "item",
 				"name": "Size:",
@@ -6928,8 +7671,99 @@
 		},
 		{
 			"name": "Hexblood",
+			"source": "RHW",
+			"edition": "one",
+			"creatureTypes": [
+				"fey"
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"speed": 30,
+			"darkvision": 60,
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"prepared": {
+						"_": {
+							"daily": {
+								"1e": [
+									"disguise self|xphb",
+									"hex|xphb"
+								]
+							}
+						}
+					}
+				}
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 4-7 feet tall) or Small (about 2-4 feet tall), chosen when you select this species"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Darkvision",
+					"entries": [
+						"You have {@sense Darkvision|XPHB} with a range of 60 feet."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Eerie Token",
+					"entries": [
+						"As a {@variantrule Bonus Action|XPHB}, you can create a magical token by harmlessly removing a lock of hair, detaching a nail, or using some other method. While the token exists, you gain the following benefits:",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Distant Message",
+									"entries": [
+										"As a {@action Magic|XPHB} action, you can send a telepathic message of 25 words or fewer to a creature holding or carrying the token, as long as you are within 10 miles of it."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Remote Viewing",
+									"entries": [
+										"If you are within 10 miles of the token, you can take a {@action Magic|XPHB} action to extend your senses through the token for 1 minute, until you have the Incapacitated condition, or until you end this state (no action required). During this state, you can see and hear from the token as if you were located where it is. When this state ends, the token is harmlessly destroyed.",
+										"Unless the token is destroyed early, it lasts until you finish a {@variantrule Long Rest|XPHB}. Once you create a token using this feature, you can't do so again until you finish a {@variantrule Long Rest|XPHB}."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Hex Magic",
+									"entries": [
+										"You always have the {@spell Disguise Self|XPHB} and {@spell Hex|XPHB} spells prepared. You can cast each spell once without a spell slot, and you regain the ability to cast it in that way when you finish a {@variantrule Long Rest|XPHB}. You can also cast the spell using any spell slots you have of the appropriate level. Intelligence, Wisdom, or Charisma is your spellcasting ability for the spells you cast with this trait (choose the ability when you select this species)."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Hexblood",
 			"source": "VRGR",
 			"page": 18,
+			"reprintedAs": [
+				"Hexblood|RHW"
+			],
 			"lineage": "VRGR",
 			"creatureTypes": [
 				"fey"
@@ -7026,7 +7860,7 @@
 							"type": "inset",
 							"name": "Becoming a Hag",
 							"entries": [
-								"Hags can undertake a ritual to irreversibly transform a hexblood they created into a new hag, either one of their own kind or that embodies the hexblood's nature. This requires that both the hag and hexblood be in the same place and consent to the lengthy ritual\u2014circumstances most hexbloods shun but might come to accept over the course of centuries. Once a hexblood undergoes this irreversible ritual, they emerge as a hag NPC no longer under the control of the hexblood's player, unless the DM rules otherwise."
+								"Hags can undertake a ritual to irreversibly transform a hexblood they created into a new hag, either one of their own kind or that embodies the hexblood's nature. This requires that both the hag and hexblood be in the same place and consent to the lengthy ritual—circumstances most hexbloods shun but might come to accept over the course of centuries. Once a hexblood undergoes this irreversible ritual, they emerge as a hag NPC no longer under the control of the hexblood's player, unless the DM rules otherwise."
 							]
 						}
 					]
@@ -7053,6 +7887,10 @@
 					"goblin": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/hobgoblin.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -7113,6 +7951,10 @@
 					"reprintedAs": true
 				}
 			},
+			"soundClip": {
+				"type": "internal",
+				"path": "races/hobgoblin.opus"
+			},
 			"hasFluffImages": true
 		},
 		{
@@ -7131,6 +7973,10 @@
 			],
 			"speed": 30,
 			"darkvision": 60,
+			"soundClip": {
+				"type": "internal",
+				"path": "races/hobgoblin.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -7249,6 +8095,10 @@
 					"light": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/hobgoblin.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -7327,7 +8177,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/human.mp3"
+				"path": "races/human.opus"
 			},
 			"entries": [
 				{
@@ -7385,6 +8235,10 @@
 					"any": 1
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/human.opus"
+			},
 			"sizeEntry": {
 				"type": "item",
 				"name": "Size:",
@@ -7419,96 +8273,6 @@
 			"hasFluffImages": true
 		},
 		{
-			"name": "Human (Amonkhet)",
-			"source": "PSA",
-			"page": 14,
-			"size": [
-				"M"
-			],
-			"speed": 30,
-			"ability": [
-				{
-					"choose": {
-						"from": [
-							"str",
-							"dex",
-							"con",
-							"int",
-							"wis",
-							"cha"
-						],
-						"count": 2
-					}
-				}
-			],
-			"age": {
-				"mature": 20,
-				"max": 100
-			},
-			"feats": [
-				{
-					"any": 1
-				}
-			],
-			"skillProficiencies": [
-				{
-					"any": 1
-				}
-			],
-			"languageProficiencies": [
-				{
-					"common": true,
-					"anyStandard": 1
-				}
-			],
-			"entries": [
-				{
-					"name": "Age",
-					"type": "entries",
-					"entries": [
-						"Humans reach adulthood in their late teens. Most human initiates have completed the trials and found a glorious or inglorious death before they turn 30. Viziers can enjoy longer service to their gods, in theory living up to a century."
-					]
-				},
-				{
-					"name": "Alignment",
-					"type": "entries",
-					"entries": [
-						"Humans tend toward no particular alignment. The best and the worst are found among them."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Size",
-					"entries": [
-						"Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium"
-					]
-				},
-				{
-					"name": "Skills",
-					"entries": [
-						"You gain proficiency in one skill of your choice."
-					],
-					"type": "entries"
-				},
-				{
-					"name": "Feat",
-					"entries": [
-						"You gain one {@5etools feat|feats.html} of your choice."
-					],
-					"type": "entries"
-				},
-				{
-					"name": "Languages",
-					"entries": [
-						"You can speak, read, and write Common and one extra language of your choice."
-					],
-					"type": "entries"
-				}
-			],
-			"hasFluff": true,
-			"hasFluffImages": true
-		},
-		{
 			"name": "Human (Innistrad)",
 			"source": "PSI",
 			"page": 8,
@@ -7526,6 +8290,10 @@
 					"anyStandard": 1
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/human.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -7623,6 +8391,10 @@
 					"anyStandard": 1
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/human.opus"
+			},
 			"hasFluff": true,
 			"hasFluffImages": true
 		},
@@ -7679,6 +8451,10 @@
 					"cha": 1
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/human.opus"
+			},
 			"hasFluff": true,
 			"hasFluffImages": true
 		},
@@ -7713,6 +8489,68 @@
 					"cha": 1
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/human.opus"
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Kalashtar",
+			"source": "EFA",
+			"page": 35,
+			"edition": "one",
+			"creatureTypes": [
+				"aberration"
+			],
+			"size": [
+				"M"
+			],
+			"speed": 30,
+			"traitTags": [
+				"Skill Proficiency"
+			],
+			"resist": [
+				"psychic"
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 6–7 feet tall)"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Dual Mind",
+					"entries": [
+						"You have {@variantrule Advantage|XPHB} on Wisdom and Charisma saving throws."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Mental Discipline",
+					"entries": [
+						"You have {@variantrule Resistance|XPHB} to Psychic damage."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Mind Link",
+					"entries": [
+						"You have telepathy with a range in feet equal to 10 times your level. When you're using this trait to speak telepathically to a creature, you can take a {@action Magic|XPHB} action to give that creature the ability to speak telepathically with you for 1 hour or until you take another {@action Magic|XPHB} action to end this effect."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Severed from Dreams",
+					"entries": [
+						"You can't be the target of the {@spell Dream|XPHB} spell. In addition, when you finish a {@variantrule Long Rest|XPHB}, you gain proficiency in one skill of your choice. This proficiency lasts until you finish another {@variantrule Long Rest|XPHB}."
+					]
+				}
+			],
 			"hasFluff": true,
 			"hasFluffImages": true
 		},
@@ -7720,6 +8558,9 @@
 			"name": "Kalashtar",
 			"source": "ERLW",
 			"page": 29,
+			"reprintedAs": [
+				"Kalashtar|EFA"
+			],
 			"size": [
 				"M"
 			],
@@ -7886,7 +8727,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/kenku.mp3"
+				"path": "races/kenku.opus"
 			},
 			"entries": [
 				{
@@ -7927,6 +8768,10 @@
 					"any": 2
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/kenku.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -8015,7 +8860,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/kenku.mp3"
+				"path": "races/kenku.opus"
 			},
 			"entries": [
 				{
@@ -8143,6 +8988,174 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Khoravar",
+			"alias": [
+				"Half-Elf"
+			],
+			"source": "EFA",
+			"page": 36,
+			"edition": "one",
+			"creatureTypes": [
+				"humanoid"
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"speed": 30,
+			"darkvision": 60,
+			"traitTags": [
+				"Skill Proficiency",
+				"Tool Proficiency"
+			],
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"1": {
+							"_": [
+								{
+									"choose": "level=0|class=Cleric;Druid;Wizard"
+								}
+							]
+						}
+					}
+				}
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 4-6 feet tall) or Small (about 2-4 feet tall), chosen when you select this species"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Darkvision",
+					"entries": [
+						"You have {@sense Darkvision|XPHB} with a range of 60 feet."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Fey Ancestry",
+					"entries": [
+						"You have {@variantrule Advantage|XPHB} on saving throws you make to avoid or end the {@condition Charmed|XPHB} condition."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Fey Gift",
+					"entries": [
+						"You know the {@spell Friends|XPHB} cantrip. Whenever you finish a {@variantrule Long Rest|XPHB}, you can replace that cantrip with a different cantrip from the Cleric, Druid, or Wizard spell list. Intelligence, Wisdom, or Charisma is your spellcasting ability for it (choose the ability when you select this species)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Lethargy Resilience",
+					"entries": [
+						"When you fail a saving throw to avoid or end the {@condition Unconscious|XPHB} condition, you can succeed instead. Once you use this trait, you can't do so again until you finish {@dice 1d4} {@variantrule Long Rest|XPHB|Long Rests}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Skill Versatility",
+					"entries": [
+						"You gain proficiency in one skill or with one tool of your choice. Whenever you finish a {@variantrule Long Rest|XPHB}, you can replace it with another skill or tool proficiency."
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Kithkin",
+			"source": "LFL",
+			"_copy": {
+				"name": "Halfling",
+				"source": "XPHB",
+				"_mod": {
+					"entries": {
+						"mode": "appendArr",
+						"items": {
+							"type": "entries",
+							"name": "Kithkin Lineage",
+							"entries": [
+								"As a native of either Lorwyn and Shadowmoor, you may gain additional traits.",
+								{
+									"type": "list",
+									"style": "list-hang-notitle",
+									"items": [
+										{
+											"type": "item",
+											"name": "Lorwyn",
+											"entries": [
+												"You do not gain any additional traits."
+											]
+										},
+										{
+											"type": "item",
+											"name": "Shadowmoor",
+											"entries": [
+												"You have {@sense Darkvision|XPHB} with a range of 120 feet."
+											]
+										}
+									]
+								}
+							]
+						}
+					}
+				}
+			},
+			"darkvision": 120,
+			"hasFluff": true,
+			"hasFluffImages": true,
+			"_versions": [
+				{
+					"name": "Kithkin; Lorwyn",
+					"source": "LFL",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "removeArr",
+								"names": "Kithkin Lineage"
+							}
+						]
+					}
+				},
+				{
+					"name": "Kithkin; Shadowmoor",
+					"source": "LFL",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "prependArr",
+								"items": {
+									"type": "entries",
+									"name": "Darkvision",
+									"entries": [
+										"You have {@sense Darkvision|XPHB} with a range of 120 feet."
+									]
+								}
+							},
+							{
+								"mode": "removeArr",
+								"names": "Kithkin Lineage"
+							}
+						]
+					},
+					"darkvision": 120
+				}
+			]
+		},
+		{
 			"name": "Kobold",
 			"source": "DMG",
 			"page": 282,
@@ -8167,6 +9180,10 @@
 					"draconic": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/kobold.opus"
+			},
 			"entries": [
 				{
 					"name": "Pack Tactics",
@@ -8221,6 +9238,10 @@
 					}
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/kobold.opus"
+			},
 			"additionalSpells": [
 				{
 					"ability": {
@@ -8380,6 +9401,10 @@
 					"draconic": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/kobold.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -8550,6 +9575,10 @@
 					"undercommon": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/kuo-toa.opus"
+			},
 			"entries": [
 				{
 					"name": "Amphibious",
@@ -8728,6 +9757,10 @@
 					"draconic": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/lizardfolk.opus"
+			},
 			"entries": [
 				{
 					"name": "Hold Breath",
@@ -8783,6 +9816,10 @@
 					}
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/lizardfolk.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -8884,6 +9921,10 @@
 					"draconic": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/lizardfolk.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -9058,6 +10099,68 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Lorwyn Changeling",
+			"source": "LFL",
+			"creatureTypes": [
+				"fey"
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"speed": 30,
+			"darkvision": 120,
+			"skillProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"deception",
+							"performance"
+						]
+					}
+				}
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 4-7 feet tall) or Small (about 2-4 feet tall), chosen when you select this species"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Shape Self",
+					"entries": [
+						"As an action, you can reshape your body to a two-legged Humanoid shape or to a four-legged Beast shape. While you have a Humanoid shape, you can wear clothing and armor made for a Humanoid of your size."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Darkvision",
+					"entries": [
+						"You have {@sense Darkvision|XPHB} with a range of 120 feet."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Delightful Imitator",
+					"entries": [
+						"You have proficiency in the {@skill Deception|XPHB} or {@skill Performance|XPHB} skill."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Unpredictable Movement",
+					"entries": [
+						"When you roll {@variantrule Initiative|XPHB}, you can immediately move up to half your {@variantrule Speed|XPHB}, provided you don't have {@variantrule Disadvantage|XPHB} on the {@variantrule Initiative|XPHB} roll."
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
 			"name": "Loxodon",
 			"source": "GGR",
 			"page": 17,
@@ -9168,6 +10271,74 @@
 			"hasFluffImages": true
 		},
 		{
+			"name": "Lupin",
+			"source": "RHW",
+			"edition": "one",
+			"creatureTypes": [
+				"humanoid"
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"speed": 30,
+			"darkvision": 60,
+			"traitTags": [
+				"Natural Weapon"
+			],
+			"skillProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"perception",
+							"stealth",
+							"survival"
+						]
+					}
+				}
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 4-7 feet tall) or Small (about 2-4 feet tall), chosen when you select this species"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Darkvision",
+					"entries": [
+						"You have {@sense Darkvision|XPHB} with a range of 60 feet."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Feral Pounce",
+					"entries": [
+						"Your {@variantrule Unarmed Strike|XPHB|Unarmed Strikes} deal Slashing damage instead of Bludgeoning damage. In addition, when you hit a creature with an {@variantrule Unarmed Strike|XPHB} as part of the {@action Attack|XPHB} action on your turn, you can use both the {@variantrule Damage|XPHB} and the Shove options. You can use this benefit only once per turn."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Howl",
+					"entries": [
+						"As a {@variantrule Bonus Action|XPHB}, you let out an unearthly howl. Each creature of your choice within 15 feet of you must succeed on a Wisdom saving throw (DC 8 plus your Constitution modifier and {@variantrule Proficiency|XPHB|Proficiency Bonus}) or have {@variantrule Disadvantage|XPHB} on attack rolls and saving throws until the start of your next turn.",
+						"You can use this trait a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Werewolf Instincts",
+					"entries": [
+						"You have proficiency in the {@skill Perception|XPHB}, {@skill Stealth|XPHB}, or {@skill Survival|XPHB} skill."
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
 			"name": "Merfolk",
 			"source": "DMG",
 			"page": 282,
@@ -9188,6 +10359,10 @@
 					"aquan": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/merfolk.opus"
+			},
 			"entries": [
 				{
 					"name": "Amphibious",
@@ -9241,6 +10416,10 @@
 					"anyStandard": 1
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/merfolk.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -9334,6 +10513,10 @@
 					"other": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/minotaur.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -9438,6 +10621,10 @@
 					]
 				}
 			},
+			"soundClip": {
+				"type": "internal",
+				"path": "races/minotaur.opus"
+			},
 			"hasFluff": true,
 			"hasFluffImages": true
 		},
@@ -9453,6 +10640,10 @@
 			"traitTags": [
 				"Natural Weapon"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/minotaur.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -9518,6 +10709,10 @@
 					"other": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/minotaur.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -9708,6 +10903,10 @@
 					"orc": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/orc.opus"
+			},
 			"entries": [
 				{
 					"name": "Aggressive",
@@ -9809,7 +11008,11 @@
 						"count": 2
 					}
 				}
-			]
+			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/orc.opus"
+			}
 		},
 		{
 			"name": "Orc",
@@ -9865,6 +11068,10 @@
 					"orc": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/orc.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -9940,6 +11147,10 @@
 			"traitTags": [
 				"Powerful Build"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/orc.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -10029,6 +11240,10 @@
 					"orc": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/orc.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -10087,6 +11302,7 @@
 			"name": "Orc",
 			"source": "XPHB",
 			"page": 195,
+			"srd52": true,
 			"basicRules2024": true,
 			"edition": "one",
 			"creatureTypes": [
@@ -10097,6 +11313,10 @@
 			],
 			"speed": 30,
 			"darkvision": 120,
+			"soundClip": {
+				"type": "internal",
+				"path": "races/orc.opus"
+			},
 			"sizeEntry": {
 				"type": "item",
 				"name": "Size:",
@@ -10161,6 +11381,10 @@
 					"orc": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/orc.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -10349,8 +11573,80 @@
 		},
 		{
 			"name": "Reborn",
+			"source": "RHW",
+			"edition": "one",
+			"creatureTypes": [
+				"humanoid"
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"speed": 30,
+			"skillProficiencies": [
+				{
+					"any": 1
+				}
+			],
+			"resist": [
+				{
+					"choose": {
+						"from": [
+							"cold",
+							"necrotic",
+							"poison"
+						]
+					}
+				}
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 4-7 feet tall) or Small (about 2-4 feet tall), chosen when you select this species"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Escaped Death",
+					"entries": [
+						"You have {@variantrule Advantage|XPHB} on {@variantrule Death Saving Throw|XPHB|Death Saving Throws}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Everlasting",
+					"entries": [
+						"You don't gain {@condition Exhaustion|XPHB} levels from dehydration, malnutrition, or suffocation. You don't need to sleep, and magic can't put you to sleep. You can finish a {@variantrule Long Rest|XPHB} in 4 hours if you spend those hours in an inactive, motionless state, during which you retain consciousness."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Knowledge from a Past Life",
+					"entries": [
+						"You gain proficiency in one skill of your choice.",
+						"In addition, you can temporarily peer into the past to aid you in the present. When you fail an ability check, you can roll {@dice 1d6} and add the number rolled to the {@dice d20}, potentially turning the failure into a success. You can do this a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Strange Endurance",
+					"entries": [
+						"You have {@variantrule Resistance|XPHB} to one of the following damage types of your choice: Cold, Necrotic, or Poison."
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Reborn",
 			"source": "VRGR",
 			"page": 20,
+			"reprintedAs": [
+				"Reborn|RHW"
+			],
 			"lineage": "VRGR",
 			"size": [
 				"S",
@@ -10400,6 +11696,87 @@
 					"name": "Knowledge from a Past Life",
 					"entries": [
 						"You temporarily remember glimpses of the past, perhaps faded memories from ages ago or a previous life. When you make an ability check that uses a skill, you can roll a {@dice d6} immediately after seeing the number on the {@dice d20} and add the number on the {@dice d6} to the check. You can use this feature a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Rimekin",
+			"source": "LFL",
+			"creatureTypes": [
+				"humanoid"
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"speed": 30,
+			"darkvision": 60,
+			"resist": [
+				"cold"
+			],
+			"additionalSpells": [
+				{
+					"known": {
+						"1": [
+							"ray of frost|xphb#c"
+						]
+					},
+					"innate": {
+						"3": {
+							"daily": {
+								"1": [
+									"ice knife|xphb"
+								]
+							}
+						},
+						"5": {
+							"daily": {
+								"1": [
+									"flame blade|xphb"
+								]
+							}
+						}
+					},
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					}
+				}
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 4-7 feet tall) or Small (about 2-4 feet tall), chosen when you select this species"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Cold Fire Magic",
+					"entries": [
+						"You know the {@spell Ray of Frost|XPHB} cantrip. When you reach character levels 3 and 5, you learn the {@spell Ice Knife|XPHB} spell and the {@spell Flame Blade|XPHB} spell, respectively. You always have those spells prepared. You can cast each once without a spell slot, and you regain the ability to cast these spells in this way when you finish a {@variantrule Long Rest|XPHB}. You can also cast the spells using any spell slots you have of the appropriate level. When you cast {@spell Flame Blade|XPHB} using this trait, the spell deals Cold damage instead of Fire damage.",
+						"Intelligence, Wisdom, or Charisma is your spellcasting ability for these spells (choose the ability when you select this species)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Cold Resistance",
+					"entries": [
+						"You have {@variantrule Resistance|XPHB} to Cold damage."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Darkvision",
+					"entries": [
+						"You have {@sense Darkvision|XPHB} with a range of 60 feet."
 					]
 				}
 			],
@@ -10457,6 +11834,10 @@
 					"anyMusicalInstrument": 1
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/satyr.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -10552,6 +11933,10 @@
 					"anyMusicalInstrument": 1
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/satyr.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -10780,10 +12165,187 @@
 		},
 		{
 			"name": "Shifter",
+			"source": "EFA",
+			"page": 37,
+			"edition": "one",
+			"creatureTypes": [
+				"humanoid"
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"speed": 30,
+			"darkvision": 60,
+			"skillProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"acrobatics",
+							"athletics",
+							"intimidation",
+							"survival"
+						]
+					}
+				}
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 4-7 feet tall) or Small (about 2-4 feet tall), chosen when you select this species"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Bestial Instincts",
+					"entries": [
+						"Channeling the beast within, you gain proficiency in one of the following skills of your choice: {@skill Acrobatics|XPHB}, {@skill Athletics|XPHB}, {@skill Intimidation|XPHB}, or {@skill Survival|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Darkvision",
+					"entries": [
+						"You have {@sense Darkvision|XPHB} with a range of 60 feet."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Shifting",
+					"entries": [
+						"As a {@variantrule Bonus Action|XPHB}, you can shape-shift to assume a more bestial appearance. This transformation lasts for 1 minute or until you revert to your normal appearance as a {@variantrule Bonus Action|XPHB}. When you shift, you gain {@variantrule Temporary Hit Points|XPHB} equal to 2 times your {@variantrule Proficiency|XPHB|Proficiency Bonus}. You can shift a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}.",
+						"Whenever you shift, you gain the benefit of one of the following options (choose when you select this species)",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Beasthide",
+									"entries": [
+										"You gain {@dice 1d6} additional {@variantrule Temporary Hit Points|XPHB}. While shifted, you have a +1 bonus to your {@variantrule Armor Class|XPHB}."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Longtooth",
+									"entries": [
+										"When you shift and as a {@variantrule Bonus Action|XPHB} on your other turns while shifted, you can use your elongated fangs to make an {@variantrule Unarmed Strike|XPHB}. If you hit with this {@variantrule Unarmed Strike|XPHB} and deal damage, you can deal Piercing damage equal to {@dice 1d6} plus your Strength modifier, instead of the normal damage of an {@variantrule Unarmed Strike|XPHB}."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Swiftstride",
+									"entries": [
+										"While you are shifted, your {@variantrule Speed|XPHB} increases by 10 feet. Additionally, you can move up to 10 feet as a {@variantrule Reaction|XPHB} when a creature ends its turn within 5 feet of you. This reactive movement doesn't provoke {@action Opportunity Attack|XPHB|Opportunity Attacks}."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Wildhunt",
+									"entries": [
+										"While shifted, you have {@variantrule Advantage|XPHB} on Wisdom checks. Additionally, no creature within 30 feet of you can have {@variantrule Advantage|XPHB} on an attack roll against you unless you have the {@condition Incapacitated|XPHB} condition."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true,
+			"_versions": [
+				{
+					"name": "Shifter; Beasthide",
+					"source": "EFA",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": "Shifting",
+								"items": {
+									"name": "Shifting (Beasthide)",
+									"type": "entries",
+									"entries": [
+										"As a {@variantrule Bonus Action|XPHB}, you can shape-shift to assume a more bestial appearance. This transformation lasts for 1 minute or until you revert to your normal appearance as a {@variantrule Bonus Action|XPHB}. When you shift, you gain {@variantrule Temporary Hit Points|XPHB} equal to 2 times your {@variantrule Proficiency|XPHB|Proficiency Bonus}. You can shift a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}.",
+										"Whenever you shift, you gain {@dice 1d6} additional {@variantrule Temporary Hit Points|XPHB}. While shifted, you have a +1 bonus to your {@variantrule Armor Class|XPHB}."
+									]
+								}
+							}
+						]
+					}
+				},
+				{
+					"name": "Shifter; Longtooth",
+					"source": "EFA",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": "Shifting",
+								"items": {
+									"name": "Shifting (Longtooth)",
+									"type": "entries",
+									"entries": [
+										"As a {@variantrule Bonus Action|XPHB}, you can shape-shift to assume a more bestial appearance. This transformation lasts for 1 minute or until you revert to your normal appearance as a {@variantrule Bonus Action|XPHB}. When you shift, you gain {@variantrule Temporary Hit Points|XPHB} equal to 2 times your {@variantrule Proficiency|XPHB|Proficiency Bonus}. You can shift a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}.",
+										"When you shift and as a {@variantrule Bonus Action|XPHB} on your other turns while shifted, you can use your elongated fangs to make an {@variantrule Unarmed Strike|XPHB}. If you hit with this {@variantrule Unarmed Strike|XPHB} and deal damage, you can deal Piercing damage equal to {@dice 1d6} plus your Strength modifier, instead of the normal damage of an {@variantrule Unarmed Strike|XPHB}."
+									]
+								}
+							}
+						]
+					}
+				},
+				{
+					"name": "Shifter; Swiftstride",
+					"source": "EFA",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": "Shifting",
+								"items": {
+									"name": "Shifting (Swiftstride)",
+									"type": "entries",
+									"entries": [
+										"As a {@variantrule Bonus Action|XPHB}, you can shape-shift to assume a more bestial appearance. This transformation lasts for 1 minute or until you revert to your normal appearance as a {@variantrule Bonus Action|XPHB}. When you shift, you gain {@variantrule Temporary Hit Points|XPHB} equal to 2 times your {@variantrule Proficiency|XPHB|Proficiency Bonus}. You can shift a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}.",
+										"While you are shifted, your {@variantrule Speed|XPHB} increases by 10 feet. Additionally, you can move up to 10 feet as a {@variantrule Reaction|XPHB} when a creature ends its turn within 5 feet of you. This reactive movement doesn't provoke {@action Opportunity Attack|XPHB|Opportunity Attacks}."
+									]
+								}
+							}
+						]
+					}
+				},
+				{
+					"name": "Shifter; Wildhunt",
+					"source": "EFA",
+					"_mod": {
+						"entries": [
+							{
+								"mode": "replaceArr",
+								"replace": "Shifting",
+								"items": {
+									"name": "Shifting (Wildhunt)",
+									"type": "entries",
+									"entries": [
+										"As a {@variantrule Bonus Action|XPHB}, you can shape-shift to assume a more bestial appearance. This transformation lasts for 1 minute or until you revert to your normal appearance as a {@variantrule Bonus Action|XPHB}. When you shift, you gain {@variantrule Temporary Hit Points|XPHB} equal to 2 times your {@variantrule Proficiency|XPHB|Proficiency Bonus}. You can shift a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus}, and you regain all expended uses when you finish a {@variantrule Long Rest|XPHB}.",
+										"While shifted, you have {@variantrule Advantage|XPHB} on Wisdom checks. Additionally, no creature within 30 feet of you can have {@variantrule Advantage|XPHB} on an attack roll against you unless you have the {@condition Incapacitated|XPHB} condition."
+									]
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Shifter",
 			"source": "ERLW",
 			"page": 33,
 			"reprintedAs": [
-				"Shifter|MPMM"
+				"Shifter|MPMM",
+				"Shifter|EFA"
 			],
 			"size": [
 				"M"
@@ -10864,6 +12426,9 @@
 			"name": "Shifter",
 			"source": "MPMM",
 			"page": 32,
+			"reprintedAs": [
+				"Shifter|EFA"
+			],
 			"lineage": "VRGR",
 			"size": [
 				"M"
@@ -11247,6 +12812,10 @@
 				"exhaustion",
 				"poisoned"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/skeleton.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -11308,6 +12877,10 @@
 					"stealth": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/tabaxi.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -11409,7 +12982,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/tabaxi.mp3"
+				"path": "races/tabaxi.opus"
 			},
 			"entries": [
 				{
@@ -11483,6 +13056,10 @@
 				"Improved Resting",
 				"Natural Armor"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/thri-kreen.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -11517,7 +13094,7 @@
 					"type": "entries",
 					"name": "Secondary Arms",
 					"entries": [
-						"You have two slightly smaller secondary arms below your primary pair of arms. The secondary arms can manipulate an object, open or close a door or container, pick up or set down a Tiny object, or wield a weapon that has the light property."
+						"You have two slightly smaller secondary arms below your primary pair of arms. The secondary arms can manipulate an object, open or close a door or container, pick up or set down a Tiny object, or wield a weapon that has the {@itemProperty L||light} property."
 					]
 				},
 				{
@@ -11581,7 +13158,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/tiefling.mp3"
+				"path": "races/tiefling.opus"
 			},
 			"additionalSpells": [
 				{
@@ -11672,8 +13249,24 @@
 			],
 			"speed": 30,
 			"darkvision": 60,
+			"resist": [
+				{
+					"choose": {
+						"from": [
+							"poison",
+							"necrotic",
+							"fire"
+						]
+					}
+				}
+			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/tiefling.opus"
+			},
 			"additionalSpells": [
 				{
+					"name": "Abyssal",
 					"ability": {
 						"choose": [
 							"int",
@@ -11683,8 +13276,89 @@
 					},
 					"known": {
 						"1": [
-							"thaumaturgy|xphb#c"
+							"thaumaturgy|xphb#c",
+							"poison spray|xphb#c"
 						]
+					},
+					"innate": {
+						"3": {
+							"daily": {
+								"1": [
+									"ray of sickness|xphb"
+								]
+							}
+						},
+						"5": {
+							"daily": {
+								"1": [
+									"hold person|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Chthonic",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"1": [
+							"thaumaturgy|xphb#c",
+							"chill touch|xphb#c"
+						]
+					},
+					"innate": {
+						"3": {
+							"daily": {
+								"1": [
+									"false life|xphb"
+								]
+							}
+						},
+						"5": {
+							"daily": {
+								"1": [
+									"ray of enfeeblement|xphb"
+								]
+							}
+						}
+					}
+				},
+				{
+					"name": "Infernal",
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"1": [
+							"thaumaturgy|xphb#c",
+							"fire bolt|xphb#c"
+						]
+					},
+					"innate": {
+						"3": {
+							"daily": {
+								"1": [
+									"hellish rebuke|xphb"
+								]
+							}
+						},
+						"5": {
+							"daily": {
+								"1": [
+									"darkness|xphb"
+								]
+							}
+						}
 					}
 				}
 			],
@@ -11727,19 +13401,19 @@
 							"rows": [
 								[
 									"Abyssal",
-									"You have Resistance to Poison damage. You also know the {@spell Poison Spray|XPHB} cantrip.",
+									"You have {@variantrule Resistance|XPHB} to Poison damage. You also know the {@spell Poison Spray|XPHB} cantrip.",
 									"{@spell Ray of Sickness|XPHB}",
 									"{@spell Hold Person|XPHB}"
 								],
 								[
 									"Chthonic",
-									"You have Resistance to Necrotic damage. You also know the {@spell Chill Touch|XPHB} cantrip.",
+									"You have {@variantrule Resistance|XPHB} to Necrotic damage. You also know the {@spell Chill Touch|XPHB} cantrip.",
 									"{@spell False Life|XPHB}",
 									"{@spell Ray of Enfeeblement|XPHB}"
 								],
 								[
 									"Infernal",
-									"You have Resistance to Fire damage. You also know the {@spell Fire Bolt|XPHB} cantrip.",
+									"You have {@variantrule Resistance|XPHB} to Fire damage. You also know the {@spell Fire Bolt|XPHB} cantrip.",
 									"{@spell Hellish Rebuke|XPHB}",
 									"{@spell Darkness|XPHB}"
 								]
@@ -11954,6 +13628,10 @@
 					}
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/tortle.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -12043,6 +13721,10 @@
 					"common": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/tortle.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -12142,6 +13824,10 @@
 					"reprintedAs": true
 				}
 			},
+			"soundClip": {
+				"type": "internal",
+				"path": "races/triton.opus"
+			},
 			"hasFluff": true,
 			"hasFluffImages": true
 		},
@@ -12164,6 +13850,10 @@
 			"resist": [
 				"cold"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/triton.opus"
+			},
 			"additionalSpells": [
 				{
 					"innate": {
@@ -12292,7 +13982,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/triton.mp3"
+				"path": "races/triton.opus"
 			},
 			"additionalSpells": [
 				{
@@ -12417,6 +14107,10 @@
 					"other": true
 				}
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/troglodyte.opus"
+			},
 			"entries": [
 				{
 					"name": "Chameleon Skin",
@@ -12491,6 +14185,10 @@
 			"resist": [
 				"necrotic"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/vampire.opus"
+			},
 			"entries": [
 				{
 					"name": "Age",
@@ -12818,8 +14516,88 @@
 		},
 		{
 			"name": "Warforged",
+			"source": "EFA",
+			"page": 38,
+			"edition": "one",
+			"creatureTypes": [
+				"construct"
+			],
+			"size": [
+				"S",
+				"M"
+			],
+			"speed": 30,
+			"traitTags": [
+				"Improved Resting",
+				"Natural Armor"
+			],
+			"skillProficiencies": [
+				{
+					"any": 1
+				}
+			],
+			"toolProficiencies": [
+				{
+					"any": 1
+				}
+			],
+			"resist": [
+				"poison"
+			],
+			"sizeEntry": {
+				"type": "item",
+				"name": "Size:",
+				"entries": [
+					"Medium (about 6-8 feet tall) or Small (about 3-4 feet tall), chosen when you select this species"
+				]
+			},
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Construct Resilience",
+					"entries": [
+						"You have {@variantrule Resistance|XPHB} to Poison damage. You also have {@variantrule Advantage|XPHB} on saving throws to avoid or end the {@condition Poisoned|XPHB} condition."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Integrated Protection",
+					"entries": [
+						"You gain a +1 bonus to your {@variantrule Armor Class|XPHB}. In addition, armor you have donned can't be removed against your will while you're alive."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Sentry's Rest",
+					"entries": [
+						"You don't need to sleep, and magic can't put you to sleep. You can finish a {@variantrule Long Rest|XPHB} in 6 hours if you spend those hours in an inactive, motionless state. During this time, you appear inert but remain conscious."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Specialized Design",
+					"entries": [
+						"You gain one skill proficiency and one tool proficiency of your choice."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Tireless",
+					"entries": [
+						"You don't gain {@condition Exhaustion|XPHB} levels from dehydration, malnutrition, or suffocation."
+					]
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
+		{
+			"name": "Warforged",
 			"source": "ERLW",
 			"page": 35,
+			"reprintedAs": [
+				"Warforged|EFA"
+			],
 			"size": [
 				"M"
 			],
@@ -13084,6 +14862,10 @@
 			"conditionImmune": [
 				"poisoned"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/yuan-ti-pureblood.opus"
+			},
 			"additionalSpells": [
 				{
 					"innate": {
@@ -13191,6 +14973,10 @@
 			"conditionImmune": [
 				"poisoned"
 			],
+			"soundClip": {
+				"type": "internal",
+				"path": "races/zombie.opus"
+			},
 			"entries": [
 				{
 					"type": "entries",
@@ -13228,9 +15014,148 @@
 					"type": "entries"
 				}
 			]
+		},
+		{
+			"name": "Human (Amonkhet)",
+			"source": "PSA",
+			"page": 14,
+			"size": [
+				"M"
+			],
+			"speed": 30,
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						],
+						"count": 2
+					}
+				}
+			],
+			"age": {
+				"mature": 20,
+				"max": 100
+			},
+			"feats": [
+				{
+					"any": 1
+				}
+			],
+			"skillProficiencies": [
+				{
+					"any": 1
+				}
+			],
+			"languageProficiencies": [
+				{
+					"common": true,
+					"anyStandard": 1
+				}
+			],
+			"entries": [
+				{
+					"name": "Age",
+					"type": "entries",
+					"entries": [
+						"Humans reach adulthood in their late teens. Most human initiates have completed the trials and found a glorious or inglorious death before they turn 30. Viziers can enjoy longer service to their gods, in theory living up to a century."
+					]
+				},
+				{
+					"name": "Alignment",
+					"type": "entries",
+					"entries": [
+						"Humans tend toward no particular alignment. The best and the worst are found among them."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Size",
+					"entries": [
+						"Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium"
+					]
+				},
+				{
+					"name": "Skills",
+					"entries": [
+						"You gain proficiency in one skill of your choice."
+					],
+					"type": "entries"
+				},
+				{
+					"name": "Feat",
+					"entries": [
+						"You gain one {@5etools feat|feats.html} of your choice."
+					],
+					"type": "entries"
+				},
+				{
+					"name": "Languages",
+					"entries": [
+						"You can speak, read, and write Common and one extra language of your choice."
+					],
+					"type": "entries"
+				}
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		}
 	],
 	"subrace": [
+		{
+			"name": "Amonkhet",
+			"source": "PSA",
+			"page": 14,
+			"_copy": {
+				"name": "Variant",
+				"source": "PHB",
+				"raceName": "Human",
+				"raceSource": "PHB",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "appendArr",
+							"items": [
+								{
+									"name": "Age",
+									"type": "entries",
+									"entries": [
+										"Humans reach adulthood in their late teens. Most human initiates have completed the trials and found a glorious or inglorious death before they turn 30. Viziers can enjoy longer service to their gods, in theory living up to a century."
+									],
+									"data": {
+										"overwrite": "Age"
+									}
+								},
+								{
+									"name": "Languages",
+									"entries": [
+										"You can speak, read, and write Common and one extra language of your choice."
+									],
+									"type": "entries",
+									"data": {
+										"overwrite": "Languages"
+									}
+								},
+								{
+									"name": "Alignment",
+									"type": "entries",
+									"entries": [
+										"Humans tend toward no particular alignment. The best and the worst are found among them."
+									]
+								}
+							]
+						}
+					]
+				}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
+		},
 		{
 			"name": "Fallen",
 			"source": "VGM",
@@ -14131,6 +16056,12 @@
 			"raceName": "Dwarf",
 			"raceSource": "PHB",
 			"page": 51,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Warding|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"int": 1
@@ -14562,6 +16493,12 @@
 			"raceName": "Elf",
 			"raceSource": "PHB",
 			"page": 49,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Shadow|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"cha": 1
@@ -16053,6 +17990,12 @@
 			"raceName": "Gnome",
 			"raceSource": "PHB",
 			"page": 47,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Scribing|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"cha": 1
@@ -16199,7 +18142,7 @@
 				{
 					"name": "Tinker",
 					"entries": [
-						"You have proficiency with artisan's tools ({@item tinker's tools|phb}). Using those tools, you can spend 1 hour and 10 gp worth of materials to construct a Tiny clockwork device (AC 5, 1 hp). The device ceases to function after 24 hours (unless you spend 1 hour repairing it to keep the device functioning), or when you use your action to dismantle it; at that time, you can reclaim the materials used to create it. You can have up to three such devices active at a time.",
+						"You have proficiency with {@item artisan's tools|PHB} ({@item tinker's tools|phb}). Using those tools, you can spend 1 hour and 10 gp worth of materials to construct a Tiny clockwork device (AC 5, 1 hp). The device ceases to function after 24 hours (unless you spend 1 hour repairing it to keep the device functioning), or when you use your action to dismantle it; at that time, you can reclaim the materials used to create it. You can have up to three such devices active at a time.",
 						"When you create a device, choose one of the following options:",
 						{
 							"type": "entries",
@@ -16241,6 +18184,7 @@
 					"dex": 2
 				}
 			],
+			"resist": null,
 			"entries": [
 				{
 					"name": "Alignment",
@@ -16292,13 +18236,6 @@
 			],
 			"entries": [
 				{
-					"name": "Grit",
-					"entries": [
-						"You have resistance to fire damage and psychic damage. In addition, when you are wearing no armor, your AC is equal to 11 + your Dexterity modifier."
-					],
-					"type": "entries"
-				},
-				{
 					"name": "Grotag Tamer",
 					"entries": [
 						"You have proficiency in the {@skill Animal Handling} skill."
@@ -16322,13 +18259,6 @@
 				}
 			],
 			"entries": [
-				{
-					"name": "Grit",
-					"entries": [
-						"You have resistance to fire damage and psychic damage. In addition, when you are wearing no armor, your AC is equal to 11 + your Dexterity modifier."
-					],
-					"type": "entries"
-				},
 				{
 					"name": "Lavastep Grit",
 					"entries": [
@@ -16359,13 +18289,6 @@
 			],
 			"entries": [
 				{
-					"name": "Grit",
-					"entries": [
-						"You have resistance to fire damage and psychic damage. In addition, when you are wearing no armor, your AC is equal to 11 + your Dexterity modifier."
-					],
-					"type": "entries"
-				},
-				{
 					"name": "Tuktuk Cunning",
 					"entries": [
 						"You have proficiency with {@item thieves' tools|phb}."
@@ -16382,6 +18305,9 @@
 			"raceSource": "PHB",
 			"page": 38,
 			"srd": true,
+			"reprintedAs": [
+				"Khoravar|EFA"
+			],
 			"hasFluff": true,
 			"hasFluffImages": true
 		},
@@ -16577,6 +18503,12 @@
 			"raceName": "Half-Elf",
 			"raceSource": "PHB",
 			"page": 40,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Detection|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"wis": 2,
@@ -16706,6 +18638,12 @@
 			"raceName": "Half-Elf",
 			"raceSource": "PHB",
 			"page": 50,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Storm|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"cha": 2,
@@ -17105,6 +19043,12 @@
 			"raceName": "Half-Orc",
 			"raceSource": "PHB",
 			"page": 41,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Finding|EFA",
+					"tag": "feat"
+				}
+			],
 			"traitTags": [
 				"Dragonmark",
 				"Skill Bonus Dice"
@@ -17118,7 +19062,7 @@
 			],
 			"soundClip": {
 				"type": "internal",
-				"path": "races/half-orc.mp3"
+				"path": "races/half-orc.opus"
 			},
 			"additionalSpells": [
 				{
@@ -17358,6 +19302,12 @@
 			"raceName": "Halfling",
 			"raceSource": "PHB",
 			"page": 43,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Healing|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"wis": 1
@@ -17470,6 +19420,12 @@
 			"raceName": "Halfling",
 			"raceSource": "PHB",
 			"page": 44,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Hospitality|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"cha": 1
@@ -17726,6 +19682,12 @@
 			"raceName": "Human",
 			"raceSource": "PHB",
 			"page": 42,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Handling|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"wis": 2,
@@ -17852,6 +19814,12 @@
 			"raceName": "Human",
 			"raceSource": "PHB",
 			"page": 45,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Making|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"int": 2,
@@ -17921,7 +19889,7 @@
 					"type": "entries",
 					"name": "Maker's Gift",
 					"entries": [
-						"You gain proficiency with one type of artisan's tools of your choice."
+						"You gain proficiency with one type of {@item artisan's tools|PHB} of your choice."
 					]
 				},
 				{
@@ -17980,6 +19948,12 @@
 			"raceName": "Human",
 			"raceSource": "PHB",
 			"page": 46,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Passage|EFA",
+					"tag": "feat"
+				}
+			],
 			"speed": 35,
 			"ability": [
 				{
@@ -18101,6 +20075,12 @@
 			"raceName": "Human",
 			"raceSource": "PHB",
 			"page": 48,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Sentinel|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"con": 2,
@@ -18265,6 +20245,12 @@
 			"raceName": "Human",
 			"raceSource": "PHB",
 			"page": 41,
+			"reprintedAs": [
+				{
+					"uid": "Mark of Finding|EFA",
+					"tag": "feat"
+				}
+			],
 			"ability": [
 				{
 					"con": 1,
@@ -18840,6 +20826,10 @@
 			"raceName": "Shifter",
 			"raceSource": "ERLW",
 			"page": 34,
+			"reprintedAs": [
+				"Shifter|MPMM",
+				"Shifter|EFA"
+			],
 			"ability": [
 				{
 					"con": 2,
@@ -18879,6 +20869,10 @@
 			"raceName": "Shifter",
 			"raceSource": "ERLW",
 			"page": 34,
+			"reprintedAs": [
+				"Shifter|MPMM",
+				"Shifter|EFA"
+			],
 			"ability": [
 				{
 					"str": 2,
@@ -18918,6 +20912,10 @@
 			"raceName": "Shifter",
 			"raceSource": "ERLW",
 			"page": 34,
+			"reprintedAs": [
+				"Shifter|MPMM",
+				"Shifter|EFA"
+			],
 			"ability": [
 				{
 					"dex": 2,
@@ -18954,6 +20952,10 @@
 			"raceName": "Shifter",
 			"raceSource": "ERLW",
 			"page": 34,
+			"reprintedAs": [
+				"Shifter|MPMM",
+				"Shifter|EFA"
+			],
 			"ability": [
 				{
 					"wis": 2,

--- a/json/spells/spells-aag.json
+++ b/json/spells/spells-aag.json
@@ -4,6 +4,9 @@
 			"name": "Air Bubble",
 			"source": "AAG",
 			"page": 22,
+			"referenceSources": [
+				"LoX"
+			],
 			"level": 2,
 			"school": "C",
 			"time": [

--- a/json/spells/spells-ai.json
+++ b/json/spells/spells-ai.json
@@ -4,6 +4,9 @@
 			"name": "Distort Value",
 			"source": "AI",
 			"page": 75,
+			"referenceSources": [
+				"OoW"
+			],
 			"level": 1,
 			"school": "I",
 			"time": [
@@ -256,6 +259,9 @@
 			"name": "Jim's Magic Missile",
 			"source": "AI",
 			"page": 76,
+			"referenceSources": [
+				"OoW"
+			],
 			"level": 1,
 			"school": "V",
 			"time": [

--- a/json/spells/spells-aitfr-avt.json
+++ b/json/spells/spells-aitfr-avt.json
@@ -10,6 +10,9 @@
 					"page": 11
 				}
 			],
+			"referenceSources": [
+				"AitFR-FCD"
+			],
 			"level": 3,
 			"school": "A",
 			"time": [

--- a/json/spells/spells-egw.json
+++ b/json/spells/spells-egw.json
@@ -39,7 +39,7 @@
 			],
 			"entries": [
 				"This spell creates a sphere centered on a point you choose within range. The sphere can have a radius of up to 40 feet. The area within this sphere is filled with magical darkness and crushing gravitational force.",
-				"For the duration, the spell's area is {@quickref difficult terrain||3}. A creature with darkvision can't see through the magical darkness, and nonmagical light can't illuminate it. No sound can be created within or pass through the area. Any creature or object entirely inside the sphere is immune to thunder damage, and creatures are {@condition deafened} while entirely inside it. Casting a spell that includes a verbal component is impossible there.",
+				"For the duration, the spell's area is {@quickref difficult terrain||3}. A creature with {@sense darkvision} can't see through the magical darkness, and nonmagical light can't illuminate it. No sound can be created within or pass through the area. Any creature or object entirely inside the sphere is immune to thunder damage, and creatures are {@condition deafened} while entirely inside it. Casting a spell that includes a verbal component is impossible there.",
 				"Any creature that enters the spell's area for the first time on a turn or starts its turn there must make a Constitution saving throw. The creature takes {@damage 8d10} force damage on a failed save, or half as much damage on a successful one. A creature reduced to 0 hit points by this damage is disintegrated. A disintegrated creature and everything it is wearing and carrying, except magic items, are reduced to a pile of fine gray dust."
 			],
 			"damageInflict": [
@@ -53,7 +53,8 @@
 			],
 			"miscTags": [
 				"DFT",
-				"OBJ"
+				"OBJ",
+				"OBS"
 			],
 			"areaTags": [
 				"S"

--- a/json/spells/spells-frhof.json
+++ b/json/spells/spells-frhof.json
@@ -413,7 +413,7 @@
 				"ritual": true
 			},
 			"entries": [
-				"You summon a group of helpful spirits, which lasts for the duration. The spirits appear as homunculi or as another Construct of your choice but are intangible and invulnerable, and they are considered to have proficiency in the {@skill Arcana|XPHB} skill and with the set or {@item Artisan's Tools|XPHB} used in the spell's casting.",
+				"You summon a group of helpful spirits, which lasts for the duration. The spirits appear as homunculi or as another Construct of your choice but are intangible and invulnerable, and they are considered to have proficiency in the {@skill Arcana|XPHB} skill and with the set of {@item Artisan's Tools|XPHB} used in the spell's casting.",
 				"If you are crafting an item, the spirits function as a single assistant for your crafting, halving the crafting time."
 			],
 			"miscTags": [

--- a/json/spells/spells-ggr.json
+++ b/json/spells/spells-ggr.json
@@ -4,6 +4,9 @@
 			"name": "Encode Thoughts",
 			"source": "GGR",
 			"page": 47,
+			"referenceSources": [
+				"AZfyT"
+			],
 			"level": 0,
 			"school": "E",
 			"time": [

--- a/json/spells/spells-idrotf.json
+++ b/json/spells/spells-idrotf.json
@@ -37,6 +37,9 @@
 				"When the magen appears, your hit point maximum decreases by an amount equal to the magen's challenge rating (minimum reduction of 1). Only a {@spell wish} spell can undo this reduction to your hit point maximum.",
 				"Any magen you create with this spell obeys your commands without question."
 			],
+			"miscTags": [
+				"PRM"
+			],
 			"areaTags": [
 				"ST"
 			]

--- a/json/spells/spells-phb.json
+++ b/json/spells/spells-phb.json
@@ -6,6 +6,9 @@
 			"page": 211,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"ToA"
+			],
 			"reprintedAs": [
 				"Acid Splash|XPHB"
 			],
@@ -73,6 +76,10 @@
 					"page": 50
 				}
 			],
+			"referenceSources": [
+				"PotA",
+				"TftYP-DiT"
+			],
 			"reprintedAs": [
 				"Aid|XPHB"
 			],
@@ -129,6 +136,25 @@
 			"source": "PHB",
 			"page": 211,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"CoS",
+				"DSotDQ",
+				"JttRC",
+				"KftGV",
+				"OotA",
+				"PotA",
+				"QftIS",
+				"SCC-TMM",
+				"SKT",
+				"SLW",
+				"TftYP-TFoF",
+				"TLK",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Alarm|XPHB"
 			],
@@ -178,6 +204,18 @@
 			"source": "PHB",
 			"page": 211,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"SKT",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Alter Self|XPHB"
 			],
@@ -244,6 +282,12 @@
 			"source": "PHB",
 			"page": 212,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"CRCotN",
+				"IDRotF",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Animal Friendship|XPHB"
 			],
@@ -310,6 +354,17 @@
 			"source": "PHB",
 			"page": 212,
 			"srd": true,
+			"referenceSources": [
+				"GoS",
+				"IDRotF",
+				"OotA",
+				"PotA",
+				"RoT",
+				"SKT",
+				"ToR",
+				"WBtW",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Animal Messenger|XPHB"
 			],
@@ -422,6 +477,19 @@
 			"source": "PHB",
 			"page": 212,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"IDRotF",
+				"LLK",
+				"LRDT",
+				"RoT",
+				"ToFW",
+				"US",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Animate Dead|XPHB"
 			],
@@ -478,6 +546,16 @@
 			"source": "PHB",
 			"page": 213,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"IDRotF",
+				"RoT",
+				"SKT",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Animate Objects|XPHB"
 			],
@@ -606,6 +684,10 @@
 			"source": "PHB",
 			"page": 213,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Antilife Shell|XPHB"
 			],
@@ -667,6 +749,21 @@
 			"page": 213,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"DC",
+				"HotDQ",
+				"IDRotF",
+				"LLK",
+				"OotA",
+				"SKT",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Antimagic Field|XPHB"
 			],
@@ -766,6 +863,14 @@
 			"source": "PHB",
 			"page": 214,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"DitLCoT",
+				"QftIS",
+				"TftYP-ToH",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Antipathy/Sympathy|XPHB"
 			],
@@ -843,6 +948,14 @@
 			"page": 214,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"DSotDQ",
+				"HotDQ",
+				"IDRotF",
+				"SKT",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Arcane Eye|XPHB"
 			],
@@ -886,6 +999,10 @@
 			"name": "Arcane Gate",
 			"source": "PHB",
 			"page": 214,
+			"referenceSources": [
+				"DSotDQ",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Arcane Gate|XPHB"
 			],
@@ -936,6 +1053,36 @@
 			"page": 215,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"GoS",
+				"HoL",
+				"HotDQ",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"LRDT",
+				"OotA",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"SCC-CK",
+				"SCC-HfMT",
+				"SCC-TMM",
+				"SDW",
+				"SjA",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-TSC",
+				"ToA",
+				"TTP",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Arcane Lock|XPHB"
 			],
@@ -982,6 +1129,9 @@
 			"name": "Armor of Agathys",
 			"source": "PHB",
 			"page": 215,
+			"referenceSources": [
+				"KftGV"
+			],
 			"reprintedAs": [
 				"Armor of Agathys|XPHB"
 			],
@@ -1036,6 +1186,9 @@
 			"name": "Arms of Hadar",
 			"source": "PHB",
 			"page": 215,
+			"referenceSources": [
+				"KftGV"
+			],
 			"reprintedAs": [
 				"Arms of Hadar|XPHB"
 			],
@@ -1091,6 +1244,13 @@
 			"page": 215,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoS",
+				"OotA",
+				"ToA",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Astral Projection|XPHB"
 			],
@@ -1153,6 +1313,19 @@
 					"source": "RMR",
 					"page": 50
 				}
+			],
+			"referenceSources": [
+				"CoS",
+				"HotDQ",
+				"JttRC",
+				"KftGV",
+				"LMoP",
+				"OotA",
+				"PaBTSO",
+				"SCC-HfMT",
+				"ToA",
+				"US",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Augury|XPHB"
@@ -1349,6 +1522,14 @@
 			"source": "PHB",
 			"page": 216,
 			"srd": true,
+			"referenceSources": [
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"ToA",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Awaken|XPHB"
 			],
@@ -1403,6 +1584,12 @@
 			"source": "PHB",
 			"page": 216,
 			"srd": true,
+			"referenceSources": [
+				"JttRC",
+				"KftGV",
+				"TftYP-TSC",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Bane|XPHB"
 			],
@@ -1463,6 +1650,9 @@
 			"name": "Banishing Smite",
 			"source": "PHB",
 			"page": 216,
+			"referenceSources": [
+				"ToA"
+			],
 			"reprintedAs": [
 				"Banishing Smite|XPHB"
 			],
@@ -1511,6 +1701,21 @@
 			"source": "PHB",
 			"page": 217,
 			"srd": true,
+			"referenceSources": [
+				"AitFR-THP",
+				"BGDIA",
+				"CM",
+				"DitLCoT",
+				"KftGV",
+				"OotA",
+				"QftIS",
+				"RtG",
+				"SKT",
+				"SLW",
+				"ToA",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Banishment|XPHB"
 			],
@@ -1577,6 +1782,12 @@
 			"source": "PHB",
 			"page": 217,
 			"srd": true,
+			"referenceSources": [
+				"GoS",
+				"JttRC",
+				"SKT",
+				"TftYP-TSC"
+			],
 			"reprintedAs": [
 				"Barkskin|XPHB"
 			],
@@ -1724,6 +1935,16 @@
 			"source": "PHB",
 			"page": 218,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"OotA",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Bestow Curse|XPHB"
 			],
@@ -1795,6 +2016,15 @@
 			"source": "PHB",
 			"page": 218,
 			"srd": "Arcane Hand",
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"OotA",
+				"SKT",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Bigby's Hand|XPHB"
 			],
@@ -1947,6 +2177,9 @@
 			"name": "Blade Ward",
 			"source": "PHB",
 			"page": 218,
+			"referenceSources": [
+				"IDRotF"
+			],
 			"reprintedAs": [
 				"Blade Ward|XPHB"
 			],
@@ -1997,6 +2230,24 @@
 					"source": "RMR",
 					"page": 50
 				}
+			],
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"DIP",
+				"GoS",
+				"JttRC",
+				"KftGV",
+				"OoW",
+				"RoT",
+				"RtG",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"ToR",
+				"VEoR"
 			],
 			"reprintedAs": [
 				"Bless|XPHB"
@@ -2055,6 +2306,16 @@
 			"source": "PHB",
 			"page": 219,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"OotA",
+				"PaBTSO",
+				"SKT",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Blight|XPHB"
 			],
@@ -2127,6 +2388,9 @@
 			"name": "Blinding Smite",
 			"source": "PHB",
 			"page": 219,
+			"referenceSources": [
+				"CoS"
+			],
 			"reprintedAs": [
 				"Blinding Smite|XPHB"
 			],
@@ -2179,6 +2443,16 @@
 			"source": "PHB",
 			"page": 219,
 			"srd": true,
+			"referenceSources": [
+				"CRCotN",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"TftYP-AtG",
+				"US",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Blindness/Deafness|XPHB"
 			],
@@ -2241,6 +2515,9 @@
 			"source": "PHB",
 			"page": 219,
 			"srd": true,
+			"referenceSources": [
+				"OotA"
+			],
 			"reprintedAs": [
 				"Blink|XPHB"
 			],
@@ -2291,6 +2568,15 @@
 					"page": 50
 				}
 			],
+			"referenceSources": [
+				"CM",
+				"DIP",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"PaBTSO",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Blur|XPHB"
 			],
@@ -2330,6 +2616,10 @@
 			"source": "PHB",
 			"page": 219,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoS"
+			],
 			"reprintedAs": [
 				"Shining Smite|XPHB"
 			],
@@ -2392,6 +2682,18 @@
 					"page": 51
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"DIP",
+				"KftGV",
+				"PotA",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Burning Hands|XPHB"
 			],
@@ -2451,6 +2753,13 @@
 			"source": "PHB",
 			"page": 220,
 			"srd": true,
+			"referenceSources": [
+				"DC",
+				"RoT",
+				"SKT",
+				"SLW",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Call Lightning|XPHB"
 			],
@@ -2516,6 +2825,18 @@
 			"source": "PHB",
 			"page": 221,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"IDRotF",
+				"OotA",
+				"SDW",
+				"ToFW",
+				"VEoR",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Calm Emotions|XPHB"
 			],
@@ -2569,6 +2890,17 @@
 			"page": 221,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"AitFR-ISF",
+				"CM",
+				"DC",
+				"OotA",
+				"PaBTSO",
+				"RoT",
+				"SDW",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Chain Lightning|XPHB"
 			],
@@ -2638,6 +2970,25 @@
 					"page": 51
 				}
 			],
+			"referenceSources": [
+				"AZfyT",
+				"BGDIA",
+				"CM",
+				"CoS",
+				"DIP",
+				"IDRotF",
+				"KftGV",
+				"LR",
+				"PaBTSO",
+				"RoT",
+				"SDW",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Charm Person|XPHB"
 			],
@@ -2703,6 +3054,10 @@
 			"source": "PHB",
 			"page": 221,
 			"srd": true,
+			"referenceSources": [
+				"CRCotN",
+				"IDRotF"
+			],
 			"reprintedAs": [
 				"Chill Touch|XPHB"
 			],
@@ -2765,6 +3120,9 @@
 			"name": "Chromatic Orb",
 			"source": "PHB",
 			"page": 221,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Chromatic Orb|XPHB"
 			],
@@ -2831,6 +3189,11 @@
 			"source": "PHB",
 			"page": 221,
 			"srd": true,
+			"referenceSources": [
+				"KftGV",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Circle of Death|XPHB"
 			],
@@ -2934,6 +3297,18 @@
 			"source": "PHB",
 			"page": 222,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"JttRC",
+				"KftGV",
+				"SCC-ARiR",
+				"SKT",
+				"TftYP-WPM",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Clairvoyance|XPHB"
 			],
@@ -2981,6 +3356,9 @@
 			"source": "PHB",
 			"page": 222,
 			"srd": true,
+			"referenceSources": [
+				"LoX"
+			],
 			"reprintedAs": [
 				"Clone|XPHB"
 			],
@@ -3024,6 +3402,14 @@
 			"name": "Cloud of Daggers",
 			"source": "PHB",
 			"page": 222,
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"IDRotF",
+				"RoT",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Cloud of Daggers|XPHB"
 			],
@@ -3081,6 +3467,23 @@
 			"source": "PHB",
 			"page": 222,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"CoS",
+				"GoS",
+				"IDRotF",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SCC-CK",
+				"SKT",
+				"TftYP-AtG",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Cloudkill|XPHB"
 			],
@@ -3146,6 +3549,13 @@
 			"source": "PHB",
 			"page": 222,
 			"srd": true,
+			"referenceSources": [
+				"OotA",
+				"QftIS",
+				"TftYP-TFoF",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Color Spray|XPHB"
 			],
@@ -3209,6 +3619,21 @@
 					"source": "RMR",
 					"page": 51
 				}
+			],
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"DoSI",
+				"GoS",
+				"HotDQ",
+				"OoW",
+				"QftIS",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-TSC",
+				"US",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Command|XPHB"
@@ -3323,6 +3748,21 @@
 			"page": 223,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CRCotN",
+				"GoS",
+				"HotDQ",
+				"OotA",
+				"RoT",
+				"TftYP-ToH",
+				"ToA",
+				"US",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Commune|XPHB"
 			],
@@ -3368,6 +3808,10 @@
 			"source": "PHB",
 			"page": 224,
 			"srd": true,
+			"referenceSources": [
+				"SKT",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Commune with Nature|XPHB"
 			],
@@ -3474,6 +3918,26 @@
 					"page": 52
 				}
 			],
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"DIP",
+				"EFR",
+				"FS",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"PaBTSO",
+				"QftIS",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-ToH",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Comprehend Languages|XPHB"
 			],
@@ -3571,6 +4035,26 @@
 			"page": 224,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"DC",
+				"IDRotF",
+				"KftGV",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"RtG",
+				"SDW",
+				"SKT",
+				"SLW",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Cone of Cold|XPHB"
 			],
@@ -3627,6 +4111,19 @@
 			"source": "PHB",
 			"page": 224,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"HotDQ",
+				"IDRotF",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"SKT",
+				"TftYP-DiT",
+				"ToFW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Confusion|XPHB"
 			],
@@ -3742,6 +4239,15 @@
 			"source": "PHB",
 			"page": 225,
 			"srd": true,
+			"referenceSources": [
+				"IDRotF",
+				"JttRC",
+				"LR",
+				"OotA",
+				"SKT",
+				"US",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Conjure Animals|XPHB"
 			],
@@ -3850,6 +4356,9 @@
 			"source": "PHB",
 			"page": 225,
 			"srd": true,
+			"referenceSources": [
+				"WDH"
+			],
 			"reprintedAs": [
 				"Conjure Celestial|XPHB"
 			],
@@ -3906,6 +4415,13 @@
 			"source": "PHB",
 			"page": 225,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"IDRotF",
+				"PotA",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Conjure Elemental|XPHB"
 			],
@@ -3963,6 +4479,10 @@
 			"source": "PHB",
 			"page": 226,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"WBtW"
+			],
 			"reprintedAs": [
 				"Conjure Fey|XPHB"
 			],
@@ -4020,6 +4540,12 @@
 			"source": "PHB",
 			"page": 226,
 			"srd": true,
+			"referenceSources": [
+				"OotA",
+				"SjA",
+				"SKT",
+				"TftYP-WPM"
+			],
 			"reprintedAs": [
 				"Conjure Minor Elementals|XPHB"
 			],
@@ -4053,7 +4579,7 @@
 				}
 			],
 			"entries": [
-				"You summon elementals that appear in unoccupied spaces that you can see within range. You choose one the following options for what appears:",
+				"You summon elementals that appear in unoccupied spaces that you can see within range. You choose one of the following options for what appears:",
 				{
 					"type": "list",
 					"items": [
@@ -4128,6 +4654,10 @@
 			"source": "PHB",
 			"page": 226,
 			"srd": true,
+			"referenceSources": [
+				"SKT",
+				"WBtW"
+			],
 			"reprintedAs": [
 				"Conjure Woodland Beings|XPHB"
 			],
@@ -4195,6 +4725,16 @@
 			"source": "PHB",
 			"page": 226,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Contact Other Plane|XPHB"
 			],
@@ -4243,6 +4783,12 @@
 			"source": "PHB",
 			"page": 227,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"CoS",
+				"OotA",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Contagion|XPHB"
 			],
@@ -4385,6 +4931,39 @@
 			"source": "PHB",
 			"page": 227,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"DSotDQ",
+				"FS",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"KKW",
+				"LoX",
+				"LRDT",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SCC-ARiR",
+				"SCC-CK",
+				"SCC-TMM",
+				"SDW",
+				"SjA",
+				"SKT",
+				"TftYP-TSC",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Continual Flame|XPHB"
 			],
@@ -4432,6 +5011,15 @@
 			"source": "PHB",
 			"page": 227,
 			"srd": true,
+			"referenceSources": [
+				"DitLCoT",
+				"GoS",
+				"JttRC",
+				"OotA",
+				"QftIS",
+				"WBtW",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Control Water|XPHB"
 			],
@@ -4522,6 +5110,11 @@
 			"source": "PHB",
 			"page": 228,
 			"srd": true,
+			"referenceSources": [
+				"IDRotF",
+				"SKT",
+				"TTP"
+			],
 			"reprintedAs": [
 				"Control Weather|XPHB"
 			],
@@ -4732,6 +5325,19 @@
 			"page": 228,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"CoS",
+				"KftGV",
+				"LR",
+				"RtG",
+				"SKT",
+				"TftYP-DiT",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Counterspell|XPHB"
 			],
@@ -4780,6 +5386,12 @@
 			"source": "PHB",
 			"page": 229,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"OotA",
+				"SDW",
+				"SKT"
+			],
 			"reprintedAs": [
 				"Create Food and Water|XPHB"
 			],
@@ -4816,6 +5428,11 @@
 			"source": "PHB",
 			"page": 229,
 			"srd": true,
+			"referenceSources": [
+				"PaBTSO",
+				"QftIS",
+				"TftYP-ToH"
+			],
 			"reprintedAs": [
 				"Create or Destroy Water|XPHB"
 			],
@@ -4882,6 +5499,10 @@
 			"source": "PHB",
 			"page": 229,
 			"srd": true,
+			"referenceSources": [
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Create Undead|XPHB"
 			],
@@ -4941,6 +5562,9 @@
 			"source": "PHB",
 			"page": 229,
 			"srd": true,
+			"referenceSources": [
+				"RtG"
+			],
 			"reprintedAs": [
 				"Creation|XPHB"
 			],
@@ -5022,6 +5646,11 @@
 			"name": "Crown of Madness",
 			"source": "PHB",
 			"page": 229,
+			"referenceSources": [
+				"KftGV",
+				"OotA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Crown of Madness|XPHB"
 			],
@@ -5079,6 +5708,9 @@
 			"name": "Crusader's Mantle",
 			"source": "PHB",
 			"page": 230,
+			"referenceSources": [
+				"CoS"
+			],
 			"reprintedAs": [
 				"Crusader's Mantle|XPHB"
 			],
@@ -5134,6 +5766,26 @@
 					"source": "RMR",
 					"page": 52
 				}
+			],
+			"referenceSources": [
+				"BGDIA",
+				"CRCotN",
+				"DC",
+				"DSotDQ",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"RMBRE",
+				"RoT",
+				"SDW",
+				"SKT",
+				"SLW",
+				"TftYP-AtG",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"ToFW",
+				"ToR",
+				"US"
 			],
 			"reprintedAs": [
 				"Cure Wounds|XPHB"
@@ -5206,6 +5858,15 @@
 					"page": 52
 				}
 			],
+			"referenceSources": [
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"ToA",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Dancing Lights|XPHB"
 			],
@@ -5260,6 +5921,26 @@
 					"page": 52
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"LMoP",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"RtG",
+				"SDW",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-THSoT",
+				"TftYP-WPM",
+				"ToA",
+				"ToFW",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Darkness|XPHB"
 			],
@@ -5298,7 +5979,8 @@
 				"If any of this spell's area overlaps with an area of light created by a spell of 2nd level or lower, the spell that created the light is dispelled."
 			],
 			"miscTags": [
-				"OBJ"
+				"OBJ",
+				"OBS"
 			],
 			"areaTags": [
 				"S"
@@ -5309,6 +5991,17 @@
 			"source": "PHB",
 			"page": 230,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"IDRotF",
+				"QftIS",
+				"SKT",
+				"TftYP-DiT",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Darkvision|XPHB"
 			],
@@ -5352,6 +6045,12 @@
 			"source": "PHB",
 			"page": 230,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"HotDQ",
+				"QftIS",
+				"TftYP-DiT"
+			],
 			"reprintedAs": [
 				"Daylight|XPHB"
 			],
@@ -5402,6 +6101,11 @@
 			"page": 230,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoA",
+				"IDRotF",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Death Ward|XPHB"
 			],
@@ -5447,6 +6151,10 @@
 			"page": 230,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"TftYP-AtG",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Delayed Blast Fireball|XPHB"
 			],
@@ -5513,6 +6221,10 @@
 			"source": "PHB",
 			"page": 231,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"KftGV"
+			],
 			"reprintedAs": [
 				"Demiplane|XPHB"
 			],
@@ -5557,6 +6269,9 @@
 			"name": "Destructive Wave",
 			"source": "PHB",
 			"page": 231,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Destructive Wave|XPHB"
 			],
@@ -5607,6 +6322,19 @@
 			"source": "PHB",
 			"page": 231,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"IDRotF",
+				"JttRC",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Detect Evil and Good|XPHB"
 			],
@@ -5662,6 +6390,55 @@
 					"source": "RMR",
 					"page": 52
 				}
+			],
+			"referenceSources": [
+				"AitFR-THP",
+				"BGDIA",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DIP",
+				"DoSI",
+				"DSotDQ",
+				"EFR",
+				"FS",
+				"GoS",
+				"HFStCM",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"LK",
+				"LMoP",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RMBRE",
+				"RoT",
+				"RtG",
+				"SCC-ARiR",
+				"SCC-TMM",
+				"SDW",
+				"SjA",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM",
+				"ToA",
+				"ToFW",
+				"TTP",
+				"VEoR",
+				"VNotEE",
+				"WBtW",
+				"WDH",
+				"WDMM",
+				"XMtS"
 			],
 			"reprintedAs": [
 				"Detect Magic|XPHB"
@@ -5752,6 +6529,22 @@
 			"source": "PHB",
 			"page": 231,
 			"srd": true,
+			"referenceSources": [
+				"CRCotN",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"RtG",
+				"SDW",
+				"SjA",
+				"SKT",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Detect Thoughts|XPHB"
 			],
@@ -5807,6 +6600,24 @@
 			"page": 233,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"DSotDQ",
+				"HotDQ",
+				"KftGV",
+				"LoX",
+				"LRDT",
+				"OotA",
+				"PaBTSO",
+				"SCC-ARiR",
+				"SDW",
+				"TftYP-DiT",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Dimension Door|XPHB"
 			],
@@ -5852,6 +6663,23 @@
 			"page": 233,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"AZfyT",
+				"BGDIA",
+				"CoS",
+				"DSotDQ",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"QftIS",
+				"SKT",
+				"SLW",
+				"TftYP-TFoF",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Disguise Self|XPHB"
 			],
@@ -5900,6 +6728,26 @@
 			"page": 233,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"PaBTSO",
+				"QftIS",
+				"RoT",
+				"SDW",
+				"SjA",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Disintegrate|XPHB"
 			],
@@ -5962,6 +6810,16 @@
 			"source": "PHB",
 			"page": 233,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"KftGV",
+				"OotA",
+				"QftIS",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Dispel Evil and Good|XPHB"
 			],
@@ -6040,6 +6898,46 @@
 					"source": "RMR",
 					"page": 53
 				}
+			],
+			"referenceSources": [
+				"AZfyT",
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DitLCoT",
+				"DSotDQ",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LR",
+				"LRDT",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SDW",
+				"SjA",
+				"SKT",
+				"SLW",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"ToA",
+				"TTP",
+				"US",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Dispel Magic|XPHB"
@@ -6145,6 +7043,25 @@
 			"page": 234,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"QftIS",
+				"SKT",
+				"ToA",
+				"US",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Divination|XPHB"
 			],
@@ -6190,6 +7107,9 @@
 			"source": "PHB",
 			"page": 234,
 			"srd": true,
+			"referenceSources": [
+				"CoS"
+			],
 			"reprintedAs": [
 				"Divine Favor|XPHB"
 			],
@@ -6236,6 +7156,10 @@
 			"source": "PHB",
 			"page": 234,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"TftYP-AtG"
+			],
 			"reprintedAs": [
 				"Divine Word|XPHB"
 			],
@@ -6364,6 +7288,15 @@
 			"page": 235,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"IDRotF",
+				"IMR",
+				"OoW",
+				"SKT",
+				"ToFW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Dominate Monster|XPHB"
 			],
@@ -6430,6 +7363,11 @@
 			"page": 235,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Dominate Person|XPHB"
 			],
@@ -6498,6 +7436,10 @@
 			"source": "PHB",
 			"page": 235,
 			"srd": "Instant Summons",
+			"referenceSources": [
+				"OotA",
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Drawmij's Instant Summons|XPHB"
 			],
@@ -6550,6 +7492,12 @@
 			"page": 236,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"PotA",
+				"RoT",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Dream|XPHB"
 			],
@@ -6599,6 +7547,12 @@
 			"source": "PHB",
 			"page": 236,
 			"srd": true,
+			"referenceSources": [
+				"IDRotF",
+				"SKT",
+				"TftYP-TSC",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Druidcraft|XPHB"
 			],
@@ -6645,6 +7599,14 @@
 			"page": 236,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CRCotN",
+				"LLK",
+				"OotA",
+				"PotA",
+				"RoT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Earthquake|XPHB"
 			],
@@ -6726,6 +7688,9 @@
 			"page": 237,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"ToA"
+			],
 			"reprintedAs": [
 				"Eldritch Blast|XPHB"
 			],
@@ -6834,6 +7799,10 @@
 			"source": "PHB",
 			"page": 237,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Enhance Ability|XPHB"
 			],
@@ -6934,6 +7903,15 @@
 			"source": "PHB",
 			"page": 237,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"LK",
+				"OotA",
+				"RoT",
+				"TftYP-TFoF",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Enlarge/Reduce|XPHB"
 			],
@@ -7062,6 +8040,13 @@
 			"source": "PHB",
 			"page": 238,
 			"srd": true,
+			"referenceSources": [
+				"AZfyT",
+				"LR",
+				"SKT",
+				"TftYP-TSC",
+				"US"
+			],
 			"reprintedAs": [
 				"Entangle|XPHB"
 			],
@@ -7167,6 +8152,16 @@
 			"page": 238,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoS",
+				"DC",
+				"GoS",
+				"SKT",
+				"ToA",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Etherealness|XPHB"
 			],
@@ -7227,6 +8222,17 @@
 			"source": "PHB",
 			"page": 238,
 			"srd": "Black Tentacles",
+			"referenceSources": [
+				"HotDQ",
+				"IDRotF",
+				"LR",
+				"OotA",
+				"QftIS",
+				"RoT",
+				"SKT",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Evard's Black Tentacles|XPHB"
 			],
@@ -7290,6 +8296,12 @@
 			"source": "PHB",
 			"page": 238,
 			"srd": true,
+			"referenceSources": [
+				"IDRotF",
+				"SDW",
+				"TftYP-TSC",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Expeditious Retreat|XPHB"
 			],
@@ -7333,6 +8345,11 @@
 			"source": "PHB",
 			"page": 238,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"OotA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Eyebite|XPHB"
 			],
@@ -7407,6 +8424,15 @@
 			"source": "PHB",
 			"page": 239,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"IDRotF",
+				"OotA",
+				"SKT",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Fabricate|XPHB"
 			],
@@ -7451,6 +8477,16 @@
 			"page": 239,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"DSotDQ",
+				"IDRotF",
+				"OotA",
+				"TftYP-TSC",
+				"ToA",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Faerie Fire|XPHB"
 			],
@@ -7502,6 +8538,13 @@
 			"source": "PHB",
 			"page": 239,
 			"srd": true,
+			"referenceSources": [
+				"AZfyT",
+				"KftGV",
+				"SCC-ARiR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"False Life|XPHB"
 			],
@@ -7554,6 +8597,19 @@
 			"source": "PHB",
 			"page": 239,
 			"srd": true,
+			"referenceSources": [
+				"AitFR-AVT",
+				"CM",
+				"GoS",
+				"OotA",
+				"SCC-ARiR",
+				"TftYP-AtG",
+				"TftYP-THSoT",
+				"TftYP-WPM",
+				"ToA",
+				"US",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Fear|XPHB"
 			],
@@ -7612,6 +8668,19 @@
 					"page": 53
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"DSotDQ",
+				"EFR",
+				"HotDQ",
+				"PotA",
+				"SjA",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Feather Fall|XPHB"
 			],
@@ -7656,6 +8725,14 @@
 			"source": "PHB",
 			"page": 239,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"OotA",
+				"PaBTSO",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Befuddlement|XPHB"
 			],
@@ -7707,6 +8784,12 @@
 			"name": "Feign Death",
 			"source": "PHB",
 			"page": 240,
+			"referenceSources": [
+				"JttRC",
+				"OotA",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Feign Death|XPHB"
 			],
@@ -7772,6 +8855,18 @@
 			"source": "PHB",
 			"page": 240,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"DC",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"OotA",
+				"QftIS",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Find Familiar|XPHB"
 			],
@@ -7826,6 +8921,10 @@
 			"source": "PHB",
 			"page": 240,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoS"
+			],
 			"reprintedAs": [
 				"Find Steed|XPHB"
 			],
@@ -7871,6 +8970,13 @@
 			"page": 240,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"SKT",
+				"ToA",
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Find the Path|XPHB"
 			],
@@ -7916,6 +9022,11 @@
 			"source": "PHB",
 			"page": 241,
 			"srd": true,
+			"referenceSources": [
+				"QftIS",
+				"TftYP-ToH",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Find Traps|XPHB"
 			],
@@ -7957,6 +9068,13 @@
 			"page": 241,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoA",
+				"CoS",
+				"TftYP-AtG",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Finger of Death|XPHB"
 			],
@@ -8012,6 +9130,15 @@
 			"page": 242,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"OotA",
+				"RMBRE",
+				"TftYP-TFoF",
+				"TftYP-WPM",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Fire Bolt|XPHB"
 			],
@@ -8071,6 +9198,15 @@
 			"source": "PHB",
 			"page": 242,
 			"srd": true,
+			"referenceSources": [
+				"KftGV",
+				"OotA",
+				"QftIS",
+				"RoT",
+				"RtG",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Fire Shield|XPHB"
 			],
@@ -8180,6 +9316,32 @@
 					"source": "RMR",
 					"page": 53
 				}
+			],
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"CoS",
+				"DC",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"RMBRE",
+				"SCC-CK",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Fireball|XPHB"
@@ -8307,6 +9469,9 @@
 			"page": 242,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Flame Strike|XPHB"
 			],
@@ -8369,6 +9534,12 @@
 					"source": "RMR",
 					"page": 53
 				}
+			],
+			"referenceSources": [
+				"DoSI",
+				"GoS",
+				"TftYP-TSC",
+				"ToA"
 			],
 			"reprintedAs": [
 				"Flaming Sphere|XPHB"
@@ -8437,6 +9608,13 @@
 			"source": "PHB",
 			"page": 243,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"IDRotF",
+				"OotA",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Flesh to Stone|XPHB"
 			],
@@ -8503,6 +9681,31 @@
 					"page": 54
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"DSotDQ",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"PotA",
+				"QftIS",
+				"RtG",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-WPM",
+				"ToFW",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Fly|XPHB"
 			],
@@ -8559,6 +9762,19 @@
 			"source": "PHB",
 			"page": 243,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"DD",
+				"IDRotF",
+				"KftGV",
+				"OoW",
+				"QftIS",
+				"SCC-ARiR",
+				"SDW",
+				"US",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Fog Cloud|XPHB"
 			],
@@ -8615,6 +9831,10 @@
 			"source": "PHB",
 			"page": 243,
 			"srd": true,
+			"referenceSources": [
+				"DC",
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Forbiddance|XPHB"
 			],
@@ -8680,6 +9900,10 @@
 			"source": "PHB",
 			"page": 243,
 			"srd": true,
+			"referenceSources": [
+				"OotA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Forcecage|XPHB"
 			],
@@ -8736,6 +9960,9 @@
 			"page": 244,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"SKT"
+			],
 			"reprintedAs": [
 				"Foresight|XPHB"
 			],
@@ -8784,6 +10011,11 @@
 			"page": 244,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"LR",
+				"PaBTSO",
+				"SKT"
+			],
 			"reprintedAs": [
 				"Freedom of Movement|XPHB"
 			],
@@ -8831,6 +10063,12 @@
 			"name": "Friends",
 			"source": "PHB",
 			"page": 244,
+			"referenceSources": [
+				"CoS",
+				"IDRotF",
+				"OotA",
+				"US"
+			],
 			"reprintedAs": [
 				"Friends|XPHB"
 			],
@@ -8877,6 +10115,18 @@
 			"source": "PHB",
 			"page": 244,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"GoS",
+				"JttRC",
+				"OotA",
+				"PotA",
+				"RoT",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Gaseous Form|XPHB"
 			],
@@ -8927,6 +10177,16 @@
 			"page": 244,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"LLK",
+				"TftYP-AtG",
+				"ToA",
+				"ToFW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Gate|XPHB"
 			],
@@ -8980,6 +10240,18 @@
 			"source": "PHB",
 			"page": 244,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"JttRC",
+				"LLK",
+				"SKT",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Geas|XPHB"
 			],
@@ -9046,6 +10318,12 @@
 			"source": "PHB",
 			"page": 245,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"DSotDQ",
+				"WBtW",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Gentle Repose|XPHB"
 			],
@@ -9140,6 +10418,10 @@
 			"source": "PHB",
 			"page": 245,
 			"srd": true,
+			"referenceSources": [
+				"ToFW",
+				"WBtW"
+			],
 			"reprintedAs": [
 				"Glibness|XPHB"
 			],
@@ -9179,6 +10461,15 @@
 			"page": 245,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"RtG",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Globe of Invulnerability|XPHB"
 			],
@@ -9237,6 +10528,35 @@
 			"source": "PHB",
 			"page": 245,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"GoS",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"KKW",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"RoT",
+				"SCC-ARiR",
+				"SCC-HfMT",
+				"SDW",
+				"SjA",
+				"SKT",
+				"SLW",
+				"TftYP-AtG",
+				"TftYP-THSoT",
+				"TftYP-TSC",
+				"TftYP-WPM",
+				"ToA",
+				"TTP",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Glyph of Warding|XPHB"
 			],
@@ -9324,6 +10644,13 @@
 			"source": "PHB",
 			"page": 246,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"OotA",
+				"SKT",
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Goodberry|XPHB"
 			],
@@ -9363,6 +10690,9 @@
 			"name": "Grasping Vine",
 			"source": "PHB",
 			"page": 246,
+			"referenceSources": [
+				"SKT"
+			],
 			"reprintedAs": [
 				"Grasping Vine|XPHB"
 			],
@@ -9416,6 +10746,14 @@
 			"source": "PHB",
 			"page": 246,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"LoX",
+				"OotA",
+				"QftIS",
+				"SCC-HfMT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Grease|XPHB"
 			],
@@ -9471,6 +10809,20 @@
 			"page": 246,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"DC",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"RoT",
+				"SKT",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Greater Invisibility|XPHB"
 			],
@@ -9518,6 +10870,36 @@
 			"page": 246,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"AitFR-DN",
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"LLK",
+				"LoX",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SKT",
+				"SLW",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Greater Restoration|XPHB"
 			],
@@ -9571,6 +10953,9 @@
 			"page": 246,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM"
+			],
 			"reprintedAs": [
 				"Guardian of Faith|XPHB"
 			],
@@ -9621,6 +11006,12 @@
 			"source": "PHB",
 			"page": 248,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"IMR",
+				"OotA",
+				"SKT"
+			],
 			"reprintedAs": [
 				"Guards and Wards|XPHB"
 			],
@@ -9721,6 +11112,14 @@
 					"page": 54
 				}
 			],
+			"referenceSources": [
+				"CM",
+				"SKT",
+				"ToA",
+				"TTP",
+				"US",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Guidance|XPHB"
 			],
@@ -9770,6 +11169,12 @@
 					"source": "RMR",
 					"page": 54
 				}
+			],
+			"referenceSources": [
+				"TftYP-TSC",
+				"ToR",
+				"TTP",
+				"US"
 			],
 			"reprintedAs": [
 				"Guiding Bolt|XPHB"
@@ -9832,6 +11237,24 @@
 			"source": "PHB",
 			"page": 248,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"GoS",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"SCC-ARiR",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"ToA",
+				"ToFW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Gust of Wind|XPHB"
 			],
@@ -9943,6 +11366,16 @@
 			"source": "PHB",
 			"page": 249,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"DSotDQ",
+				"GoS",
+				"HoL",
+				"OotA",
+				"PotA",
+				"QftIS",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Hallow|XPHB"
 			],
@@ -10080,7 +11513,8 @@
 				"charisma"
 			],
 			"miscTags": [
-				"LGT"
+				"LGT",
+				"OBS"
 			]
 		},
 		{
@@ -10088,6 +11522,14 @@
 			"source": "PHB",
 			"page": 249,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"IDRotF",
+				"OotA",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Hallucinatory Terrain|XPHB"
 			],
@@ -10137,6 +11579,9 @@
 			"page": 249,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"TftYP-DiT"
+			],
 			"reprintedAs": [
 				"Harm|XPHB"
 			],
@@ -10185,6 +11630,16 @@
 			"source": "PHB",
 			"page": 250,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"LoX",
+				"PotA",
+				"RoT",
+				"SKT",
+				"TftYP-WPM",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Haste|XPHB"
 			],
@@ -10237,6 +11692,16 @@
 			"page": 250,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"DSotDQ",
+				"LR",
+				"QftIS",
+				"SDW",
+				"TftYP-AtG",
+				"TftYP-ToH"
+			],
 			"reprintedAs": [
 				"Heal|XPHB"
 			],
@@ -10375,6 +11840,11 @@
 			"source": "PHB",
 			"page": 250,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"TftYP-THSoT",
+				"TftYP-ToH"
+			],
 			"reprintedAs": [
 				"Heat Metal|XPHB"
 			],
@@ -10441,6 +11911,10 @@
 			"source": "PHB",
 			"page": 250,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoA"
+			],
 			"reprintedAs": [
 				"Hellish Rebuke|XPHB"
 			],
@@ -10500,6 +11974,13 @@
 			"page": 250,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"QftIS",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Heroes' Feast|XPHB"
 			],
@@ -10676,6 +12157,15 @@
 			"source": "PHB",
 			"page": 251,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"LRDT",
+				"OotA",
+				"RoT",
+				"SDW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Hold Monster|XPHB"
 			],
@@ -10762,6 +12252,26 @@
 					"page": 54
 				}
 			],
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"CoS",
+				"DIP",
+				"DoSI",
+				"GoS",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"RoT",
+				"TftYP-AtG",
+				"TftYP-TFoF",
+				"TftYP-THSoT",
+				"TftYP-WPM",
+				"ToA",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Hold Person|XPHB"
 			],
@@ -10830,6 +12340,9 @@
 			"page": 251,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"DC"
+			],
 			"reprintedAs": [
 				"Holy Aura|XPHB"
 			],
@@ -10934,7 +12447,8 @@
 				"dexterity"
 			],
 			"miscTags": [
-				"DFT"
+				"DFT",
+				"OBS"
 			],
 			"areaTags": [
 				"S"
@@ -10945,6 +12459,9 @@
 			"source": "PHB",
 			"page": 251,
 			"srd": true,
+			"referenceSources": [
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Hunter's Mark|XPHB"
 			],
@@ -11003,6 +12520,11 @@
 			"source": "PHB",
 			"page": 252,
 			"srd": true,
+			"referenceSources": [
+				"SCC-ARiR",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Hypnotic Pattern|XPHB"
 			],
@@ -11056,6 +12578,18 @@
 			"page": 252,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"IDRotF",
+				"KftGV",
+				"LRDT",
+				"PotA",
+				"SKT",
+				"TftYP-WPM",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Ice Storm|XPHB"
 			],
@@ -11120,6 +12654,33 @@
 					"page": 54
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"DitLCoT",
+				"GoS",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"LMoP",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"RMBRE",
+				"RtG",
+				"SKT",
+				"TftYP-DiT",
+				"ToA",
+				"TTP",
+				"VNotEE",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Identify|XPHB"
 			],
@@ -11169,6 +12730,12 @@
 			"source": "PHB",
 			"page": 252,
 			"srd": true,
+			"referenceSources": [
+				"IDRotF",
+				"JttRC",
+				"QftIS",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Illusory Script|XPHB"
 			],
@@ -11219,6 +12786,13 @@
 			"page": 252,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"OotA",
+				"ToFW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Imprisonment|XPHB"
 			],
@@ -11325,6 +12899,10 @@
 			"source": "PHB",
 			"page": 253,
 			"srd": true,
+			"referenceSources": [
+				"OotA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Incendiary Cloud|XPHB"
 			],
@@ -11387,6 +12965,11 @@
 					"page": 55
 				}
 			],
+			"referenceSources": [
+				"TftYP-TSC",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Inflict Wounds|XPHB"
 			],
@@ -11440,6 +13023,11 @@
 			"source": "PHB",
 			"page": 254,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"OotA",
+				"TftYP-AtG"
+			],
 			"reprintedAs": [
 				"Insect Plague|XPHB"
 			],
@@ -11513,6 +13101,31 @@
 					"page": 55
 				}
 			],
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"LMoP",
+				"LoX",
+				"LRDT",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"RoT",
+				"SDW",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"TftYP-WPM",
+				"ToA",
+				"ToFW",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Invisibility|XPHB"
 			],
@@ -11572,6 +13185,14 @@
 			"source": "PHB",
 			"page": 254,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"LRDT",
+				"OotA",
+				"SKT",
+				"TftYP-WPM",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Jump|XPHB"
 			],
@@ -11616,6 +13237,37 @@
 			"page": 254,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"DSotDQ",
+				"HotDQ",
+				"IDRotF",
+				"KftGV",
+				"LRDT",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SDW",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM",
+				"ToA",
+				"TTP",
+				"VEoR",
+				"VNotEE",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Knock|XPHB"
 			],
@@ -11658,6 +13310,22 @@
 			"source": "PHB",
 			"page": 254,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"DC",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"RoT",
+				"SDW",
+				"SKT",
+				"SLW",
+				"TftYP-ToH",
+				"ToA",
+				"TTP",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Legend Lore|XPHB"
 			],
@@ -11702,6 +13370,14 @@
 			"source": "PHB",
 			"page": 254,
 			"srd": "Secret Chest",
+			"referenceSources": [
+				"IDRotF",
+				"OotA",
+				"SKT",
+				"VEoR",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Leomund's Secret Chest|XPHB"
 			],
@@ -11747,6 +13423,13 @@
 			"source": "PHB",
 			"page": 255,
 			"srd": "Tiny Hut",
+			"referenceSources": [
+				"IDRotF",
+				"IMR",
+				"ToA",
+				"TTP",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Leomund's Tiny Hut|XPHB"
 			],
@@ -11803,6 +13486,30 @@
 					"page": 55
 				}
 			],
+			"referenceSources": [
+				"AitFR-AVT",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DoSI",
+				"DSotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SDW",
+				"SLW",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-TFoF",
+				"ToA",
+				"US",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Lesser Restoration|XPHB"
 			],
@@ -11842,6 +13549,23 @@
 			"page": 255,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"AitFR-DN",
+				"CM",
+				"CoS",
+				"DitLCoT",
+				"DSotDQ",
+				"IDRotF",
+				"OotA",
+				"QftIS",
+				"RoT",
+				"SKT",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Levitate|XPHB"
 			],
@@ -11902,6 +13626,23 @@
 					"source": "RMR",
 					"page": 55
 				}
+			],
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"CRCotN",
+				"GoS",
+				"HotDQ",
+				"IMR",
+				"KftGV",
+				"LLK",
+				"OotA",
+				"PaBTSO",
+				"RtG",
+				"SDW",
+				"TftYP-WPM",
+				"US",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Light|XPHB"
@@ -12016,6 +13757,29 @@
 					"page": 56
 				}
 			],
+			"referenceSources": [
+				"CoA",
+				"CoS",
+				"DC",
+				"DIP",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"LMoP",
+				"LR",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"RMBRE",
+				"RtG",
+				"SDW",
+				"SKT",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Lightning Bolt|XPHB"
 			],
@@ -12075,6 +13839,9 @@
 			"source": "PHB",
 			"page": 256,
 			"srd": true,
+			"referenceSources": [
+				"SKT"
+			],
 			"reprintedAs": [
 				"Locate Animals or Plants|XPHB"
 			],
@@ -12119,6 +13886,14 @@
 			"page": 256,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"OotA",
+				"SKT",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Locate Creature|XPHB"
 			],
@@ -12162,6 +13937,17 @@
 			"source": "PHB",
 			"page": 256,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"CoS",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"QftIS",
+				"SKT",
+				"XMtS"
+			],
 			"reprintedAs": [
 				"Locate Object|XPHB"
 			],
@@ -12208,6 +13994,9 @@
 			"source": "PHB",
 			"page": 256,
 			"srd": true,
+			"referenceSources": [
+				"CRCotN"
+			],
 			"reprintedAs": [
 				"Longstrider|XPHB"
 			],
@@ -12270,6 +14059,25 @@
 					"page": 56
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"DIP",
+				"IDRotF",
+				"KftGV",
+				"LMoP",
+				"LR",
+				"LRDT",
+				"OotA",
+				"RtG",
+				"SKT",
+				"TftYP-TSC",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mage Armor|XPHB"
 			],
@@ -12323,6 +14131,27 @@
 					"page": 56
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"DIP",
+				"IDRotF",
+				"KftGV",
+				"LK",
+				"LoX",
+				"NRH-TLT",
+				"OoW",
+				"QftIS",
+				"RMBRE",
+				"SDW",
+				"SjA",
+				"SKT",
+				"TftYP-TFoF",
+				"TftYP-WPM",
+				"ToA",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mage Hand|XPHB"
 			],
@@ -12368,6 +14197,10 @@
 			"source": "PHB",
 			"page": 256,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Magic Circle|XPHB"
 			],
@@ -12448,6 +14281,10 @@
 			"source": "PHB",
 			"page": 257,
 			"srd": true,
+			"referenceSources": [
+				"RoT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Magic Jar|XPHB"
 			],
@@ -12512,6 +14349,28 @@
 					"page": 57
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"DIP",
+				"IDRotF",
+				"KftGV",
+				"LoX",
+				"LRDT",
+				"PaBTSO",
+				"QftIS",
+				"RMBRE",
+				"RtG",
+				"SKT",
+				"TftYP-THSoT",
+				"TftYP-WPM",
+				"ToR",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Magic Missile|XPHB"
 			],
@@ -12568,6 +14427,22 @@
 			"source": "PHB",
 			"page": 257,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"GoS",
+				"KftGV",
+				"OotA",
+				"QftIS",
+				"RoT",
+				"TftYP-AtG",
+				"TftYP-TFoF",
+				"TftYP-ToH",
+				"TftYP-TSC",
+				"TftYP-WPM",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Magic Mouth|XPHB"
 			],
@@ -12622,6 +14497,17 @@
 			"page": 257,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"KftGV",
+				"OotA",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-ToH",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Magic Weapon|XPHB"
 			],
@@ -12672,6 +14558,18 @@
 			"page": 258,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoS",
+				"GoS",
+				"IDRotF",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"TftYP-THSoT",
+				"ToA",
+				"VEoR",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Major Image|XPHB"
 			],
@@ -12733,6 +14631,13 @@
 			"page": 258,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoS",
+				"IDRotF",
+				"SDW",
+				"SLW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mass Cure Wounds|XPHB"
 			],
@@ -12800,6 +14705,9 @@
 			"page": 258,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoA"
+			],
 			"reprintedAs": [
 				"Mass Heal|XPHB"
 			],
@@ -12863,6 +14771,9 @@
 					"source": "RMR",
 					"page": 57
 				}
+			],
+			"referenceSources": [
+				"BGDIA"
 			],
 			"reprintedAs": [
 				"Mass Healing Word|XPHB"
@@ -12930,6 +14841,12 @@
 			"page": 258,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"IMR",
+				"SKT",
+				"WBtW",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Mass Suggestion|XPHB"
 			],
@@ -12992,6 +14909,12 @@
 			"page": 258,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CoS",
+				"OotA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Maze|XPHB"
 			],
@@ -13044,6 +14967,11 @@
 			"source": "PHB",
 			"page": 259,
 			"srd": true,
+			"referenceSources": [
+				"KftGV",
+				"SKT",
+				"WBtW"
+			],
 			"reprintedAs": [
 				"Meld into Stone|XPHB"
 			],
@@ -13094,6 +15022,12 @@
 			"source": "PHB",
 			"page": 259,
 			"srd": "Acid Arrow",
+			"referenceSources": [
+				"HotDQ",
+				"TftYP-DiT",
+				"TftYP-TSC",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Melf's Acid Arrow|XPHB"
 			],
@@ -13149,6 +15083,23 @@
 			"source": "PHB",
 			"page": 259,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"GoS",
+				"HotDQ",
+				"IDRotF",
+				"IMR",
+				"OotA",
+				"OoW",
+				"SCC-ARiR",
+				"SDW",
+				"SKT",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mending|XPHB"
 			],
@@ -13189,6 +15140,16 @@
 			"source": "PHB",
 			"page": 259,
 			"srd": true,
+			"referenceSources": [
+				"AZfyT",
+				"BGDIA",
+				"CM",
+				"CoA",
+				"DC",
+				"IDRotF",
+				"LoX",
+				"SKT"
+			],
 			"reprintedAs": [
 				"Message|XPHB"
 			],
@@ -13235,6 +15196,10 @@
 			"page": 259,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Meteor Swarm|XPHB"
 			],
@@ -13286,6 +15251,17 @@
 			"source": "PHB",
 			"page": 259,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"KftGV",
+				"PaBTSO",
+				"RtG",
+				"SKT",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mind Blank|XPHB"
 			],
@@ -13335,6 +15311,20 @@
 			"page": 260,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"IDRotF",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"PaBTSO",
+				"RoT",
+				"SKT",
+				"TftYP-TFoF",
+				"TftYP-ToH",
+				"ToA",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Minor Illusion|XPHB"
 			],
@@ -13381,6 +15371,10 @@
 			"source": "PHB",
 			"page": 260,
 			"srd": true,
+			"referenceSources": [
+				"OotA",
+				"SKT"
+			],
 			"reprintedAs": [
 				"Mirage Arcane|XPHB"
 			],
@@ -13423,6 +15417,18 @@
 			"source": "PHB",
 			"page": 260,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"IDRotF",
+				"KftGV",
+				"RtG",
+				"SKT",
+				"TftYP-WPM",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mirror Image|XPHB"
 			],
@@ -13466,6 +15472,11 @@
 			"source": "PHB",
 			"page": 260,
 			"srd": true,
+			"referenceSources": [
+				"IDRotF",
+				"LoX",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mislead|XPHB"
 			],
@@ -13523,6 +15534,25 @@
 					"page": 57
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"DoSI",
+				"IDRotF",
+				"KftGV",
+				"LK",
+				"LMoP",
+				"LoX",
+				"PaBTSO",
+				"RtG",
+				"SjA",
+				"SKT",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Misty Step|XPHB"
 			],
@@ -13561,6 +15591,14 @@
 			"source": "PHB",
 			"page": 261,
 			"srd": true,
+			"referenceSources": [
+				"AitFR-AVT",
+				"RtG",
+				"SKT",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Modify Memory|XPHB"
 			],
@@ -13629,6 +15667,12 @@
 			"source": "PHB",
 			"page": 261,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"IDRotF",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Moonbeam|XPHB"
 			],
@@ -13695,6 +15739,13 @@
 			"source": "PHB",
 			"page": 261,
 			"srd": "Faithful Hound",
+			"referenceSources": [
+				"AitFR-THP",
+				"CoS",
+				"SKT",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mordenkainen's Faithful Hound|XPHB"
 			],
@@ -13744,6 +15795,13 @@
 			"source": "PHB",
 			"page": 261,
 			"srd": "Magnificent Mansion",
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"OotA",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mordenkainen's Magnificent Mansion|XPHB"
 			],
@@ -13793,6 +15851,10 @@
 			"source": "PHB",
 			"page": 262,
 			"srd": "Private Sanctum",
+			"referenceSources": [
+				"QftIS",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mordenkainen's Private Sanctum|XPHB"
 			],
@@ -13864,6 +15926,11 @@
 			"page": 262,
 			"srd": "Arcane Sword",
 			"basicRules": true,
+			"referenceSources": [
+				"PotA",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Mordenkainen's Sword|XPHB"
 			],
@@ -13924,6 +15991,10 @@
 			"source": "PHB",
 			"page": 263,
 			"srd": true,
+			"referenceSources": [
+				"OotA",
+				"RoT"
+			],
 			"reprintedAs": [
 				"Move Earth|XPHB"
 			],
@@ -13973,6 +16044,17 @@
 			"source": "PHB",
 			"page": 263,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"KftGV",
+				"LR",
+				"OotA",
+				"SKT",
+				"ToFW",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Nondetection|XPHB"
 			],
@@ -14023,6 +16105,12 @@
 			"source": "PHB",
 			"page": 263,
 			"srd": "Arcanist's Magic Aura",
+			"referenceSources": [
+				"IDRotF",
+				"QftIS",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Nystul's Magic Aura|XPHB"
 			],
@@ -14086,6 +16174,9 @@
 			"source": "PHB",
 			"page": 263,
 			"srd": "Freezing Sphere",
+			"referenceSources": [
+				"AitFR-ISF"
+			],
 			"reprintedAs": [
 				"Otiluke's Freezing Sphere|XPHB"
 			],
@@ -14146,6 +16237,11 @@
 			"source": "PHB",
 			"page": 264,
 			"srd": "Resilient Sphere",
+			"referenceSources": [
+				"CRCotN",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Otiluke's Resilient Sphere|XPHB"
 			],
@@ -14216,6 +16312,14 @@
 			"page": 264,
 			"srd": "Irresistible Dance",
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"OotA",
+				"SCC-TMM",
+				"TftYP-THSoT",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Otto's Irresistible Dance|XPHB"
 			],
@@ -14266,6 +16370,12 @@
 			"source": "PHB",
 			"page": 264,
 			"srd": true,
+			"referenceSources": [
+				"CRCotN",
+				"SKT",
+				"WBtW",
+				"XMtS"
+			],
 			"reprintedAs": [
 				"Pass without Trace|XPHB"
 			],
@@ -14311,6 +16421,20 @@
 			"page": 264,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CRCotN",
+				"JttRC",
+				"KftGV",
+				"OotA",
+				"PaBTSO",
+				"QftIS",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-WPM",
+				"ToA",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Passwall|XPHB"
 			],
@@ -14356,6 +16480,16 @@
 			"name": "Phantasmal Force",
 			"source": "PHB",
 			"page": 264,
+			"referenceSources": [
+				"CM",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"LRDT",
+				"OotA",
+				"TftYP-THSoT",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Phantasmal Force|XPHB"
 			],
@@ -14428,6 +16562,16 @@
 			"source": "PHB",
 			"page": 265,
 			"srd": true,
+			"referenceSources": [
+				"AitFR-AVT",
+				"CM",
+				"CoA",
+				"IDRotF",
+				"OotA",
+				"PaBTSO",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Phantasmal Killer|XPHB"
 			],
@@ -14493,6 +16637,12 @@
 			"source": "PHB",
 			"page": 265,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"CoS",
+				"DSotDQ",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Phantom Steed|XPHB"
 			],
@@ -14540,6 +16690,9 @@
 			"source": "PHB",
 			"page": 265,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA"
+			],
 			"reprintedAs": [
 				"Planar Ally|XPHB"
 			],
@@ -14584,6 +16737,10 @@
 			"source": "PHB",
 			"page": 265,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Planar Binding|XPHB"
 			],
@@ -14654,6 +16811,27 @@
 			"source": "PHB",
 			"page": 266,
 			"srd": true,
+			"referenceSources": [
+				"AitFR-DN",
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"SLW",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Plane Shift|XPHB"
 			],
@@ -14709,6 +16887,9 @@
 			"source": "PHB",
 			"page": 266,
 			"srd": true,
+			"referenceSources": [
+				"WBtW"
+			],
 			"reprintedAs": [
 				"Plant Growth|XPHB"
 			],
@@ -14756,6 +16937,12 @@
 			"page": 266,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"OotA",
+				"TftYP-TFoF",
+				"TftYP-TSC",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Poison Spray|XPHB"
 			],
@@ -14815,6 +17002,26 @@
 			"source": "PHB",
 			"page": 266,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"CoS",
+				"DSotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PotA",
+				"SLW",
+				"TftYP-ToH",
+				"ToA",
+				"ToFW",
+				"TTP",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Polymorph|XPHB"
 			],
@@ -14925,6 +17132,11 @@
 			"page": 266,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"PotA",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Power Word Kill|XPHB"
 			],
@@ -14967,6 +17179,10 @@
 			"page": 267,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"OotA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Power Word Stun|XPHB"
 			],
@@ -15021,6 +17237,9 @@
 					"source": "RMR",
 					"page": 57
 				}
+			],
+			"referenceSources": [
+				"OoW"
 			],
 			"reprintedAs": [
 				"Prayer of Healing|XPHB"
@@ -15094,6 +17313,20 @@
 					"page": 57
 				}
 			],
+			"referenceSources": [
+				"CoS",
+				"IDRotF",
+				"KftGV",
+				"NRH-TLT",
+				"OotA",
+				"RMBRE",
+				"SKT",
+				"TftYP-TFoF",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Prestidigitation|XPHB"
 			],
@@ -15150,6 +17383,12 @@
 			"source": "PHB",
 			"page": 267,
 			"srd": true,
+			"referenceSources": [
+				"OotA",
+				"SKT",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Prismatic Spray|XPHB"
 			],
@@ -15266,6 +17505,9 @@
 			"source": "PHB",
 			"page": 267,
 			"srd": true,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Prismatic Wall|XPHB"
 			],
@@ -15301,7 +17543,7 @@
 				"A shimmering, multicolored plane of light forms a vertical opaque wall\u2014up to 90 feet long, 30 feet high, and 1 inch thick\u2014centered on a point you can see within range. Alternatively, you can shape the wall into a sphere up to 30 feet in diameter centered on a point you choose within range. The wall remains in place for the duration. If you position the wall so that it passes through a space occupied by a creature, the spell fails, and your action and the spell slot are wasted.",
 				"The wall sheds bright light out to a range of 100 feet and dim light for an additional 100 feet. You and creatures you designate at the time you cast the spell can pass through and remain near the wall without harm. If another creature that can see the wall moves to within 20 feet of it or starts its turn there, the creature must succeed on a Constitution saving throw or become {@condition blinded} for 1 minute.",
 				"The wall consists of seven layers, each with a different color. When a creature attempts to reach into or pass through the wall, it does so one layer at a time through all the wall's layers. As it passes or reaches through each layer, the creature must make a Dexterity saving throw or be affected by that layer's properties as described below.",
-				"The wall can be destroyed, also one layer at a time, in order from red to violet, by means specific to each layer. Once a layer is destroyed, it remains so for the duration of the spell. An {@spell antimagic field} has no effect on a prismatic wall.",
+				"The wall can be destroyed, also one layer at a time, in order from red to violet, by means specific to each layer. Once a layer is destroyed, it remains so for the duration of the spell. {@spell Antimagic field} has no effect on the wall, and {@spell dispel magic} can affect only the violet layer.",
 				{
 					"type": "entries",
 					"name": "Red",
@@ -15385,6 +17627,15 @@
 			"source": "PHB",
 			"page": 269,
 			"srd": true,
+			"referenceSources": [
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"SKT",
+				"ToA",
+				"US",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Produce Flame|XPHB"
 			],
@@ -15448,6 +17699,11 @@
 			"source": "PHB",
 			"page": 269,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"TftYP-ToH"
+			],
 			"reprintedAs": [
 				"Programmed Illusion|XPHB"
 			],
@@ -15497,6 +17753,12 @@
 			"source": "PHB",
 			"page": 270,
 			"srd": true,
+			"referenceSources": [
+				"AitFR-AVT",
+				"IDRotF",
+				"JttRC",
+				"KftGV"
+			],
 			"reprintedAs": [
 				"Project Image|XPHB"
 			],
@@ -15563,6 +17825,13 @@
 					"page": 58
 				}
 			],
+			"referenceSources": [
+				"LRDT",
+				"OotA",
+				"RoT",
+				"SDW",
+				"SKT"
+			],
 			"reprintedAs": [
 				"Protection from Energy|XPHB"
 			],
@@ -15613,6 +17882,15 @@
 			"source": "PHB",
 			"page": 270,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"VNotEE",
+				"WBtW",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Protection from Evil and Good|XPHB"
 			],
@@ -15672,6 +17950,14 @@
 			"source": "PHB",
 			"page": 270,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"GoS",
+				"JttRC",
+				"TftYP-AtG",
+				"TftYP-TSC",
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Protection from Poison|XPHB"
 			],
@@ -15721,6 +18007,16 @@
 			"source": "PHB",
 			"page": 270,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"GoS",
+				"OotA",
+				"QftIS",
+				"TftYP-ToH",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Purify Food and Drink|XPHB"
 			],
@@ -15764,6 +18060,26 @@
 			"page": 270,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"DC",
+				"GoS",
+				"JttRC",
+				"KftGV",
+				"OotA",
+				"QftIS",
+				"RoT",
+				"SCC-TMM",
+				"SKT",
+				"TftYP-ToH",
+				"ToA",
+				"ToFW",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Raise Dead|XPHB"
 			],
@@ -15825,6 +18141,15 @@
 			"source": "PHB",
 			"page": 270,
 			"srd": "Telepathic Bond",
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"IDRotF",
+				"LoX",
+				"OotA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Rary's Telepathic Bond|XPHB"
 			],
@@ -15873,6 +18198,9 @@
 			"source": "PHB",
 			"page": 271,
 			"srd": true,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Ray of Enfeeblement|XPHB"
 			],
@@ -15931,6 +18259,14 @@
 					"page": 58
 				}
 			],
+			"referenceSources": [
+				"NRH-TLT",
+				"OotA",
+				"RoT",
+				"SKT",
+				"TftYP-TFoF",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Ray of Frost|XPHB"
 			],
@@ -15988,6 +18324,15 @@
 			"name": "Ray of Sickness",
 			"source": "PHB",
 			"page": 271,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"OotA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Ray of Sickness|XPHB"
 			],
@@ -16096,6 +18441,11 @@
 			"source": "PHB",
 			"page": 271,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"IDRotF",
+				"ToFW"
+			],
 			"reprintedAs": [
 				"Reincarnate|XPHB"
 			],
@@ -16303,6 +18653,37 @@
 			"page": 271,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"DSotDQ",
+				"IDRotF",
+				"IMR",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"SKT",
+				"SLW",
+				"TftYP-AtG",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-ToH",
+				"ToA",
+				"ToFW",
+				"ToR",
+				"VEoR",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Remove Curse|XPHB"
 			],
@@ -16351,6 +18732,13 @@
 					"page": 58
 				}
 			],
+			"referenceSources": [
+				"SKT",
+				"ToA",
+				"TTP",
+				"US",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Resistance|XPHB"
 			],
@@ -16396,6 +18784,17 @@
 			"page": 272,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"JttRC",
+				"OotA",
+				"SKT",
+				"TftYP-ToH",
+				"ToA",
+				"ToFW"
+			],
 			"reprintedAs": [
 				"Resurrection|XPHB"
 			],
@@ -16458,6 +18857,14 @@
 			"source": "PHB",
 			"page": 272,
 			"srd": true,
+			"referenceSources": [
+				"OotA",
+				"QftIS",
+				"SKT",
+				"ToA",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Reverse Gravity|XPHB"
 			],
@@ -16518,6 +18925,21 @@
 					"page": 58
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"DSotDQ",
+				"JttRC",
+				"LMoP",
+				"PaBTSO",
+				"SKT",
+				"ToA",
+				"US",
+				"WBtW",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Revivify|XPHB"
 			],
@@ -16564,6 +18986,14 @@
 			"source": "PHB",
 			"page": 272,
 			"srd": true,
+			"referenceSources": [
+				"IMR",
+				"SjA",
+				"ToA",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Rope Trick|XPHB"
 			],
@@ -16613,6 +19043,11 @@
 					"source": "RMR",
 					"page": 58
 				}
+			],
+			"referenceSources": [
+				"BGDIA",
+				"DoSI",
+				"US"
 			],
 			"reprintedAs": [
 				"Sacred Flame|XPHB"
@@ -16681,6 +19116,13 @@
 					"page": 58
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"GoS",
+				"HotDQ",
+				"TTP"
+			],
 			"reprintedAs": [
 				"Sanctuary|XPHB"
 			],
@@ -16729,6 +19171,13 @@
 			"source": "PHB",
 			"page": 273,
 			"srd": true,
+			"referenceSources": [
+				"HotDQ",
+				"IDRotF",
+				"KftGV",
+				"TftYP-TFoF",
+				"TftYP-TSC"
+			],
 			"reprintedAs": [
 				"Scorching Ray|XPHB"
 			],
@@ -16785,6 +19234,22 @@
 			"source": "PHB",
 			"page": 273,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoA",
+				"CoS",
+				"DSotDQ",
+				"GoS",
+				"JttRC",
+				"KftGV",
+				"PotA",
+				"RtG",
+				"SKT",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Scrying|XPHB"
 			],
@@ -16943,6 +19408,20 @@
 			"source": "PHB",
 			"page": 274,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CRCotN",
+				"DSotDQ",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"QftIS",
+				"RoT",
+				"TftYP-ToH",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"See Invisibility|XPHB"
 			],
@@ -16983,6 +19462,14 @@
 			"source": "PHB",
 			"page": 274,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"DSotDQ",
+				"IDRotF",
+				"SKT",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Seeming|XPHB"
 			],
@@ -17038,6 +19525,29 @@
 			"source": "PHB",
 			"page": 274,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DSotDQ",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"PotA",
+				"RoT",
+				"SKT",
+				"TftYP-DiT",
+				"ToA",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Sending|XPHB"
 			],
@@ -17079,6 +19589,12 @@
 			"source": "PHB",
 			"page": 274,
 			"srd": true,
+			"referenceSources": [
+				"IDRotF",
+				"KftGV",
+				"SKT",
+				"TftYP-TSC"
+			],
 			"reprintedAs": [
 				"Sequester|XPHB"
 			],
@@ -17134,6 +19650,10 @@
 			"source": "PHB",
 			"page": 274,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Shapechange|XPHB"
 			],
@@ -17184,6 +19704,14 @@
 			"page": 275,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CM",
+				"GoS",
+				"KftGV",
+				"SKT",
+				"TftYP-TFoF",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Shatter|XPHB"
 			],
@@ -17249,6 +19777,23 @@
 					"source": "RMR",
 					"page": 59
 				}
+			],
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"DIP",
+				"IDRotF",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"RoT",
+				"SKT",
+				"TftYP-TFoF",
+				"TftYP-WPM",
+				"ToR",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Shield|XPHB"
@@ -17348,6 +19893,10 @@
 			"source": "PHB",
 			"page": 275,
 			"srd": true,
+			"referenceSources": [
+				"GoS",
+				"TftYP-TSC"
+			],
 			"reprintedAs": [
 				"Shillelagh|XPHB"
 			],
@@ -17397,6 +19946,15 @@
 					"source": "RMR",
 					"page": 59
 				}
+			],
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"KftGV",
+				"SDW",
+				"TftYP-TFoF",
+				"TftYP-WPM",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Shocking Grasp|XPHB"
@@ -17462,6 +20020,22 @@
 					"page": 59
 				}
 			],
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"IDRotF",
+				"KftGV",
+				"LMoP",
+				"NRH-TLT",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"RtG",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Silence|XPHB"
 			],
@@ -17519,6 +20093,14 @@
 			"page": 276,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"GoS",
+				"IDRotF",
+				"KftGV",
+				"TftYP-TFoF",
+				"WBtW"
+			],
 			"reprintedAs": [
 				"Silent Image|XPHB"
 			],
@@ -17566,6 +20148,13 @@
 			"source": "PHB",
 			"page": 276,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"SKT",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Simulacrum|XPHB"
 			],
@@ -17625,6 +20214,22 @@
 					"source": "RMR",
 					"page": 59
 				}
+			],
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"DIP",
+				"KftGV",
+				"KKW",
+				"MOT",
+				"QftIS",
+				"RMBRE",
+				"SCC-CK",
+				"SDW",
+				"TftYP-TFoF",
+				"ToA",
+				"WBtW",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Sleep|XPHB"
@@ -17700,6 +20305,10 @@
 			"source": "PHB",
 			"page": 276,
 			"srd": true,
+			"referenceSources": [
+				"TftYP-THSoT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Sleet Storm|XPHB"
 			],
@@ -17758,6 +20367,15 @@
 			"source": "PHB",
 			"page": 277,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"IDRotF",
+				"OotA",
+				"QftIS",
+				"RoT",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Slow|XPHB"
 			],
@@ -17814,6 +20432,11 @@
 			"page": 277,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"CRCotN",
+				"SDW",
+				"US"
+			],
 			"reprintedAs": [
 				"Spare the Dying|XPHB"
 			],
@@ -17866,6 +20489,19 @@
 			"source": "PHB",
 			"page": 277,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"GoS",
+				"IMR",
+				"LK",
+				"QftIS",
+				"RoT",
+				"SDW",
+				"SKT",
+				"WBtW",
+				"WDMM",
+				"XMtS"
+			],
 			"reprintedAs": [
 				"Speak with Animals|XPHB"
 			],
@@ -17912,6 +20548,33 @@
 			"page": 277,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"DSotDQ",
+				"EFR",
+				"GoS",
+				"HFStCM",
+				"HotDQ",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"LLK",
+				"LRDT",
+				"OoW",
+				"QftIS",
+				"RoT",
+				"SDW",
+				"SKT",
+				"SLW",
+				"TftYP-DiT",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Speak with Dead|XPHB"
 			],
@@ -17969,6 +20632,14 @@
 			"source": "PHB",
 			"page": 277,
 			"srd": true,
+			"referenceSources": [
+				"GoS",
+				"JttRC",
+				"OotA",
+				"RoT",
+				"SKT",
+				"WBtW"
+			],
 			"reprintedAs": [
 				"Speak with Plants|XPHB"
 			],
@@ -18020,6 +20691,18 @@
 					"page": 60
 				}
 			],
+			"referenceSources": [
+				"DIP",
+				"LK",
+				"OotA",
+				"SKT",
+				"SLW",
+				"TftYP-TFoF",
+				"TftYP-TSC",
+				"ToA",
+				"WBtW",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Spider Climb|XPHB"
 			],
@@ -18061,6 +20744,9 @@
 			"source": "PHB",
 			"page": 277,
 			"srd": true,
+			"referenceSources": [
+				"US"
+			],
 			"reprintedAs": [
 				"Spike Growth|XPHB"
 			],
@@ -18122,6 +20808,13 @@
 					"source": "RMR",
 					"page": 60
 				}
+			],
+			"referenceSources": [
+				"CoS",
+				"GoS",
+				"OotA",
+				"SKT",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Spirit Guardians|XPHB"
@@ -18195,6 +20888,17 @@
 					"page": 60
 				}
 			],
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"GoS",
+				"OoW",
+				"TftYP-TFoF",
+				"TTP",
+				"US",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Spiritual Weapon|XPHB"
 			],
@@ -18257,6 +20961,9 @@
 			"name": "Staggering Smite",
 			"source": "PHB",
 			"page": 278,
+			"referenceSources": [
+				"CoS"
+			],
 			"reprintedAs": [
 				"Staggering Smite|XPHB"
 			],
@@ -18305,6 +21012,17 @@
 			"source": "PHB",
 			"page": 278,
 			"srd": true,
+			"referenceSources": [
+				"AZfyT",
+				"CM",
+				"KftGV",
+				"OotA",
+				"PotA",
+				"RoT",
+				"TftYP-AtG",
+				"TftYP-WPM",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Stinking Cloud|XPHB"
 			],
@@ -18358,6 +21076,24 @@
 			"source": "PHB",
 			"page": 278,
 			"srd": true,
+			"referenceSources": [
+				"AitFR-FCD",
+				"CRCotN",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"KftGV",
+				"OoW",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SKT",
+				"TftYP-THSoT",
+				"ToA",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Stone Shape|XPHB"
 			],
@@ -18398,6 +21134,20 @@
 			"page": 278,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"AitFR-FCD",
+				"CM",
+				"CoA",
+				"CoS",
+				"IDRotF",
+				"KftGV",
+				"OotA",
+				"RtG",
+				"SDW",
+				"SKT",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Stoneskin|XPHB"
 			],
@@ -18451,6 +21201,10 @@
 			"source": "PHB",
 			"page": 279,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"SKT"
+			],
 			"reprintedAs": [
 				"Storm of Vengeance|XPHB"
 			],
@@ -18549,6 +21303,20 @@
 					"source": "RMR",
 					"page": 60
 				}
+			],
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"IDRotF",
+				"KftGV",
+				"RoT",
+				"SDW",
+				"SKT",
+				"ToA",
+				"US",
+				"WBtW",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Suggestion|XPHB"
@@ -18663,6 +21431,9 @@
 			"page": 279,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"VEoR"
+			],
 			"reprintedAs": [
 				"Sunburst|XPHB"
 			],
@@ -18762,6 +21533,16 @@
 			"source": "PHB",
 			"page": 280,
 			"srd": true,
+			"referenceSources": [
+				"IDRotF",
+				"JttRC",
+				"OotA",
+				"PaBTSO",
+				"SCC-HfMT",
+				"TftYP-AtG",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Symbol|XPHB"
 			],
@@ -18891,6 +21672,19 @@
 			"source": "PHB",
 			"page": 280,
 			"srd": "Hideous Laughter",
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"QftIS",
+				"SCC-TMM",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Tasha's Hideous Laughter|XPHB"
 			],
@@ -18947,6 +21741,19 @@
 			"source": "PHB",
 			"page": 280,
 			"srd": true,
+			"referenceSources": [
+				"AitFR-FCD",
+				"CM",
+				"CoA",
+				"CRCotN",
+				"IDRotF",
+				"OotA",
+				"SKT",
+				"TftYP-ToH",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Telekinesis|XPHB"
 			],
@@ -19018,6 +21825,11 @@
 			"name": "Telepathy",
 			"source": "PHB",
 			"page": 281,
+			"referenceSources": [
+				"NRH-TLT",
+				"OotA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Telepathy|XPHB"
 			],
@@ -19063,6 +21875,28 @@
 			"page": 281,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"AitFR-FCD",
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"RoT",
+				"RtG",
+				"SCC-ARiR",
+				"SKT",
+				"TftYP-DiT",
+				"ToA",
+				"ToFW",
+				"VEoR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Teleport|XPHB"
 			],
@@ -19217,6 +22051,23 @@
 			"source": "PHB",
 			"page": 282,
 			"srd": true,
+			"referenceSources": [
+				"AitFR-FCD",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DSotDQ",
+				"IMR",
+				"OotA",
+				"SKT",
+				"TftYP-DiT",
+				"ToA",
+				"ToFW",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Teleportation Circle|XPHB"
 			],
@@ -19268,6 +22119,17 @@
 			"source": "PHB",
 			"page": 282,
 			"srd": "Floating Disk",
+			"referenceSources": [
+				"EFR",
+				"GoS",
+				"IDRotF",
+				"LLK",
+				"OotA",
+				"SCC-ARiR",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Tenser's Floating Disk|XPHB"
 			],
@@ -19324,6 +22186,15 @@
 					"page": 61
 				}
 			],
+			"referenceSources": [
+				"CoS",
+				"DC",
+				"GoS",
+				"IMR",
+				"OoW",
+				"TftYP-TSC",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Thaumaturgy|XPHB"
 			],
@@ -19375,6 +22246,9 @@
 			"name": "Thorn Whip",
 			"source": "PHB",
 			"page": 282,
+			"referenceSources": [
+				"US"
+			],
 			"reprintedAs": [
 				"Thorn Whip|XPHB"
 			],
@@ -19434,6 +22308,10 @@
 			"name": "Thunderous Smite",
 			"source": "PHB",
 			"page": 282,
+			"referenceSources": [
+				"CoS",
+				"GoS"
+			],
 			"reprintedAs": [
 				"Thunderous Smite|XPHB"
 			],
@@ -19492,6 +22370,25 @@
 					"source": "RMR",
 					"page": 61
 				}
+			],
+			"referenceSources": [
+				"CoS",
+				"CRCotN",
+				"DIP",
+				"GoS",
+				"IDRotF",
+				"JttRC",
+				"OoW",
+				"RoT",
+				"SKT",
+				"TftYP-DiT",
+				"TftYP-THSoT",
+				"TftYP-TSC",
+				"TftYP-WPM",
+				"ToA",
+				"ToR",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Thunderwave|XPHB"
@@ -19553,6 +22450,18 @@
 			"page": 283,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoS",
+				"IMR",
+				"KftGV",
+				"OotA",
+				"OoW",
+				"PotA",
+				"RtG",
+				"SKT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Time Stop|XPHB"
 			],
@@ -19588,6 +22497,21 @@
 			"source": "PHB",
 			"page": 283,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"DitLCoT",
+				"GoS",
+				"LoX",
+				"OotA",
+				"OoW",
+				"PaBTSO",
+				"QftIS",
+				"RtG",
+				"SKT",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Tongues|XPHB"
 			],
@@ -19630,6 +22554,10 @@
 			"source": "PHB",
 			"page": 283,
 			"srd": true,
+			"referenceSources": [
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Transport via Plants|XPHB"
 			],
@@ -19673,6 +22601,10 @@
 			"source": "PHB",
 			"page": 283,
 			"srd": true,
+			"referenceSources": [
+				"OotA",
+				"ToA"
+			],
 			"reprintedAs": [
 				"Tree Stride|XPHB"
 			],
@@ -19717,6 +22649,12 @@
 			"source": "PHB",
 			"page": 283,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"IDRotF",
+				"TftYP-DiT",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"True Polymorph|XPHB"
 			],
@@ -19798,6 +22736,13 @@
 			"page": 284,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"DSotDQ",
+				"JttRC",
+				"ToA"
+			],
 			"reprintedAs": [
 				"True Resurrection|XPHB"
 			],
@@ -19847,6 +22792,21 @@
 			"page": 284,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoS",
+				"KftGV",
+				"OotA",
+				"SKT",
+				"TftYP-AtG",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"True Seeing|XPHB"
 			],
@@ -19891,6 +22851,9 @@
 			"source": "PHB",
 			"page": 284,
 			"srd": true,
+			"referenceSources": [
+				"IDRotF"
+			],
 			"reprintedAs": [
 				"True Strike|XPHB"
 			],
@@ -19991,6 +22954,22 @@
 			"source": "PHB",
 			"page": 284,
 			"srd": true,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"IDRotF",
+				"IMR",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"QftIS",
+				"SCC-TMM",
+				"SKT",
+				"ToA",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Unseen Servant|XPHB"
 			],
@@ -20041,6 +23020,11 @@
 			"source": "PHB",
 			"page": 285,
 			"srd": true,
+			"referenceSources": [
+				"CoS",
+				"IDRotF",
+				"WDH"
+			],
 			"reprintedAs": [
 				"Vampiric Touch|XPHB"
 			],
@@ -20102,6 +23086,9 @@
 			"source": "PHB",
 			"page": 285,
 			"srd": true,
+			"referenceSources": [
+				"IDRotF"
+			],
 			"reprintedAs": [
 				"Vicious Mockery|XPHB"
 			],
@@ -20161,6 +23148,17 @@
 			"page": 285,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"AitFR-ISF",
+				"CoS",
+				"JttRC",
+				"PotA",
+				"RoT",
+				"TftYP-THSoT",
+				"ToA",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Wall of Fire|XPHB"
 			],
@@ -20223,6 +23221,23 @@
 			"source": "PHB",
 			"page": 285,
 			"srd": true,
+			"referenceSources": [
+				"AitFR-FCD",
+				"IDRotF",
+				"KftGV",
+				"LoX",
+				"OotA",
+				"OoW",
+				"QftIS",
+				"RtG",
+				"SDW",
+				"SKT",
+				"TftYP-THSoT",
+				"TftYP-WPM",
+				"ToA",
+				"VEoR",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Wall of Force|XPHB"
 			],
@@ -20269,6 +23284,11 @@
 			"source": "PHB",
 			"page": 285,
 			"srd": true,
+			"referenceSources": [
+				"CoA",
+				"IDRotF",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Wall of Ice|XPHB"
 			],
@@ -20333,6 +23353,17 @@
 			"page": 287,
 			"srd": true,
 			"basicRules": true,
+			"referenceSources": [
+				"AitFR-FCD",
+				"AitFR-ISF",
+				"CM",
+				"CoS",
+				"OotA",
+				"RoT",
+				"SKT",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Wall of Stone|XPHB"
 			],
@@ -20510,6 +23541,22 @@
 			"source": "PHB",
 			"page": 287,
 			"srd": true,
+			"referenceSources": [
+				"CRCotN",
+				"DitLCoT",
+				"GoS",
+				"LR",
+				"OotA",
+				"PaBTSO",
+				"PotA",
+				"QftIS",
+				"RoT",
+				"SKT",
+				"ToA",
+				"ToR",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Water Breathing|XPHB"
 			],
@@ -20560,6 +23607,14 @@
 			"source": "PHB",
 			"page": 287,
 			"srd": true,
+			"referenceSources": [
+				"CRCotN",
+				"DitLCoT",
+				"QftIS",
+				"SKT",
+				"TftYP-DiT",
+				"ToFW"
+			],
 			"reprintedAs": [
 				"Water Walk|XPHB"
 			],
@@ -20617,6 +23672,19 @@
 					"source": "RMR",
 					"page": 61
 				}
+			],
+			"referenceSources": [
+				"CoS",
+				"IDRotF",
+				"IMR",
+				"OotA",
+				"QftIS",
+				"SKT",
+				"TftYP-TFoF",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"WDH",
+				"WDMM"
 			],
 			"reprintedAs": [
 				"Web|XPHB"
@@ -20683,6 +23751,9 @@
 			"source": "PHB",
 			"page": 288,
 			"srd": true,
+			"referenceSources": [
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Weird|XPHB"
 			],
@@ -20736,6 +23807,10 @@
 			"source": "PHB",
 			"page": 288,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"JttRC"
+			],
 			"reprintedAs": [
 				"Wind Walk|XPHB"
 			],
@@ -20787,6 +23862,9 @@
 			"source": "PHB",
 			"page": 288,
 			"srd": true,
+			"referenceSources": [
+				"ToA"
+			],
 			"reprintedAs": [
 				"Wind Wall|XPHB"
 			],
@@ -20840,6 +23918,30 @@
 			"source": "PHB",
 			"page": 288,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CM",
+				"CoA",
+				"CoS",
+				"CRCotN",
+				"DC",
+				"DSotDQ",
+				"HotDQ",
+				"IDRotF",
+				"IMR",
+				"LoX",
+				"OotA",
+				"QftIS",
+				"RoT",
+				"SLW",
+				"TftYP-ToH",
+				"TftYP-WPM",
+				"ToA",
+				"VEoR",
+				"WBtW",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Wish|XPHB"
 			],
@@ -20909,6 +24011,13 @@
 			"name": "Witch Bolt",
 			"source": "PHB",
 			"page": 289,
+			"referenceSources": [
+				"CM",
+				"CoS",
+				"IDRotF",
+				"WDH",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Witch Bolt|XPHB"
 			],
@@ -20969,6 +24078,13 @@
 			"source": "PHB",
 			"page": 289,
 			"srd": true,
+			"referenceSources": [
+				"BGDIA",
+				"CoA",
+				"TftYP-AtG",
+				"ToA",
+				"WDMM"
+			],
 			"reprintedAs": [
 				"Word of Recall|XPHB"
 			],
@@ -21062,6 +24178,11 @@
 			"source": "PHB",
 			"page": 289,
 			"srd": true,
+			"referenceSources": [
+				"JttRC",
+				"RoT",
+				"TftYP-AtG"
+			],
 			"reprintedAs": [
 				"Zone of Truth|XPHB"
 			],

--- a/json/spells/spells-tce.json
+++ b/json/spells/spells-tce.json
@@ -10,6 +10,12 @@
 					"page": 318
 				}
 			],
+			"referenceSources": [
+				"IDRotF"
+			],
+			"reprintedAs": [
+				"Blade of Disaster|FRHoF"
+			],
 			"level": 9,
 			"school": "C",
 			"time": [

--- a/json/spells/spells-xge.json
+++ b/json/spells/spells-xge.json
@@ -10,6 +10,9 @@
 					"page": 15
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 8,
 			"school": "N",
 			"time": [
@@ -73,6 +76,9 @@
 					"page": 15
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 1,
 			"school": "A",
 			"time": [
@@ -129,6 +135,9 @@
 					"source": "EEPC",
 					"page": 15
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 2,
 			"school": "V",
@@ -187,6 +196,9 @@
 					"page": 15
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 1,
 			"school": "D",
 			"time": [
@@ -242,6 +254,9 @@
 					"source": "EEPC",
 					"page": 15
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 6,
 			"school": "T",
@@ -311,6 +326,9 @@
 					"source": "EEPC",
 					"page": 15
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 1,
 			"school": "T",
@@ -419,6 +437,9 @@
 			"name": "Cause Fear",
 			"source": "XGE",
 			"page": 151,
+			"referenceSources": [
+				"OoW"
+			],
 			"level": 1,
 			"school": "N",
 			"time": [
@@ -491,6 +512,10 @@
 			"name": "Ceremony",
 			"source": "XGE",
 			"page": 151,
+			"referenceSources": [
+				"RtG",
+				"SLW"
+			],
 			"level": 1,
 			"school": "A",
 			"time": [
@@ -734,6 +759,9 @@
 			"name": "Charm Monster",
 			"source": "XGE",
 			"page": 151,
+			"referenceSources": [
+				"LR"
+			],
 			"reprintedAs": [
 				"Charm Monster|XPHB"
 			],
@@ -801,6 +829,9 @@
 					"page": 16
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 0,
 			"school": "T",
 			"time": [
@@ -862,6 +893,9 @@
 					"source": "EEPC",
 					"page": 16
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 5,
 			"school": "T",
@@ -938,6 +972,9 @@
 					"source": "EEPC",
 					"page": 16
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 0,
 			"school": "C",
@@ -1368,6 +1405,9 @@
 					"page": 17
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 2,
 			"school": "C",
 			"time": [
@@ -1434,6 +1474,9 @@
 					"page": 17
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 1,
 			"school": "V",
 			"time": [
@@ -1496,6 +1539,9 @@
 					"page": 17
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 2,
 			"school": "T",
 			"time": [
@@ -1546,6 +1592,9 @@
 					"source": "EEPC",
 					"page": 17
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 4,
 			"school": "T",
@@ -1723,6 +1772,9 @@
 					"page": 17
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 3,
 			"school": "T",
 			"time": [
@@ -1881,6 +1933,9 @@
 					"page": 18
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 3,
 			"school": "T",
 			"time": [
@@ -1937,6 +1992,9 @@
 					"source": "EEPC",
 					"page": 18
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 0,
 			"school": "V",
@@ -2082,6 +2140,9 @@
 					"source": "TCE",
 					"page": 50
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 0,
 			"school": "T",
@@ -2265,6 +2326,9 @@
 					"page": 19
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"reprintedAs": [
 				"Ice Knife|XPHB"
 			],
@@ -2391,6 +2455,9 @@
 					"source": "EEPC",
 					"page": 19
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 5,
 			"school": "V",
@@ -2564,6 +2631,9 @@
 					"page": 19
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 6,
 			"school": "T",
 			"time": [
@@ -2631,6 +2701,9 @@
 					"source": "EEPC",
 					"page": 19
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 6,
 			"school": "T",
@@ -2702,6 +2775,9 @@
 					"page": 19
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 6,
 			"school": "T",
 			"time": [
@@ -2766,6 +2842,9 @@
 					"source": "EEPC",
 					"page": 20
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 6,
 			"school": "T",
@@ -2955,6 +3034,9 @@
 			"savingThrow": [
 				"wisdom"
 			],
+			"miscTags": [
+				"OBS"
+			],
 			"areaTags": [
 				"S"
 			]
@@ -2968,6 +3050,9 @@
 					"source": "EEPC",
 					"page": 20
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 5,
 			"school": "V",
@@ -3026,6 +3111,9 @@
 					"source": "EEPC",
 					"page": 20
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 0,
 			"school": "T",
@@ -3133,6 +3221,9 @@
 					"page": 20
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 2,
 			"school": "T",
 			"time": [
@@ -3197,6 +3288,9 @@
 					"source": "EEPC",
 					"page": 20
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 3,
 			"school": "V",
@@ -3313,6 +3407,10 @@
 					"source": "AitFR-FCD",
 					"page": 12
 				}
+			],
+			"referenceSources": [
+				"AitFR-AVT",
+				"AitFR-FCD"
 			],
 			"level": 8,
 			"school": "C",
@@ -3432,6 +3530,9 @@
 					"source": "EEPC",
 					"page": 21
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 0,
 			"school": "T",
@@ -3634,6 +3735,9 @@
 					"page": 21
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 6,
 			"school": "A",
 			"time": [
@@ -3738,6 +3842,9 @@
 					"source": "EEPC",
 					"page": 21
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 2,
 			"school": "T",
@@ -3955,6 +4062,9 @@
 					"source": "EGW"
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 0,
 			"school": "T",
 			"time": [
@@ -4105,6 +4215,9 @@
 					"page": 22
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 2,
 			"school": "T",
 			"time": [
@@ -4206,6 +4319,9 @@
 					"source": "EEPC",
 					"page": 22
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 2,
 			"school": "V",
@@ -4394,6 +4510,9 @@
 					"page": 22
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 4,
 			"school": "V",
 			"time": [
@@ -4461,6 +4580,9 @@
 			"name": "Summon Greater Demon",
 			"source": "XGE",
 			"page": 166,
+			"referenceSources": [
+				"IMR"
+			],
 			"level": 4,
 			"school": "C",
 			"time": [
@@ -4521,6 +4643,9 @@
 			"name": "Summon Lesser Demons",
 			"source": "XGE",
 			"page": 167,
+			"referenceSources": [
+				"IMR"
+			],
 			"level": 3,
 			"school": "C",
 			"time": [
@@ -4855,6 +4980,9 @@
 					"page": 22
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"reprintedAs": [
 				"Thunderclap|XPHB"
 			],
@@ -4916,6 +5044,9 @@
 					"source": "EEPC",
 					"page": 22
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 3,
 			"school": "C",
@@ -5089,6 +5220,9 @@
 					"page": 22
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 5,
 			"school": "T",
 			"time": [
@@ -5169,6 +5303,9 @@
 					"source": "EEPC",
 					"page": 23
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"reprintedAs": [
 				"Vitriolic Sphere|XPHB"
@@ -5300,6 +5437,9 @@
 					"page": 23
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 3,
 			"school": "V",
 			"time": [
@@ -5360,6 +5500,9 @@
 					"source": "MOT"
 				}
 			],
+			"referenceSources": [
+				"PotA"
+			],
 			"level": 3,
 			"school": "V",
 			"time": [
@@ -5411,6 +5554,9 @@
 					"source": "EEPC",
 					"page": 23
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 2,
 			"school": "V",
@@ -5469,6 +5615,10 @@
 					"source": "EEPC",
 					"page": 23
 				}
+			],
+			"referenceSources": [
+				"LR",
+				"PotA"
 			],
 			"level": 4,
 			"school": "C",
@@ -5530,6 +5680,9 @@
 					"source": "EEPC",
 					"page": 24
 				}
+			],
+			"referenceSources": [
+				"PotA"
 			],
 			"level": 7,
 			"school": "V",

--- a/json/spells/spells-xphb.json
+++ b/json/spells/spells-xphb.json
@@ -58,8 +58,7 @@
 				"dexterity"
 			],
 			"miscTags": [
-				"SCL",
-				"SGT"
+				"SCL"
 			],
 			"areaTags": [
 				"MT"
@@ -71,6 +70,9 @@
 			"page": 239,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "A",
 			"time": [
@@ -125,6 +127,9 @@
 			"page": 239,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-BD"
+			],
 			"level": 1,
 			"school": "A",
 			"time": [
@@ -284,7 +289,7 @@
 				}
 			],
 			"entries": [
-				"Target a Beast that you can see within range. The target must succeed on a Wisdom saving throw or have the {@condition Charmed|XPHB} condition for the duration. If you or one of your allies deals damage to the target, the spells ends."
+				"Target a Beast that you can see within range. The target must succeed on a Wisdom saving throw or have the {@condition Charmed|XPHB} condition for the duration. If you or one of your allies deals damage to the target, the spell ends."
 			],
 			"entriesHigherLevel": [
 				{
@@ -428,6 +433,9 @@
 			"page": 240,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TWoO"
+			],
 			"level": 3,
 			"school": "N",
 			"time": [
@@ -634,7 +642,7 @@
 				}
 			],
 			"entries": [
-				"An aura of antimagic surrounds you in 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation}. No one can cast spells, take {@action Magic|XPHB} actions, or create other magical effects inside the aura, and those things can't target or otherwise affect anything inside it. Magical properties of magic items don't work inside the aura or on anything inside it.",
+				"An aura of antimagic surrounds you in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation}. No one can cast spells, take {@action Magic|XPHB} actions, or create other magical effects inside the aura, and those things can't target or otherwise affect anything inside it. Magical properties of magic items don't work inside the aura or on anything inside it.",
 				"Areas of effect created by spells or other magic can't extend into the aura, and no one can teleport into or out of it or use planar travel there. Portals close temporarily while in the aura.",
 				"Ongoing spells, except those cast by an Artifact or a deity, are suppressed in the area. While an effect is suppressed, it doesn't function, but the time it spends suppressed counts against its duration.",
 				"{@spell Dispel Magic|XPHB} has no effect on the aura, and the auras created by different {@spell Antimagic Field|XPHB} spells don't nullify each other."
@@ -820,6 +828,9 @@
 			"page": 242,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"level": 2,
 			"school": "A",
 			"time": [
@@ -1066,6 +1077,9 @@
 			"page": 244,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"level": 2,
 			"school": "D",
 			"time": [
@@ -1565,7 +1579,7 @@
 				}
 			],
 			"entries": [
-				"Choose any number of creatures within range. For the duration, each target has {@variantrule Advantage|XPHB} on Wisdom saving throws and Death Saving Throws and regains the maximum number of {@variantrule Hit Points|XPHB} possible from any healing."
+				"Choose any number of creatures within range. For the duration, each target has {@variantrule Advantage|XPHB} on Wisdom saving throws and {@variantrule Death Saving Throw|XPHB|Death Saving Throws} and regains the maximum number of {@variantrule Hit Points|XPHB} possible from any healing."
 			],
 			"miscTags": [
 				"ADV",
@@ -1802,7 +1816,7 @@
 							"type": "item",
 							"name": "Interposing Hand",
 							"entries": [
-								"The hand grants you Half {@variantrule Cover|XPHB} against attacks and other effects that originate from its space or that pass through it. In addition, its space counts as {@variantrule Difficult Terrain|XPHB} for your enemies."
+								"The hand grants you {@variantrule Cover|XPHB|Half Cover} against attacks and other effects that originate from its space or that pass through it. In addition, its space counts as {@variantrule Difficult Terrain|XPHB} for your enemies."
 							]
 						}
 					]
@@ -1813,7 +1827,7 @@
 					"type": "entries",
 					"name": "Using a Higher-Level Spell Slot",
 					"entries": [
-						"The damage of the Clenched Fist increases by {@scaledamage 4d8|5-9|2d8} and the damage of the Grasping Hand increases by {@scaledamage 2d6|5-9|2d6} for each spell slot level above 5."
+						"The damage of the Clenched Fist increases by {@scaledamage 5d8|5-9|2d8} and the damage of the Grasping Hand increases by {@scaledamage 4d6|5-9|2d6} for each spell slot level above 5."
 					]
 				}
 			],
@@ -1877,7 +1891,7 @@
 			],
 			"entries": [
 				"You create a wall of whirling blades made of magical energy. The wall appears within range and lasts for the duration. You make a straight wall up to 100 feet long, 20 feet high, and 5 feet thick, or a ringed wall up to 60 feet in diameter, 20 feet high, and 5 feet thick. The wall provides Three-Quarters {@variantrule Cover|XPHB}, and its space is {@variantrule Difficult Terrain|XPHB}.",
-				"Any creature in the wall's space makes a Dexterity saving throw, taking {@damage 6d10} Force damage on a failed save or half as much damage on a successful one. A creature also makes that save if it enters the wall's space or ends it turn there. A creature makes that save only once per turn."
+				"Any creature in the wall's space makes a Dexterity saving throw, taking {@damage 6d10} Force damage on a failed save or half as much damage on a successful one. A creature also makes that save if it enters the wall's space or ends its turn there. A creature makes that save only once per turn."
 			],
 			"damageInflict": [
 				"force"
@@ -1934,6 +1948,10 @@
 			"page": 247,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN",
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "E",
 			"time": [
@@ -2104,6 +2122,9 @@
 			"page": 248,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "T",
 			"time": [
@@ -2242,6 +2263,9 @@
 			"page": 248,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "V",
 			"time": [
@@ -2827,6 +2851,9 @@
 			"page": 250,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TFV"
+			],
 			"level": 3,
 			"school": "D",
 			"time": [
@@ -3033,6 +3060,9 @@
 			"page": 251,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"level": 1,
 			"school": "I",
 			"time": [
@@ -3314,6 +3344,9 @@
 			"page": 252,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "D",
 			"time": [
@@ -3408,6 +3441,9 @@
 			"page": 253,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 5,
 			"school": "V",
 			"time": [
@@ -3784,7 +3820,7 @@
 			],
 			"entries": [
 				"You conjure a Large, intangible spirit from the Elemental Planes that appears in an unoccupied space within range. Choose the spirit's element, which determines its damage type: air (Lightning), earth (Thunder), fire (Fire), or water (Cold). The spirit lasts for the duration.",
-				"Whenever a creature you can see enters the spirit's space or starts its turn within 5 feet of the spirit, you can force that creature to make a Dexterity saving throw if the spirit has no creature {@condition Restrained|XPHB}. On failed save, the target takes {@damage 8d8} damage of the spirit's type, and the target has the {@condition Restrained|XPHB} condition until the spell ends. At the start of each of its turns, the {@condition Restrained|XPHB} target repeats the save. On a failed save, the target takes {@damage 4d8} damage of the spirit's type. On a successful save, the target isn't {@condition Restrained|XPHB} by the spirit."
+				"Whenever a creature you can see enters the spirit's space or starts its turn within 5 feet of the spirit, you can force that creature to make a Dexterity saving throw if the spirit has no creature {@condition Restrained|XPHB}. On a failed save, the target takes {@damage 8d8} damage of the spirit's type, and the target has the {@condition Restrained|XPHB} condition until the spell ends. At the start of each of its turns, the {@condition Restrained|XPHB} target repeats the save. On a failed save, the target takes {@damage 4d8} damage of the spirit's type. On a successful save, the target isn't {@condition Restrained|XPHB} by the spirit."
 			],
 			"entriesHigherLevel": [
 				{
@@ -4185,6 +4221,9 @@
 			"page": 256,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"BQGT"
+			],
 			"level": 2,
 			"school": "V",
 			"time": [
@@ -4519,6 +4558,10 @@
 			"page": 258,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN",
+				"UtHftLH"
+			],
 			"level": 3,
 			"school": "A",
 			"time": [
@@ -4593,6 +4636,10 @@
 			"page": 258,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-BD",
+				"DrDe-BtS"
+			],
 			"level": 1,
 			"school": "T",
 			"time": [
@@ -4898,6 +4945,9 @@
 			"page": 259,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "A",
 			"time": [
@@ -4946,6 +4996,9 @@
 			"page": 259,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 0,
 			"school": "I",
 			"time": [
@@ -5026,7 +5079,8 @@
 				"If any of this spell's area overlaps with an area of {@variantrule Bright Light|XPHB} or {@variantrule Dim Light|XPHB} created by a spell of level 2 or lower, that other spell is dispelled."
 			],
 			"miscTags": [
-				"OBJ"
+				"OBJ",
+				"OBS"
 			],
 			"areaTags": [
 				"S"
@@ -5038,6 +5092,9 @@
 			"page": 260,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"level": 2,
 			"school": "T",
 			"time": [
@@ -5284,7 +5341,7 @@
 				}
 			],
 			"range": {
-				"type": "sphere",
+				"type": "emanation",
 				"distance": {
 					"type": "feet",
 					"amount": 30
@@ -5371,6 +5428,11 @@
 			"page": 262,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN",
+				"DrDe-TWoO",
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "D",
 			"time": [
@@ -5563,6 +5625,9 @@
 			"page": 262,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-BD"
+			],
 			"level": 1,
 			"school": "I",
 			"time": [
@@ -5737,6 +5802,10 @@
 			"page": 264,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-ACfaS",
+				"DrDe-SD"
+			],
 			"level": 3,
 			"school": "A",
 			"time": [
@@ -6782,6 +6851,9 @@
 			"page": 268,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "T",
 			"time": [
@@ -6848,6 +6920,9 @@
 			"page": 268,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "C",
 			"time": [
@@ -6989,7 +7064,8 @@
 					"duration": {
 						"type": "minute",
 						"amount": 1
-					}
+					},
+					"concentration": true
 				}
 			],
 			"entries": [
@@ -7099,7 +7175,7 @@
 			],
 			"entries": [
 				"Squirming, ebony tentacles fill a 20-foot square on ground that you can see within range. For the duration, these tentacles turn the ground in that area into {@variantrule Difficult Terrain|XPHB}.",
-				"Each creature in that area makes a Strength saving throw. On a failed save, it takes {@damage 3d6} Bludgeoning damage, and it has the {@condition Restrained|XPHB} condition until the spell ends. A creature also makes that save if it enters the area or ends it turn there. A creature makes that save only once per turn.",
+				"Each creature in that area makes a Strength saving throw. On a failed save, it takes {@damage 3d6} Bludgeoning damage, and it has the {@condition Restrained|XPHB} condition until the spell ends. A creature also makes that save if it enters the area or ends its turn there. A creature makes that save only once per turn.",
 				"A {@condition Restrained|XPHB} creature can take an action to make a Strength ({@skill Athletics|XPHB}) check against your spell save DC, ending the condition on itself on a success."
 			],
 			"damageInflict": [
@@ -7284,6 +7360,9 @@
 			"page": 271,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "V",
 			"time": [
@@ -7333,6 +7412,9 @@
 			"page": 271,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"level": 1,
 			"school": "N",
 			"time": [
@@ -7429,6 +7511,10 @@
 			"page": 271,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN",
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "T",
 			"time": [
@@ -7807,6 +7893,9 @@
 			"page": 274,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 0,
 			"school": "V",
 			"time": [
@@ -7970,6 +8059,12 @@
 			"page": 274,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-SD",
+				"FFotR",
+				"HotB",
+				"UtHftLH"
+			],
 			"level": 3,
 			"school": "V",
 			"time": [
@@ -8266,6 +8361,9 @@
 			"page": 276,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 3,
 			"school": "T",
 			"time": [
@@ -8320,6 +8418,9 @@
 			"page": 276,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "C",
 			"time": [
@@ -9061,6 +9162,9 @@
 			"page": 279,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"level": 3,
 			"school": "A",
 			"time": [
@@ -9153,6 +9257,9 @@
 			"page": 280,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-SD"
+			],
 			"level": 1,
 			"school": "C",
 			"time": [
@@ -9260,6 +9367,9 @@
 			"page": 280,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "C",
 			"time": [
@@ -9356,6 +9466,10 @@
 			"page": 281,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-BD",
+				"DrDe-DotSC"
+			],
 			"level": 5,
 			"school": "A",
 			"time": [
@@ -9531,7 +9645,8 @@
 			],
 			"miscTags": [
 				"OBS",
-				"PIR"
+				"PIR",
+				"PRM"
 			],
 			"areaTags": [
 				"Q"
@@ -9543,6 +9658,9 @@
 			"page": 282,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 0,
 			"school": "D",
 			"time": [
@@ -9584,6 +9702,9 @@
 			"page": 282,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "V",
 			"time": [
@@ -9643,6 +9764,11 @@
 			"page": 282,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-ACfaS",
+				"DrDe-SD",
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "V",
 			"time": [
@@ -9901,7 +10027,8 @@
 				"undead"
 			],
 			"miscTags": [
-				"LGT"
+				"LGT",
+				"OBS"
 			]
 		},
 		{
@@ -10104,6 +10231,9 @@
 			"page": 284,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "A",
 			"time": [
@@ -10508,6 +10638,9 @@
 			"page": 286,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "E",
 			"time": [
@@ -10657,7 +10790,7 @@
 				}
 			],
 			"entries": [
-				"You open a gateway to the Far Realm, a region infested with unspeakable horrors. A 20-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} of {@variantrule Darkness|XPHB} appears, centered on a point with range and lasting for the duration. The {@variantrule Sphere [Area of Effect]|XPHB|Sphere} is {@variantrule Difficult Terrain|XPHB}, and it is filled with strange whispers and slurping noises, which can be heard up to 30 feet away. No light, magical or otherwise, can illuminate the area, and creatures fully within it have the {@condition Blinded|XPHB} condition.",
+				"You open a gateway to the Far Realm, a region infested with unspeakable horrors. A 20-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} of {@variantrule Darkness|XPHB} appears, centered on a point within range and lasting for the duration. The {@variantrule Sphere [Area of Effect]|XPHB|Sphere} is {@variantrule Difficult Terrain|XPHB}, and it is filled with strange whispers and slurping noises, which can be heard up to 30 feet away. No light, magical or otherwise, can illuminate the area, and creatures fully within it have the {@condition Blinded|XPHB} condition.",
 				"Any creature that starts its turn in the area takes {@damage 2d6} Cold damage. Any creature that ends its turn there must succeed on a Dexterity saving throw or take {@damage 2d6} Acid damage from otherworldly tentacles."
 			],
 			"entriesHigherLevel": [
@@ -10680,7 +10813,8 @@
 				"dexterity"
 			],
 			"miscTags": [
-				"DFT"
+				"DFT",
+				"OBS"
 			],
 			"areaTags": [
 				"S"
@@ -10693,6 +10827,9 @@
 			"page": 287,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "D",
 			"time": [
@@ -10918,6 +11055,11 @@
 			"page": 287,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-DotSC",
+				"DrDe-TDoN",
+				"FRAiF"
+			],
 			"level": 1,
 			"school": "D",
 			"time": [
@@ -11282,6 +11424,11 @@
 			"page": 289,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN",
+				"DrDe-TFV",
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "I",
 			"time": [
@@ -11405,6 +11552,9 @@
 			"page": 290,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "T",
 			"time": [
@@ -11458,6 +11608,11 @@
 			"page": 290,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-BD",
+				"DrDe-FWtVC",
+				"DrDe-TDoN"
+			],
 			"level": 2,
 			"school": "T",
 			"time": [
@@ -11638,6 +11793,9 @@
 			"page": 291,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "A",
 			"time": [
@@ -11727,6 +11885,9 @@
 			"page": 292,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 0,
 			"school": "V",
 			"time": [
@@ -11820,6 +11981,10 @@
 			"page": 292,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-SD",
+				"UtHftLH"
+			],
 			"level": 3,
 			"school": "V",
 			"time": [
@@ -11958,6 +12123,9 @@
 			"page": 293,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"level": 2,
 			"school": "D",
 			"time": [
@@ -12002,6 +12170,9 @@
 			"page": 293,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "T",
 			"time": [
@@ -12055,6 +12226,10 @@
 			"page": 293,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN",
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "A",
 			"time": [
@@ -12100,6 +12275,10 @@
 			"page": 293,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF",
+				"UtHftLH"
+			],
 			"level": 0,
 			"school": "C",
 			"time": [
@@ -12277,6 +12456,10 @@
 			"page": 295,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN",
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "V",
 			"time": [
@@ -12331,6 +12514,9 @@
 			"page": 295,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-BD"
+			],
 			"level": 2,
 			"school": "I",
 			"time": [
@@ -12686,6 +12872,9 @@
 			"page": 296,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"level": 8,
 			"school": "C",
 			"time": [
@@ -12784,6 +12973,9 @@
 			"page": 297,
 			"srd52": "Acid Arrow",
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"level": 2,
 			"school": "V",
 			"time": [
@@ -12838,6 +13030,10 @@
 			"page": 297,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"BQGT",
+				"DrDe-ACfaS"
+			],
 			"level": 0,
 			"school": "T",
 			"time": [
@@ -13317,6 +13513,9 @@
 			"page": 299,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "C",
 			"time": [
@@ -13708,6 +13907,9 @@
 			"page": 302,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-DotSC"
+			],
 			"level": 6,
 			"school": "T",
 			"time": [
@@ -13888,7 +14090,7 @@
 				}
 			],
 			"entries": [
-				"A frigid globe streaks from you to a point of your choice within range, where it explodes in a 60-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere}. Each creature in that area makes a Constitution saving throw, taking {@damage 10d6} Cold damage on failed save or half as much damage on a successful one.",
+				"A frigid globe streaks from you to a point of your choice within range, where it explodes in a 60-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere}. Each creature in that area makes a Constitution saving throw, taking {@damage 10d6} Cold damage on a failed save or half as much damage on a successful one.",
 				"If the globe strikes a body of water, it freezes the water to a depth of 6 inches over an area 30 feet square. This ice lasts for 1 minute. Creatures that were swimming on the surface of frozen water are trapped in the ice and have the {@condition Restrained|XPHB} condition. A trapped creature can take an action to make a Strength ({@skill Athletics|XPHB}) check against your spell save DC to break free.",
 				"You can refrain from firing the globe after completing the spell's casting. If you do so, a globe about the size of a sling bullet, cool to the touch, appears in your hand. At any time, you or a creature you give the globe to can throw the globe (to a range of 40 feet) or hurl it with a sling (to the sling's normal range). It shatters on impact, with the same effect as a normal casting of the spell. You can also set the globe down without shattering it. After 1 minute, if the globe hasn't already shattered, it explodes."
 			],
@@ -14125,6 +14327,10 @@
 			"page": 304,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN",
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "I",
 			"time": [
@@ -14559,6 +14765,9 @@
 			"page": 306,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 4,
 			"school": "T",
 			"time": [
@@ -14777,6 +14986,9 @@
 			"page": 307,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "A",
 			"time": [
@@ -14825,6 +15037,9 @@
 			"page": 307,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 0,
 			"school": "T",
 			"time": [
@@ -15336,6 +15551,9 @@
 			"page": 309,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"level": 1,
 			"school": "A",
 			"time": [
@@ -15393,6 +15611,9 @@
 			"page": 310,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "A",
 			"time": [
@@ -15631,6 +15852,9 @@
 			"page": 311,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 0,
 			"school": "V",
 			"time": [
@@ -15695,6 +15919,9 @@
 			"page": 311,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "N",
 			"time": [
@@ -16165,6 +16392,9 @@
 			"page": 313,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 0,
 			"school": "V",
 			"time": [
@@ -16190,7 +16420,7 @@
 				}
 			],
 			"entries": [
-				"Flame-like radiance descends on a creature that you can see within range. The target must succeed on a Dexterity saving throw or take {@damage 1d8} Radiant damage. The target gains no benefit from Half {@variantrule Cover|XPHB} or Three-Quarters {@variantrule Cover|XPHB} for this save."
+				"Flame-like radiance descends on a creature that you can see within range. The target must succeed on a Dexterity saving throw or take {@damage 1d8} Radiant damage. The target gains no benefit from {@variantrule Cover|XPHB|Half Cover} or Three-Quarters {@variantrule Cover|XPHB} for this save."
 			],
 			"entriesHigherLevel": [
 				{
@@ -16276,6 +16506,9 @@
 			"page": 313,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "V",
 			"time": [
@@ -16574,6 +16807,9 @@
 			"page": 314,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"level": 3,
 			"school": "D",
 			"time": [
@@ -16610,6 +16846,10 @@
 			"page": 315,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-ACfaS",
+				"DrDe-TFV"
+			],
 			"level": 7,
 			"school": "T",
 			"time": [
@@ -16769,6 +17009,9 @@
 			"page": 316,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "A",
 			"time": [
@@ -16810,6 +17053,9 @@
 			"page": 316,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "A",
 			"time": [
@@ -16867,7 +17113,7 @@
 			"range": {
 				"type": "point",
 				"distance": {
-					"type": "touch"
+					"type": "self"
 				}
 			},
 			"components": {
@@ -16906,6 +17152,9 @@
 					"17": "2d6"
 				}
 			},
+			"damageInflict": [
+				"force"
+			],
 			"miscTags": [
 				"AAD",
 				"SCL"
@@ -16975,6 +17224,9 @@
 			"page": 316,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FFotR"
+			],
 			"level": 0,
 			"school": "V",
 			"time": [
@@ -17189,6 +17441,9 @@
 			"page": 317,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "E",
 			"time": [
@@ -17467,6 +17722,10 @@
 			"page": 318,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-BD",
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "D",
 			"time": [
@@ -17512,6 +17771,12 @@
 			"page": 318,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-ACfaS",
+				"DrDe-BtS",
+				"DrDe-TDoN",
+				"DrDe-TFV"
+			],
 			"level": 3,
 			"school": "N",
 			"time": [
@@ -17614,6 +17879,9 @@
 			"page": 319,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-BD"
+			],
 			"level": 2,
 			"school": "T",
 			"time": [
@@ -17718,6 +17986,9 @@
 			"page": 319,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"FFotR"
+			],
 			"level": 3,
 			"school": "C",
 			"time": [
@@ -17778,6 +18049,9 @@
 			"page": 319,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "V",
 			"time": [
@@ -18007,6 +18281,11 @@
 			"page": 321,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-BD",
+				"DrDe-TFV",
+				"UtHftLH"
+			],
 			"level": 3,
 			"school": "C",
 			"time": [
@@ -18040,6 +18319,9 @@
 			"entries": [
 				"You create a 20-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} of yellow, nauseating gas centered on a point within range. The cloud is {@variantrule Heavily Obscured|XPHB}. The cloud lingers in the air for the duration or until a strong wind (such as the one created by {@spell Gust of Wind|XPHB}) disperses it.",
 				"Each creature that starts its turn in the {@variantrule Sphere [Area of Effect]|XPHB|Sphere} must succeed on a Constitution saving throw or have the {@condition Poisoned|XPHB} condition until the end of the current turn. While {@condition Poisoned|XPHB} in this way, the creature can't take an action or a {@variantrule Bonus Action|XPHB}."
+			],
+			"conditionInflict": [
+				"poisoned"
 			],
 			"savingThrow": [
 				"constitution"
@@ -18235,6 +18517,9 @@
 			"page": 321,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 2,
 			"school": "E",
 			"time": [
@@ -18341,6 +18626,9 @@
 			"name": "Summon Beast",
 			"source": "XPHB",
 			"page": 322,
+			"referenceSources": [
+				"FRAiF"
+			],
 			"level": 2,
 			"school": "C",
 			"time": [
@@ -18396,6 +18684,9 @@
 			"name": "Summon Celestial",
 			"source": "XPHB",
 			"page": 323,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 5,
 			"school": "C",
 			"time": [
@@ -19348,7 +19639,7 @@
 			],
 			"entries": [
 				"This spell instantly transports you and up to eight willing creatures that you can see within range, or a single object that you can see within range, to a destination you select. If you target an object, it must be Large or smaller, and it can't be held or carried by an unwilling creature.",
-				"The destination you choose must be known to you, and it must be on the same plane of existence as you. Your familiarity with the destination determines whether you arrive there successfully. The DM rolls {@dice 1d100} and consults the {@variantrule Teleportation|XPHB} Outcome table and the explanations after it.",
+				"The destination you choose must be known to you, and it must be on the same plane of existence as you. Your familiarity with the destination determines whether you arrive there successfully. The DM rolls {@dice 1d100} and consults the Teleportation Outcome table and the explanations after it.",
 				{
 					"type": "table",
 					"caption": "Teleportation Outcome",
@@ -19477,6 +19768,9 @@
 			"page": 332,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-FWtVC"
+			],
 			"level": 5,
 			"school": "C",
 			"time": [
@@ -19575,6 +19869,9 @@
 			"page": 333,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 0,
 			"school": "T",
 			"time": [
@@ -19835,6 +20132,9 @@
 			"page": 334,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 1,
 			"school": "V",
 			"time": [
@@ -19923,6 +20223,9 @@
 			"name": "Toll the Dead",
 			"source": "XPHB",
 			"page": 334,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 0,
 			"school": "N",
 			"time": [
@@ -20062,8 +20365,8 @@
 				{
 					"type": "timed",
 					"duration": {
-						"type": "round",
-						"amount": 1
+						"type": "minute",
+						"amount": 10
 					}
 				}
 			],
@@ -20162,7 +20465,7 @@
 					"name": "Creature into Creature",
 					"entries": [
 						"If you turn a creature into another kind of creature, the new form can be any kind you choose that has a {@variantrule Challenge Rating|XPHB} equal to or less than the target's {@variantrule Challenge Rating|XPHB} or level. The target's game statistics are replaced by the stat block of the new form, but it retains its {@variantrule Hit Points|XPHB}, {@variantrule Hit Point Dice|XPHB}, alignment, and personality.",
-						"The target gains a number of {@variantrule Temporary Hit Points|XPHB} equal to the {@variantrule Hit Points|XPHB} of the new form. These {@variantrule Temporary Hit Points|XPHB} vanish if any remain when the spell ends. The spell ends early on the target if it has no {@variantrule Temporary Hit Points|XPHB} left.",
+						"The target gains a number of {@variantrule Temporary Hit Points|XPHB} equal to the {@variantrule Hit Points|XPHB} of the new form. These {@variantrule Temporary Hit Points|XPHB} vanish if any remain when the spell ends.",
 						"The target is limited in the actions it can perform by the anatomy of its new form, and it can't speak or cast spells.",
 						"The target's gear melds into the new form. The creature can't use or otherwise benefit from any of that equipment."
 					]
@@ -20409,6 +20712,10 @@
 			"page": 336,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN",
+				"FRAiF"
+			],
 			"level": 1,
 			"school": "C",
 			"time": [
@@ -20457,6 +20764,9 @@
 			"page": 337,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-TDoN"
+			],
 			"level": 3,
 			"school": "N",
 			"time": [
@@ -20582,6 +20892,9 @@
 			"page": 337,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"UtHftLH"
+			],
 			"level": 4,
 			"school": "V",
 			"time": [
@@ -21059,6 +21372,9 @@
 			"page": 340,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-DaS"
+			],
 			"level": 2,
 			"school": "C",
 			"time": [
@@ -21271,6 +21587,10 @@
 			"page": 341,
 			"srd52": true,
 			"basicRules2024": true,
+			"referenceSources": [
+				"DrDe-SD",
+				"UtHftLH"
+			],
 			"level": 9,
 			"school": "C",
 			"time": [

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -595,6 +595,8 @@ export const SPELL_SOURCE_COLORS: Record<string, string> = {
   GHLoE: 'bg-cyan-600',
   VG: 'bg-teal-600',
   'AitFR-AVT': 'bg-green-600',
+  FRHoF: 'bg-amber-600',
+  RHW: 'bg-rose-700',
 };
 
 export const SPELL_SOURCE_BOOKS: Record<string, string> = {
@@ -629,6 +631,8 @@ export const SPELL_SOURCE_BOOKS: Record<string, string> = {
   DMG: "Dungeon Master's Guide",
   DMG2024: "Dungeon Master's Guide 2024",
   XDMG: "Dungeon Master's Guide 2024",
+  FRHoF: 'Forgotten Realms: Heroes of Faerûn',
+  RHW: 'Ravenloft: Horrors Within',
 };
 
 // Auto-save settings


### PR DESCRIPTION
Updates the static game data in `json/` from the 5etools **v2.25.2** snapshot to **v2.33.1**, which brings in **Ravenloft: Horrors Within (RHW)**. Also registers RHW and FRHoF as known sources in the UI.

## New RHW content

| Type | Count |
|---|---|
| Feats | 11 |
| Backgrounds | 4 |
| Races | 4 |
| Items | 2 |
| Monsters (`bestiary-rhw.json`) | 70 |
| Subclasses | 7 |

Subclasses: Artificer/Reanimator, Bard/College of Spirits, Cleric/Grave Domain, Ranger/Hollow Warden, Rogue/Phantom, Sorcerer/Shadow Sorcery, Warlock/Undead Patron.

RHW ships **no spells** — there is no `spells-rhw.json` upstream.

## Also included in the version jump

- 8 new bestiary files: `abh`, `efa`, `fraif`, `hotb`, `lfl`, `nf`, `rhw`, `wtthc`
- New items (10 IDRotF, 1 TftYP), 5 new item types, 4 new book entries
- Errata across the refreshed files

## Source registration

`FRHoF` and `RHW` added to `SPELL_SOURCE_BOOKS` / `SPELL_SOURCE_COLORS` in `src/utils/constants.ts`. Previously their content rendered with the raw source code as its label and an unstyled badge. (Forgotten Realms: Heroes of Faerûn content was already present in `json/` from the old snapshot but had never been registered.)

## Merged, not overwritten

Upstream deleted content between these two versions. A wholesale replace would have silently removed it from the app, so `feats.json`, `backgrounds.json`, `races.json` and `items.json` were merged — entries present locally but absent upstream are preserved:

- 18 Adventurers League backgrounds (`ALCurseOfStrahd`, `ALElementalEvil`, `ALRageOfDemons`)
- 7 TDCSR feats, 7 TDCSR backgrounds
- Human (Amonkhet) — `PSA`
- Lantern of Tracking — `IDRotF`

`spells-tdcsr.json` and `bestiary-tdcsr.json` are likewise kept.

**Two entries dropped as superseded**, because upstream now carries them under a different source and keeping both copies would duplicate them in the pickers:

- Dhampir: `ABH` → `RHW`/`VRGR`
- Soul Coin: `CoA` → `BGDIA`

## Verification

- All 108 data files parse as valid JSON
- `npx tsc --noEmit` exits 0
- RHW counts re-confirmed after the prettier pre-commit hook reformatted the files

## Known follow-up (not addressed here)

RHW reprints six VRGR entries — backgrounds Haunted One and Investigator, races Dhampir, Hexblood, Reborn, and the item Harkon's Bite. `raceDataLoader` dedups by name so the races resolve to a single entry, but `backgroundDataLoader` and `featDataLoader` have no dedup pass, so **Haunted One and Investigator will each appear twice in the background picker** with different source badges. Fixing that means either adding source-priority dedup to those loaders or dropping the RHW reprints — worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)