### PR TITLE
fix(character): always-prepared spells, caster tab, and avatar persistence

### DIFF
--- a/src/components/SpellManagement.tsx
+++ b/src/components/SpellManagement.tsx
@@ -44,6 +44,7 @@ import {
   convertProcessedSpellToFormData,
   spellToFormData,
   createInitialSpellFormData,
+  isSpellPrepared,
   type SpellFormData,
 } from '@/utils/spellConversion';
 import { SpellFormFields } from '@/components/shared/spells';
@@ -120,7 +121,7 @@ const SpellCard: React.FC<{
     return (
       <div
         className={`flex items-center justify-between rounded-lg border-2 p-3 transition-all hover:shadow-md ${
-          spell.isPrepared
+          isSpellPrepared(spell)
             ? 'border-accent-green-border-strong bg-surface-raised'
             : 'border-divider bg-surface-raised hover:border-accent-purple-border'
         }`}
@@ -201,10 +202,16 @@ const SpellCard: React.FC<{
           </Button>
           <Button
             onClick={onTogglePrepared}
-            variant={spell.isPrepared ? 'success' : 'outline'}
+            variant={isSpellPrepared(spell) ? 'success' : 'outline'}
             size="xs"
+            disabled={spell.isAlwaysPrepared}
+            title={
+              spell.isAlwaysPrepared
+                ? 'Always prepared — cannot be unprepared'
+                : undefined
+            }
           >
-            {spell.isPrepared ? 'Prepared' : 'Prepare'}
+            {isSpellPrepared(spell) ? 'Prepared' : 'Prepare'}
           </Button>
           <Button
             onClick={onView}
@@ -240,7 +247,7 @@ const SpellCard: React.FC<{
   return (
     <div
       className={`rounded-lg border-2 p-4 transition-all hover:shadow-md ${
-        spell.isPrepared
+        isSpellPrepared(spell)
           ? 'border-accent-green-border-strong bg-surface-raised'
           : 'border-divider bg-surface-raised hover:border-accent-purple-border'
       }`}
@@ -376,10 +383,16 @@ const SpellCard: React.FC<{
 
           <Button
             onClick={onTogglePrepared}
-            variant={spell.isPrepared ? 'success' : 'outline'}
+            variant={isSpellPrepared(spell) ? 'success' : 'outline'}
             size="sm"
+            disabled={spell.isAlwaysPrepared}
+            title={
+              spell.isAlwaysPrepared
+                ? 'Always prepared — cannot be unprepared'
+                : undefined
+            }
           >
-            {spell.isPrepared ? 'Prepared' : 'Prepare'}
+            {isSpellPrepared(spell) ? 'Prepared' : 'Prepare'}
           </Button>
 
           <div className="flex gap-1">

--- a/src/components/ui/character/CharacterSheetHeader.tsx
+++ b/src/components/ui/character/CharacterSheetHeader.tsx
@@ -63,7 +63,7 @@ export default function CharacterSheetHeader({
   onAddToast,
   extraHeaderContent,
 }: CharacterSheetHeaderProps) {
-  const { exportCharacter } = useCharacterStore();
+  const { exportCharacter, updateCharacter } = useCharacterStore();
   const { getCharacterById, updateCharacterData } = usePlayerStore();
 
   // Get character data for avatar
@@ -71,12 +71,18 @@ export default function CharacterSheetHeader({
 
   // Handle avatar change
   const handleAvatarChange = (newAvatar: string | undefined) => {
+    // Update the live character store first — it is the source of truth that
+    // useCharacterRosterSync writes back to the roster. Without this, the roster
+    // write-back would overwrite (clobber) the uploaded avatar on the next edit
+    // or reload.
+    updateCharacter({ avatar: newAvatar });
+
+    // Also update the roster blob directly for immediate display feedback.
     if (playerCharacter?.characterData) {
       updateCharacterData(characterId, {
         ...playerCharacter.characterData,
         avatar: newAvatar,
       });
-    } else {
     }
   };
 

--- a/src/store/__tests__/characterStore-class.test.ts
+++ b/src/store/__tests__/characterStore-class.test.ts
@@ -194,6 +194,70 @@ describe('characterStore — class, level, multiclass, hit dice, XP', () => {
     });
   });
 
+  // ─── loadCharacterState ───────────────────────────────────────────────────
+
+  describe('loadCharacterState', () => {
+    it('recalculates spell slots for a freshly-created full caster whose stored slots are all zero', () => {
+      const newDruid = makeCharacter({
+        class: {
+          name: 'Druid',
+          isCustom: false,
+          spellcaster: 'full',
+          hitDie: 8,
+        },
+        level: 1,
+        totalLevel: 1,
+        classes: undefined,
+        spellSlots: {
+          1: { max: 0, used: 0 },
+          2: { max: 0, used: 0 },
+          3: { max: 0, used: 0 },
+          4: { max: 0, used: 0 },
+          5: { max: 0, used: 0 },
+          6: { max: 0, used: 0 },
+          7: { max: 0, used: 0 },
+          8: { max: 0, used: 0 },
+          9: { max: 0, used: 0 },
+        },
+      });
+
+      useCharacterStore.getState().loadCharacterState(newDruid);
+
+      const { spellSlots } = useCharacterStore.getState().character;
+      expect(spellSlots[1].max).toBe(2);
+    });
+
+    it('preserves used spell slots when recalculating on load', () => {
+      const wizard = makeCharacter({
+        class: {
+          name: 'Wizard',
+          isCustom: false,
+          spellcaster: 'full',
+          hitDie: 6,
+        },
+        level: 3,
+        totalLevel: 3,
+        classes: undefined,
+        spellSlots: {
+          1: { max: 4, used: 2 },
+          2: { max: 2, used: 0 },
+          3: { max: 0, used: 0 },
+          4: { max: 0, used: 0 },
+          5: { max: 0, used: 0 },
+          6: { max: 0, used: 0 },
+          7: { max: 0, used: 0 },
+          8: { max: 0, used: 0 },
+          9: { max: 0, used: 0 },
+        },
+      });
+
+      useCharacterStore.getState().loadCharacterState(wizard);
+
+      const { spellSlots } = useCharacterStore.getState().character;
+      expect(spellSlots[1].used).toBe(2);
+    });
+  });
+
   // ─── addClassLevel ────────────────────────────────────────────────────────
 
   describe('addClassLevel', () => {

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -816,9 +816,32 @@ export const useCharacterStore = create<CharacterStore>()(
       loadCharacterState: characterState => {
         const migratedCharacter = migrateCharacterData(characterState);
         const multiclassCharacter = migrateToMulticlass(migratedCharacter);
+
+        // Spell slots and pact magic are derived from class + level, but they are
+        // only computed on class/level changes. Recalculate them on load so that
+        // freshly-created casters (and any characters saved before this ran) get
+        // correct slots without having to toggle their level.
+        const recalculatedSpellSlots = updateSpellSlotsPreservingUsed(
+          calculateCharacterSpellSlots(multiclassCharacter),
+          multiclassCharacter.spellSlots
+        );
+
+        const recalculatedPactMagic =
+          calculateCharacterPactMagic(multiclassCharacter);
+        if (multiclassCharacter.pactMagic && recalculatedPactMagic) {
+          recalculatedPactMagic.slots.used = Math.min(
+            multiclassCharacter.pactMagic.slots.used,
+            recalculatedPactMagic.slots.max
+          );
+        }
+
         withExternalApply(() =>
           set({
-            character: multiclassCharacter,
+            character: {
+              ...multiclassCharacter,
+              spellSlots: recalculatedSpellSlots,
+              pactMagic: recalculatedPactMagic,
+            },
             hasUnsavedChanges: false,
             saveStatus: 'saved',
             lastSaved: new Date(),

--- a/src/utils/spellConversion.ts
+++ b/src/utils/spellConversion.ts
@@ -10,6 +10,17 @@ import { detectSpellAoe } from './spellAoeDetection';
 import { formatSpellDescriptionForEditor } from './referenceParser';
 
 /**
+ * A spell counts as prepared if it is explicitly prepared OR always prepared
+ * (e.g. domain/patron spells). Always-prepared spells cannot be unprepared, so
+ * every "is this spell prepared?" check must treat them as prepared.
+ */
+export function isSpellPrepared(
+  spell: Pick<Spell, 'isPrepared' | 'isAlwaysPrepared'>
+): boolean {
+  return !!spell.isPrepared || !!spell.isAlwaysPrepared;
+}
+
+/**
  * Convert ProcessedSpell (from spellbook) to SpellFormData (for character sheet)
  */
 export type FreeCastMode = 'normal' | 'at_will' | 'innate';


### PR DESCRIPTION
## Summary
Fixes three reported bugs in the character sheet:

- **Always-prepared spells not treated as prepared** — marking a spell "Always Prepared" only set `isAlwaysPrepared`, but the SpellManagement list UI (card border, Prepare button) only checked `isPrepared`, so the spell still looked unprepared. Added a shared `isSpellPrepared` helper and use it consistently; the Prepare toggle is now disabled for always-prepared spells.
- **New Druid (and other casters) missing the Spells tab** — tab visibility is gated by having spell slots, but slots are derived data only recomputed on class/level changes. A new level-1 Druid had all-zero slots until the level was toggled. `loadCharacterState` now recalculates spell slots + pact magic (preserving `used`), so casters get correct slots on load and repair already-created characters automatically.
- **Avatar lost after reload** — `handleAvatarChange` only wrote the S3 URL to `playerStore`; `useCharacterRosterSync` then clobbered it from `characterStore` on load/edit. Avatar changes now also update `characterStore` (the write-back source of truth).

## Test plan
- [x] `npm run type-check` passes
- [x] `characterStore-class` suite passes (61/61), including 2 new load-time spell-slot recalculation tests
- [ ] Manually mark a spell "Always Prepared" → shows as prepared, toggle disabled
- [ ] Create a new Druid → Spells tab visible immediately at level 1
- [ ] Upload an avatar, reload → avatar persists

Note: avatars uploaded before this fix were dropped from state and need re-uploading.

Made with [Cursor](https://cursor.com)