### PR TITLE
feat(inventory): show weapon charges in Weapons tab

### DIFF
--- a/src/components/__tests__/equipment-smoke.test.tsx
+++ b/src/components/__tests__/equipment-smoke.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { WeaponCard } from '@/components/ui/game/equipment/WeaponCard';
 import { WeaponRow } from '@/components/ui/character/equipment/WeaponRow';
@@ -104,6 +104,10 @@ describe('WeaponCard', () => {
 });
 
 describe('WeaponRow', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   const defaultProps = {
     weapon: mockWeaponWithCharges,
     characterLevel: 5,
@@ -122,7 +126,9 @@ describe('WeaponRow', () => {
   it('shows individual charge chips when expanded', async () => {
     const user = userEvent.setup();
     render(<WeaponRow {...defaultProps} />);
-    await user.click(screen.getByRole('button', { name: /Sun Blade/i }));
+    const header = screen.getByText('Sun Blade').closest('button');
+    expect(header).toBeTruthy();
+    await user.click(header!);
     expect(screen.getByText('Flame Tongue')).toBeInTheDocument();
     expect(screen.getByText('Individual Charges')).toBeInTheDocument();
   });

--- a/src/components/__tests__/equipment-smoke.test.tsx
+++ b/src/components/__tests__/equipment-smoke.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { WeaponCard } from '@/components/ui/game/equipment/WeaponCard';
+import { WeaponRow } from '@/components/ui/character/equipment/WeaponRow';
 import { MagicItemRow } from '@/components/ui/character/equipment/MagicItemRow';
 import { ItemCard } from '@/components/ui/game/inventory/ItemCard';
 import { ChargePoolDisplay } from '@/components/ui/character/equipment/ChargePoolDisplay';
@@ -23,6 +25,22 @@ const mockWeapon: Weapon = {
   isEquipped: true,
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
+};
+
+const mockWeaponWithCharges: Weapon = {
+  ...mockWeapon,
+  id: 'w-charges',
+  name: 'Sun Blade',
+  isEquipped: false,
+  charges: [
+    {
+      id: 'c1',
+      name: 'Flame Tongue',
+      maxCharges: 3,
+      usedCharges: 1,
+      restType: 'long',
+    },
+  ],
 };
 
 const mockMagicItem: MagicItem = {
@@ -82,6 +100,31 @@ describe('WeaponCard', () => {
   it('shows equipped status', () => {
     render(<WeaponCard {...defaultProps} />);
     expect(screen.getAllByText('Equipped').length).toBeGreaterThan(0);
+  });
+});
+
+describe('WeaponRow', () => {
+  const defaultProps = {
+    weapon: mockWeaponWithCharges,
+    characterLevel: 5,
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    onToggleEquip: vi.fn(),
+    onExpendCharge: vi.fn(),
+    onRestoreCharge: vi.fn(),
+  };
+
+  it('shows compact individual charge total when collapsed', () => {
+    render(<WeaponRow {...defaultProps} />);
+    expect(screen.getByText('2/3')).toBeInTheDocument();
+  });
+
+  it('shows individual charge chips when expanded', async () => {
+    const user = userEvent.setup();
+    render(<WeaponRow {...defaultProps} />);
+    await user.click(screen.getByRole('button', { name: /Sun Blade/i }));
+    expect(screen.getByText('Flame Tongue')).toBeInTheDocument();
+    expect(screen.getByText('Individual Charges')).toBeInTheDocument();
   });
 });
 

--- a/src/components/ui/character/equipment/WeaponRow.tsx
+++ b/src/components/ui/character/equipment/WeaponRow.tsx
@@ -1,17 +1,33 @@
 'use client';
 
 import React, { useState } from 'react';
-import type { Weapon } from '@/types/character';
-import { ChevronDown, ChevronRight, Edit2, Trash2, Swords } from 'lucide-react';
+import type { Weapon, WeaponCharge } from '@/types/character';
+import {
+  ChevronDown,
+  ChevronRight,
+  Edit2,
+  Trash2,
+  Swords,
+  Zap,
+  Sparkles,
+  Clock,
+  Sun,
+  Minus,
+  Plus,
+} from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { Badge } from '@/components/ui/layout/badge';
 import { ChargePoolDisplay } from './ChargePoolDisplay';
+import { calculateWeaponChargeMax } from '@/utils/calculations';
 
 interface WeaponRowProps {
   weapon: Weapon;
+  characterLevel: number;
   onEdit: (weapon: Weapon) => void;
   onDelete: (id: string) => void;
   onToggleEquip: (id: string, equipped: boolean) => void;
+  onExpendCharge?: (weaponId: string, chargeId: string) => void;
+  onRestoreCharge?: (weaponId: string, chargeId: string) => void;
   onExpendChargePoolAbility?: (weaponId: string, abilityId: string) => void;
   onRestoreChargePool?: (weaponId: string, amount: number) => void;
   onSetChargePoolUsed?: (weaponId: string, usedCount: number) => void;
@@ -19,15 +35,30 @@ interface WeaponRowProps {
 
 export function WeaponRow({
   weapon,
+  characterLevel,
   onEdit,
   onDelete,
   onToggleEquip,
+  onExpendCharge,
+  onRestoreCharge,
   onExpendChargePoolAbility,
   onRestoreChargePool,
   onSetChargePoolUsed,
 }: WeaponRowProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const pool = weapon.chargePool;
+
+  const hasCharges = !!weapon.charges && weapon.charges.length > 0;
+
+  let individualRemaining = 0;
+  let individualMax = 0;
+  if (hasCharges) {
+    for (const charge of weapon.charges!) {
+      const max = calculateWeaponChargeMax(charge, characterLevel);
+      individualMax += max;
+      individualRemaining += max - (charge.usedCharges || 0);
+    }
+  }
 
   const damageText =
     Array.isArray(weapon.damage) && weapon.damage.length > 0
@@ -85,6 +116,22 @@ export function WeaponRow({
           <span className="text-muted hidden text-xs sm:inline">
             {damageText}
           </span>
+          {hasCharges && (
+            <div className="flex items-center gap-1.5">
+              <Zap size={12} className="text-accent-amber-text" />
+              <span
+                className={`text-xs font-bold ${
+                  individualRemaining <= 0
+                    ? 'text-accent-red-text-muted'
+                    : individualRemaining <= Math.ceil(individualMax * 0.25)
+                      ? 'text-accent-orange-text-muted'
+                      : 'text-accent-amber-text'
+                }`}
+              >
+                {individualRemaining}/{individualMax}
+              </span>
+            </div>
+          )}
           {pool && (
             <ChargePoolDisplay
               pool={pool}
@@ -127,6 +174,25 @@ export function WeaponRow({
             </div>
           )}
 
+          {hasCharges && (
+            <div className="space-y-1.5">
+              <span className="text-body text-xs font-semibold uppercase">
+                Individual Charges
+              </span>
+              <div className="flex flex-wrap gap-2">
+                {weapon.charges!.map(charge => (
+                  <IndividualChargeChip
+                    key={charge.id}
+                    charge={charge}
+                    characterLevel={characterLevel}
+                    onExpend={() => onExpendCharge?.(weapon.id, charge.id)}
+                    onRestore={() => onRestoreCharge?.(weapon.id, charge.id)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
           {pool && (
             <ChargePoolDisplay
               pool={pool}
@@ -162,6 +228,72 @@ export function WeaponRow({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function IndividualChargeChip({
+  charge,
+  characterLevel,
+  onExpend,
+  onRestore,
+}: {
+  charge: WeaponCharge;
+  characterLevel: number;
+  onExpend: () => void;
+  onRestore: () => void;
+}) {
+  const maxCharges = calculateWeaponChargeMax(charge, characterLevel);
+  const used = charge.usedCharges || 0;
+  const remaining = maxCharges - used;
+  const isExhausted = remaining <= 0;
+  const isFull = used <= 0;
+
+  return (
+    <div
+      className={`inline-flex items-center gap-1.5 rounded-lg border px-2 py-1.5 ${
+        isExhausted
+          ? 'border-accent-red-border bg-accent-red-bg'
+          : 'border-accent-amber-border bg-accent-amber-bg'
+      }`}
+    >
+      <Sparkles
+        size={10}
+        className={
+          isExhausted
+            ? 'text-accent-red-text-muted'
+            : 'text-accent-amber-text-muted'
+        }
+      />
+      <span className="text-heading max-w-[100px] truncate text-xs font-medium">
+        {charge.name}
+      </span>
+      <button
+        type="button"
+        onClick={onRestore}
+        disabled={isFull}
+        className={`rounded p-0.5 ${isFull ? 'text-faint cursor-not-allowed' : 'text-accent-green-text-muted hover:bg-accent-green-bg'}`}
+        title="Restore 1"
+      >
+        <Plus size={10} />
+      </button>
+      <span
+        className={`text-xs font-bold ${isExhausted ? 'text-accent-red-text' : 'text-heading'}`}
+      >
+        {remaining}/{maxCharges}
+      </span>
+      <button
+        type="button"
+        onClick={onExpend}
+        disabled={isExhausted}
+        className={`rounded p-0.5 ${isExhausted ? 'text-faint cursor-not-allowed' : 'text-accent-red-text-muted hover:bg-accent-red-bg'}`}
+        title="Use 1"
+      >
+        <Minus size={10} />
+      </button>
+      <span className="text-faint text-[10px]">
+        {charge.restType === 'dawn' ? <Sun size={10} /> : <Clock size={10} />}
+      </span>
     </div>
   );
 }

--- a/src/components/ui/character/equipment/WeaponsTab.tsx
+++ b/src/components/ui/character/equipment/WeaponsTab.tsx
@@ -31,6 +31,8 @@ export function WeaponsTab() {
     deleteWeapon,
     equipWeapon,
     reorderWeapons,
+    expendWeaponCharge,
+    restoreWeaponCharge,
     expendWeaponChargePoolAbility,
     restoreWeaponChargePool,
     setWeaponChargePoolUsed,
@@ -152,9 +154,12 @@ export function WeaponsTab() {
           renderItem={weapon => (
             <WeaponRow
               weapon={weapon}
+              characterLevel={character.level}
               onEdit={handleEdit}
               onDelete={id => deleteWeapon(id)}
               onToggleEquip={(id, eq) => equipWeapon(id, eq)}
+              onExpendCharge={expendWeaponCharge}
+              onRestoreCharge={restoreWeaponCharge}
               onExpendChargePoolAbility={expendWeaponChargePoolAbility}
               onRestoreChargePool={restoreWeaponChargePool}
               onSetChargePoolUsed={setWeaponChargePoolUsed}


### PR DESCRIPTION
## Summary
- Show individual weapon charges in Inventory → Weapons, matching magic-item inventory behavior
- Collapsed row: compact remaining/max total; expanded: Individual Charges chips with +/- wired to existing store actions
- Charge pool UI and Actions tab unchanged

## Test plan
- [ ] Add a weapon with an individual charge ability → collapsed row shows remaining/max without expanding
- [ ] Expand the row → Individual Charges chips appear; expend/restore updates the count
- [ ] Equip the weapon → Actions tab shows the same used/remaining counts
- [ ] Weapon with only a charge pool (no individual charges) still looks unchanged
- [ ] `npx vitest run src/components/__tests__/equipment-smoke.test.tsx` passes