### PR TITLE
feat: automatic cantrip damage scaling at levels 5/11/17

### DIFF
--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'next/navigation';
 import { usePlayerStore } from '@/store/playerStore';
 import { useCharacterStore } from '@/store/characterStore';
 import { useAutoSave } from '@/hooks/useAutoSave';
+import { useCantripScalingBackfill } from '@/hooks/useCantripScalingBackfill';
 import { usePlayerSync } from '@/hooks/usePlayerSync';
 import { SyncIndicator } from '@/components/ui/campaign/SyncIndicator';
 import { PartyHPSidebar } from '@/components/ui/campaign/PartyHPSidebar';
@@ -441,6 +442,8 @@ export default function CharacterSheet() {
   ]);
 
   const { manualSave } = useAutoSave({ onAfterSave: handleAfterSave });
+
+  useCantripScalingBackfill();
 
   // Auto-migrate existing traits to extended features once a character loads
   // (mirrors the same load event the roster-sync hook fires on).

--- a/src/components/QuickSpells.tsx
+++ b/src/components/QuickSpells.tsx
@@ -25,6 +25,8 @@ import {
   getCharacterSpellcastingAbility,
   rollDamage,
 } from '@/utils/calculations';
+import { getScaledSpellDamage } from '@/utils/cantripScaling';
+import { getTotalLevel } from '@/utils/multiclass';
 import { SpellCastModal } from '@/components/ui/game/SpellCastModal';
 import SpellDetailsModal from '@/components/ui/game/SpellDetailsModal';
 import { RollSummary } from '@/types/dice';
@@ -70,6 +72,7 @@ interface LevelSectionProps {
   onSpellAction: (spell: Spell, action: string) => void;
   favoriteSpells: string[];
   onToggleFavorite: (spellId: string) => void;
+  totalLevel: number;
   slotMax?: number;
   slotUsed?: number;
   onSlotChange?: (used: number) => void;
@@ -82,6 +85,7 @@ const SpellCard: React.FC<{
   spellSaveDC: number | null;
   onAction: (action: string) => void;
   onToggleFavorite: () => void;
+  totalLevel: number;
 }> = ({
   spell,
   compact,
@@ -89,6 +93,7 @@ const SpellCard: React.FC<{
   spellSaveDC,
   onAction,
   onToggleFavorite,
+  totalLevel,
 }) => {
   const isCantrip = spell.level === 0;
   const isAtWill = spell.freeCastMax === 0;
@@ -96,6 +101,7 @@ const SpellCard: React.FC<{
   const freeCastsRemaining = isInnate
     ? spell.freeCastMax! - (spell.freeCastsUsed || 0)
     : 0;
+  const displayDamage = getScaledSpellDamage(spell, totalLevel);
 
   if (compact) {
     return (
@@ -275,9 +281,9 @@ const SpellCard: React.FC<{
             {spell.savingThrow} Save DC {spellSaveDC || '?'}
           </Badge>
         )}
-        {spell.damage && (
+        {displayDamage && (
           <Badge variant="warning" size="sm">
-            {spell.damage} {spell.damageType && `${spell.damageType}`}
+            {displayDamage} {spell.damageType && `${spell.damageType}`}
           </Badge>
         )}
       </div>
@@ -295,6 +301,7 @@ const LevelSection: React.FC<LevelSectionProps> = ({
   onSpellAction,
   favoriteSpells,
   onToggleFavorite,
+  totalLevel,
   slotMax,
   slotUsed,
   onSlotChange,
@@ -387,6 +394,7 @@ const LevelSection: React.FC<LevelSectionProps> = ({
                 spellSaveDC={spellSaveDC}
                 onAction={action => onSpellAction(spell, action)}
                 onToggleFavorite={() => onToggleFavorite(spell.id)}
+                totalLevel={totalLevel}
               />
             ))}
           </div>
@@ -405,6 +413,7 @@ export function QuickSpells({
   const { character, updateSpellSlot, toggleSpellFavorite, toggleReaction } =
     useCharacterStore();
   const { castSpell } = useCastSpell();
+  const totalLevel = getTotalLevel(character);
 
   // Local state
   const [castModalOpen, setCastModalOpen] = useState(false);
@@ -496,7 +505,7 @@ export function QuickSpells({
             roll,
             spellAttackBonus,
             isCrit,
-            spell.damage,
+            getScaledSpellDamage(spell, totalLevel),
             spell.damageType
           );
           return;
@@ -516,7 +525,7 @@ export function QuickSpells({
       roll,
       spellAttackBonus,
       isCrit,
-      spell.damage,
+      getScaledSpellDamage(spell, totalLevel),
       spell.damageType
     );
   };
@@ -530,20 +539,21 @@ export function QuickSpells({
       spell.name,
       spellSaveDC,
       spell.savingThrow,
-      spell.damage,
+      getScaledSpellDamage(spell, totalLevel),
       spell.damageType
     );
   };
 
   const rollSpellDamage = async (spell: Spell) => {
-    if (!spell.damage) {
+    const damage = getScaledSpellDamage(spell, totalLevel);
+    if (!damage) {
       alert('This spell does not have damage dice specified');
       return;
     }
 
     if (animateRoll) {
       try {
-        const rollResult = await animateRoll(spell.damage);
+        const rollResult = await animateRoll(damage);
         if (
           rollResult &&
           typeof rollResult === 'object' &&
@@ -562,7 +572,7 @@ export function QuickSpells({
       }
     }
 
-    const damageResult = rollDamage(spell.damage);
+    const damageResult = rollDamage(damage);
     showDamageRoll(spell.name, damageResult, spell.damageType);
   };
 
@@ -722,6 +732,7 @@ export function QuickSpells({
                   spellSaveDC={spellSaveDC}
                   onAction={action => handleSpellAction(spell, action)}
                   onToggleFavorite={() => toggleSpellFavorite(spell.id)}
+                  totalLevel={totalLevel}
                 />
               ))}
             </div>
@@ -741,6 +752,7 @@ export function QuickSpells({
             onSpellAction={handleSpellAction}
             favoriteSpells={favoriteSpells}
             onToggleFavorite={toggleSpellFavorite}
+            totalLevel={totalLevel}
           />
         )}
 
@@ -764,6 +776,7 @@ export function QuickSpells({
                   onSpellAction={handleSpellAction}
                   favoriteSpells={favoriteSpells}
                   onToggleFavorite={toggleSpellFavorite}
+                  totalLevel={totalLevel}
                   slotMax={slot?.max}
                   slotUsed={slot?.used}
                   onSlotChange={used =>
@@ -819,6 +832,7 @@ export function QuickSpells({
             toggleSpellFavorite(viewingSpell.id);
           }}
           onCast={() => openCastModal(viewingSpell)}
+          characterLevel={totalLevel}
         />
       )}
     </>

--- a/src/components/SpellManagement.tsx
+++ b/src/components/SpellManagement.tsx
@@ -40,6 +40,8 @@ import { SpellCastModal } from '@/components/ui/game/SpellCastModal';
 import DragDropList from '@/components/ui/layout/DragDropList';
 import { SpellAutocomplete } from '@/components/ui/forms/SpellAutocomplete';
 import { useSpellsData } from '@/hooks/useSpellsData';
+import { getScaledSpellDamage } from '@/utils/cantripScaling';
+import { getTotalLevel } from '@/utils/multiclass';
 import {
   convertProcessedSpellToFormData,
   spellToFormData,
@@ -93,6 +95,7 @@ const SpellCard: React.FC<{
   spell: Spell;
   compact: boolean;
   isFavorite: boolean;
+  totalLevel: number;
   onEdit: () => void;
   onDelete: () => void;
   onView: () => void;
@@ -103,6 +106,7 @@ const SpellCard: React.FC<{
   spell,
   compact,
   isFavorite,
+  totalLevel,
   onEdit,
   onDelete,
   onView,
@@ -116,6 +120,7 @@ const SpellCard: React.FC<{
   const freeCastsRemaining = isInnate
     ? spell.freeCastMax! - (spell.freeCastsUsed || 0)
     : 0;
+  const displayDamage = getScaledSpellDamage(spell, totalLevel);
 
   if (compact) {
     return (
@@ -356,10 +361,10 @@ const SpellCard: React.FC<{
               )}
           </div>
 
-          {spell.damage && (
+          {displayDamage && (
             <div className="mb-2">
               <Badge variant="danger" size="sm">
-                {spell.damage} {spell.damageType}
+                {displayDamage} {spell.damageType}
               </Badge>
             </div>
           )}
@@ -436,6 +441,7 @@ const LevelSection: React.FC<{
   onToggle: () => void;
   compact: boolean;
   favoriteSpells: string[];
+  totalLevel: number;
   onSpellEdit: (spell: Spell) => void;
   onSpellDelete: (id: string) => void;
   onSpellView: (spell: Spell) => void;
@@ -453,6 +459,7 @@ const LevelSection: React.FC<{
   onToggle,
   compact,
   favoriteSpells,
+  totalLevel,
   onSpellEdit,
   onSpellDelete,
   onSpellView,
@@ -577,6 +584,7 @@ const LevelSection: React.FC<{
                 spell={spell}
                 compact={compact}
                 isFavorite={favoriteSpells.includes(spell.id)}
+                totalLevel={totalLevel}
                 onEdit={() => onSpellEdit(spell)}
                 onDelete={() => onSpellDelete(spell.id)}
                 onView={() => onSpellView(spell)}
@@ -604,6 +612,7 @@ export const SpellManagement: React.FC = () => {
     toggleReaction,
     addSummon,
   } = useCharacterStore();
+  const totalLevel = getTotalLevel(character);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [formData, setFormData] = useState<SpellFormData>(
@@ -1321,6 +1330,7 @@ export const SpellManagement: React.FC = () => {
               onToggle={() => toggleLevelExpanded(level)}
               compact={compactView}
               favoriteSpells={favoriteSpells}
+              totalLevel={totalLevel}
               onSpellEdit={handleEdit}
               onSpellDelete={handleDelete}
               onSpellView={setViewingSpell}
@@ -1434,6 +1444,7 @@ export const SpellManagement: React.FC = () => {
           isFavorite={favoriteSpells.includes(viewingSpell.id)}
           onToggleFavorite={() => toggleSpellFavorite(viewingSpell.id)}
           onCast={() => handleCastSpell(viewingSpell)}
+          characterLevel={totalLevel}
         />
       )}
 

--- a/src/components/SpellManagement.tsx
+++ b/src/components/SpellManagement.tsx
@@ -40,7 +40,10 @@ import { SpellCastModal } from '@/components/ui/game/SpellCastModal';
 import DragDropList from '@/components/ui/layout/DragDropList';
 import { SpellAutocomplete } from '@/components/ui/forms/SpellAutocomplete';
 import { useSpellsData } from '@/hooks/useSpellsData';
-import { getScaledSpellDamage } from '@/utils/cantripScaling';
+import {
+  getScaledSpellDamage,
+  resolveDamageScalingOnEdit,
+} from '@/utils/cantripScaling';
 import { getTotalLevel } from '@/utils/multiclass';
 import {
   convertProcessedSpellToFormData,
@@ -811,6 +814,7 @@ export const SpellManagement: React.FC = () => {
         const updated = {
           ...spell,
           ...spellData,
+          damageScaling: resolveDamageScalingOnEdit(spell, spellData.damage),
           updatedAt: new Date().toISOString(),
         };
         if (spellData.freeCastMax === undefined) {

--- a/src/components/ui/campaign/PlayerDetailDialog/SpellsTab.tsx
+++ b/src/components/ui/campaign/PlayerDetailDialog/SpellsTab.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from 'react';
 import { ChevronDown, ChevronRight, Eye, Star, Wand2 } from 'lucide-react';
 import { Badge } from '@/components/ui/layout/badge';
 import SpellDetailsModal from '@/components/ui/game/SpellDetailsModal';
+import { getTotalLevel } from '@/utils/multiclass';
 import { ensureArray, formatMod } from './shared';
 import {
   calculateSpellAttackBonus,
@@ -349,6 +350,7 @@ export function SpellsTab({ char }: SpellsTabProps) {
           spell={viewingSpell}
           isOpen={!!viewingSpell}
           onClose={() => setViewingSpell(null)}
+          characterLevel={getTotalLevel(char)}
         />
       )}
     </div>

--- a/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.tsx
+++ b/src/components/ui/campaign/player-vtt/CharacterDock/DockSpells.tsx
@@ -12,6 +12,7 @@ import {
   calculateSpellSaveDC,
   getCharacterSpellcastingAbility,
 } from '@/utils/calculations';
+import { getTotalLevel } from '@/utils/multiclass';
 import type { SpellSlots } from '@/types/character';
 import type { SpellAoe } from '@/types/spellAoe';
 
@@ -152,6 +153,7 @@ export function DockSpells(props: DockSpellsProps) {
           isOpen
           onClose={closeDetailsModal}
           onCast={() => handleCastClick(viewingSpell)}
+          characterLevel={getTotalLevel(character)}
         />
       )}
     </div>

--- a/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
+++ b/src/components/ui/character/LevelUpWizard/LevelUpWizard.hooks.ts
@@ -23,6 +23,7 @@ import {
 } from '@/utils/calculations';
 import { calculateHitDicePools, migrateToMulticlass } from '@/utils/multiclass';
 import { detectSpellAoe } from '@/utils/spellAoeDetection';
+import { getCantripUpgrades } from '@/utils/cantripScaling';
 import {
   matchClassByName,
   getEditionOptions,
@@ -424,6 +425,11 @@ export function useLevelUpWizard(character: CharacterState) {
     ? getCantripsKnownDelta(matchedClass, newClassLevel - 1, newClassLevel)
     : 0;
 
+  const cantripUpgrades = useMemo(
+    () => getCantripUpgrades(migrated.spells || [], totalLevel, newTotalLevel),
+    [migrated.spells, totalLevel, newTotalLevel]
+  );
+
   const applyLevelUp = useCallback(() => {
     if (!targetClass) return;
     const classIdx = targetClassIndex;
@@ -627,6 +633,7 @@ export function useLevelUpWizard(character: CharacterState) {
     allSpells,
     spellsKnownDelta,
     cantripsKnownDelta,
+    cantripUpgrades,
     currentStep,
     canGoNext: canGoNext(),
     goNext,

--- a/src/components/ui/character/LevelUpWizard/index.tsx
+++ b/src/components/ui/character/LevelUpWizard/index.tsx
@@ -215,6 +215,7 @@ export default function LevelUpWizard({ isOpen, onClose }: LevelUpWizardProps) {
               isCustomClass={state.isCustomClass}
               spellsKnownDelta={wizard.spellsKnownDelta}
               cantripsKnownDelta={wizard.cantripsKnownDelta}
+              cantripUpgrades={wizard.cantripUpgrades}
             />
           )}
         </DialogBody>

--- a/src/components/ui/character/LevelUpWizard/steps/ConfirmationStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/ConfirmationStep.tsx
@@ -3,6 +3,7 @@
 import { Check, ArrowUp, Sparkles, BookOpen, Heart, Sword } from 'lucide-react';
 import type { ClassFeature } from '@/types/classes';
 import type { CharacterAbilities } from '@/types/character';
+import type { CantripUpgrade } from '@/utils/cantripScaling';
 import type { ASIChoice, SubclassSpellGrant } from '../LevelUpWizard.types';
 
 interface ConfirmationStepProps {
@@ -23,6 +24,7 @@ interface ConfirmationStepProps {
   isCustomClass: boolean;
   spellsKnownDelta: number;
   cantripsKnownDelta: number;
+  cantripUpgrades: CantripUpgrade[];
 }
 
 export default function ConfirmationStep({
@@ -43,6 +45,7 @@ export default function ConfirmationStep({
   isCustomClass,
   spellsKnownDelta,
   cantripsKnownDelta,
+  cantripUpgrades,
 }: ConfirmationStepProps) {
   const displayFeatures = [...features, ...subclassFeatures].filter(
     f => f.name !== 'Ability Score Improvement' && f.name !== 'Epic Boon'
@@ -196,6 +199,29 @@ export default function ConfirmationStep({
           <p className="text-muted text-xs italic">
             Custom class — update features and abilities manually.
           </p>
+        )}
+
+        {/* Cantrip damage increases */}
+        {cantripUpgrades.length > 0 && (
+          <div className="flex items-start gap-2">
+            <Sparkles size={14} className="text-accent-purple-text mt-0.5" />
+            <div>
+              <span className="text-heading text-sm font-medium">
+                Cantrip Damage Increases:
+              </span>
+              <ul className="text-body mt-1 space-y-0.5 text-sm">
+                {cantripUpgrades.map(upgrade => (
+                  <li key={upgrade.name} className="flex items-center gap-1">
+                    <Check
+                      size={12}
+                      className="text-accent-emerald-text flex-shrink-0"
+                    />
+                    {upgrade.name}: {upgrade.from} → {upgrade.to}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
         )}
 
         {/* Spell notes */}

--- a/src/components/ui/character/LevelUpWizard/steps/ConfirmationStep.tsx
+++ b/src/components/ui/character/LevelUpWizard/steps/ConfirmationStep.tsx
@@ -210,8 +210,14 @@ export default function ConfirmationStep({
                 Cantrip Damage Increases:
               </span>
               <ul className="text-body mt-1 space-y-0.5 text-sm">
-                {cantripUpgrades.map(upgrade => (
-                  <li key={upgrade.name} className="flex items-center gap-1">
+                {cantripUpgrades.map((upgrade, i) => (
+                  // Render-only, never reordered — index-suffixed key avoids
+                  // collisions when the same cantrip name appears twice
+                  // (e.g. both editions upgrading on the same level-up).
+                  <li
+                    key={`${upgrade.name}-${i}`}
+                    className="flex items-center gap-1"
+                  >
                     <Check
                       size={12}
                       className="text-accent-emerald-text flex-shrink-0"

--- a/src/components/ui/game/SpellDetailsModal.tsx
+++ b/src/components/ui/game/SpellDetailsModal.tsx
@@ -13,6 +13,7 @@ import {
   DialogBody,
   DialogFooter,
 } from '@/components/ui/feedback/dialog';
+import { getScaledSpellDamage } from '@/utils/cantripScaling';
 
 interface SpellDetailsModalProps {
   spell: Spell;
@@ -21,6 +22,7 @@ interface SpellDetailsModalProps {
   isFavorite?: boolean;
   onToggleFavorite?: () => void;
   onCast?: () => void;
+  characterLevel?: number; // total character level; enables cantrip damage scaling on the damage line
 }
 
 export default function SpellDetailsModal({
@@ -30,8 +32,13 @@ export default function SpellDetailsModal({
   isFavorite = false,
   onToggleFavorite,
   onCast,
+  characterLevel,
 }: SpellDetailsModalProps) {
   const isCantrip = spell.level === 0;
+  const displayDamage =
+    characterLevel !== undefined
+      ? getScaledSpellDamage(spell, characterLevel)
+      : spell.damage;
 
   return (
     <Dialog
@@ -177,7 +184,7 @@ export default function SpellDetailsModal({
             </div>
 
             {/* Combat Info */}
-            {(spell.actionType || spell.damage) && (
+            {(spell.actionType || displayDamage) && (
               <div className="border-divider bg-surface-raised rounded-lg border-2 p-4">
                 <h3 className="text-heading mb-3 text-lg font-bold">
                   Combat Details
@@ -193,9 +200,9 @@ export default function SpellDetailsModal({
                       {spell.savingThrow} Save
                     </Badge>
                   )}
-                  {spell.damage && (
+                  {displayDamage && (
                     <Badge variant="danger" size="sm">
-                      {spell.damage} {spell.damageType || 'damage'}
+                      {displayDamage} {spell.damageType || 'damage'}
                     </Badge>
                   )}
                 </div>

--- a/src/hooks/useCantripScalingBackfill.ts
+++ b/src/hooks/useCantripScalingBackfill.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useCharacterStore } from '@/store/characterStore';
+import { fetchSpells } from '@/hooks/useSpellsData';
+import {
+  extractCantripScaling,
+  findScalingSpellMatch,
+} from '@/utils/cantripScaling';
+
+/**
+ * Lazily attaches damageScaling tables to already-stored cantrips that were
+ * added before cantrip scaling existed (damageScaling === undefined). Runs at
+ * most one fetch per mount and only when such a cantrip exists; null
+ * (user-custom) entries are never touched. Homebrew cantrips with no JSON
+ * match stay undefined — the spell fetch is module-cached, so re-checks are
+ * free within a session.
+ */
+export function useCantripScalingBackfill(): void {
+  const spells = useCharacterStore(state => state.character.spells);
+  const backfillCantripScaling = useCharacterStore(
+    state => state.backfillCantripScaling
+  );
+
+  const needsBackfill = spells.some(
+    spell => spell.level === 0 && spell.damageScaling === undefined
+  );
+
+  useEffect(() => {
+    if (!needsBackfill) return;
+    let cancelled = false;
+
+    fetchSpells()
+      .then(processed => {
+        if (cancelled) return;
+        const entries: Array<{
+          spellId: string;
+          scaling: Record<number, string>;
+        }> = [];
+        for (const spell of spells) {
+          if (spell.level !== 0 || spell.damageScaling !== undefined) continue;
+          const match = findScalingSpellMatch(
+            processed,
+            spell.name,
+            spell.source
+          );
+          if (!match) continue;
+          const scaling = extractCantripScaling(
+            match.scalingLevelDice,
+            spell.damage
+          );
+          if (scaling) entries.push({ spellId: spell.id, scaling });
+        }
+        if (entries.length > 0) backfillCantripScaling(entries);
+      })
+      .catch(error => {
+        console.warn('Cantrip scaling backfill skipped:', error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [needsBackfill, spells, backfillCantripScaling]);
+}

--- a/src/hooks/useCantripScalingBackfill.ts
+++ b/src/hooks/useCantripScalingBackfill.ts
@@ -7,6 +7,7 @@ import { fetchSpells } from '@/hooks/useSpellsData';
 import {
   extractCantripScaling,
   findScalingSpellMatch,
+  isSafeScalingBackfillMatch,
 } from '@/utils/cantripScaling';
 
 /**
@@ -45,7 +46,7 @@ export function useCantripScalingBackfill(): void {
             spell.name,
             spell.source
           );
-          if (!match) continue;
+          if (!match || !isSafeScalingBackfillMatch(spell, match)) continue;
           const scaling = extractCantripScaling(
             match.scalingLevelDice,
             spell.damage

--- a/src/hooks/useSpellsData.ts
+++ b/src/hooks/useSpellsData.ts
@@ -22,9 +22,10 @@ let cachedSpells: ProcessedSpell[] | null = null;
 let cachePromise: Promise<ProcessedSpell[]> | null = null;
 
 /**
- * Fetch spells from the API
+ * Fetch spells from the API. Module-level cached and shared across callers
+ * (including non-hook consumers like `useCantripScalingBackfill`).
  */
-async function fetchSpells(): Promise<ProcessedSpell[]> {
+export async function fetchSpells(): Promise<ProcessedSpell[]> {
   // Return cached spells if available
   if (cachedSpells) {
     return cachedSpells;

--- a/src/store/__tests__/characterStore-cantripBackfill.test.ts
+++ b/src/store/__tests__/characterStore-cantripBackfill.test.ts
@@ -36,6 +36,8 @@ describe('backfillCantripScaling', () => {
           makeSpell({ id: 's-leveled', level: 3 }),
         ],
       }),
+      hasUnsavedChanges: false,
+      saveStatus: 'saved',
     });
   });
 
@@ -77,6 +79,22 @@ describe('backfillCantripScaling', () => {
       .getState()
       .backfillCantripScaling([{ spellId: 's-custom', scaling: TABLE }]);
     expect(useCharacterStore.getState().character).toBe(before);
+  });
+
+  it('flags a real backfill for auto-save (hasUnsavedChanges/saveStatus)', () => {
+    useCharacterStore
+      .getState()
+      .backfillCantripScaling([{ spellId: 's-fresh', scaling: TABLE }]);
+    expect(useCharacterStore.getState().hasUnsavedChanges).toBe(true);
+    expect(useCharacterStore.getState().saveStatus).toBe('saving');
+  });
+
+  it('leaves hasUnsavedChanges untouched when nothing applies', () => {
+    useCharacterStore
+      .getState()
+      .backfillCantripScaling([{ spellId: 's-custom', scaling: TABLE }]);
+    expect(useCharacterStore.getState().hasUnsavedChanges).toBe(false);
+    expect(useCharacterStore.getState().saveStatus).toBe('saved');
   });
 
   it('does not touch base damage', () => {

--- a/src/store/__tests__/characterStore-cantripBackfill.test.ts
+++ b/src/store/__tests__/characterStore-cantripBackfill.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { useCharacterStore } from '@/store/characterStore';
+import { makeCharacter } from '@/utils/__tests__/test-utils';
+import type { Spell } from '@/types/character';
+
+function makeSpell(overrides: Partial<Spell>): Spell {
+  const now = new Date().toISOString();
+  return {
+    id: 'spell_test',
+    name: 'Test Cantrip',
+    level: 0,
+    school: 'Evocation',
+    castingTime: '1 action',
+    range: 'Touch',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Instantaneous',
+    description: 'Test',
+    damage: '1d8',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+const TABLE = { 1: '1d8', 5: '2d8', 11: '3d8', 17: '4d8' };
+
+describe('backfillCantripScaling', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({
+      character: makeCharacter({
+        spells: [
+          makeSpell({ id: 's-fresh' }),
+          makeSpell({ id: 's-custom', damageScaling: null }),
+          makeSpell({ id: 's-done', damageScaling: { 1: '1d8', 5: '2d8' } }),
+          makeSpell({ id: 's-leveled', level: 3 }),
+        ],
+      }),
+    });
+  });
+
+  it('attaches scaling only to never-enriched cantrips', () => {
+    useCharacterStore
+      .getState()
+      .backfillCantripScaling([{ spellId: 's-fresh', scaling: TABLE }]);
+    const spells = useCharacterStore.getState().character.spells;
+    expect(spells.find(s => s.id === 's-fresh')!.damageScaling).toEqual(TABLE);
+  });
+
+  it('never overwrites null (user-custom) or existing tables', () => {
+    useCharacterStore.getState().backfillCantripScaling([
+      { spellId: 's-custom', scaling: TABLE },
+      { spellId: 's-done', scaling: TABLE },
+    ]);
+    const spells = useCharacterStore.getState().character.spells;
+    expect(spells.find(s => s.id === 's-custom')!.damageScaling).toBeNull();
+    expect(spells.find(s => s.id === 's-done')!.damageScaling).toEqual({
+      1: '1d8',
+      5: '2d8',
+    });
+  });
+
+  it('ignores non-cantrips and unknown ids', () => {
+    useCharacterStore.getState().backfillCantripScaling([
+      { spellId: 's-leveled', scaling: TABLE },
+      { spellId: 'nope', scaling: TABLE },
+    ]);
+    const spells = useCharacterStore.getState().character.spells;
+    expect(
+      spells.find(s => s.id === 's-leveled')!.damageScaling
+    ).toBeUndefined();
+  });
+
+  it('is a no-op (same character reference) when nothing applies', () => {
+    const before = useCharacterStore.getState().character;
+    useCharacterStore
+      .getState()
+      .backfillCantripScaling([{ spellId: 's-custom', scaling: TABLE }]);
+    expect(useCharacterStore.getState().character).toBe(before);
+  });
+
+  it('does not touch base damage', () => {
+    useCharacterStore
+      .getState()
+      .backfillCantripScaling([{ spellId: 's-fresh', scaling: TABLE }]);
+    expect(
+      useCharacterStore
+        .getState()
+        .character.spells.find(s => s.id === 's-fresh')!.damage
+    ).toBe('1d8');
+  });
+});

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -461,6 +461,9 @@ interface CharacterStore {
   useClassResource: (id: string, amount?: number) => void;
   restoreClassResource: (id: string, amount?: number) => void;
   resetClassResource: (id: string) => void;
+  backfillCantripScaling: (
+    entries: Array<{ spellId: string; scaling: Record<number, string> }>
+  ) => void;
 
   // Armor Class management
   updateTempArmorClass: (tempAC: number) => void;
@@ -1227,6 +1230,29 @@ export const useCharacterStore = create<CharacterStore>()(
           hasUnsavedChanges: true,
           saveStatus: 'saving',
         }));
+      },
+
+      backfillCantripScaling: entries => {
+        set(state => {
+          const tableById = new Map(entries.map(e => [e.spellId, e.scaling]));
+          let changed = false;
+          const spells = state.character.spells.map(spell => {
+            const scaling = tableById.get(spell.id);
+            if (
+              !scaling ||
+              spell.level !== 0 ||
+              spell.damageScaling !== undefined
+            ) {
+              return spell;
+            }
+            changed = true;
+            return { ...spell, damageScaling: scaling };
+          });
+          if (!changed) return state;
+          return {
+            character: { ...state.character, spells },
+          };
+        });
       },
 
       // Armor Class management

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -1251,6 +1251,8 @@ export const useCharacterStore = create<CharacterStore>()(
           if (!changed) return state;
           return {
             character: { ...state.character, spells },
+            hasUnsavedChanges: true,
+            saveStatus: 'saving' as const,
           };
         });
       },

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -284,6 +284,7 @@ export interface Spell {
   freeCastsUsed?: number; // how many free casts used since last long rest
   tags?: string[];
   aoe?: SpellAoe | null; // undefined = never detected; null = no AoE (detected-none or user-cleared)
+  damageScaling?: Record<number, string> | null; // undefined = never enriched; null = user-customized damage (scaling off); object = character-level threshold → dice, e.g. { 1: '1d8', 5: '2d8', 11: '3d8', 17: '4d8' }
   createdAt: string;
   updatedAt: string;
 }

--- a/src/types/spells.ts
+++ b/src/types/spells.ts
@@ -93,7 +93,7 @@ export interface RawSpellData {
   meta?: SpellMeta;
   entries: (string | SpellEntry)[];
   entriesHigherLevel?: SpellEntryHigherLevel[];
-  scalingLevelDice?: SpellScalingLevelDice;
+  scalingLevelDice?: SpellScalingLevelDice | SpellScalingLevelDice[];
   damageInflict?: string[];
   conditionInflict?: string[];
   savingThrow?: string[];
@@ -149,6 +149,7 @@ export interface ProcessedSpell {
   tags: string[]; // Searchable tags
   damage?: string[]; // Damage types
   saves?: string[]; // Saving throws
+  scalingLevelDice?: SpellScalingLevelDice | SpellScalingLevelDice[]; // Raw cantrip scaling data, passed through for damageScaling extraction
   isCantrip: boolean;
   isSrd: boolean;
 }

--- a/src/utils/__tests__/cantripScaling.realdata.test.ts
+++ b/src/utils/__tests__/cantripScaling.realdata.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { loadAllSpells } from '@/utils/spellDataLoader';
+import { convertProcessedSpellToFormData } from '@/utils/spellConversion';
+import type { ProcessedSpell } from '@/types/spells';
+
+// Loads the real json/spells/*.json data — pins that scalingLevelDice
+// survives processing and conversion into a character-ready scaling table.
+let spells: ProcessedSpell[];
+
+beforeAll(async () => {
+  spells = await loadAllSpells();
+});
+
+function spellBySource(name: string, source: string): ProcessedSpell {
+  const found = spells.find(s => s.name === name && s.source === source);
+  expect(found, `${name} (${source}) should exist`).toBeDefined();
+  return found!;
+}
+
+describe('cantrip scaling real-data pipeline', () => {
+  it('Shocking Grasp (PHB2024) converts with the full scaling table', () => {
+    const form = convertProcessedSpellToFormData(
+      spellBySource('Shocking Grasp', 'PHB2024')
+    );
+    expect(form.damageScaling).toEqual({
+      1: '1d8',
+      5: '2d8',
+      11: '3d8',
+      17: '4d8',
+    });
+  });
+
+  it('Shillelagh (PHB2024) scales dice size, not count', () => {
+    const form = convertProcessedSpellToFormData(
+      spellBySource('Shillelagh', 'PHB2024')
+    );
+    expect(form.damageScaling).toEqual({
+      1: '1d8',
+      5: '1d10',
+      11: '1d12',
+      17: '2d6',
+    });
+  });
+
+  it('Toll the Dead (PHB2024) picks the base d8 track from the array shape', () => {
+    const form = convertProcessedSpellToFormData(
+      spellBySource('Toll the Dead', 'PHB2024')
+    );
+    expect(form.damageScaling?.[1]).toBe('1d8');
+    expect(form.damageScaling?.[5]).toBe('2d8');
+  });
+
+  it('Eldritch Blast (PHB2024) has no scaling table (ray-count scaling)', () => {
+    const form = convertProcessedSpellToFormData(
+      spellBySource('Eldritch Blast', 'PHB2024')
+    );
+    expect(form.damageScaling).toBeUndefined();
+  });
+
+  it('leveled spells never get a scaling table', () => {
+    const form = convertProcessedSpellToFormData(
+      spellBySource('Fireball', 'PHB2024')
+    );
+    expect(form.damageScaling).toBeUndefined();
+  });
+
+  it('every processed cantrip with scalingLevelDice yields a usable table', () => {
+    const scalingCantrips = spells.filter(
+      s => s.isCantrip && s.scalingLevelDice
+    );
+    expect(scalingCantrips.length).toBeGreaterThanOrEqual(30);
+    for (const spell of scalingCantrips) {
+      const form = convertProcessedSpellToFormData(spell);
+      expect(
+        form.damageScaling,
+        `${spell.name} (${spell.source})`
+      ).toBeDefined();
+      // No level-1 row guaranteed (True Strike starts at 5) — but every row
+      // that exists must be plain rollable dice, never a {{...}} template.
+      const rows = Object.values(form.damageScaling!);
+      expect(rows.length, `${spell.name} rows`).toBeGreaterThan(0);
+      for (const dice of rows) {
+        expect(dice, `${spell.name} (${spell.source}) row`).toMatch(
+          /^\d+d\d+$/
+        );
+      }
+    }
+  });
+});

--- a/src/utils/__tests__/cantripScaling.test.ts
+++ b/src/utils/__tests__/cantripScaling.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  extractCantripScaling,
+  getScaledSpellDamage,
+  getCantripUpgrades,
+  resolveDamageScalingOnEdit,
+} from '@/utils/cantripScaling';
+import type { SpellScalingLevelDice } from '@/types/spells';
+import type { Spell } from '@/types/character';
+
+const SHOCKING_GRASP: SpellScalingLevelDice = {
+  label: 'Lightning damage',
+  scaling: { '1': '1d8', '5': '2d8', '11': '3d8', '17': '4d8' },
+};
+
+const TOLL_THE_DEAD: SpellScalingLevelDice[] = [
+  {
+    label: 'Necrotic damage',
+    scaling: { '1': '1d8', '5': '2d8', '11': '3d8', '17': '4d8' },
+  },
+  {
+    label: 'Necrotic damage to wounded creature',
+    scaling: { '1': '1d12', '5': '2d12', '11': '3d12', '17': '4d12' },
+  },
+];
+
+// Real shape from spells-tce.json: first track is formula placeholders, second
+// is plain dice with NO level-1 row.
+const GREEN_FLAME_BLADE: SpellScalingLevelDice[] = [
+  {
+    label: 'fire damage to secondary creature',
+    scaling: {
+      '1': '{{spellcasting_mod}}',
+      '5': '1d8 + {{spellcasting_mod}}',
+      '11': '2d8 + {{spellcasting_mod}}',
+      '17': '3d8 + {{spellcasting_mod}}',
+    },
+  },
+  {
+    label: 'fire damage on hit',
+    scaling: { '5': '1d8', '11': '2d8', '17': '3d8' },
+  },
+];
+
+function cantrip(
+  overrides: Partial<Spell>
+): Pick<Spell, 'level' | 'damage' | 'damageScaling' | 'name'> {
+  return { name: 'Test Cantrip', level: 0, damage: '1d8', ...overrides };
+}
+
+describe('extractCantripScaling', () => {
+  it('normalizes the single-object shape to a numeric-keyed table', () => {
+    expect(extractCantripScaling(SHOCKING_GRASP)).toEqual({
+      1: '1d8',
+      5: '2d8',
+      11: '3d8',
+      17: '4d8',
+    });
+  });
+
+  it('picks the array track whose level-1 die matches the base damage', () => {
+    expect(extractCantripScaling(TOLL_THE_DEAD, '1d12')).toEqual({
+      1: '1d12',
+      5: '2d12',
+      11: '3d12',
+      17: '4d12',
+    });
+  });
+
+  it('falls back to the first track when no base damage matches', () => {
+    expect(extractCantripScaling(TOLL_THE_DEAD, '2d6')).toEqual({
+      1: '1d8',
+      5: '2d8',
+      11: '3d8',
+      17: '4d8',
+    });
+    expect(extractCantripScaling(TOLL_THE_DEAD)).toEqual({
+      1: '1d8',
+      5: '2d8',
+      11: '3d8',
+      17: '4d8',
+    });
+  });
+
+  it('drops placeholder-formula tracks and rows (Green-Flame Blade)', () => {
+    // Track 1 is all {{spellcasting_mod}} templates → unusable; track 2 wins
+    // even though the base damage matches neither.
+    expect(extractCantripScaling(GREEN_FLAME_BLADE, '1d8')).toEqual({
+      5: '1d8',
+      11: '2d8',
+      17: '3d8',
+    });
+  });
+
+  it('returns undefined for missing or empty input', () => {
+    expect(extractCantripScaling(undefined)).toBeUndefined();
+    expect(extractCantripScaling([])).toBeUndefined();
+    expect(extractCantripScaling({ label: 'x', scaling: {} })).toBeUndefined();
+    expect(
+      extractCantripScaling({
+        label: 'x',
+        scaling: { '1': '{{spellcasting_mod}}' },
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe('getScaledSpellDamage', () => {
+  const scaled = cantrip({
+    damageScaling: { 1: '1d8', 5: '2d8', 11: '3d8', 17: '4d8' },
+  });
+
+  it.each([
+    [1, '1d8'],
+    [4, '1d8'],
+    [5, '2d8'],
+    [10, '2d8'],
+    [11, '3d8'],
+    [16, '3d8'],
+    [17, '4d8'],
+    [20, '4d8'],
+  ])('level %i → %s', (level, expected) => {
+    expect(getScaledSpellDamage(scaled, level)).toBe(expected);
+  });
+
+  it('returns base damage when scaling is null (user-custom)', () => {
+    expect(
+      getScaledSpellDamage(cantrip({ damage: '3d4', damageScaling: null }), 17)
+    ).toBe('3d4');
+  });
+
+  it('returns base damage when scaling is undefined', () => {
+    expect(getScaledSpellDamage(cantrip({}), 17)).toBe('1d8');
+  });
+
+  it('passes leveled spells through untouched', () => {
+    expect(
+      getScaledSpellDamage(
+        { level: 3, damage: '8d6', damageScaling: { 1: '1d8', 5: '2d8' } },
+        17
+      )
+    ).toBe('8d6');
+  });
+
+  it('returns undefined for a cantrip with no damage at all', () => {
+    expect(
+      getScaledSpellDamage(
+        { level: 0, damage: undefined, damageScaling: undefined },
+        5
+      )
+    ).toBeUndefined();
+  });
+
+  it('falls back to base damage below the lowest threshold (True Strike-style table)', () => {
+    const trueStrike = cantrip({
+      damage: undefined,
+      damageScaling: { 5: '1d6', 11: '2d6', 17: '3d6' },
+    });
+    expect(getScaledSpellDamage(trueStrike, 3)).toBeUndefined();
+    expect(getScaledSpellDamage(trueStrike, 5)).toBe('1d6');
+  });
+});
+
+describe('getCantripUpgrades', () => {
+  const spells = [
+    cantrip({
+      name: 'Shocking Grasp',
+      damageScaling: { 1: '1d8', 5: '2d8', 11: '3d8', 17: '4d8' },
+    }),
+    cantrip({ name: 'Custom Zap', damageScaling: null }),
+    cantrip({ name: 'No Table' }),
+    { name: 'Fireball', level: 3, damage: '8d6' },
+  ] as Spell[];
+
+  it('lists only cantrips whose dice change across the level-up', () => {
+    expect(getCantripUpgrades(spells, 4, 5)).toEqual([
+      { name: 'Shocking Grasp', from: '1d8', to: '2d8' },
+    ]);
+  });
+
+  it('returns empty when no threshold is crossed', () => {
+    expect(getCantripUpgrades(spells, 5, 6)).toEqual([]);
+  });
+});
+
+describe('resolveDamageScalingOnEdit', () => {
+  const table = { 1: '1d8', 5: '2d8' };
+
+  it('returns null when damage changed on a scaling cantrip', () => {
+    expect(
+      resolveDamageScalingOnEdit({ damage: '1d8', damageScaling: table }, '2d6')
+    ).toBeNull();
+  });
+
+  it('keeps the table when damage is unchanged', () => {
+    expect(
+      resolveDamageScalingOnEdit({ damage: '1d8', damageScaling: table }, '1d8')
+    ).toEqual(table);
+  });
+
+  it('stays null once user-customized', () => {
+    expect(
+      resolveDamageScalingOnEdit({ damage: '2d6', damageScaling: null }, '3d6')
+    ).toBeNull();
+  });
+
+  it('stays undefined for never-enriched spells', () => {
+    expect(
+      resolveDamageScalingOnEdit(
+        { damage: '1d8', damageScaling: undefined },
+        '2d6'
+      )
+    ).toBeUndefined();
+  });
+});

--- a/src/utils/__tests__/cantripScaling.test.ts
+++ b/src/utils/__tests__/cantripScaling.test.ts
@@ -6,6 +6,7 @@ import {
   getCantripUpgrades,
   resolveDamageScalingOnEdit,
   findScalingSpellMatch,
+  isSafeScalingBackfillMatch,
 } from '@/utils/cantripScaling';
 import type { SpellScalingLevelDice, ProcessedSpell } from '@/types/spells';
 import type { Spell } from '@/types/character';
@@ -269,7 +270,100 @@ describe('findScalingSpellMatch', () => {
     ).toBeUndefined();
   });
 
+  it('never matches a same-name same-source entry that is not a cantrip', () => {
+    expect(
+      findScalingSpellMatch(
+        [processed({ source: 'PHB', isCantrip: false })],
+        'Shocking Grasp',
+        'PHB'
+      )
+    ).toBeUndefined();
+  });
+
   it('returns undefined for unknown names', () => {
     expect(findScalingSpellMatch(pool, 'Fire Bolt')).toBeUndefined();
+  });
+});
+
+describe('isSafeScalingBackfillMatch', () => {
+  it('rejects a no-damage cantrip matched to a different-source entry (cross-edition True Strike)', () => {
+    const trueStrike2014 = { damage: undefined, source: 'PHB' };
+    const trueStrike2024Match = { source: 'PHB2024' };
+    expect(
+      isSafeScalingBackfillMatch(trueStrike2014, trueStrike2024Match)
+    ).toBe(false);
+  });
+
+  it('allows a damage-bearing cantrip to enrich via a different-source match', () => {
+    const shockingGrasp2014 = { damage: '1d8', source: 'PHB' };
+    const shockingGrasp2024Match = { source: 'PHB2024' };
+    expect(
+      isSafeScalingBackfillMatch(shockingGrasp2014, shockingGrasp2024Match)
+    ).toBe(true);
+  });
+
+  it('allows a no-damage cantrip when the match source agrees with the stored source', () => {
+    expect(
+      isSafeScalingBackfillMatch(
+        { damage: undefined, source: 'PHB2024' },
+        { source: 'PHB2024' }
+      )
+    ).toBe(true);
+  });
+
+  it('allows a no-damage, no-source stored spell (nothing to contradict)', () => {
+    expect(
+      isSafeScalingBackfillMatch(
+        { damage: undefined, source: undefined },
+        { source: 'PHB2024' }
+      )
+    ).toBe(true);
+  });
+});
+
+describe('backfill decision: findScalingSpellMatch + isSafeScalingBackfillMatch', () => {
+  it('produces no backfill entry for 2014 True Strike when only PHB2024 has scaling', () => {
+    const storedSpell = {
+      name: 'True Strike',
+      source: 'PHB',
+      damage: undefined,
+      damageScaling: undefined,
+    };
+    const pool = [
+      processed({
+        id: 'true-strike-xphb',
+        name: 'True Strike',
+        source: 'PHB2024',
+        scalingLevelDice: {
+          label: 'x',
+          scaling: { '5': '1d6', '11': '2d6', '17': '3d6' },
+        },
+      }),
+    ];
+
+    const match = findScalingSpellMatch(
+      pool,
+      storedSpell.name,
+      storedSpell.source
+    );
+    expect(match).toBeDefined();
+    expect(isSafeScalingBackfillMatch(storedSpell, match!)).toBe(false);
+  });
+
+  it('still produces a backfill entry for damage-bearing Shocking Grasp when only PHB2024 candidate exists', () => {
+    const storedSpell = {
+      name: 'Shocking Grasp',
+      source: 'PHB',
+      damage: '1d8',
+    };
+    const pool = [processed({ id: 'sg-xphb', source: 'PHB2024' })];
+
+    const match = findScalingSpellMatch(
+      pool,
+      storedSpell.name,
+      storedSpell.source
+    );
+    expect(match).toBeDefined();
+    expect(isSafeScalingBackfillMatch(storedSpell, match!)).toBe(true);
   });
 });

--- a/src/utils/__tests__/cantripScaling.test.ts
+++ b/src/utils/__tests__/cantripScaling.test.ts
@@ -5,8 +5,9 @@ import {
   getScaledSpellDamage,
   getCantripUpgrades,
   resolveDamageScalingOnEdit,
+  findScalingSpellMatch,
 } from '@/utils/cantripScaling';
-import type { SpellScalingLevelDice } from '@/types/spells';
+import type { SpellScalingLevelDice, ProcessedSpell } from '@/types/spells';
 import type { Spell } from '@/types/character';
 
 const SHOCKING_GRASP: SpellScalingLevelDice = {
@@ -212,5 +213,63 @@ describe('resolveDamageScalingOnEdit', () => {
         '2d6'
       )
     ).toBeUndefined();
+  });
+});
+
+function processed(overrides: Partial<ProcessedSpell>): ProcessedSpell {
+  return {
+    id: 'x',
+    name: 'Shocking Grasp',
+    level: 0,
+    school: 'V',
+    schoolName: 'Evocation',
+    source: 'PHB2024',
+    isRitual: false,
+    concentration: false,
+    castingTime: '1 action',
+    range: 'Touch',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Instantaneous',
+    description: '',
+    classes: [],
+    tags: [],
+    isCantrip: true,
+    isSrd: false,
+    scalingLevelDice: { label: 'x', scaling: { '1': '1d8', '5': '2d8' } },
+    ...overrides,
+  };
+}
+
+describe('findScalingSpellMatch', () => {
+  const pool = [
+    processed({ id: 'phb', source: 'PHB' }),
+    processed({ id: 'xphb', source: 'PHB2024' }),
+    processed({ id: 'no-scaling', source: 'TCE', scalingLevelDice: undefined }),
+  ];
+
+  it('prefers the entry matching the stored source', () => {
+    expect(findScalingSpellMatch(pool, 'Shocking Grasp', 'PHB')?.id).toBe(
+      'phb'
+    );
+  });
+
+  it('falls back to PHB2024 when source does not match', () => {
+    expect(findScalingSpellMatch(pool, 'shocking grasp', 'XGE')?.id).toBe(
+      'xphb'
+    );
+    expect(findScalingSpellMatch(pool, 'Shocking Grasp')?.id).toBe('xphb');
+  });
+
+  it('only considers cantrips that carry scaling data', () => {
+    expect(
+      findScalingSpellMatch(
+        [processed({ scalingLevelDice: undefined })],
+        'Shocking Grasp'
+      )
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for unknown names', () => {
+    expect(findScalingSpellMatch(pool, 'Fire Bolt')).toBeUndefined();
   });
 });

--- a/src/utils/cantripScaling.ts
+++ b/src/utils/cantripScaling.ts
@@ -132,6 +132,26 @@ export function findScalingSpellMatch(
 }
 
 /**
+ * Guards `findScalingSpellMatch` results against cross-edition name
+ * collisions before a backfill is applied. Same-named spells sometimes
+ * exist in both 2014 and 2024 sourcebooks with different mechanics (e.g.
+ * 2014 True Strike has no damage; 2024 True Strike is a scaling cantrip). If
+ * the stored spell has no base damage of its own AND the match came from a
+ * different source, the match is likely that other edition's spell rather
+ * than the same one re-keyed — attaching its table would fabricate damage
+ * that the stored spell never had. Damage-bearing spells are always safe to
+ * enrich via the PHB2024 fallback, since a real dice value confirms the
+ * stored spell already deals damage.
+ */
+export function isSafeScalingBackfillMatch(
+  spell: Pick<Spell, 'damage' | 'source'>,
+  match: Pick<ProcessedSpell, 'source'>
+): boolean {
+  if (spell.damage) return true;
+  return !spell.source || match.source === spell.source;
+}
+
+/**
  * damageScaling value after a spell-editor save: a manual damage change on a
  * scaling cantrip turns scaling off (null); otherwise the prior state is kept.
  */

--- a/src/utils/cantripScaling.ts
+++ b/src/utils/cantripScaling.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Spell } from '@/types/character';
-import type { SpellScalingLevelDice } from '@/types/spells';
+import type { ProcessedSpell, SpellScalingLevelDice } from '@/types/spells';
 
 export type CantripDamageScaling = Record<number, string>;
 
@@ -108,6 +108,27 @@ export function getCantripUpgrades(
     }
   }
   return upgrades;
+}
+
+/**
+ * Best spell-data candidate for backfilling a stored cantrip: same source
+ * first, then 2024 rules (PHB2024), then any entry carrying scaling data.
+ */
+export function findScalingSpellMatch(
+  processed: ProcessedSpell[],
+  name: string,
+  source?: string
+): ProcessedSpell | undefined {
+  const nameLower = name.toLowerCase();
+  const candidates = processed.filter(
+    p => p.isCantrip && p.scalingLevelDice && p.name.toLowerCase() === nameLower
+  );
+  if (candidates.length === 0) return undefined;
+  return (
+    (source && candidates.find(c => c.source === source)) ||
+    candidates.find(c => c.source === 'PHB2024') ||
+    candidates[0]
+  );
 }
 
 /**

--- a/src/utils/cantripScaling.ts
+++ b/src/utils/cantripScaling.ts
@@ -1,0 +1,123 @@
+/**
+ * Cantrip damage scaling (5e character-level thresholds 1/5/11/17).
+ *
+ * `Spell.damageScaling` tri-state contract (mirrors `Spell.aoe`):
+ *   undefined = never enriched from spell data (backfill candidate)
+ *   null      = user-customized damage; scaling permanently off
+ *   object    = character-level threshold → dice
+ */
+
+import type { Spell } from '@/types/character';
+import type { SpellScalingLevelDice } from '@/types/spells';
+
+export type CantripDamageScaling = Record<number, string>;
+
+export interface CantripUpgrade {
+  name: string;
+  from: string;
+  to: string;
+}
+
+/** Plain rollable dice, e.g. "1d8", "2d6" — rejects {{spellcasting_mod}} templates. */
+const DICE_PATTERN = /^\d+d\d+$/;
+
+function cleanTrack(
+  track: SpellScalingLevelDice
+): CantripDamageScaling | undefined {
+  const table: CantripDamageScaling = {};
+  for (const [threshold, dice] of Object.entries(track.scaling ?? {})) {
+    const level = Number(threshold);
+    if (!Number.isInteger(level) || level < 1) continue;
+    if (typeof dice !== 'string' || !DICE_PATTERN.test(dice)) continue;
+    table[level] = dice;
+  }
+  return Object.keys(table).length > 0 ? table : undefined;
+}
+
+function lowestThresholdDie(table: CantripDamageScaling): string {
+  const lowest = Math.min(...Object.keys(table).map(Number));
+  return table[lowest]!;
+}
+
+/**
+ * Normalize raw 5etools `scalingLevelDice` into a numeric threshold → dice
+ * table. Multi-track cantrips (Toll the Dead, Booming Blade) store an array:
+ * pick the track whose lowest-threshold die matches the already-extracted
+ * base damage, falling back to the first usable track. Tracks made of
+ * formula placeholders (Green-Flame Blade's "{{spellcasting_mod}}") are
+ * dropped entirely.
+ */
+export function extractCantripScaling(
+  scalingLevelDice: SpellScalingLevelDice | SpellScalingLevelDice[] | undefined,
+  baseDamage?: string
+): CantripDamageScaling | undefined {
+  if (!scalingLevelDice) return undefined;
+  const rawTracks = Array.isArray(scalingLevelDice)
+    ? scalingLevelDice
+    : [scalingLevelDice];
+  const tracks = rawTracks
+    .map(cleanTrack)
+    .filter((t): t is CantripDamageScaling => t !== undefined);
+  if (tracks.length === 0) return undefined;
+
+  return (
+    (baseDamage && tracks.find(t => lowestThresholdDie(t) === baseDamage)) ||
+    tracks[0]
+  );
+}
+
+/**
+ * Effective damage dice for a spell at the given TOTAL character level
+ * (multiclass sum). Non-cantrips, null/absent scaling, and levels below the
+ * lowest threshold all fall back to the stored base damage.
+ */
+export function getScaledSpellDamage(
+  spell: Pick<Spell, 'level' | 'damage' | 'damageScaling'>,
+  characterLevel: number
+): string | undefined {
+  if (spell.level !== 0 || !spell.damageScaling) return spell.damage;
+  let best: number | undefined;
+  for (const key of Object.keys(spell.damageScaling)) {
+    const threshold = Number(key);
+    if (
+      threshold <= characterLevel &&
+      (best === undefined || threshold > best)
+    ) {
+      best = threshold;
+    }
+  }
+  return best !== undefined ? spell.damageScaling[best] : spell.damage;
+}
+
+/**
+ * Cantrips whose dice change between two character levels — level-up wizard
+ * summary data.
+ */
+export function getCantripUpgrades(
+  spells: Spell[],
+  oldLevel: number,
+  newLevel: number
+): CantripUpgrade[] {
+  const upgrades: CantripUpgrade[] = [];
+  for (const spell of spells) {
+    if (spell.level !== 0 || !spell.damageScaling) continue;
+    const from = getScaledSpellDamage(spell, oldLevel);
+    const to = getScaledSpellDamage(spell, newLevel);
+    if (from && to && from !== to) {
+      upgrades.push({ name: spell.name, from, to });
+    }
+  }
+  return upgrades;
+}
+
+/**
+ * damageScaling value after a spell-editor save: a manual damage change on a
+ * scaling cantrip turns scaling off (null); otherwise the prior state is kept.
+ */
+export function resolveDamageScalingOnEdit(
+  original: Pick<Spell, 'damage' | 'damageScaling'>,
+  newDamage: string | undefined
+): CantripDamageScaling | null | undefined {
+  if (original.damageScaling && newDamage !== original.damage) return null;
+  return original.damageScaling;
+}

--- a/src/utils/spellConversion.ts
+++ b/src/utils/spellConversion.ts
@@ -8,6 +8,7 @@ import { Spell, SpellActionType } from '@/types/character';
 import type { SpellAoe } from '@/types/spellAoe';
 import { detectSpellAoe } from './spellAoeDetection';
 import { formatSpellDescriptionForEditor } from './referenceParser';
+import { extractCantripScaling, CantripDamageScaling } from './cantripScaling';
 
 /**
  * A spell counts as prepared if it is explicitly prepared OR always prepared
@@ -54,6 +55,8 @@ export interface SpellFormData {
   freeCastMax: number;
   /** AoE template geometry. Always a value or explicit null in the form — never undefined. */
   aoe: SpellAoe | null;
+  /** Cantrip scaling table. undefined = none/never enriched; null = user-custom (scaling off). */
+  damageScaling?: CantripDamageScaling | null;
 }
 
 /**
@@ -181,6 +184,11 @@ export function convertProcessedSpellToFormData(
     ? formatSpellDescriptionForEditor(spell.higherLevelDescription)
     : '';
 
+  const damageScaling =
+    spell.level === 0
+      ? extractCantripScaling(spell.scalingLevelDice, extractedDamage)
+      : undefined;
+
   return {
     name: spell.name,
     level: spell.level,
@@ -209,6 +217,7 @@ export function convertProcessedSpellToFormData(
     freeCastMode: 'normal',
     freeCastMax: 1,
     aoe: detectSpellAoe(spell.description, spell.range),
+    damageScaling,
   };
 }
 
@@ -257,6 +266,7 @@ export function convertFormDataToSpell(
           : undefined,
     freeCastsUsed: formData.freeCastMode !== 'normal' ? 0 : undefined,
     aoe: formData.aoe,
+    damageScaling: formData.damageScaling,
     createdAt: now,
     updatedAt: now,
   };
@@ -388,5 +398,6 @@ export function spellToFormData(spell: Spell): SpellFormData {
     freeCastMode,
     freeCastMax,
     aoe: spell.aoe ?? null,
+    damageScaling: spell.damageScaling,
   };
 }

--- a/src/utils/spellDataLoader.ts
+++ b/src/utils/spellDataLoader.ts
@@ -1566,6 +1566,7 @@ function processSpell(rawSpell: RawSpellData): ProcessedSpell {
     ],
     damage: rawSpell.damageInflict,
     saves: rawSpell.savingThrow,
+    scalingLevelDice: rawSpell.scalingLevelDice,
     isCantrip: rawSpell.level === 0,
     isSrd: rawSpell.srd || false,
   };


### PR DESCRIPTION
## Summary

Cantrip damage now scales automatically with total character level (D&D 5e thresholds 5/11/17) — Shocking Grasp shows and rolls 2d8 at level 5, Shillelagh 1d10, etc. Driven by the machine-readable `scalingLevelDice` data already present in `json/spells/*.json` (41 of 80 cantrips; non-dice scalers like Eldritch Blast are out of scope by design).

## How it works

- **`Spell.damageScaling`** — new tri-state field on stored spells, mirroring the `aoe` contract: `undefined` = never enriched, `null` = user-customized damage (scaling off), object = `{1:'1d8', 5:'2d8', 11:'3d8', 17:'4d8'}`. Base `damage` string is never mutated.
- **Add flow** — the spell loader carries `scalingLevelDice` through `ProcessedSpell`; conversion attaches the normalized table for cantrips (covers spellbook autocomplete, granted spells, NPC editors via the shared conversion functions). Multi-track shapes (Toll the Dead, Booming Blade) pick the track matching the base damage; formula-placeholder tracks (Green-Flame Blade's `{{spellcasting_mod}}`) are filtered out.
- **Existing characters** — `useCantripScalingBackfill` lazily enriches stored cantrips when spell data loads (conditional fetch, module-cached), via a store action that only writes to `undefined` entries and flags auto-save. Guarded against cross-edition fabrication: a no-damage 2014 cantrip (True Strike) never inherits the 2024 table.
- **Display + rolls** — QuickSpells badge and all three roll paths, spell cards, and `SpellDetailsModal` (new optional `characterLevel` prop; DM SpellsTab and player VTT dock pass it, NPC callers unchanged) compute effective dice via `getScaledSpellDamage(spell, totalLevel)`.
- **Manual edits win** — editing a scaling cantrip's damage in the spell editor sets `damageScaling: null`; delete + re-add restores auto-scaling.
- **Level-up wizard** — confirmation step lists cantrip upgrades ("Shocking Grasp: 1d8 → 2d8") when a threshold is crossed; informational only.

## Testing

- 41 new unit tests: extraction shapes (object/array/placeholder tracks), threshold boundaries (4/5/10/11/16/17/20), tri-state semantics, store backfill (incl. same-reference no-op + auto-save flags), match preference (source → PHB2024 → first), cross-edition guard.
- Real-data pipeline test sweeps every processed cantrip in `json/spells/` and pins that all scaling rows are plain rollable dice.
- Full suite: 235 files, 3451 passed, 1 pre-existing skip. Type-check + lint clean.

Note for reviewers: manual theme walkthrough (dark/parchment) of the wizard section and badges was not run headlessly — tokens are copied from verified sibling blocks, but a quick visual check is welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)