### PR TITLE
Add editable stat blocks for custom combatants

### DIFF
--- a/src/components/__tests__/add-combatant-dialog.test.tsx
+++ b/src/components/__tests__/add-combatant-dialog.test.tsx
@@ -194,6 +194,45 @@ describe('AddCombatantDialog', () => {
     expect(entity.playerDisposition).toBe('enemy');
   });
 
+  it('custom combatant can save a fully editable stat block', () => {
+    const onAddEntity = vi.fn();
+    render(<AddCombatantDialog {...defaultProps} onAddEntity={onAddEntity} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /custom/i }));
+    fireEvent.change(screen.getByPlaceholderText(/cursed statue/i), {
+      target: { value: 'Clockwork Sentry' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^edit stat block$/i }));
+
+    fireEvent.change(screen.getByRole('textbox', { name: /str score/i }), {
+      target: { value: '18' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: /^type$/i }), {
+      target: { value: 'construct' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /actions & traits/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add actions entry/i }));
+    fireEvent.change(
+      screen.getByRole('textbox', { name: /actions entry name/i }),
+      { target: { value: 'Slam' } }
+    );
+    fireEvent.change(
+      screen.getByRole('textbox', { name: /actions entry text/i }),
+      { target: { value: 'Melee Weapon Attack: +6 to hit.' } }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /add npc/i }));
+
+    const entity = onAddEntity.mock.calls[0][0];
+    expect(entity.monsterStatBlock).toMatchObject({
+      str: 18,
+      type: 'construct',
+      actions: [{ name: 'Slam', text: 'Melee Weapon Attack: +6 to hit.' }],
+    });
+    expect(entity.proficiencyBonus).toBe(2);
+    expect(entity.abilities).toEqual([]);
+  });
+
   it('NPC delete button triggers confirmation dialog', () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
     render(<AddCombatantDialog {...defaultProps} />);

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/CustomTab.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/CustomTab.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import React from 'react';
+import { FilePen } from 'lucide-react';
 import { NumberInput } from '@/components/ui/forms/NumberInput';
+import { Button } from '@/components/ui/forms/button';
 import type { PlayerDisposition } from '@/types/encounter';
 import { SharedOptions } from './SharedOptions';
 
@@ -22,6 +24,8 @@ interface CustomTabProps {
   onPlayerAliasChange: (v: string) => void;
   disposition: PlayerDisposition;
   onDispositionChange: (v: PlayerDisposition) => void;
+  onEditStatBlock: () => void;
+  hasStatBlockEdits: boolean;
 }
 
 export function CustomTab({
@@ -41,6 +45,8 @@ export function CustomTab({
   onPlayerAliasChange,
   disposition,
   onDispositionChange,
+  onEditStatBlock,
+  hasStatBlockEdits,
 }: CustomTabProps) {
   return (
     <div className="space-y-3 pb-4">
@@ -111,6 +117,15 @@ export function CustomTab({
           label="Init Mod"
         />
       </div>
+
+      <Button
+        variant="outline"
+        fullWidth
+        onClick={onEditStatBlock}
+        leftIcon={<FilePen size={14} />}
+      >
+        Edit stat block{hasStatBlockEdits ? ' (edited)' : ''}
+      </Button>
 
       <SharedOptions
         hideName={hideName}

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/StatBlockEditor.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/StatBlockEditor.tsx
@@ -14,6 +14,7 @@ interface StatBlockEditorProps {
   onDraftChange: (draft: MonsterEditDraft) => void;
   onReset: () => void;
   onBack: () => void;
+  resetLabel?: string;
 }
 
 type EditorTab = 'stats' | 'actions';
@@ -34,6 +35,7 @@ export function StatBlockEditor({
   onDraftChange,
   onReset,
   onBack,
+  resetLabel = 'Reset to original',
 }: StatBlockEditorProps) {
   const [tab, setTab] = useState<EditorTab>('stats');
 
@@ -53,7 +55,7 @@ export function StatBlockEditor({
           onClick={onReset}
           className="text-muted hover:text-heading flex items-center gap-1 text-[12px] font-bold transition-colors"
         >
-          <RotateCcw size={12} /> Reset to original
+          <RotateCcw size={12} /> {resetLabel}
         </button>
       </div>
 

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/buildEntity.ts
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/buildEntity.ts
@@ -155,6 +155,8 @@ export interface CustomBuildOpts {
   isHidden: boolean;
   playerAlias?: string;
   playerDisposition: PlayerDisposition;
+  statBlock?: MonsterStatBlock;
+  proficiencyBonus?: number;
 }
 
 export function buildCustomEntity(
@@ -165,6 +167,7 @@ export function buildCustomEntity(
     name: opts.name.trim(),
     initiative: null,
     initiativeModifier: opts.initMod,
+    proficiencyBonus: opts.proficiencyBonus,
     currentHp: opts.hp || 1,
     maxHp: opts.hp || 1,
     tempHp: 0,
@@ -173,5 +176,9 @@ export function buildCustomEntity(
     isHidden: opts.isHidden,
     playerAlias: opts.playerAlias?.trim() || undefined,
     playerDisposition: opts.playerDisposition,
+    monsterStatBlock: opts.statBlock,
+    abilities: opts.statBlock
+      ? buildAbilitiesFromStatBlock(opts.statBlock)
+      : undefined,
   };
 }

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/index.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/index.tsx
@@ -19,8 +19,13 @@ import { NpcTab } from './NpcTab';
 import { MonsterTab } from './MonsterTab';
 import { CustomTab } from './CustomTab';
 import { buildMonsterEntities, buildCustomEntity } from './buildEntity';
-import { createMonsterEditDraft } from './monsterEditDraft';
+import {
+  createCustomEditDraft,
+  createMonsterEditDraft,
+  setDraftInitiative,
+} from './monsterEditDraft';
 import type { MonsterEditDraft } from './monsterEditDraft';
+import { StatBlockEditor } from './StatBlockEditor';
 
 export interface AddCombatantDialogProps {
   open: boolean;
@@ -88,6 +93,8 @@ export function AddCombatantDialog({
   const [cHideName, setCHideName] = useState(false);
   const [cAlias, setCAlias] = useState('');
   const [cDisposition, setCDisposition] = useState<PlayerDisposition>('enemy');
+  const [cDraft, setCDraft] = useState<MonsterEditDraft | null>(null);
+  const [cEditing, setCEditing] = useState(false);
 
   const resetMonsterState = () => {
     setSelMonster(null);
@@ -110,6 +117,8 @@ export function AddCombatantDialog({
     setCHideName(false);
     setCAlias('');
     setCDisposition('enemy');
+    setCDraft(null);
+    setCEditing(false);
   };
 
   // Selecting a (different) monster always discards any stat block draft.
@@ -181,12 +190,31 @@ export function AddCombatantDialog({
         type: cType,
         hp: parseInt(cHp) || 10,
         ac: parseInt(cAc) || 10,
-        initMod: parseInt(cInit) || 0,
+        initMod: cDraft?.initiativeModifier ?? (parseInt(cInit) || 0),
         isHidden: cHideName,
         playerAlias: cAlias || undefined,
         playerDisposition: cDisposition,
+        statBlock: cDraft?.statBlock,
+        proficiencyBonus: cDraft?.proficiencyBonus,
       })
     );
+  };
+
+  const handleCustomInitChange = (value: string) => {
+    setCInit(value);
+    if (cDraft) {
+      setCDraft(setDraftInitiative(cDraft, parseInt(value) || 0));
+    }
+  };
+
+  const handleCustomEditStatBlock = () => {
+    setCDraft(d => d ?? createCustomEditDraft(parseInt(cInit) || 0));
+    setCEditing(true);
+  };
+
+  const handleCustomDraftChange = (draft: MonsterEditDraft) => {
+    setCDraft(draft);
+    setCInit(String(draft.initiativeModifier));
   };
 
   const showFooter =
@@ -282,26 +310,41 @@ export function AddCombatantDialog({
               onEditorReset={handleResetDraft}
             />
           )}
-          {tab === 'custom' && (
-            <CustomTab
-              name={cName}
-              onNameChange={setCName}
-              type={cType}
-              onTypeChange={setCType}
-              hp={cHp}
-              onHpChange={setCHp}
-              ac={cAc}
-              onAcChange={setCAc}
-              initMod={cInit}
-              onInitModChange={setCInit}
-              hideName={cHideName}
-              onHideNameChange={setCHideName}
-              playerAlias={cAlias}
-              onPlayerAliasChange={setCAlias}
-              disposition={cDisposition}
-              onDispositionChange={setCDisposition}
-            />
-          )}
+          {tab === 'custom' &&
+            (cEditing && cDraft ? (
+              <StatBlockEditor
+                monsterName={cName.trim() || 'custom combatant'}
+                draft={cDraft}
+                onDraftChange={handleCustomDraftChange}
+                onReset={() => {
+                  const draft = createCustomEditDraft(parseInt(cInit) || 0);
+                  setCDraft(draft);
+                }}
+                onBack={() => setCEditing(false)}
+                resetLabel="Reset stat block"
+              />
+            ) : (
+              <CustomTab
+                name={cName}
+                onNameChange={setCName}
+                type={cType}
+                onTypeChange={setCType}
+                hp={cHp}
+                onHpChange={setCHp}
+                ac={cAc}
+                onAcChange={setCAc}
+                initMod={cInit}
+                onInitModChange={handleCustomInitChange}
+                hideName={cHideName}
+                onHideNameChange={setCHideName}
+                playerAlias={cAlias}
+                onPlayerAliasChange={setCAlias}
+                disposition={cDisposition}
+                onDispositionChange={setCDisposition}
+                onEditStatBlock={handleCustomEditStatBlock}
+                hasStatBlockEdits={cDraft !== null}
+              />
+            ))}
         </div>
 
         {/* Anchored footer — shown only for monster (with selection) and custom */}

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/monsterEditDraft.ts
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/monsterEditDraft.ts
@@ -32,6 +32,46 @@ export function createMonsterEditDraft(
   };
 }
 
+/** Create a complete, neutral stat block for a combatant built from scratch. */
+export function createCustomEditDraft(
+  initiativeModifier = 0
+): MonsterEditDraft {
+  return {
+    statBlock: {
+      str: 10,
+      dex: 10,
+      con: 10,
+      int: 10,
+      wis: 10,
+      cha: 10,
+      saves: '',
+      skills: '',
+      speed: '30 ft.',
+      resistances: '',
+      immunities: '',
+      vulnerabilities: '',
+      conditionImmunities: [],
+      senses: '',
+      passivePerception: 10,
+      traits: [],
+      actions: [],
+      reactions: [],
+      bonusActions: [],
+      lairActions: [],
+      cr: '0',
+      type: 'custom creature',
+      size: 'Medium',
+      languages: '',
+      alignment: 'unaligned',
+      hpFormula: '',
+    },
+    initiativeModifier,
+    initiativeDirty: initiativeModifier !== 0,
+    proficiencyBonus: 2,
+    proficiencyDirty: false,
+  };
+}
+
 export function updateDraftStatBlock(
   draft: MonsterEditDraft,
   patch: Partial<MonsterStatBlock>


### PR DESCRIPTION
## Summary
- add the monster-style stat block editor to custom encounter combatants
- persist custom ability scores, combat metadata, traits, actions, bonus actions, and reactions
- generate trackable limited-use abilities from custom stat blocks
- add coverage for creating a custom combatant with edited stats and actions

## Testing
- `npm test -- --run src/components/__tests__/add-combatant-dialog.test.tsx src/components/ui/encounter/combat-screen/AddCombatantDialog/monsterEditDraft.test.ts`
- focused ESLint check
- `git diff --check`

## Note
- repository-wide `npm run type-check` remains blocked by existing Playwright/FieldNotes dependency and API type errors unrelated to this change