### PR TITLE
feat(encounter): stat block layout tweaks — header stat line + saves in ability grid

### DIFF
--- a/src/components/__tests__/combatant-detail-vitals.test.tsx
+++ b/src/components/__tests__/combatant-detail-vitals.test.tsx
@@ -258,7 +258,9 @@ describe('DetailHeader', () => {
     expect(actions.onUpdate).toHaveBeenCalledWith('npc-1', {
       name: 'Goblin Boss',
     });
-    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', { name: 'Combatant name' })
+    ).not.toBeInTheDocument();
   });
 
   it('non-player: rename commits on blur too', async () => {
@@ -289,7 +291,9 @@ describe('DetailHeader', () => {
     await user.keyboard('{Escape}');
 
     expect(actions.onUpdate).not.toHaveBeenCalled();
-    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', { name: 'Combatant name' })
+    ).not.toBeInTheDocument();
     expect(screen.getByText('Goblin')).toBeInTheDocument();
   });
 

--- a/src/components/__tests__/combatant-detail.test.tsx
+++ b/src/components/__tests__/combatant-detail.test.tsx
@@ -138,6 +138,9 @@ describe('CombatantDetail — monster with full stat block', () => {
     expect(screen.getByText('Combat Details')).toBeInTheDocument();
     expect(screen.getByText(/legendary actions/i)).toBeInTheDocument();
     expect(screen.getByText(/active effects/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: 'Initiative Mod' })
+    ).toBeInTheDocument();
   });
 
   it('ability score edit patches monsterStatBlock via onUpdate', () => {

--- a/src/components/__tests__/detail-ability-scores.test.tsx
+++ b/src/components/__tests__/detail-ability-scores.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { DetailAbilityScores } from '@/components/ui/encounter/combat-screen/detail/DetailAbilityScores';
+import type { EncounterEntity, MonsterStatBlock } from '@/types/encounter';
+import type { EntityActions } from '@/components/ui/encounter/combat-screen/types';
+
+afterEach(cleanup);
+
+function makeActions(): EntityActions {
+  return {
+    onUpdate: vi.fn(),
+    onRemove: vi.fn(),
+    onDamage: vi.fn(),
+    onHeal: vi.fn(),
+    onAddTempHp: vi.fn(),
+    onSetMaxHp: vi.fn(),
+    onAddCondition: vi.fn(),
+    onRemoveCondition: vi.fn(),
+    onSetConditionRounds: vi.fn(),
+    onUseAbility: vi.fn(),
+    onRestoreAbility: vi.fn(),
+    onUseLegendaryAction: vi.fn(),
+    onResetLegendaryActions: vi.fn(),
+    onSetConcentration: vi.fn(),
+    onUseLairAction: vi.fn(),
+    onSetInitiative: vi.fn(),
+    onLongRest: vi.fn(),
+  };
+}
+
+// Mods: STR +5, DEX +4, CON +3, INT +2, WIS +1, CHA -1 — all distinct so
+// every fallback "SV <mod>" string is unique in the grid.
+const statBlock: MonsterStatBlock = {
+  str: 20,
+  dex: 18,
+  con: 16,
+  int: 15,
+  wis: 12,
+  cha: 8,
+  saves: 'Dex +9, Con +8',
+  skills: '',
+  speed: '30 ft.',
+  resistances: '',
+  immunities: '',
+  vulnerabilities: '',
+  conditionImmunities: [],
+  senses: '',
+  passivePerception: 10,
+  traits: [],
+  actions: [],
+  bonusActions: [],
+  reactions: [],
+  lairActions: [],
+  cr: '5',
+  type: 'fiend',
+  size: 'Large',
+  languages: 'Common',
+  alignment: 'Lawful Evil',
+  hpFormula: '10d10+30',
+};
+
+const monsterEntity: EncounterEntity = {
+  id: 'monster-1',
+  type: 'monster',
+  name: 'Abhorrent Overlord',
+  initiative: 12,
+  initiativeModifier: 4,
+  currentHp: 85,
+  maxHp: 85,
+  tempHp: 0,
+  armorClass: 16,
+  conditions: [],
+  monsterStatBlock: statBlock,
+};
+
+describe('DetailAbilityScores — saves column', () => {
+  it('shows the parsed save for proficient abilities (amber) and the modifier fallback for the rest (faint)', () => {
+    render(
+      <DetailAbilityScores entity={monsterEntity} actions={makeActions()} />
+    );
+
+    const dexSave = screen.getByText('SV +9');
+    expect(dexSave).toHaveClass('text-accent-amber-text');
+    const conSave = screen.getByText('SV +8');
+    expect(conSave).toHaveClass('text-accent-amber-text');
+
+    const strSave = screen.getByText('SV +5');
+    expect(strSave).toHaveClass('text-faint');
+    expect(screen.getByText('SV +2')).toHaveClass('text-faint'); // INT
+    expect(screen.getByText('SV +1')).toHaveClass('text-faint'); // WIS
+    expect(screen.getByText('SV -1')).toHaveClass('text-faint'); // CHA
+  });
+
+  it('re-renders save values when the entity saves string changes (grid derives from the prop)', () => {
+    const actions = makeActions();
+    const { rerender } = render(
+      <DetailAbilityScores entity={monsterEntity} actions={actions} />
+    );
+    expect(screen.getByText('SV +9')).toBeInTheDocument();
+
+    rerender(
+      <DetailAbilityScores
+        entity={{
+          ...monsterEntity,
+          monsterStatBlock: { ...statBlock, saves: 'Dex +12' },
+        }}
+        actions={actions}
+      />
+    );
+
+    expect(screen.getByText('SV +12')).toBeInTheDocument();
+    // CON is no longer proficient — falls back to its +3 modifier.
+    expect(screen.getByText('SV +3')).toHaveClass('text-faint');
+    expect(screen.queryByText('SV +8')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/detail-combat-info.test.tsx
+++ b/src/components/__tests__/detail-combat-info.test.tsx
@@ -182,6 +182,24 @@ describe('DetailCombatInfo — field inventory', () => {
     );
   });
 
+  it('editing Saving Throws patches monsterStatBlock.saves via onUpdate', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Saving Throws');
+    await user.clear(input);
+    await user.type(input, 'Dex +9');
+    await user.tab();
+
+    expect(actions.onUpdate).toHaveBeenCalledWith(
+      'monster-1',
+      expect.objectContaining({
+        monsterStatBlock: expect.objectContaining({ saves: 'Dex +9' }),
+      })
+    );
+  });
+
   it('editing Condition Immunities splits the comma-separated input into an array', async () => {
     const actions = makeActions();
     const user = userEvent.setup();

--- a/src/components/__tests__/detail-combat-info.test.tsx
+++ b/src/components/__tests__/detail-combat-info.test.tsx
@@ -88,14 +88,16 @@ const playerEntity: EncounterEntity = {
 };
 
 describe('DetailCombatInfo — field inventory', () => {
-  it('monster with a stat block: renders all fields including Initiative Mod and Proficiency Bonus', () => {
+  it('monster with a stat block: renders detail fields; Init/PB/Speed live in the header now', () => {
     const actions = makeActions();
     render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
 
     expect(screen.getByText('Combat Details')).toBeInTheDocument();
-    expect(screen.getByLabelText('Initiative Mod')).toHaveValue(1);
-    expect(screen.getByLabelText('Proficiency Bonus')).toHaveValue(2);
-    expect(screen.getByLabelText('Speed')).toHaveValue('30 ft.');
+    expect(screen.queryByLabelText('Initiative Mod')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Proficiency Bonus')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Speed')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Saving Throws')).toHaveValue(
       'Str +5, Con +4'
     );
@@ -111,57 +113,6 @@ describe('DetailCombatInfo — field inventory', () => {
     expect(screen.getByLabelText('Senses')).toHaveValue('Darkvision 60 ft.');
     expect(screen.getByLabelText('Languages')).toHaveValue('Common');
     expect(screen.getByLabelText('Passive Perception')).toHaveValue(13);
-  });
-
-  it('editing Initiative Mod commits initiativeModifier via onUpdate (rolled initiative untouched)', async () => {
-    const actions = makeActions();
-    const user = userEvent.setup();
-    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
-
-    const input = screen.getByLabelText('Initiative Mod');
-    await user.clear(input);
-    await user.type(input, '3');
-    await user.tab();
-
-    expect(actions.onUpdate).toHaveBeenCalledWith('monster-1', {
-      initiativeModifier: 3,
-    });
-    expect(actions.onSetInitiative).not.toHaveBeenCalled();
-    expect(actions.onUpdate).not.toHaveBeenCalledWith(
-      'monster-1',
-      expect.objectContaining({ initiative: expect.anything() })
-    );
-  });
-
-  it('clearing Initiative Mod to empty is a no-op (modifier cannot be null)', async () => {
-    const actions = makeActions();
-    const user = userEvent.setup();
-    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
-
-    const input = screen.getByLabelText('Initiative Mod');
-    await user.clear(input);
-    await user.tab();
-
-    expect(actions.onUpdate).not.toHaveBeenCalledWith(
-      'monster-1',
-      expect.objectContaining({ initiativeModifier: expect.anything() })
-    );
-    expect(actions.onSetInitiative).not.toHaveBeenCalled();
-  });
-
-  it('editing Proficiency Bonus commits via onUpdate on blur', async () => {
-    const actions = makeActions();
-    const user = userEvent.setup();
-    render(<DetailCombatInfo entity={monsterEntity} actions={actions} />);
-
-    const input = screen.getByLabelText('Proficiency Bonus');
-    await user.clear(input);
-    await user.type(input, '4');
-    await user.tab();
-
-    expect(actions.onUpdate).toHaveBeenCalledWith('monster-1', {
-      proficiencyBonus: 4,
-    });
   });
 
   it('editing a stat-block field (Skills) patches monsterStatBlock via onUpdate', async () => {
@@ -240,14 +191,17 @@ describe('DetailCombatInfo — field inventory', () => {
 });
 
 describe('DetailCombatInfo — player entities stay read-only', () => {
-  it('player: Initiative Mod renders as signed static text, Proficiency Bonus is hidden', () => {
+  it('player: Initiative Mod and Proficiency Bonus rows are gone (they live in the header)', () => {
     const actions = makeActions();
-    render(<DetailCombatInfo entity={playerEntity} actions={actions} />);
+    const syncedPlayer: EncounterEntity = {
+      ...playerEntity,
+      monsterStatBlock: statBlock,
+    };
+    render(<DetailCombatInfo entity={syncedPlayer} actions={actions} />);
 
-    expect(screen.getByText('Initiative Mod')).toBeInTheDocument();
-    expect(screen.getByText('+3')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Initiative Mod')).not.toBeInTheDocument();
+    expect(screen.queryByText('Initiative Mod')).not.toBeInTheDocument();
     expect(screen.queryByText('Proficiency Bonus')).not.toBeInTheDocument();
+    expect(screen.queryByText('Speed')).not.toBeInTheDocument();
   });
 
   it('player entity with a synced stat block never renders editable inputs', () => {
@@ -258,9 +212,9 @@ describe('DetailCombatInfo — player entities stay read-only', () => {
     };
     render(<DetailCombatInfo entity={syncedPlayer} actions={actions} />);
 
-    expect(screen.getByText('Speed')).toBeInTheDocument();
-    expect(screen.getByText('30 ft.')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Speed')).not.toBeInTheDocument();
+    expect(screen.getByText('Saving Throws')).toBeInTheDocument();
+    expect(screen.getByText('Str +5, Con +4')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Saving Throws')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Skills')).not.toBeInTheDocument();
   });
 });
@@ -282,6 +236,27 @@ describe('DetailCombatInfo — hidden when there is nothing to show', () => {
     };
     const { container } = render(
       <DetailCombatInfo entity={bareEntity} actions={actions} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when only initiative modifier and proficiency bonus are set (they live in the header now)', () => {
+    const actions = makeActions();
+    const headerOnlyEntity: EncounterEntity = {
+      id: 'bare-2',
+      type: 'monster',
+      name: 'Mystery',
+      initiative: null,
+      initiativeModifier: 2,
+      proficiencyBonus: 3,
+      currentHp: 1,
+      maxHp: 1,
+      tempHp: 0,
+      armorClass: 10,
+      conditions: [],
+    };
+    const { container } = render(
+      <DetailCombatInfo entity={headerOnlyEntity} actions={actions} />
     );
     expect(container.firstChild).toBeNull();
   });

--- a/src/components/__tests__/header-stat-line.test.tsx
+++ b/src/components/__tests__/header-stat-line.test.tsx
@@ -1,0 +1,251 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HeaderStatLine } from '@/components/ui/encounter/combat-screen/detail/HeaderStatLine';
+import type { EncounterEntity, MonsterStatBlock } from '@/types/encounter';
+import type { EntityActions } from '@/components/ui/encounter/combat-screen/types';
+
+afterEach(cleanup);
+
+function makeActions(): EntityActions {
+  return {
+    onUpdate: vi.fn(),
+    onRemove: vi.fn(),
+    onDamage: vi.fn(),
+    onHeal: vi.fn(),
+    onAddTempHp: vi.fn(),
+    onSetMaxHp: vi.fn(),
+    onAddCondition: vi.fn(),
+    onRemoveCondition: vi.fn(),
+    onSetConditionRounds: vi.fn(),
+    onUseAbility: vi.fn(),
+    onRestoreAbility: vi.fn(),
+    onUseLegendaryAction: vi.fn(),
+    onResetLegendaryActions: vi.fn(),
+    onSetConcentration: vi.fn(),
+    onUseLairAction: vi.fn(),
+    onSetInitiative: vi.fn(),
+    onLongRest: vi.fn(),
+  };
+}
+
+const statBlock: MonsterStatBlock = {
+  str: 16,
+  dex: 12,
+  con: 14,
+  int: 11,
+  wis: 13,
+  cha: 10,
+  saves: 'Str +5',
+  skills: '',
+  speed: '30 ft.',
+  resistances: '',
+  immunities: '',
+  vulnerabilities: '',
+  conditionImmunities: [],
+  senses: '',
+  passivePerception: 13,
+  traits: [],
+  actions: [],
+  bonusActions: [],
+  reactions: [],
+  lairActions: [],
+  cr: '3',
+  type: 'humanoid',
+  size: 'Medium',
+  languages: 'Common',
+  alignment: 'Neutral',
+  hpFormula: '6d8+12',
+};
+
+const monsterEntity: EncounterEntity = {
+  id: 'monster-1',
+  type: 'monster',
+  name: 'Goblin Boss',
+  initiative: 15,
+  initiativeModifier: 1,
+  proficiencyBonus: 2,
+  currentHp: 21,
+  maxHp: 21,
+  tempHp: 0,
+  armorClass: 17,
+  conditions: [],
+  monsterStatBlock: statBlock,
+};
+
+const playerEntity: EncounterEntity = {
+  id: 'player-1',
+  type: 'player',
+  name: 'Aragorn',
+  initiative: 18,
+  initiativeModifier: 3,
+  currentHp: 40,
+  maxHp: 44,
+  tempHp: 0,
+  armorClass: 16,
+  conditions: [],
+  monsterStatBlock: statBlock,
+};
+
+describe('HeaderStatLine — non-player editing', () => {
+  it('renders Speed, Init, and PB inputs with current values', () => {
+    render(<HeaderStatLine entity={monsterEntity} actions={makeActions()} />);
+
+    expect(screen.getByLabelText('Speed')).toHaveValue('30 ft.');
+    expect(screen.getByLabelText('Initiative Mod')).toHaveValue('1');
+    expect(screen.getByLabelText('Proficiency Bonus')).toHaveValue('2');
+  });
+
+  it('editing Speed patches monsterStatBlock.speed on blur', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<HeaderStatLine entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Speed');
+    await user.clear(input);
+    await user.type(input, '40 ft.');
+    await user.tab();
+
+    expect(actions.onUpdate).toHaveBeenCalledWith(
+      'monster-1',
+      expect.objectContaining({
+        monsterStatBlock: expect.objectContaining({ speed: '40 ft.' }),
+      })
+    );
+  });
+
+  it('editing Init commits initiativeModifier (rolled initiative untouched)', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<HeaderStatLine entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Initiative Mod');
+    await user.clear(input);
+    await user.type(input, '7');
+    await user.tab();
+
+    expect(actions.onUpdate).toHaveBeenCalledWith('monster-1', {
+      initiativeModifier: 7,
+    });
+    expect(actions.onSetInitiative).not.toHaveBeenCalled();
+  });
+
+  it('clearing Init commits 0 on blur (NumberField min-fallback)', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<HeaderStatLine entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Initiative Mod');
+    await user.clear(input);
+    await user.tab();
+
+    expect(actions.onUpdate).toHaveBeenCalledWith('monster-1', {
+      initiativeModifier: 0,
+    });
+  });
+
+  it('clearing PB never calls onUpdate (value retained in state)', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    render(<HeaderStatLine entity={monsterEntity} actions={actions} />);
+
+    const input = screen.getByLabelText('Proficiency Bonus');
+    await user.clear(input);
+    await user.tab();
+
+    expect(actions.onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('typing into an unset PB commits proficiencyBonus', async () => {
+    const actions = makeActions();
+    const user = userEvent.setup();
+    const noPb: EncounterEntity = {
+      ...monsterEntity,
+      proficiencyBonus: undefined,
+    };
+    render(<HeaderStatLine entity={noPb} actions={actions} />);
+
+    const input = screen.getByLabelText('Proficiency Bonus');
+    expect(input).toHaveValue('');
+    await user.type(input, '3');
+
+    expect(actions.onUpdate).toHaveBeenCalledWith('monster-1', {
+      proficiencyBonus: 3,
+    });
+  });
+
+  it('without a stat block the Speed line is hidden but Init/PB inputs remain', () => {
+    const noSb: EncounterEntity = {
+      ...monsterEntity,
+      monsterStatBlock: undefined,
+    };
+    render(<HeaderStatLine entity={noSb} actions={makeActions()} />);
+
+    expect(screen.queryByLabelText('Speed')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Initiative Mod')).toBeInTheDocument();
+    expect(screen.getByLabelText('Proficiency Bonus')).toBeInTheDocument();
+  });
+
+  it('with a stat block but empty speed, non-players still get an editable Speed input', () => {
+    const emptySpeed: EncounterEntity = {
+      ...monsterEntity,
+      monsterStatBlock: { ...statBlock, speed: '' },
+    };
+    render(<HeaderStatLine entity={emptySpeed} actions={makeActions()} />);
+
+    expect(screen.getByLabelText('Speed')).toHaveValue('');
+  });
+});
+
+describe('HeaderStatLine — players are static', () => {
+  it('shows static Speed and signed Init, hides PB when unset, renders no inputs', () => {
+    render(<HeaderStatLine entity={playerEntity} actions={makeActions()} />);
+
+    expect(screen.getByText('Speed')).toBeInTheDocument();
+    expect(screen.getByText('30 ft.')).toBeInTheDocument();
+    expect(screen.getByText('Init')).toBeInTheDocument();
+    expect(screen.getByText('+3')).toBeInTheDocument();
+    expect(screen.queryByText('PB')).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('shows signed PB when set', () => {
+    const withPb: EncounterEntity = { ...playerEntity, proficiencyBonus: 4 };
+    render(<HeaderStatLine entity={withPb} actions={makeActions()} />);
+
+    expect(screen.getByText('PB')).toBeInTheDocument();
+    expect(screen.getByText('+4')).toBeInTheDocument();
+  });
+
+  it('hides the Speed line for a player with an empty speed', () => {
+    const emptySpeed: EncounterEntity = {
+      ...playerEntity,
+      monsterStatBlock: { ...statBlock, speed: '' },
+    };
+    render(<HeaderStatLine entity={emptySpeed} actions={makeActions()} />);
+
+    expect(screen.queryByText('Speed')).not.toBeInTheDocument();
+  });
+});
+
+describe('HeaderStatLine — lair renders nothing', () => {
+  it('returns null for lair entities', () => {
+    const lair: EncounterEntity = {
+      id: 'lair-1',
+      type: 'lair',
+      name: 'The Lair',
+      initiative: 20,
+      initiativeModifier: 0,
+      currentHp: 0,
+      maxHp: 0,
+      tempHp: 0,
+      armorClass: 0,
+      conditions: [],
+    };
+    const { container } = render(
+      <HeaderStatLine entity={lair} actions={makeActions()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
@@ -123,7 +123,11 @@ export function StudioPanel({
           />
         ) : selectedEntity ? (
           <>
-            <CombatantDetail entity={selectedEntity} actions={actions} />
+            <CombatantDetail
+              entity={selectedEntity}
+              actions={actions}
+              key={selectedEntity.id}
+            />
             {onTokenIdentityChange && (
               <TokenSettings
                 key={selectedEntity.id}

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
@@ -126,7 +126,7 @@ export function StudioPanel({
             <CombatantDetail
               entity={selectedEntity}
               actions={actions}
-              key={selectedEntity.id}
+              key={`detail-${selectedEntity.id}`}
             />
             {onTokenIdentityChange && (
               <TokenSettings

--- a/src/components/ui/encounter/combat-screen/detail/DetailAbilityScores.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailAbilityScores.tsx
@@ -2,10 +2,10 @@
 
 import React from 'react';
 import { NumberField } from '@/components/ui/forms/NumberInput';
+import { parseSavesString, type AbilityKey } from './DetailAbilityScores.utils';
 import type { DetailSectionProps } from './DetailHeader';
 
 const ABILITY_LABELS = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'] as const;
-type AbilityKey = 'str' | 'dex' | 'con' | 'int' | 'wis' | 'cha';
 const ABILITY_KEYS: AbilityKey[] = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 
 function signedMod(score: number): string {
@@ -17,6 +17,7 @@ export function DetailAbilityScores({ entity, actions }: DetailSectionProps) {
   const sb = entity.monsterStatBlock;
   if (!sb) return null;
 
+  const saveByAbility = parseSavesString(sb.saves);
   const isPlayer = entity.type === 'player';
 
   const handleChange = (key: AbilityKey, val: number | undefined) => {
@@ -35,6 +36,7 @@ export function DetailAbilityScores({ entity, actions }: DetailSectionProps) {
       <div className="grid grid-cols-6 gap-1">
         {ABILITY_KEYS.map((key, i) => {
           const score = sb[key];
+          const save = saveByAbility[key];
           return (
             <div
               key={key}
@@ -58,6 +60,15 @@ export function DetailAbilityScores({ entity, actions }: DetailSectionProps) {
               <span className="text-accent-emerald-text-muted text-[10px]">
                 {signedMod(score)}
               </span>
+              {save != null ? (
+                <span className="text-accent-amber-text text-[10px] font-semibold">
+                  SV {save}
+                </span>
+              ) : (
+                <span className="text-faint text-[10px]">
+                  SV {signedMod(score)}
+                </span>
+              )}
             </div>
           );
         })}

--- a/src/components/ui/encounter/combat-screen/detail/DetailAbilityScores.utils.ts
+++ b/src/components/ui/encounter/combat-screen/detail/DetailAbilityScores.utils.ts
@@ -1,0 +1,33 @@
+export type AbilityKey = 'str' | 'dex' | 'con' | 'int' | 'wis' | 'cha';
+
+const ABILITY_KEY_SET = new Set<string>([
+  'str',
+  'dex',
+  'con',
+  'int',
+  'wis',
+  'cha',
+]);
+
+/**
+ * Parses a stat-block saves display string ("DEX +5, CON +8") into a map of
+ * ability key -> save value string. Values keep their sign verbatim (the
+ * bestiary loader already formats them). Malformed tokens are skipped;
+ * empty/undefined input yields an empty map.
+ */
+export function parseSavesString(
+  saves: string | undefined
+): Partial<Record<AbilityKey, string>> {
+  if (!saves) return {};
+  const result: Partial<Record<AbilityKey, string>> = {};
+  for (const token of saves.split(',')) {
+    const trimmed = token.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^([a-zA-Z]{3})\s+(\S.*)$/);
+    if (!match) continue;
+    const key = match[1].toLowerCase();
+    if (!ABILITY_KEY_SET.has(key)) continue;
+    result[key as AbilityKey] = match[2].trim();
+  }
+  return result;
+}

--- a/src/components/ui/encounter/combat-screen/detail/DetailCombatInfo.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailCombatInfo.tsx
@@ -66,7 +66,6 @@ export function DetailCombatInfo({ entity, actions }: DetailSectionProps) {
   const sb = entity.monsterStatBlock;
   const isPlayer = entity.type === 'player';
   const canEdit = !isPlayer && sb != null;
-  const canEditBasics = !isPlayer;
 
   const resistances =
     (sb != null ? sbField(sb, 'resistances') : undefined) ??
@@ -81,24 +80,11 @@ export function DetailCombatInfo({ entity, actions }: DetailSectionProps) {
     (sb != null ? sbField(sb, 'senses') : undefined) ??
     entity.senses?.map(s => `${s.name} ${s.range} ft.`).join(', ');
 
-  // Editable input is type="number" — a "+" prefix is invalid number syntax
-  // and the browser blanks the field, so only the static display gets the sign.
-  const initiativeModValue = String(entity.initiativeModifier);
-  const initiativeModDisplay =
-    entity.initiativeModifier >= 0
-      ? `+${entity.initiativeModifier}`
-      : String(entity.initiativeModifier);
-  const proficiencyBonusValue =
-    entity.proficiencyBonus != null
-      ? String(entity.proficiencyBonus)
-      : undefined;
   const passivePerceptionValue =
     sb?.passivePerception != null ? String(sb.passivePerception) : undefined;
 
   const hasAnyData =
     sb != null ||
-    entity.initiativeModifier !== 0 ||
-    entity.proficiencyBonus != null ||
     (entity.damageResistances?.length ?? 0) > 0 ||
     (entity.damageImmunities?.length ?? 0) > 0 ||
     (entity.conditionImmunities?.length ?? 0) > 0 ||
@@ -133,58 +119,13 @@ export function DetailCombatInfo({ entity, actions }: DetailSectionProps) {
     });
   };
 
-  const updateInitiativeModifier = (value: string) => {
-    const trimmed = value.trim();
-    if (trimmed === '') return;
-    const num = parseInt(trimmed, 10);
-    if (!Number.isNaN(num))
-      actions.onUpdate(entity.id, { initiativeModifier: num });
-  };
-
-  const updateProficiencyBonus = (value: string) => {
-    const trimmed = value.trim();
-    if (trimmed === '') return;
-    const num = parseInt(trimmed, 10);
-    if (!Number.isNaN(num))
-      actions.onUpdate(entity.id, { proficiencyBonus: num });
-  };
-
   return (
     <div className="border-divider space-y-0 border-t p-4">
       <h3 className="text-heading mb-1 text-xs font-semibold tracking-wider uppercase">
         Combat Details
       </h3>
-      {canEditBasics ? (
-        <>
-          <InfoRow
-            label="Initiative Mod"
-            value={initiativeModValue}
-            editable
-            type="number"
-            onChange={updateInitiativeModifier}
-          />
-          <InfoRow
-            label="Proficiency Bonus"
-            value={proficiencyBonusValue}
-            editable
-            type="number"
-            onChange={updateProficiencyBonus}
-          />
-        </>
-      ) : (
-        <>
-          <StaticRow label="Initiative Mod" value={initiativeModDisplay} />
-          <StaticRow label="Proficiency Bonus" value={proficiencyBonusValue} />
-        </>
-      )}
       {canEdit ? (
         <>
-          <InfoRow
-            label="Speed"
-            value={sb?.speed}
-            editable
-            onChange={v => updateSb('speed', v)}
-          />
           <InfoRow
             label="Saving Throws"
             value={sb?.saves}
@@ -243,7 +184,6 @@ export function DetailCombatInfo({ entity, actions }: DetailSectionProps) {
         </>
       ) : (
         <>
-          <StaticRow label="Speed" value={sb?.speed} />
           <StaticRow label="Saving Throws" value={sb?.saves} />
           <StaticRow label="Skills" value={sb?.skills} />
           <StaticRow label="Resistances" value={resistances} />

--- a/src/components/ui/encounter/combat-screen/detail/DetailHeader.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailHeader.tsx
@@ -5,6 +5,7 @@ import { Eye, Pencil, X } from 'lucide-react';
 import type { EncounterEntity } from '@/types/encounter';
 import type { EntityActions } from '../types';
 import { HeaderControls } from './HeaderControls';
+import { HeaderStatLine } from './HeaderStatLine';
 
 export interface DetailSectionProps {
   entity: EncounterEntity;
@@ -134,6 +135,7 @@ export function DetailHeader({
             )}
           </div>
           {meta && <p className="text-muted mt-0.5 text-xs">{meta}</p>}
+          <HeaderStatLine entity={entity} actions={actions} />
         </div>
 
         <div className="flex shrink-0 items-center gap-1.5">

--- a/src/components/ui/encounter/combat-screen/detail/HeaderStatLine.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/HeaderStatLine.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React from 'react';
+import { NumberField } from '@/components/ui/forms/NumberInput';
+import type { EncounterEntity } from '@/types/encounter';
+import type { EntityActions } from '../types';
+
+interface HeaderStatLineProps {
+  entity: EncounterEntity;
+  actions: EntityActions;
+}
+
+function signed(n: number): string {
+  return n >= 0 ? `+${n}` : `${n}`;
+}
+
+/**
+ * Compact Speed / Init / PB line under the combatant name — the 5e.tools-style
+ * "spot it instantly" stats. Editable inline for non-players; static for
+ * players (synced from their sheet). Speed needs a stat block as its patch
+ * target; a non-player with a stat block keeps an editable (possibly empty)
+ * input so a missing speed can still be set.
+ */
+export function HeaderStatLine({ entity, actions }: HeaderStatLineProps) {
+  if (entity.type === 'lair') return null;
+
+  const isPlayer = entity.type === 'player';
+  const sb = entity.monsterStatBlock;
+  const showSpeedLine =
+    sb != null && (!isPlayer || (sb.speed?.length ?? 0) > 0);
+  const showPb = !isPlayer || entity.proficiencyBonus != null;
+
+  const updateSpeed = (value: string) => {
+    if (!sb) return;
+    actions.onUpdate(entity.id, {
+      monsterStatBlock: { ...sb, speed: value },
+    });
+  };
+
+  return (
+    <div className="mt-1 space-y-0.5">
+      {showSpeedLine && (
+        <div className="flex items-center gap-1.5">
+          <span className="text-muted text-xs font-semibold">Speed</span>
+          {isPlayer ? (
+            <span className="text-body text-xs">{sb.speed}</span>
+          ) : (
+            <input
+              type="text"
+              defaultValue={sb.speed ?? ''}
+              onBlur={e => updateSpeed(e.target.value)}
+              className="bg-surface-raised border-divider text-body min-w-0 flex-1 rounded border px-2 py-0.5 text-xs"
+              aria-label="Speed"
+            />
+          )}
+        </div>
+      )}
+      <div className="flex items-center gap-1.5">
+        <span className="text-muted text-xs font-semibold">Init</span>
+        {isPlayer ? (
+          <span className="text-body text-xs">
+            {signed(entity.initiativeModifier)}
+          </span>
+        ) : (
+          <NumberField
+            value={entity.initiativeModifier}
+            onChange={v => {
+              if (v !== undefined)
+                actions.onUpdate(entity.id, { initiativeModifier: v });
+            }}
+            className="bg-surface-raised text-body w-12 rounded px-1 py-0.5 text-center text-xs shadow-sm"
+            aria-label="Initiative Mod"
+          />
+        )}
+        {showPb && (
+          <>
+            <span className="text-faint text-xs">·</span>
+            <span className="text-muted text-xs font-semibold">PB</span>
+            {isPlayer ? (
+              <span className="text-body text-xs">
+                {signed(entity.proficiencyBonus as number)}
+              </span>
+            ) : (
+              <NumberField
+                value={entity.proficiencyBonus}
+                onChange={v => {
+                  if (v !== undefined)
+                    actions.onUpdate(entity.id, { proficiencyBonus: v });
+                }}
+                allowEmpty
+                className="bg-surface-raised text-body w-12 rounded px-1 py-0.5 text-center text-xs shadow-sm"
+                aria-label="Proficiency Bonus"
+              />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/encounter/combat-screen/detail/__tests__/DetailAbilityScores.utils.test.ts
+++ b/src/components/ui/encounter/combat-screen/detail/__tests__/DetailAbilityScores.utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { parseSavesString } from '@/components/ui/encounter/combat-screen/detail/DetailAbilityScores.utils';
+
+describe('parseSavesString', () => {
+  it('parses a typical loader-formatted string', () => {
+    expect(parseSavesString('DEX +5, CON +8')).toEqual({
+      dex: '+5',
+      con: '+8',
+    });
+  });
+
+  it('accepts lowercase and mixed-case ability keys', () => {
+    expect(parseSavesString('Dex +6, con +15')).toEqual({
+      dex: '+6',
+      con: '+15',
+    });
+  });
+
+  it('keeps negative values verbatim', () => {
+    expect(parseSavesString('STR -1')).toEqual({ str: '-1' });
+  });
+
+  it('returns an empty map for an empty string', () => {
+    expect(parseSavesString('')).toEqual({});
+  });
+
+  it('returns an empty map for undefined', () => {
+    expect(parseSavesString(undefined)).toEqual({});
+  });
+
+  it('skips malformed tokens and keeps valid ones', () => {
+    // "Wisdom +3" is not a 3-letter key; "CON" has no value.
+    expect(parseSavesString('Wisdom +3, DEX +5, CON')).toEqual({ dex: '+5' });
+  });
+
+  it('skips unknown three-letter keys', () => {
+    expect(parseSavesString('FOO +2')).toEqual({});
+  });
+
+  it('tolerates extra whitespace around tokens and values', () => {
+    expect(parseSavesString('  dex   +5 ,  wis +2 ')).toEqual({
+      dex: '+5',
+      wis: '+2',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two glanceability fixes to the combatant detail panel, modeled on 5e.tools. Both the encounter tracker and the DM battlemap StudioPanel render the shared `CombatantDetail`, so one change covers both surfaces.

- **Header stat line** — Speed, Initiative Mod, and Proficiency Bonus move from the buried "Combat Details" list to a compact line directly under the entity name (`Speed 30 ft., Fly 60 ft.` / `Init +4 · PB +4`). Editable inline for non-players (Speed blur-commit text input; Init/PB via `NumberField`), static for players. New `HeaderStatLine` component.
- **Saves in the ability grid** — each ability card gains an `SV +N` line: amber when the ability is listed in the stat block's saves string (proficient), faint modifier fallback otherwise. New pure `parseSavesString` util; editing stays on the Saving Throws string row.
- **Combat Details cleanup** — the three relocated rows removed; section now keys off stat-block/defense data only.

Pinned editing semantics (per spec): clearing Init commits `0` on blur; clearing PB commits nothing (value retained).

## Also fixed along the way

- Scoped two tree-wide `queryByRole('textbox')` assertions in `combatant-detail-vitals.test.tsx` that collided with the new header inputs.
- Keyed `CombatantDetail` in StudioPanel (`detail-${id}`) — the unkeyed panel let uncontrolled inputs carry stale text across token switches.

## Test plan

- 8 new parser unit tests; 12 new `HeaderStatLine` tests; 2 grid tests (proficient/fallback render + rerender-from-prop); Saving Throws patch test; updated `detail-combat-info` suite (9 tests) incl. new hidden-section case.
- Full unit project: 224 files / 3363 tests green. Storybook `CombatantDetail` stories 5/5. Lint + type-check clean.
- [ ] Manual both-themes visual pass: encounter detail panel + battlemap StudioPanel (header line, amber saves, faint fallbacks).

Spec: `docs/superpowers/specs/2026-08-03-statblock-layout-tweaks-design.md` (local, git-excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)