### PR TITLE
Add reusable combat statuses and preserve circular token avatars

### DIFF
--- a/src/components/__tests__/combat-custom-statuses.test.tsx
+++ b/src/components/__tests__/combat-custom-statuses.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CombatConfigDialog } from '@/components/ui/encounter/CombatConfigDialog';
+import { DetailEffects } from '@/components/ui/encounter/combat-screen/detail/DetailEffects';
+import { useEncounterStore } from '@/store/encounterStore';
+import { DEFAULT_COMBAT_CONFIG, type EncounterEntity } from '@/types/encounter';
+import type { EntityActions } from '@/components/ui/encounter/combat-screen/types';
+
+const entity: EncounterEntity = {
+  id: 'custom-status-target',
+  type: 'npc',
+  name: 'Target',
+  initiative: 10,
+  initiativeModifier: 0,
+  currentHp: 10,
+  maxHp: 10,
+  tempHp: 0,
+  armorClass: 10,
+  conditions: [],
+};
+
+describe('custom combat statuses', () => {
+  beforeEach(() => {
+    useEncounterStore.setState({
+      encounters: [],
+      activeEncounterId: null,
+      combatConfig: { ...DEFAULT_COMBAT_CONFIG, customStatuses: [] },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('saves reusable statuses from combat configuration', async () => {
+    const user = userEvent.setup();
+    render(<CombatConfigDialog open onOpenChange={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Status name'), 'Marked');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(useEncounterStore.getState().combatConfig.customStatuses).toEqual([
+      'Marked',
+    ]);
+  });
+
+  it('offers saved statuses in the combatant condition palette', async () => {
+    const user = userEvent.setup();
+    useEncounterStore.getState().setCombatConfig({
+      customStatuses: ['Marked'],
+    });
+    const onAddCondition = vi.fn();
+    const actions = { onAddCondition } as unknown as EntityActions;
+
+    render(<DetailEffects entity={entity} actions={actions} />);
+    await user.click(screen.getByRole('button', { name: 'Marked' }));
+
+    expect(onAddCondition).toHaveBeenCalledWith(entity.id, {
+      name: 'Marked',
+      kind: 'debuff',
+      source: 'dm',
+    });
+  });
+});

--- a/src/components/ui/campaign/dm-vtt/combatantToken.ts
+++ b/src/components/ui/campaign/dm-vtt/combatantToken.ts
@@ -1,7 +1,10 @@
 import { createImage, createShape } from '@fieldnotes/core';
 
 import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
-import { tokenAvatarUrl } from '@/components/ui/campaign/location-map/PlayerTokenTool';
+import {
+  buildCircularTokenUrl,
+  tokenAvatarUrl,
+} from '@/components/ui/campaign/location-map/PlayerTokenTool';
 import {
   snapTokenCenter,
   TOKEN_ELEMENT_ZINDEX,
@@ -61,6 +64,25 @@ export interface DmTokenConfig {
   tokenSize?: TokenCellSize;
   /** Fired once after placement (tool has handed back to select). */
   onPlaced: () => void;
+}
+
+/** Builds the same circular, ringed portrait used by player-placed tokens. */
+export async function prepareCombatantTokenAvatar(
+  entity: Pick<
+    EncounterEntity,
+    'id' | 'avatarUrl' | 'type' | 'playerDisposition'
+  > &
+    Partial<Pick<EncounterEntity, 'legendaryActions'>>
+): Promise<string | undefined> {
+  const avatar = tokenAvatarUrl(entity.avatarUrl);
+  if (!avatar) return undefined;
+  return (
+    (await buildCircularTokenUrl(
+      avatar,
+      dispositionColor(entity),
+      `combatant-${entity.id}`
+    )) ?? avatar
+  );
 }
 
 /** Stamps a grid-snapped, creature-size-aware combatant token and adds it to the store. */

--- a/src/components/ui/campaign/dm-vtt/useDmVttPlacementAndSelection.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttPlacementAndSelection.ts
@@ -54,7 +54,7 @@ export function useDmVttPlacementAndSelection({
   }, []);
 
   const armPlacement = useCallback(
-    async (entity: EncounterEntity) => {
+    (entity: EncounterEntity) => {
       if (status !== 'live') {
         addToast({
           type: 'info',
@@ -63,18 +63,22 @@ export function useDmVttPlacementAndSelection({
         });
         return;
       }
-      const config: DmTokenConfig = {
-        entityId: entity.id,
-        name: entity.name,
-        avatarUrl: await prepareCombatantTokenAvatar(entity),
-        color: entity.color ?? dispositionColor(entity),
-        tokenSize: entity.tokenSize,
-        onPlaced: () => {
-          setPendingPlacement(null); // SYNCHRONOUS — see comment above.
-          selectEntity(entity.id);
-        },
+      const arm = (avatarUrl?: string) => {
+        const config: DmTokenConfig = {
+          entityId: entity.id,
+          name: entity.name,
+          avatarUrl,
+          color: entity.color ?? dispositionColor(entity),
+          tokenSize: entity.tokenSize,
+          onPlaced: () => {
+            setPendingPlacement(null); // SYNCHRONOUS — see comment above.
+            selectEntity(entity.id);
+          },
+        };
+        setPendingPlacement({ entityName: entity.name, config });
       };
-      setPendingPlacement({ entityName: entity.name, config });
+      if (entity.avatarUrl) void prepareCombatantTokenAvatar(entity).then(arm);
+      else arm();
     },
     [status, addToast, selectEntity]
   );

--- a/src/components/ui/campaign/dm-vtt/useDmVttPlacementAndSelection.ts
+++ b/src/components/ui/campaign/dm-vtt/useDmVttPlacementAndSelection.ts
@@ -2,7 +2,10 @@
 
 import { useCallback, useRef, useState } from 'react';
 
-import { dispositionColor } from './combatantToken';
+import {
+  dispositionColor,
+  prepareCombatantTokenAvatar,
+} from './combatantToken';
 import { selectedEntityId as resolveSelectedEntity } from './useCombatantTokens';
 
 import type { Viewport } from '@fieldnotes/core';
@@ -51,7 +54,7 @@ export function useDmVttPlacementAndSelection({
   }, []);
 
   const armPlacement = useCallback(
-    (entity: EncounterEntity) => {
+    async (entity: EncounterEntity) => {
       if (status !== 'live') {
         addToast({
           type: 'info',
@@ -63,7 +66,7 @@ export function useDmVttPlacementAndSelection({
       const config: DmTokenConfig = {
         entityId: entity.id,
         name: entity.name,
-        avatarUrl: entity.avatarUrl,
+        avatarUrl: await prepareCombatantTokenAvatar(entity),
         color: entity.color ?? dispositionColor(entity),
         tokenSize: entity.tokenSize,
         onPlaced: () => {

--- a/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
+++ b/src/components/ui/campaign/dm-vtt/useRosterDrag.ts
@@ -2,7 +2,11 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { dispositionColor, stampCombatantToken } from './combatantToken';
+import {
+  dispositionColor,
+  prepareCombatantTokenAvatar,
+  stampCombatantToken,
+} from './combatantToken';
 
 import { cellUnit } from '@/components/ui/campaign/location-map/cellUnit';
 
@@ -132,6 +136,9 @@ export function useRosterDrag({
             vp.camera.zoom
           )
         : null;
+      const preparedAvatar = entity.avatarUrl
+        ? prepareCombatantTokenAvatar(entity)
+        : null;
 
       const handleMove = (ev: PointerEvent) => {
         const start = startPointRef.current;
@@ -161,11 +168,17 @@ export function useRosterDrag({
         if (!vp || !canvasEl) return;
         const rect = canvasEl.getBoundingClientRect();
         if (!isInsideRect(rect, ev.clientX, ev.clientY)) return;
-        stampAtScreenPoint(vp, canvasEl, entity, {
-          x: ev.clientX,
-          y: ev.clientY,
-        });
-        onDropPlaced(entity.id);
+        const place = (avatarUrl?: string) => {
+          stampAtScreenPoint(
+            vp,
+            canvasEl,
+            avatarUrl ? { ...entity, avatarUrl } : entity,
+            { x: ev.clientX, y: ev.clientY }
+          );
+          onDropPlaced(entity.id);
+        };
+        if (preparedAvatar) void preparedAvatar.then(place);
+        else place();
       };
 
       window.addEventListener('pointermove', handleMove);

--- a/src/components/ui/encounter/CombatConfigDialog.tsx
+++ b/src/components/ui/encounter/CombatConfigDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { Trash2 } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -81,6 +81,10 @@ export function CombatConfigDialog({
       combatConfig.enemyConditionsDisplay ?? 'off'
     );
   const [bands, setBands] = useState<HpStateBand[]>(combatConfig.hpStateBands);
+  const [customStatuses, setCustomStatuses] = useState<string[]>(
+    combatConfig.customStatuses ?? []
+  );
+  const [newStatus, setNewStatus] = useState('');
 
   // Re-sync local state when dialog opens or store changes
   useEffect(() => {
@@ -88,6 +92,8 @@ export function CombatConfigDialog({
       setHpDisplay(combatConfig.enemyHpDisplay);
       setConditionsDisplay(combatConfig.enemyConditionsDisplay ?? 'off');
       setBands(combatConfig.hpStateBands);
+      setCustomStatuses(combatConfig.customStatuses ?? []);
+      setNewStatus('');
     }
   }, [open, combatConfig]);
 
@@ -123,6 +129,17 @@ export function CombatConfigDialog({
     setBands([...DEFAULT_HP_STATE_BANDS]);
   };
 
+  const handleAddStatus = () => {
+    const name = newStatus.trim();
+    if (!name) return;
+    if (
+      customStatuses.some(status => status.toLowerCase() === name.toLowerCase())
+    )
+      return;
+    setCustomStatuses(prev => [...prev, name]);
+    setNewStatus('');
+  };
+
   const handleSave = () => {
     const cleaned = bands
       .filter(b => b.label.trim() !== '')
@@ -132,6 +149,7 @@ export function CombatConfigDialog({
       enemyHpDisplay: hpDisplay,
       hpStateBands: cleaned,
       enemyConditionsDisplay: conditionsDisplay,
+      customStatuses,
     });
     onOpenChange(false);
   };
@@ -256,6 +274,70 @@ export function CombatConfigDialog({
               description="Players see condition icons and concentration on enemy tokens. Your own party's conditions are always visible to them."
               wrapperClassName="gap-4"
             />
+          </div>
+
+          <div className="border-divider space-y-3 border-t pt-4">
+            <div>
+              <h3 className="text-heading text-sm font-medium">
+                Custom statuses
+              </h3>
+              <p className="text-muted mt-1 text-xs">
+                Save reusable condition presets that appear in every combat.
+              </p>
+            </div>
+
+            {customStatuses.length > 0 && (
+              <div className="space-y-2">
+                {customStatuses.map(status => (
+                  <div
+                    key={status.toLowerCase()}
+                    className="bg-surface-secondary flex items-center justify-between rounded-md px-3 py-2"
+                  >
+                    <span className="text-body text-sm">{status}</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        setCustomStatuses(prev =>
+                          prev.filter(item => item !== status)
+                        )
+                      }
+                      type="button"
+                      aria-label={`Remove ${status}`}
+                    >
+                      <Trash2 size={14} className="text-muted" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="flex items-end gap-2">
+              <Input
+                value={newStatus}
+                onChange={e => setNewStatus(e.target.value)}
+                aria-label="Status name"
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleAddStatus();
+                  }
+                }}
+                label="Status name"
+                placeholder="e.g. Marked"
+                wrapperClassName="flex-1"
+              />
+              <Button
+                variant="outline"
+                size="md"
+                onClick={handleAddStatus}
+                disabled={!newStatus.trim()}
+                type="button"
+              >
+                <Plus size={14} />
+                Add
+              </Button>
+            </div>
           </div>
         </DialogBody>
 

--- a/src/components/ui/encounter/EncounterView.tsx
+++ b/src/components/ui/encounter/EncounterView.tsx
@@ -205,6 +205,7 @@ export function EncounterView({
     currentHp: p.characterData?.hitPoints?.current ?? 0,
     maxHp: p.characterData?.hitPoints?.max ?? 0,
     dexterity: p.characterData?.abilities?.dexterity ?? 10,
+    avatarUrl: p.characterData?.avatar,
   }));
 
   // Build player sync timestamp map for freshness indicators

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/buildEntity.test.ts
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/buildEntity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { buildNpcEntity, buildPlayerEntity } from './buildEntity';
+import type { CampaignNPC } from '@/types/encounter';
+
+describe('encounter entity avatars', () => {
+  it('carries a campaign player portrait into the encounter', () => {
+    const entity = buildPlayerEntity({
+      id: 'player-1',
+      name: 'Aria',
+      class: 'Rogue',
+      level: 5,
+      armorClass: 15,
+      currentHp: 30,
+      maxHp: 30,
+      dexterity: 18,
+      avatarUrl: 'https://example.com/aria.png',
+    });
+
+    expect(entity.avatarUrl).toBe('https://example.com/aria.png');
+  });
+
+  it('carries an NPC dashboard portrait into the encounter', () => {
+    const npc: CampaignNPC = {
+      id: 'npc-1',
+      campaignCode: 'TEST',
+      name: 'Captain Vale',
+      armorClass: '16',
+      maxHp: 45,
+      speed: '30 ft.',
+      avatarUrl: 'https://example.com/vale.png',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    const entity = buildNpcEntity(npc, {
+      isHidden: false,
+      playerDisposition: 'neutral',
+      campaignCode: 'TEST',
+    });
+
+    expect(entity.avatarUrl).toBe('https://example.com/vale.png');
+  });
+});

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/buildEntity.ts
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/buildEntity.ts
@@ -32,6 +32,7 @@ export interface CampaignPlayer {
   currentHp: number;
   maxHp: number;
   dexterity: number;
+  avatarUrl?: string;
 }
 
 export function buildPlayerEntity(
@@ -53,6 +54,7 @@ export function buildPlayerEntity(
     campaignCode,
     isHidden: false,
     color: playerColors?.[player.id],
+    avatarUrl: player.avatarUrl,
   };
 }
 
@@ -99,6 +101,7 @@ export function buildNpcEntity(
     npcSourceId: npc.id,
     campaignCode: opts.campaignCode,
     spellcasting: buildNpcSpellcasting(npc),
+    avatarUrl: npc.avatarUrl,
   };
 }
 

--- a/src/components/ui/encounter/combat-screen/AddCombatantDialog/index.tsx
+++ b/src/components/ui/encounter/combat-screen/AddCombatantDialog/index.tsx
@@ -41,6 +41,7 @@ export interface AddCombatantDialogProps {
     currentHp: number;
     maxHp: number;
     dexterity: number;
+    avatarUrl?: string;
   }>;
   npcs: CampaignNPC[];
   playerColors?: Record<string, string>;

--- a/src/components/ui/encounter/combat-screen/detail/DetailEffects.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailEffects.tsx
@@ -5,15 +5,32 @@ import { Plus } from 'lucide-react';
 import type { DetailSectionProps } from './DetailHeader';
 import { DEBUFF_PALETTE, BUFF_PALETTE } from '../effectPalettes';
 import { ActiveEffectChip } from './ActiveEffectChip';
+import { useEncounterStore } from '@/store/encounterStore';
 
 type PaletteTab = 'conditions' | 'buffs';
 
 export function DetailEffects({ entity, actions }: DetailSectionProps) {
   const [tab, setTab] = useState<PaletteTab>('conditions');
   const [customInput, setCustomInput] = useState('');
+  const customStatuses = useEncounterStore(
+    state => state.combatConfig.customStatuses ?? []
+  );
 
   const activeNames = new Set(entity.conditions.map(c => c.name));
-  const palette = tab === 'conditions' ? DEBUFF_PALETTE : BUFF_PALETTE;
+  const palette =
+    tab === 'conditions'
+      ? [
+          ...DEBUFF_PALETTE,
+          ...customStatuses
+            .filter(
+              name =>
+                !DEBUFF_PALETTE.some(
+                  entry => entry.name.toLowerCase() === name.toLowerCase()
+                )
+            )
+            .map(name => ({ name, kind: 'debuff' as const })),
+        ]
+      : BUFF_PALETTE;
 
   const handleAddCustom = () => {
     const name = customInput.trim();

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -226,7 +226,7 @@ export interface CombatConfig {
   hpStateBands: HpStateBand[];
   enemyConditionsDisplay: EnemyConditionsDisplay;
   /** DM-defined condition presets available in every combat. */
-  customStatuses: string[];
+  customStatuses?: string[];
 }
 
 export const DEFAULT_HP_STATE_BANDS: HpStateBand[] = [

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -225,6 +225,8 @@ export interface CombatConfig {
   enemyHpDisplay: EnemyHpDisplay;
   hpStateBands: HpStateBand[];
   enemyConditionsDisplay: EnemyConditionsDisplay;
+  /** DM-defined condition presets available in every combat. */
+  customStatuses: string[];
 }
 
 export const DEFAULT_HP_STATE_BANDS: HpStateBand[] = [
@@ -240,6 +242,7 @@ export const DEFAULT_COMBAT_CONFIG: CombatConfig = {
   enemyHpDisplay: 'off',
   hpStateBands: DEFAULT_HP_STATE_BANDS,
   enemyConditionsDisplay: 'off',
+  customStatuses: [],
 };
 
 export interface NPCInventoryItem {


### PR DESCRIPTION
## Summary
- let DMs save and remove reusable custom status presets in Combat Configuration
- expose saved statuses in every combatant condition palette
- carry dashboard NPC portraits and campaign player avatars into encounter entities
- prepare circular, ringed portraits for DM click and drag token placement, matching player-placed tokens

## Testing
- `npx eslint` on all changed files
- `npm test -- --run src/components/__tests__/combat-custom-statuses.test.tsx src/components/ui/encounter/combat-screen/AddCombatantDialog/buildEntity.test.ts src/components/__tests__/add-combatant-dialog.test.tsx src/components/ui/campaign/dm-vtt/__tests__/combatantToken.test.ts src/components/ui/campaign/dm-vtt/__tests__/useRosterDrag.test.ts src/components/ui/campaign/location-map/__tests__/PlayerTokenTool.test.ts` (60 tests passed)
- `git diff --check`