### PR TITLE
fix: infinite update loop in DetailEffects when persisted combatConfig lacks customStatuses

### DIFF
--- a/src/components/__tests__/detail-effects.test.tsx
+++ b/src/components/__tests__/detail-effects.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { DetailEffects } from '@/components/ui/encounter/combat-screen/detail/DetailEffects';
+import { useEncounterStore } from '@/store/encounterStore';
+import { DEFAULT_COMBAT_CONFIG } from '@/types/encounter';
+import type { EncounterEntity } from '@/types/encounter';
+import type { EntityActions } from '@/components/ui/encounter/combat-screen/types';
+
+afterEach(cleanup);
+
+function makeActions(): EntityActions {
+  return {
+    onUpdate: vi.fn(),
+    onRemove: vi.fn(),
+    onDamage: vi.fn(),
+    onHeal: vi.fn(),
+    onAddTempHp: vi.fn(),
+    onSetMaxHp: vi.fn(),
+    onAddCondition: vi.fn(),
+    onRemoveCondition: vi.fn(),
+    onSetConditionRounds: vi.fn(),
+    onUseAbility: vi.fn(),
+    onRestoreAbility: vi.fn(),
+    onSpendResource: vi.fn(() => true),
+    onRestoreResource: vi.fn(),
+    onUseLegendaryAction: vi.fn(),
+    onResetLegendaryActions: vi.fn(),
+    onSetConcentration: vi.fn(),
+    onUseLairAction: vi.fn(),
+    onSetInitiative: vi.fn(),
+    onLongRest: vi.fn(),
+    onShortRest: vi.fn(),
+  };
+}
+
+const entity: EncounterEntity = {
+  id: 'npc-1',
+  type: 'npc',
+  name: 'Guard',
+  initiative: 12,
+  initiativeModifier: 1,
+  currentHp: 11,
+  maxHp: 11,
+  tempHp: 0,
+  armorClass: 16,
+  conditions: [],
+};
+
+describe('DetailEffects — combatConfig.customStatuses selector', () => {
+  beforeEach(() => {
+    useEncounterStore.setState({ combatConfig: DEFAULT_COMBAT_CONFIG });
+  });
+
+  it('renders without an update loop when persisted combatConfig lacks customStatuses (legacy data)', () => {
+    // Pre-custom-statuses localStorage hydrates a combatConfig without the
+    // field; the selector fallback must stay referentially stable or React's
+    // useSyncExternalStore loops ("The result of getSnapshot should be cached").
+    useEncounterStore.setState({
+      combatConfig: {
+        enemyHpDisplay: 'off',
+        hpStateBands: [],
+        enemyConditionsDisplay: 'off',
+      },
+    });
+
+    expect(() =>
+      render(<DetailEffects entity={entity} actions={makeActions()} />)
+    ).not.toThrow();
+    expect(screen.getByText('Conditions')).toBeTruthy();
+  });
+
+  it('renders defined custom statuses in the conditions palette', () => {
+    useEncounterStore.setState({
+      combatConfig: {
+        ...DEFAULT_COMBAT_CONFIG,
+        customStatuses: ['Marked by Fate'],
+      },
+    });
+
+    render(<DetailEffects entity={entity} actions={makeActions()} />);
+    expect(screen.getByText('Marked by Fate')).toBeTruthy();
+  });
+});

--- a/src/components/ui/encounter/combat-screen/detail/DetailEffects.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailEffects.tsx
@@ -9,11 +9,16 @@ import { useEncounterStore } from '@/store/encounterStore';
 
 type PaletteTab = 'conditions' | 'buffs';
 
+// Stable fallback: pre-custom-statuses persisted combatConfig lacks the field,
+// and a per-call `?? []` makes the selector snapshot a fresh reference every
+// render — useSyncExternalStore then loops ("getSnapshot should be cached").
+const EMPTY_CUSTOM_STATUSES: string[] = [];
+
 export function DetailEffects({ entity, actions }: DetailSectionProps) {
   const [tab, setTab] = useState<PaletteTab>('conditions');
   const [customInput, setCustomInput] = useState('');
   const customStatuses = useEncounterStore(
-    state => state.combatConfig.customStatuses ?? []
+    state => state.combatConfig.customStatuses ?? EMPTY_CUSTOM_STATUSES
   );
 
   const activeNames = new Set(entity.conditions.map(c => c.name));


### PR DESCRIPTION
## Summary

Hotfix for a runtime crash in the combatant detail panel: `Maximum update depth exceeded` / "The result of getSnapshot should be cached to avoid an infinite loop" at `DetailEffects.tsx:15`.

## Root cause

`useEncounterStore(state => state.combatConfig.customStatuses ?? [])` allocates a **new array on every getSnapshot call** whenever `customStatuses` is `undefined`. Zustand v5 uses `useSyncExternalStore`; an unstable snapshot reference fails `Object.is`, forcing a re-render, which calls the selector again — infinite loop.

`customStatuses` is `undefined` for anyone whose encounter store was persisted **before the custom-statuses feature** (dd076d8): the persist config has no migrate/merge for `combatConfig`, so the hydrated object simply lacks the field. Fresh storage gets `DEFAULT_COMBAT_CONFIG` (`customStatuses: []`), which is why dev environments and tests never hit it. Latent since dd076d8, unrelated to #199 — surfaced when opening the detail panel with legacy localStorage.

## Fix

Module-level `EMPTY_CUSTOM_STATUSES` constant as the selector fallback — the snapshot is now referentially stable. One line + comment.

Scanned the codebase for the same pattern: this was the only in-render Zustand selector with a per-call `?? []` fallback (`CombatConfigDialog`'s are in `useState`/effect, safe).

## Test plan

- [x] New regression test reproduces the loop pre-fix (render throws) and passes post-fix: legacy `combatConfig` without `customStatuses` renders cleanly
- [x] Sanity test: defined custom statuses still appear in the conditions palette
- [x] Full unit suite: 3439 passed / 1 skipped
- [x] `npm run type-check` + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)