### PR TITLE
feat: DM XP awards with pending level-up flow + House Rules reorder

### DIFF
--- a/src/app/api/campaign/[code]/shared/__tests__/xp-awards.test.ts
+++ b/src/app/api/campaign/[code]/shared/__tests__/xp-awards.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  resetRedis,
+  seedRedis,
+  seedRedisSet,
+  seedRedisList,
+  getRedisLists,
+  mockRedis,
+} from '@/test/mocks/redis';
+import { createNextRequest, createRouteParams } from '@/test/helpers';
+import { GET, POST, DELETE } from '../route';
+import { NextRequest } from 'next/server';
+import type { DmXpAward, DmXpAwardEnvelope } from '@/types/sharedState';
+
+const CODE = 'XPTEST';
+const DM_ID = 'dm-1';
+const PLAYER_ID = 'player-1';
+const xpKey = `campaign:${CODE}:xp:${PLAYER_ID}`;
+
+function makeAward(overrides: Partial<DmXpAward> = {}): DmXpAward {
+  return {
+    id: 'award-1',
+    mode: 'add',
+    amount: 300,
+    awardedAt: '2026-08-03T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function postXp(award: unknown, playerId = PLAYER_ID, dmId = DM_ID) {
+  const req = createNextRequest(`/api/campaign/${CODE}/shared`, {
+    method: 'POST',
+    body: { feature: 'xp', data: { playerId, award }, dmId },
+  });
+  return POST(req as NextRequest, createRouteParams({ code: CODE }));
+}
+
+function getShared() {
+  const req = new NextRequest(
+    `http://localhost/api/campaign/${CODE}/shared?role=player&playerId=${PLAYER_ID}`
+  );
+  return GET(req, createRouteParams({ code: CODE }));
+}
+
+function deleteXp(receipt: unknown) {
+  const req = createNextRequest(`/api/campaign/${CODE}/shared`, {
+    method: 'DELETE',
+    body: { playerId: PLAYER_ID, type: 'xp', receipt },
+  });
+  return DELETE(req as NextRequest, createRouteParams({ code: CODE }));
+}
+
+beforeEach(() => {
+  resetRedis();
+  seedRedis(`campaign:${CODE}`, { dmId: DM_ID, name: 'Test' });
+  seedRedisSet(`campaign:${CODE}:players`, [PLAYER_ID]);
+});
+
+describe('POST feature=xp', () => {
+  it('enqueues a valid award', async () => {
+    const res = await postXp(makeAward());
+    expect(res.status).toBe(200);
+    const list = getRedisLists().get(xpKey)!;
+    expect(list).toHaveLength(1);
+    expect(JSON.parse(list[0])).toEqual(makeAward());
+  });
+
+  it.each([
+    ['bad mode', makeAward({ mode: 'grant' as never })],
+    ['non-integer amount', makeAward({ amount: 1.5 })],
+    ['non-finite amount', makeAward({ amount: Infinity })],
+    ['add with 0', makeAward({ amount: 0 })],
+    ['set with -1', makeAward({ mode: 'set', amount: -1 })],
+    ['empty id', makeAward({ id: '' })],
+    ['oversize id', makeAward({ id: 'x'.repeat(65) })],
+    ['malformed date', makeAward({ awardedAt: 'not-a-date' })],
+    ['oversize date', makeAward({ awardedAt: '2026'.repeat(11) })],
+  ])('rejects %s with 400', async (_label, award) => {
+    const res = await postXp(award);
+    expect(res.status).toBe(400);
+    expect(getRedisLists().get(xpKey)).toBeUndefined();
+  });
+
+  it('set with 0 is valid', async () => {
+    const res = await postXp(makeAward({ mode: 'set', amount: 0 }));
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects unknown playerId with 400 and creates no key', async () => {
+    const res = await postXp(makeAward(), 'stranger');
+    expect(res.status).toBe(400);
+    expect(getRedisLists().get(`campaign:${CODE}:xp:stranger`)).toBeUndefined();
+  });
+
+  it('rejects a non-DM caller with 403', async () => {
+    const res = await postXp(makeAward(), PLAYER_ID, 'imposter');
+    expect(res.status).toBe(403);
+  });
+
+  it('preserves enqueue order and rejects at the cap atomically', async () => {
+    seedRedisList(
+      xpKey,
+      Array.from({ length: 99 }, (_, i) =>
+        JSON.stringify(makeAward({ id: `seed-${i}`, amount: 1 }))
+      )
+    );
+    const [a, b] = await Promise.all([
+      postXp(makeAward({ id: 'race-a' })),
+      postXp(makeAward({ id: 'race-b' })),
+    ]);
+    const statuses = [a.status, b.status].sort();
+    expect(statuses).toEqual([200, 409]); // exactly one landed
+    expect(getRedisLists().get(xpKey)).toHaveLength(100);
+  });
+});
+
+describe('GET xpAwards', () => {
+  it('returns awards with receipts equal to the stored strings, in order', async () => {
+    await postXp(makeAward({ id: 'first', mode: 'set', amount: 900 }));
+    await postXp(makeAward({ id: 'second', amount: 50 }));
+    const res = await getShared();
+    const body = await res.json();
+    const awards: DmXpAwardEnvelope[] = body.xpAwards;
+    expect(awards.map(e => e.award.id)).toEqual(['first', 'second']);
+    const stored = getRedisLists().get(xpKey)!;
+    expect(awards.map(e => e.receipt)).toEqual(stored);
+  });
+
+  it('removes malformed entries during GET and does not return them', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    seedRedisList(xpKey, [
+      'not json at all',
+      JSON.stringify(makeAward({ id: 'good' })),
+    ]);
+    const res = await getShared();
+    const body = await res.json();
+    expect(body.xpAwards.map((e: DmXpAwardEnvelope) => e.award.id)).toEqual([
+      'good',
+    ]);
+    expect(getRedisLists().get(xpKey)).toHaveLength(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Removed malformed XP award entry',
+      expect.any(Object)
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns an empty array when no queue exists', async () => {
+    const res = await getShared();
+    const body = await res.json();
+    expect(body.xpAwards).toEqual([]);
+  });
+});
+
+describe('DELETE type=xp', () => {
+  it('removes exactly one matching entry by receipt', async () => {
+    await postXp(makeAward({ id: 'a' }));
+    await postXp(makeAward({ id: 'b' }));
+    const stored = getRedisLists().get(xpKey)!;
+    const receiptA = stored[0];
+    const res = await deleteXp(receiptA);
+    expect(res.status).toBe(200);
+    const after = getRedisLists().get(xpKey)!;
+    expect(after).toHaveLength(1);
+    expect(JSON.parse(after[0]).id).toBe('b');
+  });
+
+  it('ack of an already-removed receipt is safe', async () => {
+    await postXp(makeAward({ id: 'a' }));
+    const receipt = getRedisLists().get(xpKey)![0];
+    await deleteXp(receipt);
+    const res = await deleteXp(receipt);
+    expect(res.status).toBe(200);
+  });
+
+  it('deletes the key when the queue empties and refreshes expiry otherwise', async () => {
+    await postXp(makeAward({ id: 'a' }));
+    await postXp(makeAward({ id: 'b' }));
+    const stored = [...getRedisLists().get(xpKey)!];
+    mockRedis.expire.mockClear();
+    await deleteXp(stored[0]);
+    expect(getRedisLists().has(xpKey)).toBe(true);
+    expect(mockRedis.expire).toHaveBeenCalledWith(xpKey, expect.any(Number));
+    await deleteXp(stored[1]);
+    expect(getRedisLists().has(xpKey)).toBe(false);
+  });
+
+  it('rejects a missing receipt with 400', async () => {
+    const res = await deleteXp(undefined);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/campaign/[code]/shared/__tests__/xp-awards.test.ts
+++ b/src/app/api/campaign/[code]/shared/__tests__/xp-awards.test.ts
@@ -112,6 +112,17 @@ describe('POST feature=xp', () => {
     expect(statuses).toEqual([200, 409]); // exactly one landed
     expect(getRedisLists().get(xpKey)).toHaveLength(100);
   });
+
+  it('responds 500 when the EVAL reply is neither "ok" nor "full"', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    mockRedis.eval.mockResolvedValueOnce('unexpected-reply' as never);
+    const res = await postXp(makeAward());
+    expect(res.status).toBe(500);
+    expect(getRedisLists().get(xpKey)).toBeUndefined();
+    consoleErrorSpy.mockRestore();
+  });
 });
 
 describe('GET xpAwards', () => {
@@ -175,16 +186,20 @@ describe('DELETE type=xp', () => {
     expect(res.status).toBe(200);
   });
 
-  it('deletes the key when the queue empties and refreshes expiry otherwise', async () => {
+  it('leaves the list empty when the queue empties, and refreshes expiry otherwise', async () => {
     await postXp(makeAward({ id: 'a' }));
     await postXp(makeAward({ id: 'b' }));
     const stored = [...getRedisLists().get(xpKey)!];
     mockRedis.expire.mockClear();
     await deleteXp(stored[0]);
-    expect(getRedisLists().has(xpKey)).toBe(true);
+    expect(getRedisLists().get(xpKey)).toHaveLength(1);
     expect(mockRedis.expire).toHaveBeenCalledWith(xpKey, expect.any(Number));
+    mockRedis.expire.mockClear();
     await deleteXp(stored[1]);
-    expect(getRedisLists().has(xpKey)).toBe(false);
+    expect(getRedisLists().get(xpKey)).toHaveLength(0);
+    // No explicit DEL on empty (would race a concurrent enqueue) — expiry is
+    // simply not refreshed once nothing remains.
+    expect(mockRedis.expire).not.toHaveBeenCalled();
   });
 
   it('rejects a missing receipt with 400', async () => {

--- a/src/app/api/campaign/[code]/shared/__tests__/xp-awards.test.ts
+++ b/src/app/api/campaign/[code]/shared/__tests__/xp-awards.test.ts
@@ -158,6 +158,29 @@ describe('GET xpAwards', () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it('removes parseable JSON entries that fail full award validation', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    seedRedisList(xpKey, [
+      JSON.stringify(makeAward({ id: 'bad', amount: 'oops' as never })),
+      JSON.stringify(makeAward({ id: 'good' })),
+    ]);
+
+    const res = await getShared();
+    const body = await res.json();
+
+    expect(body.xpAwards.map((e: DmXpAwardEnvelope) => e.award.id)).toEqual([
+      'good',
+    ]);
+    expect(getRedisLists().get(xpKey)).toHaveLength(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Removed malformed XP award entry',
+      expect.any(Object)
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
   it('returns an empty array when no queue exists', async () => {
     const res = await getShared();
     const body = await res.json();

--- a/src/app/api/campaign/[code]/shared/route.ts
+++ b/src/app/api/campaign/[code]/shared/route.ts
@@ -1,19 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server';
 import {
   getRedis,
+  getRawRedis,
   campaignSharedKey,
   campaignMessagesKey,
   campaignEffectsKey,
   campaignTransfersKey,
   campaignPlayersKey,
+  campaignXpKey,
   refreshCampaignTTL,
   SLIDING_TTL_SECONDS,
 } from '@/lib/redis';
 import { verifyDmAuthority } from '@/lib/dmAuth';
 import { sendInitiativePoke } from '@/lib/relayPoke';
+import {
+  enqueueXpAward,
+  readXpAwards,
+  ackXpAward,
+  validateDmXpAward,
+} from '@/lib/xpAwardQueue';
 import type {
   DmMessage,
   DmEffect,
+  DmXpAward,
+  DmXpAwardEnvelope,
   SharedCalendar,
   SharedCalendarPlayer,
   SharedCampaignState,
@@ -104,6 +114,7 @@ export async function GET(
     let dmEffects: DmEffect[] = [];
     let customCounter: SharedCampaignState['customCounter'] = null;
     let transfers: ItemTransfer[] = [];
+    let xpAwards: DmXpAwardEnvelope[] = [];
 
     if (playerId) {
       const [messagesRaw, effectsRaw, countersRaw, transfersRaw] =
@@ -139,6 +150,11 @@ export async function GET(
             ? JSON.parse(transfersRaw)
             : transfersRaw;
       }
+
+      xpAwards = await readXpAwards(
+        getRawRedis(),
+        campaignXpKey(code, playerId)
+      );
     }
 
     await refreshCampaignTTL(redis, code);
@@ -153,6 +169,7 @@ export async function GET(
       battleMap,
       initiativeRequest,
       settings,
+      xpAwards,
     };
     return NextResponse.json(state);
   } catch (error) {
@@ -280,6 +297,52 @@ export async function POST(
       return NextResponse.json({ success: true });
     }
 
+    if (feature === 'xp') {
+      const { playerId: targetPlayerId, award } = data as {
+        playerId: string;
+        award: DmXpAward;
+      };
+
+      if (!targetPlayerId || typeof targetPlayerId !== 'string') {
+        return NextResponse.json(
+          { error: 'playerId is required for xp' },
+          { status: 400 }
+        );
+      }
+
+      const validationError = validateDmXpAward(award);
+      if (validationError) {
+        return NextResponse.json({ error: validationError }, { status: 400 });
+      }
+
+      // Never create queue keys for players who are not in the campaign
+      const isMember = await redis.sismember(
+        campaignPlayersKey(code),
+        targetPlayerId
+      );
+      if (!isMember) {
+        return NextResponse.json(
+          { error: 'playerId is not a member of this campaign' },
+          { status: 400 }
+        );
+      }
+
+      const result = await enqueueXpAward(
+        getRawRedis(),
+        campaignXpKey(code, targetPlayerId),
+        award
+      );
+      if (result === 'full') {
+        return NextResponse.json(
+          { error: 'XP award queue is full for this player' },
+          { status: 409 }
+        );
+      }
+
+      await refreshCampaignTTL(redis, code);
+      return NextResponse.json({ success: true });
+    }
+
     if (feature === 'item_transfer') {
       const { transfer, playerId: targetPlayerId } = data as {
         transfer: ItemTransfer;
@@ -386,6 +449,18 @@ export async function DELETE(
           });
         }
       }
+      return NextResponse.json({ success: true });
+    }
+
+    if (type === 'xp') {
+      const { receipt } = body;
+      if (!receipt || typeof receipt !== 'string') {
+        return NextResponse.json(
+          { error: 'receipt is required' },
+          { status: 400 }
+        );
+      }
+      await ackXpAward(getRawRedis(), campaignXpKey(code, playerId), receipt);
       return NextResponse.json({ success: true });
     }
 

--- a/src/app/dm/campaign/[code]/page.tsx
+++ b/src/app/dm/campaign/[code]/page.tsx
@@ -25,6 +25,7 @@ import {
   ChevronDown,
   ChevronRight,
   ScrollText,
+  TrendingUp,
 } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { Switch } from '@/components/ui/forms/switch';
@@ -39,6 +40,7 @@ import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { PlayerSummaryCard } from '@/components/ui/campaign/PlayerSummaryCard';
 import { PlayerDetailDialog } from '@/components/ui/campaign/PlayerDetailDialog';
 import { SendMessageDialog } from '@/components/ui/campaign/SendMessageDialog';
+import { AwardXpDialog } from '@/components/ui/campaign/AwardXpDialog';
 import { NPCSection } from '@/components/ui/campaign/NPCSection';
 import { useCampaignSync } from '@/hooks/useCampaignSync';
 import { useDmCounterSync } from '@/hooks/useDmCounterSync';
@@ -122,6 +124,7 @@ export default function CampaignViewPage() {
   );
   const [npcSendDialogOpen, setNpcSendDialogOpen] = useState(false);
   const [isNpcSendingItem, setIsNpcSendingItem] = useState(false);
+  const [awardXpOpen, setAwardXpOpen] = useState(false);
 
   const playersSectionOpen =
     localCampaign?.dmDashboardUi?.playersSectionOpen ?? true;
@@ -607,6 +610,14 @@ export default function CampaignViewPage() {
                   >
                     Message All
                   </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    leftIcon={<TrendingUp size={14} />}
+                    onClick={() => setAwardXpOpen(true)}
+                  >
+                    Award XP
+                  </Button>
                 </div>
               </div>
 
@@ -725,6 +736,8 @@ export default function CampaignViewPage() {
             setMessageTarget(selectedPlayer);
             setSelectedPlayer(null);
           }}
+          campaignCode={code}
+          dmId={dmId}
         />
       )}
 
@@ -746,6 +759,14 @@ export default function CampaignViewPage() {
         onClose={() => setMessageTarget(null)}
         players={players}
         targetPlayer={messageTarget === 'all' ? null : messageTarget}
+        campaignCode={code}
+        dmId={dmId}
+      />
+
+      <AwardXpDialog
+        open={awardXpOpen}
+        onClose={() => setAwardXpOpen(false)}
+        players={players}
         campaignCode={code}
         dmId={dmId}
       />

--- a/src/app/dm/campaign/[code]/page.tsx
+++ b/src/app/dm/campaign/[code]/page.tsx
@@ -451,6 +451,74 @@ export default function CampaignViewPage() {
       </div>
 
       <main className="mx-auto max-w-7xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
+        {/* House Rules */}
+        {!loading && !error && (
+          <div>
+            <div className="mb-4 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() =>
+                  setDmDashboardUi(code, {
+                    houseRulesSectionOpen: !houseRulesSectionOpen,
+                  })
+                }
+                className="text-muted hover:text-body hover:bg-surface-secondary shrink-0 rounded-md p-1 transition-colors"
+                aria-expanded={houseRulesSectionOpen}
+                aria-controls="dm-campaign-house-rules-section"
+                title={
+                  houseRulesSectionOpen
+                    ? 'Collapse house rules'
+                    : 'Expand house rules'
+                }
+              >
+                {houseRulesSectionOpen ? (
+                  <ChevronDown size={20} />
+                ) : (
+                  <ChevronRight size={20} />
+                )}
+              </button>
+              <div className="flex min-w-0 items-center gap-2">
+                <ScrollText size={20} className="text-muted shrink-0" />
+                <h2 className="text-heading text-lg font-semibold">
+                  House Rules
+                </h2>
+              </div>
+            </div>
+
+            {houseRulesSectionOpen && (
+              <Card id="dm-campaign-house-rules-section">
+                <CardHeader>
+                  <CardDescription>
+                    Rules that apply to every player in this campaign.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <p
+                        id="stackable-inspiration-label"
+                        className="text-heading font-medium"
+                      >
+                        Stackable heroic inspiration
+                      </p>
+                      <p className="text-muted text-sm">
+                        When on, players can hold more than one Heroic
+                        Inspiration. When off, they follow classic rules (at
+                        most one).
+                      </p>
+                    </div>
+                    <Switch
+                      checked={stackableInspiration}
+                      onCheckedChange={handleToggleStackableInspiration}
+                      aria-labelledby="stackable-inspiration-label"
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        )}
+
         {loading ? (
           <div className="flex items-center justify-center py-20">
             <div className="text-muted animate-pulse text-lg">
@@ -620,74 +688,6 @@ export default function CampaignViewPage() {
               </div>
             )}
           </>
-        )}
-
-        {/* House Rules */}
-        {!loading && !error && (
-          <div>
-            <div className="mb-4 flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() =>
-                  setDmDashboardUi(code, {
-                    houseRulesSectionOpen: !houseRulesSectionOpen,
-                  })
-                }
-                className="text-muted hover:text-body hover:bg-surface-secondary shrink-0 rounded-md p-1 transition-colors"
-                aria-expanded={houseRulesSectionOpen}
-                aria-controls="dm-campaign-house-rules-section"
-                title={
-                  houseRulesSectionOpen
-                    ? 'Collapse house rules'
-                    : 'Expand house rules'
-                }
-              >
-                {houseRulesSectionOpen ? (
-                  <ChevronDown size={20} />
-                ) : (
-                  <ChevronRight size={20} />
-                )}
-              </button>
-              <div className="flex min-w-0 items-center gap-2">
-                <ScrollText size={20} className="text-muted shrink-0" />
-                <h2 className="text-heading text-lg font-semibold">
-                  House Rules
-                </h2>
-              </div>
-            </div>
-
-            {houseRulesSectionOpen && (
-              <Card id="dm-campaign-house-rules-section">
-                <CardHeader>
-                  <CardDescription>
-                    Rules that apply to every player in this campaign.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <p
-                        id="stackable-inspiration-label"
-                        className="text-heading font-medium"
-                      >
-                        Stackable heroic inspiration
-                      </p>
-                      <p className="text-muted text-sm">
-                        When on, players can hold more than one Heroic
-                        Inspiration. When off, they follow classic rules (at
-                        most one).
-                      </p>
-                    </div>
-                    <Switch
-                      checked={stackableInspiration}
-                      onCheckedChange={handleToggleStackableInspiration}
-                      aria-labelledby="stackable-inspiration-label"
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-            )}
-          </div>
         )}
 
         {/* NPC Management */}

--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -20,7 +20,7 @@ import {
 import { DmEffectsNotification } from '@/components/ui/campaign/DmEffectsNotification';
 import { DmCounterNotification } from '@/components/ui/campaign/DmCounterNotification';
 import { useDmConditionOverrides } from '@/hooks/useDmConditionOverrides';
-import type { DmEffect, ItemTransfer } from '@/types/sharedState';
+import type { DmEffect, ItemTransfer, DmXpAward } from '@/types/sharedState';
 import ExperimentalFeaturesSection from '@/components/ui/layout/ExperimentalFeaturesSection';
 import ErrorBoundary from '@/components/ui/feedback/ErrorBoundary';
 import { ToastContainer, useToast } from '@/components/ui/feedback/Toast';
@@ -66,6 +66,7 @@ import { useInitiativePrompt } from '@/components/ui/campaign/useInitiativePromp
 import RestDialog from '@/components/ui/character/RestDialog';
 import { useCalendarStore } from '@/store/calendarStore';
 import { useSharedCampaignState } from '@/hooks/useSharedCampaignState';
+import { useDmXpAwardProcessor } from '@/hooks/useDmXpAwardProcessor';
 import { useJoinedBattleMap } from '@/hooks/useJoinedBattleMap';
 import { useBattleMapPokes } from '@/hooks/useBattleMapPokes';
 import { useMaterializeCampaignStackable } from '@/hooks/useMaterializeCampaignStackable';
@@ -162,6 +163,7 @@ export default function CharacterSheet() {
     resetPactMagicSlots,
     addExperience,
     setExperience,
+    applyDmXpAward,
     addFeature,
     updateFeature,
     deleteFeature,
@@ -305,6 +307,7 @@ export default function CharacterSheet() {
     acknowledgeMessage,
     acknowledgeDmEffects,
     acknowledgeTransfers,
+    acknowledgeXpAward,
     pendingTransfers,
     clearPendingTransfer,
     refetchNow,
@@ -436,6 +439,31 @@ export default function CharacterSheet() {
       });
     }
   }, [sharedState?.customCounter]);
+
+  // Apply queued DM XP awards (idempotent), ack each, and toast new ones.
+  const handleXpAwardApplied = useCallback(
+    (award: DmXpAward, becamePending: boolean) => {
+      const headline =
+        award.mode === 'add'
+          ? `DM granted ${award.amount.toLocaleString()} XP`
+          : `DM set your XP to ${award.amount.toLocaleString()}`;
+      addToast({
+        type: 'success',
+        title: headline,
+        message: becamePending
+          ? 'Level up available! Use the Level Up button on the Stats tab.'
+          : '',
+      });
+    },
+    [addToast]
+  );
+
+  useDmXpAwardProcessor({
+    xpAwards: sharedState?.xpAwards,
+    applyDmXpAward,
+    acknowledgeXpAward,
+    onApplied: handleXpAwardApplied,
+  });
 
   const calendarDays = sharedCalendar
     ? getCampaignDays(

--- a/src/components/__tests__/character-xp-awards.test.ts
+++ b/src/components/__tests__/character-xp-awards.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCharacterStore } from '@/store/characterStore';
+import { shouldLevelUp } from '@/utils/calculations';
+import type { DmXpAward } from '@/types/sharedState';
+
+function makeAward(overrides: Partial<DmXpAward> = {}): DmXpAward {
+  return {
+    id: 'award-1',
+    mode: 'add',
+    amount: 300,
+    awardedAt: '2026-08-03T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function resetCharacter() {
+  useCharacterStore.getState().resetCharacter();
+}
+
+describe('XP without auto-level', () => {
+  beforeEach(resetCharacter);
+
+  it('addExperience changes XP only — level, classes, hit dice untouched', () => {
+    const before = useCharacterStore.getState().character;
+    // 300 XP crosses the level-2 threshold for a fresh level-1 character
+    useCharacterStore.getState().addExperience(300);
+    const after = useCharacterStore.getState().character;
+    expect(after.experience).toBe(before.experience + 300);
+    expect(after.totalLevel).toBe(before.totalLevel);
+    expect(after.level).toBe(before.level);
+    expect(after.classes).toEqual(before.classes);
+    expect(after.hitDicePools).toEqual(before.hitDicePools);
+  });
+
+  it('setExperience changes XP only and clamps below zero', () => {
+    const before = useCharacterStore.getState().character;
+    useCharacterStore.getState().setExperience(6500);
+    expect(useCharacterStore.getState().character.experience).toBe(6500);
+    expect(useCharacterStore.getState().character.totalLevel).toBe(
+      before.totalLevel
+    );
+    useCharacterStore.getState().setExperience(-5);
+    expect(useCharacterStore.getState().character.experience).toBe(0);
+  });
+
+  it('addExperience clamps the result at zero', () => {
+    useCharacterStore.getState().setExperience(100);
+    useCharacterStore.getState().addExperience(-500);
+    expect(useCharacterStore.getState().character.experience).toBe(0);
+  });
+
+  it('derived pending: shouldLevelUp true above threshold, false below', () => {
+    expect(shouldLevelUp(0, 1)).toBe(false);
+    expect(shouldLevelUp(300, 1)).toBe(true); // level 2 at 300 XP
+    expect(shouldLevelUp(299, 1)).toBe(false);
+    // XP below the current level's floor never signals a (de-)level
+    expect(shouldLevelUp(0, 5)).toBe(false);
+    // Multi-level gap: pending persists until level catches up (2700 XP = level 4)
+    expect(shouldLevelUp(2700, 1)).toBe(true);
+    expect(shouldLevelUp(2700, 3)).toBe(true);
+    expect(shouldLevelUp(2700, 4)).toBe(false);
+  });
+});
+
+describe('applyDmXpAward', () => {
+  beforeEach(resetCharacter);
+
+  it('applies an add award and reports becamePending on threshold cross', () => {
+    const result = useCharacterStore
+      .getState()
+      .applyDmXpAward(makeAward({ amount: 300 }));
+    expect(result).toEqual({ status: 'applied', becamePending: true });
+    const char = useCharacterStore.getState().character;
+    expect(char.experience).toBe(300);
+    expect(char.appliedDmXpAwardIds).toEqual(['award-1']);
+    expect(char.level).toBe(1); // still level 1 — no auto-leveling
+  });
+
+  it('applies a set award', () => {
+    const result = useCharacterStore
+      .getState()
+      .applyDmXpAward(makeAward({ id: 'a-set', mode: 'set', amount: 900 }));
+    expect(result.status).toBe('applied');
+    expect(useCharacterStore.getState().character.experience).toBe(900);
+  });
+
+  it('duplicate id is a no-op returning duplicate', () => {
+    useCharacterStore.getState().applyDmXpAward(makeAward({ amount: 100 }));
+    const result = useCharacterStore
+      .getState()
+      .applyDmXpAward(makeAward({ amount: 100 }));
+    expect(result).toEqual({ status: 'duplicate', becamePending: false });
+    expect(useCharacterStore.getState().character.experience).toBe(100);
+    expect(useCharacterStore.getState().character.appliedDmXpAwardIds).toEqual([
+      'award-1',
+    ]);
+  });
+
+  it('becamePending is false when already pending before the award', () => {
+    useCharacterStore.getState().setExperience(300); // already pending at level 1
+    const result = useCharacterStore
+      .getState()
+      .applyDmXpAward(makeAward({ id: 'a-2', amount: 100 }));
+    expect(result).toEqual({ status: 'applied', becamePending: false });
+  });
+
+  it('trims applied ids with append-and-slice(-150)', () => {
+    for (let i = 0; i < 155; i++) {
+      useCharacterStore
+        .getState()
+        .applyDmXpAward(makeAward({ id: `bulk-${i}`, amount: 1 }));
+    }
+    const ids = useCharacterStore.getState().character.appliedDmXpAwardIds!;
+    expect(ids).toHaveLength(150);
+    expect(ids[0]).toBe('bulk-5');
+    expect(ids[149]).toBe('bulk-154');
+  });
+});

--- a/src/components/__tests__/dm-xp-award-processor.test.tsx
+++ b/src/components/__tests__/dm-xp-award-processor.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useDmXpAwardProcessor } from '@/hooks/useDmXpAwardProcessor';
+import type { DmXpAward, DmXpAwardEnvelope } from '@/types/sharedState';
+
+function makeEnvelope(
+  id: string,
+  overrides: Partial<DmXpAward> = {}
+): DmXpAwardEnvelope {
+  const award: DmXpAward = {
+    id,
+    mode: 'add',
+    amount: 100,
+    awardedAt: '2026-08-03T00:00:00.000Z',
+    ...overrides,
+  };
+  return { award, receipt: JSON.stringify(award) };
+}
+
+describe('useDmXpAwardProcessor', () => {
+  it('applies awards in order, acks each, and notifies applied ones', async () => {
+    const calls: string[] = [];
+    const applyDmXpAward = vi.fn((award: DmXpAward) => {
+      calls.push(`apply:${award.id}`);
+      return { status: 'applied' as const, becamePending: award.id === 'b' };
+    });
+    const acknowledgeXpAward = vi.fn(async (receipt: string) => {
+      calls.push(`ack:${(JSON.parse(receipt) as DmXpAward).id}`);
+    });
+    const onApplied = vi.fn();
+
+    renderHook(() =>
+      useDmXpAwardProcessor({
+        xpAwards: [
+          makeEnvelope('a', { mode: 'set', amount: 900 }),
+          makeEnvelope('b'),
+        ],
+        applyDmXpAward,
+        acknowledgeXpAward,
+        onApplied,
+      })
+    );
+
+    await waitFor(() => expect(acknowledgeXpAward).toHaveBeenCalledTimes(2));
+    expect(calls).toEqual(['apply:a', 'ack:a', 'apply:b', 'ack:b']);
+    expect(onApplied).toHaveBeenCalledTimes(2);
+    expect(onApplied).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ id: 'a' }),
+      false
+    );
+    expect(onApplied).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ id: 'b' }),
+      true
+    );
+  });
+
+  it('duplicate awards ack silently without notifying', async () => {
+    const applyDmXpAward = vi.fn(() => ({
+      status: 'duplicate' as const,
+      becamePending: false,
+    }));
+    const acknowledgeXpAward = vi.fn(async () => {});
+    const onApplied = vi.fn();
+
+    renderHook(() =>
+      useDmXpAwardProcessor({
+        xpAwards: [makeEnvelope('dup')],
+        applyDmXpAward,
+        acknowledgeXpAward,
+        onApplied,
+      })
+    );
+
+    await waitFor(() => expect(acknowledgeXpAward).toHaveBeenCalledTimes(1));
+    expect(onApplied).not.toHaveBeenCalled();
+  });
+
+  it('stops the cycle when an ack fails; earlier awards stay processed', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const applyDmXpAward = vi.fn(() => ({
+      status: 'applied' as const,
+      becamePending: false,
+    }));
+    const acknowledgeXpAward = vi.fn(async (_receipt: string) => {});
+    acknowledgeXpAward
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('network'));
+    const onApplied = vi.fn();
+
+    renderHook(() =>
+      useDmXpAwardProcessor({
+        xpAwards: [makeEnvelope('a'), makeEnvelope('b'), makeEnvelope('c')],
+        applyDmXpAward,
+        acknowledgeXpAward,
+        onApplied,
+      })
+    );
+
+    await waitFor(() => expect(acknowledgeXpAward).toHaveBeenCalledTimes(2));
+    // 'c' is never attempted this cycle
+    expect(applyDmXpAward).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('single-flight: a re-render with the same pending list does not double-process', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => (release = resolve));
+    const applyDmXpAward = vi.fn(() => ({
+      status: 'applied' as const,
+      becamePending: false,
+    }));
+    const acknowledgeXpAward = vi.fn(async () => {
+      await gate;
+    });
+    const onApplied = vi.fn();
+    const xpAwards = [makeEnvelope('slow')];
+
+    const { rerender } = renderHook(props => useDmXpAwardProcessor(props), {
+      initialProps: {
+        xpAwards,
+        applyDmXpAward,
+        acknowledgeXpAward,
+        onApplied,
+      },
+    });
+    // Second effect run while the first is still awaiting the ack
+    rerender({
+      xpAwards: [...xpAwards],
+      applyDmXpAward,
+      acknowledgeXpAward,
+      onApplied,
+    });
+    release();
+    await waitFor(() => expect(acknowledgeXpAward).toHaveBeenCalledTimes(1));
+    expect(applyDmXpAward).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/__tests__/dm-xp-award-processor.test.tsx
+++ b/src/components/__tests__/dm-xp-award-processor.test.tsx
@@ -137,4 +137,37 @@ describe('useDmXpAwardProcessor', () => {
     await waitFor(() => expect(acknowledgeXpAward).toHaveBeenCalledTimes(1));
     expect(applyDmXpAward).toHaveBeenCalledTimes(1);
   });
+
+  it('onApplied fires before ack, so ack failure does not prevent notification', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const applyDmXpAward = vi.fn(() => ({
+      status: 'applied' as const,
+      becamePending: false,
+    }));
+    const acknowledgeXpAward = vi.fn(async () => {
+      throw new Error('network error');
+    });
+    const onApplied = vi.fn();
+
+    renderHook(() =>
+      useDmXpAwardProcessor({
+        xpAwards: [makeEnvelope('a')],
+        applyDmXpAward,
+        acknowledgeXpAward,
+        onApplied,
+      })
+    );
+
+    await waitFor(() => expect(onApplied).toHaveBeenCalledTimes(1));
+    // onApplied fires for the applied award even though ack failed
+    expect(onApplied).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ id: 'a' }),
+      false
+    );
+    // ack was attempted and failed
+    expect(acknowledgeXpAward).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });

--- a/src/components/__tests__/xp-award-dm-ui.test.tsx
+++ b/src/components/__tests__/xp-award-dm-ui.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { XpAwardControl } from '@/components/ui/campaign/XpAwardControl';
+import { AwardXpDialog } from '@/components/ui/campaign/AwardXpDialog';
+import type { CampaignPlayerData } from '@/types/campaign';
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+});
+
+function lastPostedAward() {
+  const [, init] = fetchMock.mock.calls.at(-1)!;
+  return JSON.parse(init.body as string);
+}
+
+function makePlayer(id: string, name: string): CampaignPlayerData {
+  return {
+    playerId: id,
+    playerName: name,
+    characterName: `${name}'s hero`,
+  } as CampaignPlayerData;
+}
+
+describe('XpAwardControl', () => {
+  it('posts an add award with the correct payload', async () => {
+    const user = userEvent.setup();
+    render(
+      <XpAwardControl
+        campaignCode="ABC"
+        dmId="dm-1"
+        playerId="p-1"
+        lastSyncedXp={1200}
+      />
+    );
+    expect(screen.getByText(/last synced: 1,200 xp/i)).toBeTruthy();
+
+    await user.type(screen.getByLabelText('XP to add'), '300');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const body = lastPostedAward();
+    expect(body.feature).toBe('xp');
+    expect(body.dmId).toBe('dm-1');
+    expect(body.data.playerId).toBe('p-1');
+    expect(body.data.award).toMatchObject({ mode: 'add', amount: 300 });
+    expect(body.data.award.id).toBeTruthy();
+  });
+
+  it('retry re-posts the ORIGINAL award with the same id', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'boom' }),
+    });
+    render(
+      <XpAwardControl
+        campaignCode="ABC"
+        dmId="dm-1"
+        playerId="p-1"
+        lastSyncedXp={0}
+      />
+    );
+    await user.type(screen.getByLabelText('XP to add'), '100');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+    await screen.findByText('boom');
+    const firstAward = lastPostedAward().data.award;
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const retriedAward = lastPostedAward().data.award;
+    expect(retriedAward).toEqual(firstAward); // same id — no fresh UUID
+  });
+});
+
+describe('AwardXpDialog', () => {
+  const players = [makePlayer('p-1', 'Alice'), makePlayer('p-2', 'Bob')];
+
+  it('posts one add award per selected player', async () => {
+    const user = userEvent.setup();
+    render(
+      <AwardXpDialog
+        open
+        onClose={() => {}}
+        players={players}
+        campaignCode="ABC"
+        dmId="dm-1"
+      />
+    );
+    await user.type(screen.getByLabelText(/xp to add/i), '250');
+    await user.click(screen.getByRole('button', { name: /award to 2/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const bodies = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse(init.body as string)
+    );
+    expect(bodies.map(b => b.data.playerId).sort()).toEqual(['p-1', 'p-2']);
+    for (const b of bodies) {
+      expect(b.data.award).toMatchObject({ mode: 'add', amount: 250 });
+    }
+    const ids = bodies.map(b => b.data.award.id);
+    expect(new Set(ids).size).toBe(2); // distinct ids per player
+  });
+
+  it('shows per-player failure and retries with the original award', async () => {
+    const user = userEvent.setup();
+    // First wave: p-1 ok, p-2 fails
+    fetchMock.mockImplementation(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string);
+      if (body.data.playerId === 'p-2') {
+        return { ok: false, status: 500, json: async () => ({}) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+    render(
+      <AwardXpDialog
+        open
+        onClose={() => {}}
+        players={players}
+        campaignCode="ABC"
+        dmId="dm-1"
+      />
+    );
+    await user.type(screen.getByLabelText(/xp to add/i), '100');
+    await user.click(screen.getByRole('button', { name: /award to 2/i }));
+    await screen.findByText(/failed for/i);
+
+    const failedBody = fetchMock.mock.calls
+      .map(([, init]) => JSON.parse((init as RequestInit).body as string))
+      .find(b => b.data.playerId === 'p-2')!;
+
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    await user.click(screen.getByRole('button', { name: /retry failed/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const retried = lastPostedAward();
+    expect(retried.data.playerId).toBe('p-2');
+    expect(retried.data.award).toEqual(failedBody.data.award); // verbatim, same id
+  });
+});

--- a/src/components/__tests__/xp-award-dm-ui.test.tsx
+++ b/src/components/__tests__/xp-award-dm-ui.test.tsx
@@ -147,4 +147,32 @@ describe('AwardXpDialog', () => {
     expect(retried.data.playerId).toBe('p-2');
     expect(retried.data.award).toEqual(failedBody.data.award); // verbatim, same id
   });
+
+  it('after fully successful send, amount is cleared and award button is disabled', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+    render(
+      <AwardXpDialog
+        open
+        onClose={() => {}}
+        players={players}
+        campaignCode="ABC"
+        dmId="dm-1"
+      />
+    );
+
+    const amountInput = screen.getByLabelText(/xp to add/i) as HTMLInputElement;
+    const awardButton = screen.getByRole('button', { name: /award to 2/i });
+
+    await user.type(amountInput, '250');
+    expect(awardButton).not.toBeDisabled();
+
+    await user.click(awardButton);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    // After success, amount should be cleared
+    expect(amountInput.value).toBe('');
+    // Button should be disabled since amount is now required and empty
+    expect(awardButton).toBeDisabled();
+  });
 });

--- a/src/components/__tests__/xp-award-dm-ui.test.tsx
+++ b/src/components/__tests__/xp-award-dm-ui.test.tsx
@@ -81,6 +81,35 @@ describe('XpAwardControl', () => {
     const retriedAward = lastPostedAward().data.award;
     expect(retriedAward).toEqual(firstAward); // same id — no fresh UUID
   });
+
+  it('locks and describes the original payload while a retry is pending', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'boom' }),
+    });
+    render(
+      <XpAwardControl
+        campaignCode="ABC"
+        dmId="dm-1"
+        playerId="p-1"
+        lastSyncedXp={0}
+      />
+    );
+
+    const amountInput = screen.getByLabelText('XP to add');
+    const modeSwitch = screen.getByLabelText(/toggle between add and set xp/i);
+    await user.type(amountInput, '100');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+    await screen.findByText('boom');
+
+    expect(amountInput).toBeDisabled();
+    expect(modeSwitch).toBeDisabled();
+    expect(
+      screen.getByText(/retry will resend the original add award of 100 xp/i)
+    ).toBeTruthy();
+  });
 });
 
 describe('AwardXpDialog', () => {

--- a/src/components/__tests__/xp-tracker-pending.test.tsx
+++ b/src/components/__tests__/xp-tracker-pending.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { XPTracker } from '@/components/shared/character/XPTracker';
+
+describe('XPTracker pending level-up', () => {
+  let mockHandlers: {
+    onAddXP: (xpToAdd: number) => void;
+    onSetXP: (newXP: number) => void;
+  };
+
+  beforeEach(() => {
+    mockHandlers = {
+      onAddXP: vi.fn(),
+      onSetXP: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+  it('shows the persistent pending badge when pendingLevelUp', () => {
+    render(
+      <XPTracker
+        currentXP={300}
+        currentLevel={1}
+        pendingLevelUp
+        onAddXP={mockHandlers.onAddXP}
+        onSetXP={mockHandlers.onSetXP}
+      />
+    );
+    expect(screen.getByText(/level up available/i)).toBeTruthy();
+  });
+
+  it('hides the badge when hideLevelUpAlert is set', () => {
+    render(
+      <XPTracker
+        currentXP={300}
+        currentLevel={1}
+        pendingLevelUp
+        hideLevelUpAlert
+        onAddXP={mockHandlers.onAddXP}
+        onSetXP={mockHandlers.onSetXP}
+      />
+    );
+    expect(screen.queryByText(/level up available/i)).toBeNull();
+  });
+
+  it('shows no badge when not pending', () => {
+    render(
+      <XPTracker
+        currentXP={100}
+        currentLevel={1}
+        onAddXP={mockHandlers.onAddXP}
+        onSetXP={mockHandlers.onSetXP}
+      />
+    );
+    expect(screen.queryByText(/level up available/i)).toBeNull();
+  });
+
+  it('replaces the to-next-level figure with a pending label while pending', () => {
+    render(
+      <XPTracker
+        currentXP={300}
+        currentLevel={1}
+        pendingLevelUp
+        onAddXP={mockHandlers.onAddXP}
+        onSetXP={mockHandlers.onSetXP}
+      />
+    );
+    const pendingLabels = screen.getAllByText(/level-up pending/i);
+    expect(pendingLabels.length).toBeGreaterThan(0);
+  });
+
+  it('shows the normal to-next-level figure when not pending', () => {
+    render(
+      <XPTracker
+        currentXP={0}
+        currentLevel={1}
+        onAddXP={mockHandlers.onAddXP}
+        onSetXP={mockHandlers.onSetXP}
+      />
+    );
+    const xpTexts = screen.getAllByText(/300/);
+    expect(xpTexts.length).toBeGreaterThan(0); // 300 XP to level 2
+  });
+});

--- a/src/components/__tests__/xp-tracker-pending.test.tsx
+++ b/src/components/__tests__/xp-tracker-pending.test.tsx
@@ -65,10 +65,13 @@ describe('XPTracker pending level-up', () => {
         pendingLevelUp
         onAddXP={mockHandlers.onAddXP}
         onSetXP={mockHandlers.onSetXP}
+        hideThresholds
       />
     );
     const pendingLabels = screen.getAllByText(/level-up pending/i);
     expect(pendingLabels.length).toBeGreaterThan(0);
+    // Verify that the numeric "0 XP" to-next-level figure is suppressed
+    expect(screen.queryByText(/0 XP/)).toBeNull();
   });
 
   it('shows the normal to-next-level figure when not pending', () => {

--- a/src/components/shared/character/XPTracker.tsx
+++ b/src/components/shared/character/XPTracker.tsx
@@ -7,7 +7,6 @@ import {
   getXPForLevel,
   getXPToNextLevel,
   getXPProgress,
-  shouldLevelUp,
 } from '@/utils/calculations';
 
 interface XPTrackerProps {
@@ -23,6 +22,7 @@ interface XPTrackerProps {
   hideProgressBar?: boolean;
   hideLevelUpAlert?: boolean;
   hideThresholds?: boolean;
+  pendingLevelUp?: boolean;
 
   className?: string;
 }
@@ -38,11 +38,11 @@ export function XPTracker({
   hideProgressBar = false,
   hideLevelUpAlert = false,
   hideThresholds = false,
+  pendingLevelUp = false,
   className = '',
 }: XPTrackerProps) {
   const [mode, setMode] = useState<'add' | 'set'>('add');
   const [inputValue, setInputValue] = useState('');
-  const [showLevelUp, setShowLevelUp] = useState(false);
 
   const xpToNext = getXPToNextLevel(currentXP, currentLevel);
   const progress = getXPProgress(currentXP, currentLevel);
@@ -56,16 +56,8 @@ export function XPTracker({
 
     if (mode === 'add' && onAddXP) {
       onAddXP(value);
-      if (!hideLevelUpAlert && shouldLevelUp(currentXP + value, currentLevel)) {
-        setShowLevelUp(true);
-        setTimeout(() => setShowLevelUp(false), 3000);
-      }
     } else if (mode === 'set' && onSetXP) {
       onSetXP(value);
-      if (!hideLevelUpAlert && shouldLevelUp(value, currentLevel)) {
-        setShowLevelUp(true);
-        setTimeout(() => setShowLevelUp(false), 3000);
-      }
     }
 
     setInputValue('');
@@ -84,10 +76,10 @@ export function XPTracker({
           <TrendingUp size={compact ? 16 : 20} />
           {compact ? 'XP' : 'Experience Points'}
         </h3>
-        {!hideLevelUpAlert && showLevelUp && (
-          <div className="flex animate-pulse items-center space-x-1 font-bold text-green-600">
+        {!hideLevelUpAlert && pendingLevelUp && (
+          <div className="border-accent-emerald-border bg-accent-emerald-bg text-accent-emerald-text flex animate-pulse items-center gap-1 rounded-md border px-2 py-0.5 font-bold">
             <TrendingUp size={16} />
-            <span className="text-sm">LEVEL UP!</span>
+            <span className="text-sm">Level up available!</span>
           </div>
         )}
       </div>
@@ -127,9 +119,15 @@ export function XPTracker({
         <div className="space-y-2">
           <div className="flex justify-between text-sm">
             <span className="text-muted">To Next Level:</span>
-            <span className="text-heading font-semibold">
-              {xpToNext.toLocaleString()} XP
-            </span>
+            {pendingLevelUp ? (
+              <span className="text-accent-emerald-text font-semibold">
+                Level-up pending
+              </span>
+            ) : (
+              <span className="text-heading font-semibold">
+                {xpToNext.toLocaleString()} XP
+              </span>
+            )}
           </div>
           <div
             className={`bg-bg-tertiary w-full rounded-full ${compact ? 'h-2' : 'h-3'}`}
@@ -140,7 +138,9 @@ export function XPTracker({
             />
           </div>
           <div className="text-muted text-center text-xs">
-            {progress.toFixed(1)}% to Level {currentLevel + 1}
+            {pendingLevelUp
+              ? 'Level-up pending — use the Level Up button'
+              : `${progress.toFixed(1)}% to Level ${currentLevel + 1}`}
           </div>
         </div>
       )}

--- a/src/components/shared/character/__tests__/XPTracker.test.tsx
+++ b/src/components/shared/character/__tests__/XPTracker.test.tsx
@@ -73,26 +73,22 @@ describe('XPTracker', () => {
     expect(input).toHaveValue(null);
   });
 
-  it('shows level-up alert when XP reaches next level threshold', () => {
-    vi.useFakeTimers();
-    // currentXP=13500 + add 500 = 14000 >= 14000 (level 6 threshold)
-    // shouldLevelUp(14000, 5) => calculateLevelFromXP(14000) = 6 > 5 => true
-    render(<XPTracker {...defaultProps} currentXP={13500} />);
+  it('shows persistent badge when pendingLevelUp prop is set', () => {
+    // After PR #205, the level-up indicator is persistent and derived from the prop
+    // The component no longer auto-shows transient alerts on XP changes
+    render(
+      <XPTracker {...defaultProps} currentXP={13500} pendingLevelUp={true} />
+    );
 
-    const input = screen.getByPlaceholderText('XP to add...');
-    fireEvent.change(input, { target: { value: '500' } });
+    expect(screen.getByText(/level up available/i)).toBeInTheDocument();
+  });
 
-    const addButton = screen.getByRole('button', { name: 'Add' });
-    fireEvent.click(addButton);
+  it('does not show badge when pendingLevelUp prop is false', () => {
+    render(
+      <XPTracker {...defaultProps} currentXP={13500} pendingLevelUp={false} />
+    );
 
-    expect(screen.getByText('LEVEL UP!')).toBeInTheDocument();
-
-    act(() => {
-      vi.advanceTimersByTime(3000);
-    });
-    expect(screen.queryByText('LEVEL UP!')).not.toBeInTheDocument();
-
-    vi.useRealTimers();
+    expect(screen.queryByText(/level up available/i)).not.toBeInTheDocument();
   });
 
   it('does not show level-up alert when below threshold', () => {

--- a/src/components/ui/campaign/AwardXpDialog.tsx
+++ b/src/components/ui/campaign/AwardXpDialog.tsx
@@ -80,6 +80,10 @@ export function AwardXpDialog({
     );
     setOutcomes(nextOutcomes);
     setFailedAwards(nextFailed);
+    // Clear amount after successful send (no failures remain)
+    if (nextFailed.size === 0) {
+      setAmount(undefined);
+    }
     setSending(false);
   };
 

--- a/src/components/ui/campaign/AwardXpDialog.tsx
+++ b/src/components/ui/campaign/AwardXpDialog.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+} from '@/components/ui/feedback/dialog';
+import { Button } from '@/components/ui/forms/button';
+import { Checkbox } from '@/components/ui/forms/checkbox';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
+import { postXpAward } from './XpAwardControl';
+import type { CampaignPlayerData } from '@/types/campaign';
+import type { DmXpAward } from '@/types/sharedState';
+
+interface AwardXpDialogProps {
+  open: boolean;
+  onClose: () => void;
+  players: CampaignPlayerData[];
+  campaignCode: string;
+  dmId: string;
+}
+
+type SendOutcome = 'ok' | 'failed';
+
+export function AwardXpDialog({
+  open,
+  onClose,
+  players,
+  campaignCode,
+  dmId,
+}: AwardXpDialogProps) {
+  const [amount, setAmount] = useState<number | undefined>(undefined);
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+  const [sending, setSending] = useState(false);
+  const [outcomes, setOutcomes] = useState<Map<string, SendOutcome> | null>(
+    null
+  );
+  // Awards for failed/unknown sends, kept VERBATIM (same id) for retry — a
+  // lost response may still have enqueued the award; players dedupe by id.
+  const [failedAwards, setFailedAwards] = useState<Map<string, DmXpAward>>(
+    new Map()
+  );
+
+  const selectedPlayers = players.filter(p => !excluded.has(p.playerId));
+  const valid = amount !== undefined && amount >= 1;
+
+  const reset = () => {
+    setAmount(undefined);
+    setExcluded(new Set());
+    setOutcomes(null);
+    setFailedAwards(new Map());
+  };
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      reset();
+      onClose();
+    }
+  };
+
+  const sendAwards = async (targets: Map<string, DmXpAward>) => {
+    setSending(true);
+    const nextOutcomes = new Map(outcomes ?? []);
+    const nextFailed = new Map(failedAwards);
+    await Promise.all(
+      [...targets.entries()].map(async ([playerId, award]) => {
+        try {
+          await postXpAward(campaignCode, dmId, playerId, award);
+          nextOutcomes.set(playerId, 'ok');
+          nextFailed.delete(playerId);
+        } catch {
+          nextOutcomes.set(playerId, 'failed');
+          nextFailed.set(playerId, award);
+        }
+      })
+    );
+    setOutcomes(nextOutcomes);
+    setFailedAwards(nextFailed);
+    setSending(false);
+  };
+
+  const handleSend = () => {
+    if (!valid || selectedPlayers.length === 0) return;
+    const targets = new Map<string, DmXpAward>(
+      selectedPlayers.map(p => [
+        p.playerId,
+        {
+          id: crypto.randomUUID(),
+          mode: 'add' as const,
+          amount: amount!,
+          awardedAt: new Date().toISOString(),
+        },
+      ])
+    );
+    sendAwards(targets);
+  };
+
+  const handleRetry = () => {
+    if (failedAwards.size === 0) return;
+    sendAwards(new Map(failedAwards));
+  };
+
+  const playerName = (playerId: string) =>
+    players.find(p => p.playerId === playerId)?.characterName ?? playerId;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Award XP to Party</DialogTitle>
+        </DialogHeader>
+        <DialogBody className="space-y-4">
+          <div className="space-y-1">
+            <label
+              htmlFor="award-xp-amount"
+              className="text-body text-sm font-medium"
+            >
+              XP to add
+            </label>
+            <NumberInput
+              id="award-xp-amount"
+              value={amount}
+              onChange={setAmount}
+              min={1}
+              allowEmpty
+              placeholder="e.g. 300"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <span className="text-body text-sm font-medium">Players</span>
+            {players.map(p => (
+              <label
+                key={p.playerId}
+                className="flex items-center gap-2 text-sm"
+              >
+                <Checkbox
+                  checked={!excluded.has(p.playerId)}
+                  onCheckedChange={checked => {
+                    setExcluded(prev => {
+                      const next = new Set(prev);
+                      if (checked) next.delete(p.playerId);
+                      else next.add(p.playerId);
+                      return next;
+                    });
+                  }}
+                />
+                <span className="text-heading">{p.characterName}</span>
+                <span className="text-muted">({p.playerName})</span>
+                {outcomes?.get(p.playerId) === 'ok' && (
+                  <span className="text-accent-emerald-text text-xs">sent</span>
+                )}
+                {outcomes?.get(p.playerId) === 'failed' && (
+                  <span className="text-accent-red-text text-xs">failed</span>
+                )}
+              </label>
+            ))}
+          </div>
+
+          {failedAwards.size > 0 && (
+            <p className="text-accent-red-text text-sm">
+              Failed for: {[...failedAwards.keys()].map(playerName).join(', ')}
+            </p>
+          )}
+        </DialogBody>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => handleOpenChange(false)}
+          >
+            Close
+          </Button>
+          {failedAwards.size > 0 && (
+            <Button
+              variant="warning"
+              size="sm"
+              onClick={handleRetry}
+              disabled={sending}
+            >
+              {sending ? 'Sending...' : 'Retry failed'}
+            </Button>
+          )}
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSend}
+            disabled={!valid || selectedPlayers.length === 0 || sending}
+          >
+            {sending ? 'Sending...' : `Award to ${selectedPlayers.length}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/campaign/PlayerDetailDialog/OverviewTab.tsx
+++ b/src/components/ui/campaign/PlayerDetailDialog/OverviewTab.tsx
@@ -23,6 +23,7 @@ import {
   Languages,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/layout/badge';
+import { XpAwardControl } from '@/components/ui/campaign/XpAwardControl';
 import { SectionTitle, ensureArray, formatMod } from './shared';
 import { calculateEncumbrance, EncumbranceInfo } from '@/utils/encumbrance';
 import {
@@ -91,6 +92,9 @@ interface OverviewTabProps {
   customCounterLabel?: string;
   counterValue: number;
   onAdjustCounter?: (delta: number) => void;
+  campaignCode?: string;
+  dmId?: string;
+  playerId?: string;
 }
 
 export function OverviewTab({
@@ -98,6 +102,9 @@ export function OverviewTab({
   customCounterLabel,
   counterValue,
   onAdjustCounter,
+  campaignCode,
+  dmId,
+  playerId,
 }: OverviewTabProps) {
   const currentHp = char.hitPoints?.current ?? 0;
   const maxHp = char.hitPoints?.max ?? 0;
@@ -155,6 +162,17 @@ export function OverviewTab({
           }
         />
       </div>
+
+      {campaignCode && dmId && playerId && (
+        <div className="bg-surface-secondary rounded-lg p-3">
+          <XpAwardControl
+            campaignCode={campaignCode}
+            dmId={dmId}
+            playerId={playerId}
+            lastSyncedXp={char.experience ?? 0}
+          />
+        </div>
+      )}
 
       {/* ── Inspiration & Custom Counter ── */}
       <div className="flex flex-wrap gap-3">

--- a/src/components/ui/campaign/PlayerDetailDialog/index.tsx
+++ b/src/components/ui/campaign/PlayerDetailDialog/index.tsx
@@ -27,6 +27,8 @@ interface PlayerDetailDialogProps {
   counterValue?: number;
   onAdjustCounter?: (delta: number) => void;
   onSendMessage?: () => void;
+  campaignCode?: string;
+  dmId?: string;
 }
 
 export function PlayerDetailDialog({
@@ -37,6 +39,8 @@ export function PlayerDetailDialog({
   counterValue = 0,
   onAdjustCounter,
   onSendMessage,
+  campaignCode,
+  dmId,
 }: PlayerDetailDialogProps) {
   const [activeTab, setActiveTab] = useState<DetailTab>('overview');
 
@@ -136,6 +140,9 @@ export function PlayerDetailDialog({
               customCounterLabel={customCounterLabel}
               counterValue={counterValue}
               onAdjustCounter={onAdjustCounter}
+              campaignCode={campaignCode}
+              dmId={dmId}
+              playerId={player.playerId}
             />
           )}
           {activeTab === 'spells' && showSpellsTab && <SpellsTab char={char} />}

--- a/src/components/ui/campaign/XpAwardControl.tsx
+++ b/src/components/ui/campaign/XpAwardControl.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import { TrendingUp } from 'lucide-react';
+import { Button } from '@/components/ui/forms/button';
+import { NumberInput } from '@/components/ui/forms/NumberInput';
+import { Switch } from '@/components/ui/forms/switch';
+import type { DmXpAward } from '@/types/sharedState';
+
+interface XpAwardControlProps {
+  campaignCode: string;
+  dmId: string;
+  playerId: string;
+  /** XP from the player's last synced snapshot — may be stale. */
+  lastSyncedXp: number;
+}
+
+export async function postXpAward(
+  campaignCode: string,
+  dmId: string,
+  playerId: string,
+  award: DmXpAward
+): Promise<void> {
+  const res = await fetch(`/api/campaign/${campaignCode}/shared`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ feature: 'xp', data: { playerId, award }, dmId }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Failed (${res.status})`);
+  }
+}
+
+export function XpAwardControl({
+  campaignCode,
+  dmId,
+  playerId,
+  lastSyncedXp,
+}: XpAwardControlProps) {
+  const [mode, setMode] = useState<'add' | 'set'>('add');
+  const [amount, setAmount] = useState<number | undefined>(undefined);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+  // Retained on failure so Retry re-sends the ORIGINAL award (same id) — a
+  // lost response may still have enqueued it; the player dedupes by id.
+  const [failedAward, setFailedAward] = useState<DmXpAward | null>(null);
+
+  const minAmount = mode === 'add' ? 1 : 0;
+  const valid = amount !== undefined && amount >= minAmount;
+
+  const send = async (award: DmXpAward) => {
+    setSending(true);
+    setError(null);
+    setSent(false);
+    try {
+      await postXpAward(campaignCode, dmId, playerId, award);
+      setFailedAward(null);
+      setAmount(undefined);
+      setSent(true);
+    } catch (err) {
+      setFailedAward(award);
+      setError(err instanceof Error ? err.message : 'Failed to send XP award');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleSend = () => {
+    if (!valid) return;
+    send({
+      id: crypto.randomUUID(),
+      mode,
+      amount: amount!,
+      awardedAt: new Date().toISOString(),
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-heading flex items-center gap-1.5 text-sm font-medium">
+          <TrendingUp size={14} />
+          Award XP
+        </span>
+        <span className="text-faint text-xs">
+          Last synced: {lastSyncedXp.toLocaleString()} XP
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <span
+          className={`text-xs font-medium ${mode === 'add' ? 'text-heading' : 'text-muted'}`}
+        >
+          Add
+        </span>
+        <Switch
+          checked={mode === 'set'}
+          onCheckedChange={checked => setMode(checked ? 'set' : 'add')}
+          size="sm"
+          aria-label="Toggle between add and set XP"
+        />
+        <span
+          className={`text-xs font-medium ${mode === 'set' ? 'text-heading' : 'text-muted'}`}
+        >
+          Set
+        </span>
+        <NumberInput
+          value={amount}
+          onChange={setAmount}
+          min={minAmount}
+          allowEmpty
+          placeholder={mode === 'add' ? 'XP to add...' : 'Total XP...'}
+          aria-label={mode === 'add' ? 'XP to add' : 'Total XP'}
+          className="flex-1"
+        />
+        {failedAward ? (
+          <Button
+            variant="warning"
+            size="sm"
+            onClick={() => send(failedAward)}
+            disabled={sending}
+          >
+            {sending ? 'Sending...' : 'Retry'}
+          </Button>
+        ) : (
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSend}
+            disabled={!valid || sending}
+          >
+            {sending ? 'Sending...' : 'Send'}
+          </Button>
+        )}
+      </div>
+      {mode === 'set' && (
+        <p className="text-faint text-xs">
+          Sets the player&apos;s total XP — overwrites changes they made since
+          the last sync.
+        </p>
+      )}
+      {error && <p className="text-accent-red-text text-xs">{error}</p>}
+      {sent && !error && (
+        <p className="text-accent-emerald-text text-xs">XP award sent.</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/campaign/XpAwardControl.tsx
+++ b/src/components/ui/campaign/XpAwardControl.tsx
@@ -99,6 +99,7 @@ export function XpAwardControl({
           onCheckedChange={checked => setMode(checked ? 'set' : 'add')}
           size="sm"
           aria-label="Toggle between add and set XP"
+          disabled={sending || failedAward !== null}
         />
         <span
           className={`text-xs font-medium ${mode === 'set' ? 'text-heading' : 'text-muted'}`}
@@ -113,6 +114,7 @@ export function XpAwardControl({
           placeholder={mode === 'add' ? 'XP to add...' : 'Total XP...'}
           aria-label={mode === 'add' ? 'XP to add' : 'Total XP'}
           className="flex-1"
+          disabled={sending || failedAward !== null}
         />
         {failedAward ? (
           <Button
@@ -134,6 +136,13 @@ export function XpAwardControl({
           </Button>
         )}
       </div>
+      {failedAward && (
+        <p className="text-accent-amber-text text-xs">
+          Retry will resend the original{' '}
+          {failedAward.mode === 'add' ? 'add' : 'set'} award of{' '}
+          {failedAward.amount.toLocaleString()} XP with the same delivery ID.
+        </p>
+      )}
       {mode === 'set' && (
         <p className="text-faint text-xs">
           Sets the player&apos;s total XP — overwrites changes they made since

--- a/src/components/ui/campaign/__tests__/useInitiativePrompt.test.ts
+++ b/src/components/ui/campaign/__tests__/useInitiativePrompt.test.ts
@@ -22,6 +22,7 @@ const baseState: SharedCampaignState = {
     requestedAt: 1,
   },
   settings: null,
+  xpAwards: [],
 };
 
 describe('useInitiativePrompt', () => {

--- a/src/components/ui/character/XPTracker.tsx
+++ b/src/components/ui/character/XPTracker.tsx
@@ -8,6 +8,7 @@ interface XPTrackerProps {
   currentLevel: number;
   onAddXP: (xpToAdd: number) => void;
   onSetXP: (newXP: number) => void;
+  pendingLevelUp?: boolean;
   className?: string;
 }
 
@@ -16,6 +17,7 @@ export default function XPTracker({
   currentLevel,
   onAddXP,
   onSetXP,
+  pendingLevelUp,
   className = '',
 }: XPTrackerProps) {
   // Use the shared XPTracker component with full functionality
@@ -31,6 +33,7 @@ export default function XPTracker({
       hideProgressBar={false}
       hideLevelUpAlert={false}
       hideThresholds={false}
+      pendingLevelUp={pendingLevelUp}
       className={className}
     />
   );

--- a/src/components/ui/character/tabbedSheetConfig.tsx
+++ b/src/components/ui/character/tabbedSheetConfig.tsx
@@ -43,6 +43,7 @@ import {
   calculateSpellAttackBonus,
   calculateCarryingCapacity,
   calculateSpellSaveDC,
+  shouldLevelUp,
 } from '@/utils/calculations';
 import { calculateTotalWeight } from '@/utils/encumbrance';
 import {
@@ -69,11 +70,24 @@ function WizardHatIcon({ size = 14 }: { size?: number }) {
   );
 }
 
-function LevelUpButton() {
+function LevelUpButton({
+  pendingLevelUp = false,
+}: {
+  pendingLevelUp?: boolean;
+}) {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <>
-      <Button variant="primary" size="sm" onClick={() => setIsOpen(true)}>
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={() => setIsOpen(true)}
+        className={
+          pendingLevelUp
+            ? 'ring-accent-emerald-border animate-pulse ring-2'
+            : undefined
+        }
+      >
         <WizardHatIcon size={14} />
         Level Up
       </Button>
@@ -413,20 +427,31 @@ export function createTabbedSheetConfig(
                 }
                 onRollSavingThrow={params.rollSavingThrow}
               />
-              <div className="border-accent-amber-border bg-surface-raised rounded-lg border p-6 shadow-lg">
-                <div className="border-divider mb-4 flex items-center justify-between border-b pb-2">
-                  <h2 className="text-heading text-lg font-bold">
-                    Experience Points
-                  </h2>
-                  {totalLevel < 20 && <LevelUpButton />}
-                </div>
-                <XPTracker
-                  currentXP={character.experience}
-                  currentLevel={totalLevel}
-                  onAddXP={params.addExperience}
-                  onSetXP={params.setExperience}
-                />
-              </div>
+              {(() => {
+                const pendingLevelUp = shouldLevelUp(
+                  character.experience,
+                  totalLevel
+                );
+                return (
+                  <div className="border-accent-amber-border bg-surface-raised rounded-lg border p-6 shadow-lg">
+                    <div className="border-divider mb-4 flex items-center justify-between border-b pb-2">
+                      <h2 className="text-heading text-lg font-bold">
+                        Experience Points
+                      </h2>
+                      {totalLevel < 20 && (
+                        <LevelUpButton pendingLevelUp={pendingLevelUp} />
+                      )}
+                    </div>
+                    <XPTracker
+                      currentXP={character.experience}
+                      currentLevel={totalLevel}
+                      onAddXP={params.addExperience}
+                      onSetXP={params.setExperience}
+                      pendingLevelUp={pendingLevelUp}
+                    />
+                  </div>
+                );
+              })()}
             </div>
 
             <div className="lg:sticky lg:top-4">

--- a/src/hooks/__tests__/useSharedCampaignState.test.ts
+++ b/src/hooks/__tests__/useSharedCampaignState.test.ts
@@ -20,6 +20,7 @@ const makeSharedState = (
   battleMap: null,
   initiativeRequest: null,
   settings: null,
+  xpAwards: [],
   ...overrides,
 });
 

--- a/src/hooks/useDmXpAwardProcessor.ts
+++ b/src/hooks/useDmXpAwardProcessor.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+import type { DmXpAward, DmXpAwardEnvelope } from '@/types/sharedState';
+
+interface UseDmXpAwardProcessorArgs {
+  xpAwards: DmXpAwardEnvelope[] | undefined;
+  applyDmXpAward: (award: DmXpAward) => {
+    status: 'applied' | 'duplicate';
+    becamePending: boolean;
+  };
+  acknowledgeXpAward: (receipt: string) => Promise<void>;
+  /** Called once per NEWLY applied award (never for duplicates). */
+  onApplied: (award: DmXpAward, becamePending: boolean) => void;
+}
+
+/**
+ * Applies queued DM XP awards in enqueue order: apply (idempotent, dedup by
+ * award id) then ack, one at a time. A failure stops the cycle — the queue is
+ * refetched on the next poll and idempotency makes reprocessing safe. The
+ * single-flight ref prevents overlapping poll/effect runs from double-acking.
+ */
+export function useDmXpAwardProcessor({
+  xpAwards,
+  applyDmXpAward,
+  acknowledgeXpAward,
+  onApplied,
+}: UseDmXpAwardProcessorArgs) {
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (!xpAwards || xpAwards.length === 0) return;
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+
+    (async () => {
+      for (const { award, receipt } of xpAwards) {
+        try {
+          const result = applyDmXpAward(award);
+          await acknowledgeXpAward(receipt);
+          if (result.status === 'applied') {
+            onApplied(award, result.becamePending);
+          }
+        } catch (err) {
+          console.error(
+            'Failed to process DM XP award; will retry next poll',
+            err
+          );
+          break;
+        }
+      }
+    })().finally(() => {
+      inFlightRef.current = false;
+    });
+  }, [xpAwards, applyDmXpAward, acknowledgeXpAward, onApplied]);
+}

--- a/src/hooks/useDmXpAwardProcessor.ts
+++ b/src/hooks/useDmXpAwardProcessor.ts
@@ -35,10 +35,10 @@ export function useDmXpAwardProcessor({
       for (const { award, receipt } of xpAwards) {
         try {
           const result = applyDmXpAward(award);
-          await acknowledgeXpAward(receipt);
           if (result.status === 'applied') {
             onApplied(award, result.becamePending);
           }
+          await acknowledgeXpAward(receipt);
         } catch (err) {
           console.error(
             'Failed to process DM XP award; will retry next poll',

--- a/src/hooks/useSharedCampaignState.ts
+++ b/src/hooks/useSharedCampaignState.ts
@@ -20,6 +20,11 @@ interface UseSharedCampaignStateResult {
   acknowledgeMessage: (messageId: string) => Promise<void>;
   acknowledgeDmEffects: () => Promise<void>;
   acknowledgeTransfers: () => Promise<void>;
+  /**
+   * Acknowledge one XP award by receipt. THROWS on failure (unlike the other
+   * acknowledge helpers) — the award processor must stop, not continue.
+   */
+  acknowledgeXpAward: (receipt: string) => Promise<void>;
   pendingTransfers: ItemTransfer[];
   clearPendingTransfer: (transferId: string) => void;
   /** Immediate refetch (e.g. on a relay poke). Debounced: at most one per second. */
@@ -247,6 +252,30 @@ export function useSharedCampaignState(
     }
   }, [campaignCode, playerId]);
 
+  const acknowledgeXpAward = useCallback(
+    async (receipt: string) => {
+      if (!campaignCode || !playerId) {
+        throw new Error('Cannot acknowledge XP award outside a campaign');
+      }
+      const res = await fetch(`/api/campaign/${campaignCode}/shared`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ playerId, type: 'xp', receipt }),
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to acknowledge XP award (${res.status})`);
+      }
+      setSharedState(prev => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          xpAwards: (prev.xpAwards ?? []).filter(e => e.receipt !== receipt),
+        };
+      });
+    },
+    [campaignCode, playerId]
+  );
+
   const clearPendingTransfer = useCallback((transferId: string) => {
     setPendingTransfers(prev => prev.filter(t => t.id !== transferId));
   }, []);
@@ -259,6 +288,7 @@ export function useSharedCampaignState(
     acknowledgeMessage,
     acknowledgeDmEffects,
     acknowledgeTransfers,
+    acknowledgeXpAward,
     pendingTransfers,
     clearPendingTransfer,
     refetchNow,

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -24,6 +24,28 @@ export function getRedis(): Redis {
   return redis;
 }
 
+let rawRedis: Redis | null = null;
+
+/**
+ * Client with automaticDeserialization disabled. The XP award queue needs the
+ * EXACT stored list strings back (they double as ack receipts); the default
+ * client would JSON.parse LRANGE results and the receipt would no longer be
+ * the stored string.
+ */
+export function getRawRedis(): Redis {
+  if (!rawRedis) {
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) {
+      throw new Error(
+        'Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN environment variables'
+      );
+    }
+    rawRedis = new Redis({ url, token, automaticDeserialization: false });
+  }
+  return rawRedis;
+}
+
 export function campaignKey(code: string): string {
   return `campaign:${code}`;
 }
@@ -50,6 +72,10 @@ export function campaignEffectsKey(code: string, playerId: string): string {
 
 export function campaignTransfersKey(code: string, playerId: string): string {
   return `campaign:${code}:transfers:${playerId}`;
+}
+
+export function campaignXpKey(code: string, playerId: string): string {
+  return `campaign:${code}:xp:${playerId}`;
 }
 
 export function campaignRemovedKey(code: string, playerId: string): string {

--- a/src/lib/xpAwardQueue.ts
+++ b/src/lib/xpAwardQueue.ts
@@ -1,0 +1,115 @@
+import type { Redis } from '@upstash/redis';
+import { SLIDING_TTL_SECONDS } from '@/lib/redis';
+import type { DmXpAward, DmXpAwardEnvelope } from '@/types/sharedState';
+
+export const XP_QUEUE_CAP = 100;
+const XP_AWARD_ID_MAX_LENGTH = 64;
+const XP_AWARD_DATE_MAX_LENGTH = 40;
+
+// Atomic capped enqueue: cap check, append, and expiry refresh in one script
+// so concurrent requests can never both observe length 99 and overshoot.
+// KEYS[1] = queue key; ARGV[1] = serialized award; ARGV[2] = cap; ARGV[3] = ttl.
+const ENQUEUE_SCRIPT = `
+if redis.call('LLEN', KEYS[1]) >= tonumber(ARGV[2]) then
+  return 'full'
+end
+redis.call('RPUSH', KEYS[1], ARGV[1])
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+return 'ok'
+`;
+
+/** Serialize ONCE and atomically append; 'full' when the queue is at cap. */
+export async function enqueueXpAward(
+  redis: Redis,
+  key: string,
+  award: DmXpAward
+): Promise<'ok' | 'full'> {
+  const serialized = JSON.stringify(award);
+  const result = await redis.eval(
+    ENQUEUE_SCRIPT,
+    [key],
+    [serialized, String(XP_QUEUE_CAP), String(SLIDING_TTL_SECONDS)]
+  );
+  return result === 'full' ? 'full' : 'ok';
+}
+
+/**
+ * Read all queued awards in enqueue order. Each receipt is the exact stored
+ * string (requires the raw client — never re-serialize). Malformed entries are
+ * removed in place so they don't consume capacity or re-log every poll.
+ */
+export async function readXpAwards(
+  redis: Redis,
+  key: string
+): Promise<DmXpAwardEnvelope[]> {
+  const entries = await redis.lrange<string>(key, 0, -1);
+  const envelopes: DmXpAwardEnvelope[] = [];
+  for (const receipt of entries) {
+    let award: DmXpAward | null = null;
+    try {
+      const parsed = JSON.parse(receipt) as DmXpAward;
+      if (parsed && typeof parsed.id === 'string') award = parsed;
+    } catch {
+      // fall through to removal
+    }
+    if (award) {
+      envelopes.push({ award, receipt });
+    } else {
+      await redis.lrem(key, 1, receipt);
+      console.error('Removed malformed XP award entry', { key });
+    }
+  }
+  return envelopes;
+}
+
+/** Remove exactly one matching entry, then refresh or delete the key. */
+export async function ackXpAward(
+  redis: Redis,
+  key: string,
+  receipt: string
+): Promise<void> {
+  await redis.lrem(key, 1, receipt);
+  const remaining = await redis.llen(key);
+  if (remaining > 0) {
+    await redis.expire(key, SLIDING_TTL_SECONDS);
+  } else {
+    await redis.del(key);
+  }
+}
+
+/** Strict server-side validation. Returns an error message, or null when valid. */
+export function validateDmXpAward(value: unknown): string | null {
+  if (!value || typeof value !== 'object') return 'award must be an object';
+  const a = value as Record<string, unknown>;
+  if (
+    typeof a.id !== 'string' ||
+    a.id.length === 0 ||
+    a.id.length > XP_AWARD_ID_MAX_LENGTH
+  ) {
+    return 'award.id must be a non-empty string of at most 64 characters';
+  }
+  if (a.mode !== 'add' && a.mode !== 'set') {
+    return "award.mode must be 'add' or 'set'";
+  }
+  if (
+    typeof a.amount !== 'number' ||
+    !Number.isFinite(a.amount) ||
+    !Number.isInteger(a.amount)
+  ) {
+    return 'award.amount must be a finite integer';
+  }
+  if (a.mode === 'add' && a.amount < 1) {
+    return 'add awards require amount >= 1';
+  }
+  if (a.mode === 'set' && a.amount < 0) {
+    return 'set awards require amount >= 0';
+  }
+  if (
+    typeof a.awardedAt !== 'string' ||
+    a.awardedAt.length > XP_AWARD_DATE_MAX_LENGTH ||
+    Number.isNaN(Date.parse(a.awardedAt))
+  ) {
+    return 'award.awardedAt must be a valid ISO date string';
+  }
+  return null;
+}

--- a/src/lib/xpAwardQueue.ts
+++ b/src/lib/xpAwardQueue.ts
@@ -30,7 +30,11 @@ export async function enqueueXpAward(
     [key],
     [serialized, String(XP_QUEUE_CAP), String(SLIDING_TTL_SECONDS)]
   );
-  return result === 'full' ? 'full' : 'ok';
+  // Fail loud on anything unexpected — silently treating an unrecognized
+  // reply as 'ok' would let the route return 200 while the award was never
+  // stored (the caller's try/catch turns this throw into a 500).
+  if (result === 'ok' || result === 'full') return result;
+  throw new Error(`enqueueXpAward: unexpected EVAL reply: ${String(result)}`);
 }
 
 /**
@@ -62,7 +66,15 @@ export async function readXpAwards(
   return envelopes;
 }
 
-/** Remove exactly one matching entry, then refresh or delete the key. */
+/**
+ * Remove exactly one matching entry, then refresh expiry if entries remain.
+ *
+ * No explicit DEL when the queue empties: LREM → LLEN is not atomic, so a
+ * concurrent enqueue landing between them could see remaining === 0 from a
+ * list a fresh RPUSH just repopulated, and DEL would destroy that award.
+ * Redis already deletes a list key on its own once the last element is
+ * removed, so skipping DEL here is both safe and sufficient.
+ */
 export async function ackXpAward(
   redis: Redis,
   key: string,
@@ -72,8 +84,6 @@ export async function ackXpAward(
   const remaining = await redis.llen(key);
   if (remaining > 0) {
     await redis.expire(key, SLIDING_TTL_SECONDS);
-  } else {
-    await redis.del(key);
   }
 }
 

--- a/src/lib/xpAwardQueue.ts
+++ b/src/lib/xpAwardQueue.ts
@@ -51,8 +51,10 @@ export async function readXpAwards(
   for (const receipt of entries) {
     let award: DmXpAward | null = null;
     try {
-      const parsed = JSON.parse(receipt) as DmXpAward;
-      if (parsed && typeof parsed.id === 'string') award = parsed;
+      const parsed: unknown = JSON.parse(receipt);
+      if (validateDmXpAward(parsed) === null) {
+        award = parsed as DmXpAward;
+      }
     } catch {
       // fall through to removal
     }

--- a/src/store/__tests__/characterStore-class.test.ts
+++ b/src/store/__tests__/characterStore-class.test.ts
@@ -568,17 +568,15 @@ describe('characterStore — class, level, multiclass, hit dice, XP', () => {
       expect(useCharacterStore.getState().hasUnsavedChanges).toBe(true);
     });
 
-    it('updates character level when XP crosses a threshold', () => {
+    it('adds XP without auto-leveling', () => {
       // Level 5 requires 6500, level 6 requires 14000. Start at 6500.
-      // Adding 7500 puts us at 14000 — level 6.
+      // Adding 7500 puts us at 14000 XP, but level does not auto-update.
+      const levelBefore = useCharacterStore.getState().character.level;
       useCharacterStore.getState().addExperience(7500);
-      expect(useCharacterStore.getState().character.level).toBe(6);
-    });
-
-    it('does not reduce level when XP stays within current level range', () => {
-      // Adding 500 XP stays at level 5 (still below 14000)
-      useCharacterStore.getState().addExperience(500);
-      expect(useCharacterStore.getState().character.level).toBe(5);
+      expect(useCharacterStore.getState().character.experience).toBe(
+        6500 + 7500
+      );
+      expect(useCharacterStore.getState().character.level).toBe(levelBefore);
     });
 
     it('no longer sets showLevelUpAnimation (state-observer owns it)', () => {
@@ -622,16 +620,20 @@ describe('characterStore — class, level, multiclass, hit dice, XP', () => {
       expect(useCharacterStore.getState().hasUnsavedChanges).toBe(true);
     });
 
-    it('updates character level based on new XP', () => {
-      // 14000 XP = level 6
+    it('sets XP without auto-leveling', () => {
+      // Character starts at level 5; setting XP does not auto-update level
+      const levelBefore = useCharacterStore.getState().character.level;
       useCharacterStore.getState().setExperience(14000);
-      expect(useCharacterStore.getState().character.level).toBe(6);
+      expect(useCharacterStore.getState().character.experience).toBe(14000);
+      expect(useCharacterStore.getState().character.level).toBe(levelBefore);
     });
 
-    it('can set experience to 0 and keep level at 1', () => {
+    it('can set experience to 0 without changing level', () => {
+      // Character starts at level 5; setting XP to 0 does not auto-level
+      const levelBefore = useCharacterStore.getState().character.level;
       useCharacterStore.getState().setExperience(0);
       expect(useCharacterStore.getState().character.experience).toBe(0);
-      expect(useCharacterStore.getState().character.level).toBe(1);
+      expect(useCharacterStore.getState().character.level).toBe(levelBefore);
     });
 
     it('no longer sets showLevelUpAnimation (state-observer owns it)', () => {

--- a/src/store/characterActionClassification.ts
+++ b/src/store/characterActionClassification.ts
@@ -83,6 +83,7 @@ export const CHARACTER_ACTION_CLASSIFICATION: Record<string, ActionClass> = {
   // — XP —
   addExperience: 'CANONICAL',
   setExperience: 'CANONICAL',
+  applyDmXpAward: 'CANONICAL',
   // — rich text —
   addFeature: 'CANONICAL',
   updateFeature: 'CANONICAL',

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -33,6 +33,7 @@ import {
   AbilityName,
   TemporaryBuff,
 } from '@/types/character';
+import type { DmXpAward } from '@/types/sharedState';
 import { ProcessedSpell } from '@/types/spells';
 import {
   DEFAULT_CHARACTER_STATE,
@@ -49,11 +50,11 @@ import {
   hasSpellcasting,
   updateSpellSlotsPreservingUsed,
   calculateModifier,
-  calculateLevelFromXP,
   getXPForLevel,
   calculateTraitMaxUses,
   calculateWeaponChargeMax,
   calculateMagicItemChargeMax,
+  shouldLevelUp,
 } from '@/utils/calculations';
 import { migrateToMulticlass, calculateHitDicePools } from '@/utils/multiclass';
 import {
@@ -580,6 +581,10 @@ interface CharacterStore {
   // XP management
   addExperience: (xpToAdd: number) => void;
   setExperience: (newXP: number) => void;
+  applyDmXpAward: (award: DmXpAward) => {
+    status: 'applied' | 'duplicate';
+    becamePending: boolean;
+  };
 
   // Rich text content management
   addFeature: (
@@ -2572,175 +2577,56 @@ export const useCharacterStore = create<CharacterStore>()(
 
         // XP management
         addExperience: xpToAdd => {
-          const currentState = get();
-          const newXP = currentState.character.experience + xpToAdd;
-          const newLevel = calculateLevelFromXP(newXP);
-
-          set(state => {
-            // Ensure character has multiclass structure
-            const migratedCharacter = migrateToMulticlass(state.character);
-
-            // Update class levels based on new total level
-            const updatedClasses = [...(migratedCharacter.classes || [])];
-            if (updatedClasses.length === 1) {
-              updatedClasses[0] = {
-                ...updatedClasses[0],
-                level: newLevel,
-              };
-            } else if (updatedClasses.length > 1) {
-              // Adjust the primary class to reach the target total level
-              const currentTotal = updatedClasses.reduce(
-                (sum, cls) => sum + cls.level,
-                0
-              );
-              const levelDifference = newLevel - currentTotal;
-
-              if (levelDifference !== 0) {
-                const primaryIndex = updatedClasses.reduce(
-                  (maxIndex, cls, index) =>
-                    cls.level > updatedClasses[maxIndex].level
-                      ? index
-                      : maxIndex,
-                  0
-                );
-
-                updatedClasses[primaryIndex] = {
-                  ...updatedClasses[primaryIndex],
-                  level: Math.max(
-                    1,
-                    updatedClasses[primaryIndex].level + levelDifference
-                  ),
-                };
-              }
-            }
-
-            // Recalculate hit dice pools
-            const hitDicePools = calculateHitDicePools(
-              updatedClasses,
-              migratedCharacter.hitDicePools
-            );
-
-            const updatedCharacter = {
-              ...migratedCharacter,
-              classes: updatedClasses,
-              totalLevel: newLevel,
-              level: newLevel,
-              hitDicePools,
-            };
-
-            // Recalculate spell slots using multiclass-aware functions
-            const newSpellSlots =
-              calculateCharacterSpellSlots(updatedCharacter);
-            const preservedSpellSlots = updateSpellSlotsPreservingUsed(
-              newSpellSlots,
-              state.character.spellSlots
-            );
-
-            const pactMagic = calculateCharacterPactMagic(updatedCharacter);
-            // Preserve existing pact magic used slots if possible
-            if (state.character.pactMagic && pactMagic) {
-              pactMagic.slots.used = Math.min(
-                state.character.pactMagic.slots.used,
-                pactMagic.slots.max
-              );
-            }
-
-            return {
-              character: {
-                ...updatedCharacter,
-                experience: newXP,
-                spellSlots: preservedSpellSlots,
-                pactMagic,
-              },
-              hasUnsavedChanges: true,
-              saveStatus: 'saving',
-            };
-          });
+          set(state => ({
+            character: {
+              ...state.character,
+              experience: Math.max(0, state.character.experience + xpToAdd),
+            },
+            hasUnsavedChanges: true,
+            saveStatus: 'saving',
+          }));
         },
 
         setExperience: newXP => {
-          const newLevel = calculateLevelFromXP(newXP);
+          set(state => ({
+            character: {
+              ...state.character,
+              experience: Math.max(0, newXP),
+            },
+            hasUnsavedChanges: true,
+            saveStatus: 'saving',
+          }));
+        },
 
-          set(state => {
-            // Ensure character has multiclass structure
-            const migratedCharacter = migrateToMulticlass(state.character);
-
-            // Update class levels based on new total level
-            const updatedClasses = [...(migratedCharacter.classes || [])];
-            if (updatedClasses.length === 1) {
-              updatedClasses[0] = {
-                ...updatedClasses[0],
-                level: newLevel,
-              };
-            } else if (updatedClasses.length > 1) {
-              // Adjust the primary class to reach the target total level
-              const currentTotal = updatedClasses.reduce(
-                (sum, cls) => sum + cls.level,
-                0
-              );
-              const levelDifference = newLevel - currentTotal;
-
-              if (levelDifference !== 0) {
-                const primaryIndex = updatedClasses.reduce(
-                  (maxIndex, cls, index) =>
-                    cls.level > updatedClasses[maxIndex].level
-                      ? index
-                      : maxIndex,
-                  0
-                );
-
-                updatedClasses[primaryIndex] = {
-                  ...updatedClasses[primaryIndex],
-                  level: Math.max(
-                    1,
-                    updatedClasses[primaryIndex].level + levelDifference
-                  ),
-                };
-              }
-            }
-
-            // Recalculate hit dice pools
-            const hitDicePools = calculateHitDicePools(
-              updatedClasses,
-              migratedCharacter.hitDicePools
-            );
-
-            const updatedCharacter = {
-              ...migratedCharacter,
-              classes: updatedClasses,
-              totalLevel: newLevel,
-              level: newLevel,
-              hitDicePools,
-            };
-
-            // Recalculate spell slots using multiclass-aware functions
-            const newSpellSlots =
-              calculateCharacterSpellSlots(updatedCharacter);
-            const preservedSpellSlots = updateSpellSlotsPreservingUsed(
-              newSpellSlots,
-              state.character.spellSlots
-            );
-
-            const pactMagic = calculateCharacterPactMagic(updatedCharacter);
-            // Preserve existing pact magic used slots if possible
-            if (state.character.pactMagic && pactMagic) {
-              pactMagic.slots.used = Math.min(
-                state.character.pactMagic.slots.used,
-                pactMagic.slots.max
-              );
-            }
-
-            return {
-              character: {
-                ...updatedCharacter,
-                experience: newXP,
-                spellSlots: preservedSpellSlots,
-                pactMagic,
-              },
-              hasUnsavedChanges: true,
-              saveStatus: 'saving',
-            };
-          });
+        applyDmXpAward: award => {
+          const { character } = get();
+          const applied = character.appliedDmXpAwardIds ?? [];
+          if (applied.includes(award.id)) {
+            return { status: 'duplicate' as const, becamePending: false };
+          }
+          const currentLevel = character.totalLevel || character.level || 1;
+          const pendingBefore = shouldLevelUp(
+            character.experience,
+            currentLevel
+          );
+          const newXP =
+            award.mode === 'add'
+              ? Math.max(0, character.experience + award.amount)
+              : Math.max(0, award.amount);
+          const pendingAfter = shouldLevelUp(newXP, currentLevel);
+          set(state => ({
+            character: {
+              ...state.character,
+              experience: newXP,
+              appliedDmXpAwardIds: [...applied, award.id].slice(-150),
+            },
+            hasUnsavedChanges: true,
+            saveStatus: 'saving',
+          }));
+          return {
+            status: 'applied' as const,
+            becamePending: !pendingBefore && pendingAfter,
+          };
         },
 
         // Rich text content management

--- a/src/test/mocks/redis.ts
+++ b/src/test/mocks/redis.ts
@@ -20,6 +20,10 @@ export function seedRedisSet(key: string, members: string[]) {
   sets.set(key, new Set(members));
 }
 
+export function seedRedisList(key: string, values: string[]) {
+  lists.set(key, [...values]);
+}
+
 export function getRedisStore() {
   return store;
 }
@@ -131,6 +135,47 @@ export const mockRedis = {
     return 'OK';
   }),
 
+  rpush: vi.fn(async (key: string, ...values: string[]) => {
+    if (!lists.has(key)) lists.set(key, []);
+    const list = lists.get(key)!;
+    list.push(...values);
+    return list.length;
+  }),
+
+  lrem: vi.fn(async (key: string, count: number, value: string) => {
+    const list = lists.get(key);
+    if (!list) return 0;
+    const limit = count === 0 ? Infinity : Math.abs(count);
+    let removed = 0;
+    // count >= 0 removes head-to-tail — the only direction the app uses
+    for (let i = 0; i < list.length && removed < limit; ) {
+      if (list[i] === value) {
+        list.splice(i, 1);
+        removed++;
+      } else {
+        i++;
+      }
+    }
+    return removed;
+  }),
+
+  llen: vi.fn(async (key: string) => (lists.get(key) ?? []).length),
+
+  // Emulates the ONE Lua script in src/lib/xpAwardQueue.ts (atomic capped
+  // enqueue). Extend the branch if another script is ever added.
+  eval: vi.fn(async (script: string, keys: string[], args: string[]) => {
+    if (script.includes('RPUSH') && script.includes('LLEN')) {
+      const [key] = keys;
+      const [value, cap] = args;
+      const list = lists.get(key) ?? [];
+      if (list.length >= Number(cap)) return 'full';
+      lists.set(key, list);
+      list.push(value);
+      return 'ok';
+    }
+    throw new Error('mockRedis.eval: unrecognized script');
+  }),
+
   hset: vi.fn(async (key: string, field: string, value: string) => {
     if (!hashes.has(key)) hashes.set(key, new Map());
     const h = hashes.get(key)!;
@@ -166,7 +211,10 @@ export const mockRedis = {
 
 vi.mock('@/lib/redis', () => ({
   getRedis: () => mockRedis,
+  getRawRedis: () => mockRedis,
   campaignKey: (code: string) => `campaign:${code}`,
+  campaignXpKey: (code: string, playerId: string) =>
+    `campaign:${code}:xp:${playerId}`,
   campaignPlayersKey: (code: string) => `campaign:${code}:players`,
   campaignPlayerKey: (code: string, playerId: string) =>
     `campaign:${code}:player:${playerId}`,

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -579,6 +579,9 @@ export interface CharacterState {
   level: number; // Total character level (for backwards compatibility)
 
   experience: number;
+  // DM XP award ids already applied to this character (idempotency guard).
+  // Optional so legacy characters need no migration; capped at 150 entries.
+  appliedDmXpAwardIds?: string[];
   background: string;
   alignment: string;
   creatureType: string;

--- a/src/types/sharedState.ts
+++ b/src/types/sharedState.ts
@@ -52,6 +52,21 @@ export interface ItemTransfer {
   sentAt: string; // ISO timestamp
 }
 
+// DM-granted XP award queued for a player (applied idempotently by id)
+export interface DmXpAward {
+  id: string; // crypto.randomUUID() on the DM client
+  mode: 'add' | 'set';
+  amount: number; // finite integer; add >= 1, set >= 0
+  awardedAt: string; // ISO timestamp
+}
+
+// Queue entry returned by GET: award plus the exact stored Redis-list string,
+// echoed back verbatim on DELETE so the server can LREM the precise entry.
+export interface DmXpAwardEnvelope {
+  award: DmXpAward;
+  receipt: string;
+}
+
 // DM custom counter synced per-player (e.g. "Desperation Points")
 export interface SharedCustomCounter {
   label: string;

--- a/src/types/sharedState.ts
+++ b/src/types/sharedState.ts
@@ -170,6 +170,7 @@ export interface SharedCampaignState {
   battleMap: SharedBattleMapState | null;
   initiativeRequest: InitiativeRollRequest | null;
   settings: { stackableInspiration: boolean } | null;
+  xpAwards: DmXpAwardEnvelope[];
 }
 
 // POST body for DM pushing shared state


### PR DESCRIPTION
## Summary

- **DM XP awards (Foundry-style):** DM can add or set XP for any campaign player, per-player (PlayerDetailDialog) or in bulk ("Award XP" next to "Message All"). Awards travel through a per-player Redis LIST queue on the existing `shared` route.
- **XP never auto-levels anymore:** `addExperience`/`setExperience` mutate XP only. Crossing a threshold shows a persistent "Level up available!" badge in XPTracker and a pulsing Level Up button; the character levels only through the LevelUpWizard (or the manual level input, which is unchanged).
- **Cosmetic:** House Rules section moved above Players so Players and NPCs sit adjacent (visibility rules unchanged: hidden during loading/error, shown above the waiting-for-players state).

## Delivery contract (hardened)

- `DmXpAward { id, mode: 'add'|'set', amount, awardedAt }`; server validates strictly (mode, finite integer, add ≥ 1 / set ≥ 0, id ≤ 64, parseable date, campaign membership, DM authority).
- Enqueue = one atomic Lua script (LLEN cap 100 + RPUSH + EXPIRE) on a raw `automaticDeserialization: false` client; unexpected EVAL replies fail loud (500).
- GET returns `{ award, receipt }` where receipt is the exact stored string; malformed entries are LREM-cleaned during GET. Ack = `LREM key 1 <receipt>`, one award per call; expiry refreshed only when entries remain (no racy DEL).
- Player applies awards in order via idempotent `applyDmXpAward` (dedupe by id, capped 150, classified CANONICAL for cross-tab sync), acks per award only after the store action succeeds, stops the cycle on failure, single-flight guarded. Toast fires before ack so applied awards always notify; duplicates ack silently.
- DM-side retries re-send the ORIGINAL award object (same id) — safe because players dedupe.

## Tests

44 new tests across store, route (validation matrix, atomic cap race at 99, receipt exactness, malformed cleanup, double-ack safety), processor (ordering, duplicate-silent, stop-on-failure, single-flight, ack-failure-still-notifies), and UI (pending badge + hideLevelUpAlert, payloads, same-id retry, bulk UUID distinctness, post-success clear). Full unit suite: 3574 passed / 1 skipped. Type-check clean.

Note: live EVAL against the local serverless-redis-http proxy was not smoke-tested (mock-verified only); worth one manual check with docker-compose before first production use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)