### PR TITLE
feat: add hidden placement mode to battlemaps

### DIFF
--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -5,6 +5,9 @@ import {
   ArrowTool,
   MeasureTool,
   TemplateTool,
+  NoteTool,
+  TextTool,
+  ShapeTool,
   AutoSave,
   type Tool,
   type Viewport,
@@ -62,6 +65,9 @@ export interface DmBattleMapCanvasState {
   handleToggleHiddenPlacement: () => void;
   hiddenElementCount: number;
   handleRevealAll: () => void;
+  selectedElementId: string | null;
+  selectedElementIsDmOnly: boolean;
+  handleToggleSelectedDmOnly: () => void;
 }
 
 /**
@@ -89,11 +95,21 @@ export function useDmBattleMapCanvas({
   const hiddenPlacementUnsubRef = useRef<(() => void) | null>(null);
   const [hiddenPlacementActive, setHiddenPlacementActive] = useState(false);
   const hiddenPlacementActiveRef = useRef(false);
+  const [selectedElementId, setSelectedElementId] = useState<string | null>(
+    null
+  );
   const hiddenElementCount = useBattleMapStore(
     state =>
       Object.keys(
         state.battleMaps[campaignCode]?.[battleMapId]?.dmOnlyElements ?? {}
       ).length
+  );
+  const selectedElementIsDmOnly = useBattleMapStore(state =>
+    selectedElementId
+      ? (state.battleMaps[campaignCode]?.[battleMapId]?.dmOnlyElements[
+          selectedElementId
+        ] ?? false)
+      : false
   );
   // The connection is created once inside the fire-once `handleReady`
   // callback; a plain closure over `onPoke` would go stale if the prop's
@@ -109,6 +125,14 @@ export function useDmBattleMapCanvas({
       selectTool,
       new PencilTool({ color: '#F4C430', width: 2.6 }),
       new ArrowTool({ color: '#F4C430', width: 2 }),
+      new ShapeTool({
+        shape: 'rectangle',
+        strokeColor: '#F4C430',
+        strokeWidth: 2,
+        fillColor: 'transparent',
+      }),
+      new TextTool(),
+      new NoteTool(),
       new MeasureTool({ feetPerCell: 5 }),
       new TemplateTool({
         templateShape: 'circle',
@@ -192,7 +216,6 @@ export function useDmBattleMapCanvas({
       // re-applying remote elements as full updates (including layerId).
       attachUnknownLayerMirror(vp, 'dm', () => vp.requestRender());
       pinUnsubRef.current?.();
-      hiddenPlacementUnsubRef.current?.();
       // Play canvas never arranges maps — the annotations layer (DM tokens,
       // notes, text) must stay unlocked, repairing any state persisted locked
       // by the setup editor's arrange-maps mode.
@@ -202,6 +225,9 @@ export function useDmBattleMapCanvas({
 
       const selectTool = vp.toolManager.getTool<SelectTool>('select');
       selectTool?.onSelectionChange(() => {
+        setSelectedElementId(
+          selectTool.selectedIds.length === 1 ? selectTool.selectedIds[0] : null
+        );
         onSelectionChange?.(selectTool.selectedIds);
       });
 
@@ -293,6 +319,16 @@ export function useDmBattleMapCanvas({
     }
   }, [viewport, campaignCode, battleMapId]);
 
+  const handleToggleSelectedDmOnly = useCallback(() => {
+    if (!viewport || !selectedElementId) return;
+    useBattleMapStore
+      .getState()
+      .toggleDmOnly(campaignCode, battleMapId, selectedElementId);
+    if (viewport.store.getById(selectedElementId)) {
+      viewport.store.update(selectedElementId, {});
+    }
+  }, [viewport, selectedElementId, campaignCode, battleMapId]);
+
   return {
     viewport,
     status,
@@ -303,5 +339,8 @@ export function useDmBattleMapCanvas({
     handleToggleHiddenPlacement,
     hiddenElementCount,
     handleRevealAll,
+    selectedElementId,
+    selectedElementIsDmOnly,
+    handleToggleSelectedDmOnly,
   };
 }

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -58,6 +58,10 @@ export interface DmBattleMapCanvasState {
   tools: Tool[];
   handleReady: (vp: Viewport) => void;
   handleClearDrawings: () => void;
+  hiddenPlacementActive: boolean;
+  handleToggleHiddenPlacement: () => void;
+  hiddenElementCount: number;
+  handleRevealAll: () => void;
 }
 
 /**
@@ -82,6 +86,15 @@ export function useDmBattleMapCanvas({
   const autoSaveRef = useRef<AutoSave | null>(null);
   const connectionRef = useRef<{ stop: () => void } | null>(null);
   const pinUnsubRef = useRef<(() => void) | null>(null);
+  const hiddenPlacementUnsubRef = useRef<(() => void) | null>(null);
+  const [hiddenPlacementActive, setHiddenPlacementActive] = useState(false);
+  const hiddenPlacementActiveRef = useRef(false);
+  const hiddenElementCount = useBattleMapStore(
+    state =>
+      Object.keys(
+        state.battleMaps[campaignCode]?.[battleMapId]?.dmOnlyElements ?? {}
+      ).length
+  );
   // The connection is created once inside the fire-once `handleReady`
   // callback; a plain closure over `onPoke` would go stale if the prop's
   // identity changes later (e.g. encounterId change) after the connection
@@ -158,12 +171,28 @@ export function useDmBattleMapCanvas({
       vp.store.on('remove', saveOnLocalOps);
       vp.store.on('update', saveOnLocalOps);
 
+      // Attach before live sync so a local addition is marked private before
+      // the sync client resolves the audience for its first outbound upsert.
+      hiddenPlacementUnsubRef.current?.();
+      hiddenPlacementUnsubRef.current = vp.store.on('add', (element, meta) => {
+        if (
+          !hiddenPlacementActiveRef.current ||
+          (meta?.origin !== undefined && meta.origin !== 'local')
+        ) {
+          return;
+        }
+        useBattleMapStore
+          .getState()
+          .setDmOnly(campaignCode, battleMapId, element.id, true);
+      });
+
       // Mirror unknown remote layers (player tokens) into the player band —
       // without this they sort at layer order 0, under DM-added images.
       // Covers both new elements (add) and relay snapshot reconcile
       // re-applying remote elements as full updates (including layerId).
       attachUnknownLayerMirror(vp, 'dm', () => vp.requestRender());
       pinUnsubRef.current?.();
+      hiddenPlacementUnsubRef.current?.();
       // Play canvas never arranges maps — the annotations layer (DM tokens,
       // notes, text) must stay unlocked, repairing any state persisted locked
       // by the setup editor's arrange-maps mode.
@@ -241,5 +270,38 @@ export function useDmBattleMapCanvas({
     viewport.requestRender();
   }, [viewport]);
 
-  return { viewport, status, tools, handleReady, handleClearDrawings };
+  const handleToggleHiddenPlacement = useCallback(() => {
+    setHiddenPlacementActive(current => {
+      const next = !current;
+      hiddenPlacementActiveRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const handleRevealAll = useCallback(() => {
+    if (!viewport) return;
+    const hiddenIds = Object.keys(
+      useBattleMapStore.getState().battleMaps[campaignCode]?.[battleMapId]
+        ?.dmOnlyElements ?? {}
+    );
+    if (hiddenIds.length === 0) return;
+    useBattleMapStore
+      .getState()
+      .updateBattleMap(campaignCode, battleMapId, { dmOnlyElements: {} });
+    for (const id of hiddenIds) {
+      if (viewport.store.getById(id)) viewport.store.update(id, {});
+    }
+  }, [viewport, campaignCode, battleMapId]);
+
+  return {
+    viewport,
+    status,
+    tools,
+    handleReady,
+    handleClearDrawings,
+    hiddenPlacementActive,
+    handleToggleHiddenPlacement,
+    hiddenElementCount,
+    handleRevealAll,
+  };
 }

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -19,8 +19,16 @@ export type { DmBattleMapCanvasProps };
  */
 export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
   const { children, tokenInfoToggle } = props;
-  const { viewport, tools, handleReady, handleClearDrawings } =
-    useDmBattleMapCanvas(props);
+  const {
+    viewport,
+    tools,
+    handleReady,
+    handleClearDrawings,
+    hiddenPlacementActive,
+    handleToggleHiddenPlacement,
+    hiddenElementCount,
+    handleRevealAll,
+  } = useDmBattleMapCanvas(props);
 
   return (
     <ViewportContext.Provider value={viewport}>
@@ -36,6 +44,10 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
           <DmVttToolbar
             onClearDrawings={handleClearDrawings}
             tokenInfoToggle={tokenInfoToggle}
+            hiddenPlacementActive={hiddenPlacementActive}
+            onToggleHiddenPlacement={handleToggleHiddenPlacement}
+            hiddenElementCount={hiddenElementCount}
+            onRevealAll={handleRevealAll}
           />
         )}
         {viewport && (

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -28,6 +28,9 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
     handleToggleHiddenPlacement,
     hiddenElementCount,
     handleRevealAll,
+    selectedElementId,
+    selectedElementIsDmOnly,
+    handleToggleSelectedDmOnly,
   } = useDmBattleMapCanvas(props);
 
   return (
@@ -48,10 +51,13 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
             onToggleHiddenPlacement={handleToggleHiddenPlacement}
             hiddenElementCount={hiddenElementCount}
             onRevealAll={handleRevealAll}
+            selectedElementId={selectedElementId}
+            selectedElementIsDmOnly={selectedElementIsDmOnly}
+            onToggleSelectedDmOnly={handleToggleSelectedDmOnly}
           />
         )}
         {viewport && (
-          <div className="border-divider absolute top-[7.25rem] left-1/2 z-10 max-w-[92vw] -translate-x-1/2 overflow-hidden rounded-xl border shadow-lg">
+          <div className="border-divider absolute top-[8.25rem] left-1/2 z-10 max-w-[92vw] -translate-x-1/2 overflow-hidden rounded-xl border shadow-lg">
             <DmLocationToolOptions mode="battlemap" />
           </div>
         )}

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -30,6 +30,10 @@ const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
 export interface DmVttToolbarProps {
   onClearDrawings: () => void;
   tokenInfoToggle: { mode: TokenInfoMode | null; onCycle: () => void };
+  hiddenPlacementActive: boolean;
+  onToggleHiddenPlacement: () => void;
+  hiddenElementCount: number;
+  onRevealAll: () => void;
 }
 
 const TOKEN_INFO_ICON: Record<TokenInfoMode, typeof Eye> = {
@@ -52,6 +56,10 @@ const TOKEN_INFO_LABEL: Record<TokenInfoMode, string> = {
 export function DmVttToolbar({
   onClearDrawings,
   tokenInfoToggle,
+  hiddenPlacementActive,
+  onToggleHiddenPlacement,
+  hiddenElementCount,
+  onRevealAll,
 }: DmVttToolbarProps) {
   const [activeTool, setTool] = useActiveTool();
   const TokenInfoIcon = TOKEN_INFO_ICON[tokenInfoToggle.mode ?? 'compact'];
@@ -72,6 +80,37 @@ export function DmVttToolbar({
         ))}
       </div>
       <div className="flex items-center gap-1">
+        <Button
+          variant={hiddenPlacementActive ? 'warning' : 'ghost'}
+          onClick={onToggleHiddenPlacement}
+          className="min-h-[44px] px-2"
+          title={
+            hiddenPlacementActive
+              ? 'New elements are hidden from players'
+              : 'New elements are visible to players'
+          }
+          aria-label="Place hidden elements"
+          aria-pressed={hiddenPlacementActive}
+        >
+          <EyeOff size={16} />
+          <span className="ml-1.5 hidden text-xs xl:inline">
+            {hiddenPlacementActive ? 'Placing hidden' : 'Place hidden'}
+          </span>
+        </Button>
+        {hiddenElementCount > 0 && (
+          <Button
+            variant="ghost"
+            onClick={onRevealAll}
+            className="min-h-[44px] px-2"
+            title={`Reveal all ${hiddenElementCount} hidden element${hiddenElementCount === 1 ? '' : 's'}`}
+            aria-label={`Reveal all hidden elements (${hiddenElementCount})`}
+          >
+            <Eye size={16} />
+            <span className="ml-1.5 hidden text-xs xl:inline">
+              Reveal all ({hiddenElementCount})
+            </span>
+          </Button>
+        )}
         <Button
           variant="ghost"
           onClick={onClearDrawings}

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -7,6 +7,9 @@ import {
   MoveUpRight,
   Ruler,
   Circle,
+  Type,
+  StickyNote,
+  Shapes,
   Eraser,
   Eye,
   Minus,
@@ -23,6 +26,9 @@ const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
   { name: 'select', label: 'Select', Icon: MousePointer2 },
   { name: 'pencil', label: 'Draw', Icon: Pencil },
   { name: 'arrow', label: 'Arrow', Icon: MoveUpRight },
+  { name: 'shape', label: 'Shape', Icon: Shapes },
+  { name: 'text', label: 'Text', Icon: Type },
+  { name: 'note', label: 'Sticky Note', Icon: StickyNote },
   { name: 'measure', label: 'Measure', Icon: Ruler },
   { name: 'template', label: 'Template', Icon: Circle },
 ];
@@ -34,6 +40,9 @@ export interface DmVttToolbarProps {
   onToggleHiddenPlacement: () => void;
   hiddenElementCount: number;
   onRevealAll: () => void;
+  selectedElementId: string | null;
+  selectedElementIsDmOnly: boolean;
+  onToggleSelectedDmOnly: () => void;
 }
 
 const TOKEN_INFO_ICON: Record<TokenInfoMode, typeof Eye> = {
@@ -60,11 +69,14 @@ export function DmVttToolbar({
   onToggleHiddenPlacement,
   hiddenElementCount,
   onRevealAll,
+  selectedElementId,
+  selectedElementIsDmOnly,
+  onToggleSelectedDmOnly,
 }: DmVttToolbarProps) {
   const [activeTool, setTool] = useActiveTool();
   const TokenInfoIcon = TOKEN_INFO_ICON[tokenInfoToggle.mode ?? 'compact'];
   return (
-    <div className="bg-surface-raised border-divider absolute top-16 left-1/2 z-10 flex -translate-x-1/2 items-center gap-3 rounded-xl border p-1 shadow-lg">
+    <div className="bg-surface-raised border-divider absolute top-20 left-1/2 z-10 flex max-w-[94vw] -translate-x-1/2 items-center gap-3 overflow-x-auto rounded-xl border p-1 shadow-lg">
       <div className="flex items-center gap-1">
         {DM_TOOLS.map(({ name, label, Icon }) => (
           <Button
@@ -97,18 +109,40 @@ export function DmVttToolbar({
             {hiddenPlacementActive ? 'Placing hidden' : 'Place hidden'}
           </span>
         </Button>
-        {hiddenElementCount > 0 && (
+        <Button
+          variant="ghost"
+          onClick={onRevealAll}
+          disabled={hiddenElementCount === 0}
+          className="min-h-[44px] px-2"
+          title={
+            hiddenElementCount === 0
+              ? 'No hidden elements to reveal'
+              : `Reveal all ${hiddenElementCount} hidden element${hiddenElementCount === 1 ? '' : 's'}`
+          }
+          aria-label={`Reveal all hidden elements (${hiddenElementCount})`}
+        >
+          <Eye size={16} />
+          <span className="ml-1.5 hidden text-xs xl:inline">
+            Reveal all ({hiddenElementCount})
+          </span>
+        </Button>
+        {selectedElementId && (
           <Button
-            variant="ghost"
-            onClick={onRevealAll}
+            variant={selectedElementIsDmOnly ? 'warning' : 'ghost'}
+            onClick={onToggleSelectedDmOnly}
             className="min-h-[44px] px-2"
-            title={`Reveal all ${hiddenElementCount} hidden element${hiddenElementCount === 1 ? '' : 's'}`}
-            aria-label={`Reveal all hidden elements (${hiddenElementCount})`}
+            title={
+              selectedElementIsDmOnly
+                ? 'Reveal selected element to players'
+                : 'Hide selected element from players'
+            }
+            aria-label={
+              selectedElementIsDmOnly
+                ? 'Reveal selected element'
+                : 'Hide selected element'
+            }
           >
-            <Eye size={16} />
-            <span className="ml-1.5 hidden text-xs xl:inline">
-              Reveal all ({hiddenElementCount})
-            </span>
+            {selectedElementIsDmOnly ? <Eye size={16} /> : <EyeOff size={16} />}
           </Button>
         )}
         <Button

--- a/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
@@ -23,11 +23,14 @@ describe('DmVttToolbar', () => {
         onToggleHiddenPlacement={vi.fn()}
         hiddenElementCount={0}
         onRevealAll={vi.fn()}
+        selectedElementId={null}
+        selectedElementIsDmOnly={false}
+        onToggleSelectedDmOnly={vi.fn()}
       />
     );
     const toolbar = container.firstChild as HTMLElement;
     const classes = toolbar.className.split(/\s+/);
-    expect(classes).toContain('top-16');
+    expect(classes).toContain('top-20');
     expect(classes).not.toEqual(
       expect.arrayContaining([expect.stringMatching(/^min-\[1350px\]:top-3$/)])
     );
@@ -44,6 +47,9 @@ describe('DmVttToolbar', () => {
         onToggleHiddenPlacement={onToggle}
         hiddenElementCount={2}
         onRevealAll={onRevealAll}
+        selectedElementId="trap-1"
+        selectedElementIsDmOnly
+        onToggleSelectedDmOnly={vi.fn()}
       />
     );
 
@@ -57,5 +63,8 @@ describe('DmVttToolbar', () => {
     );
     expect(onToggle).toHaveBeenCalledOnce();
     expect(onRevealAll).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole('button', { name: 'Reveal selected element' })
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, fireEvent, screen } from '@testing-library/react';
 
 import { DmVttToolbar } from '@/components/ui/campaign/dm-vtt/DmVttToolbar';
 
@@ -19,6 +19,10 @@ describe('DmVttToolbar', () => {
       <DmVttToolbar
         onClearDrawings={vi.fn()}
         tokenInfoToggle={{ mode: 'compact', onCycle: vi.fn() }}
+        hiddenPlacementActive={false}
+        onToggleHiddenPlacement={vi.fn()}
+        hiddenElementCount={0}
+        onRevealAll={vi.fn()}
       />
     );
     const toolbar = container.firstChild as HTMLElement;
@@ -27,5 +31,31 @@ describe('DmVttToolbar', () => {
     expect(classes).not.toEqual(
       expect.arrayContaining([expect.stringMatching(/^min-\[1350px\]:top-3$/)])
     );
+  });
+
+  it('toggles hidden placement and offers reveal all', () => {
+    const onToggle = vi.fn();
+    const onRevealAll = vi.fn();
+    render(
+      <DmVttToolbar
+        onClearDrawings={vi.fn()}
+        tokenInfoToggle={{ mode: 'compact', onCycle: vi.fn() }}
+        hiddenPlacementActive
+        onToggleHiddenPlacement={onToggle}
+        hiddenElementCount={2}
+        onRevealAll={onRevealAll}
+      />
+    );
+
+    const placement = screen.getByRole('button', {
+      name: 'Place hidden elements',
+    });
+    expect(placement).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(placement);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Reveal all hidden elements (2)' })
+    );
+    expect(onToggle).toHaveBeenCalledOnce();
+    expect(onRevealAll).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -123,6 +123,10 @@ export interface DmLocationEditorState {
   selectedElementId: string | null;
   isDmOnly: boolean;
   handleToggleDmOnly: () => void;
+  hiddenPlacementActive: boolean;
+  handleToggleHiddenPlacement: () => void;
+  hiddenElementCount: number;
+  handleRevealAll: () => void;
 
   // Loading states
   syncing: boolean;
@@ -172,6 +176,7 @@ export function useDmLocationEditor(
   const autoSaveRef = useRef<AutoSave | null>(null);
   const connectionRef = useRef<{ stop: () => void } | null>(null);
   const pinUnsubRef = useRef<(() => void) | null>(null);
+  const hiddenPlacementUnsubRef = useRef<(() => void) | null>(null);
   const [syncStatus, setSyncStatus] = useState<
     BattleMapConnectionStatus | 'disabled'
   >('disabled');
@@ -227,6 +232,8 @@ export function useDmLocationEditor(
     selectedElementId != null
       ? (dmOnlyElements[selectedElementId] ?? false)
       : false;
+  const [hiddenPlacementActive, setHiddenPlacementActive] = useState(false);
+  const hiddenPlacementActiveRef = useRef(false);
 
   // Loading states
   const [syncing, setSyncing] = useState(false);
@@ -354,6 +361,23 @@ export function useDmLocationEditor(
       vp.store.on('add', saveAndMarkDirty);
       vp.store.on('remove', saveAndMarkDirty);
       vp.store.on('update', saveAndMarkDirty);
+
+      // Register before live sync starts so a newly-created local element is
+      // marked DM-only before the sync client resolves its audience. Remote
+      // additions (including player tokens) must never inherit this setting.
+      hiddenPlacementUnsubRef.current?.();
+      hiddenPlacementUnsubRef.current = vp.store.on('add', (element, meta) => {
+        if (
+          mode !== 'battlemap' ||
+          !hiddenPlacementActiveRef.current ||
+          (meta?.origin !== undefined && meta.origin !== 'local')
+        ) {
+          return;
+        }
+        useBattleMapStore
+          .getState()
+          .setDmOnly(campaignCode, location.id, element.id, true);
+      });
 
       // Layers aren't synced: player tokens arrive referencing player-*
       // layer ids that don't exist on this canvas and would sort at layer
@@ -483,6 +507,7 @@ export function useDmLocationEditor(
       autoSaveRef.current?.stop();
       connectionRef.current?.stop();
       pinUnsubRef.current?.();
+      hiddenPlacementUnsubRef.current?.();
     };
   }, []);
 
@@ -618,6 +643,32 @@ export function useDmLocationEditor(
     mode,
     getVp,
   ]);
+
+  const handleToggleHiddenPlacement = useCallback(() => {
+    setHiddenPlacementActive(current => {
+      const next = !current;
+      hiddenPlacementActiveRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const handleRevealAll = useCallback(() => {
+    if (mode !== 'battlemap') return;
+    const vp = getVp();
+    if (!vp) return;
+    const hiddenIds = Object.keys(
+      useBattleMapStore.getState().battleMaps[campaignCode]?.[location.id]
+        ?.dmOnlyElements ?? {}
+    );
+    if (hiddenIds.length === 0) return;
+
+    battleMapStoreUpdate(campaignCode, location.id, { dmOnlyElements: {} });
+    // Re-emit surviving elements after clearing their flags. The sync client
+    // stamps them for the player audience and publishes an upsert immediately.
+    for (const id of hiddenIds) {
+      if (vp.store.getById(id)) vp.store.update(id, {});
+    }
+  }, [mode, getVp, campaignCode, location.id, battleMapStoreUpdate]);
 
   const handleDeleteSelected = useCallback(() => {
     const vp = getVp();
@@ -925,6 +976,10 @@ export function useDmLocationEditor(
     selectedElementId,
     isDmOnly,
     handleToggleDmOnly,
+    hiddenPlacementActive,
+    handleToggleHiddenPlacement,
+    hiddenElementCount: Object.keys(dmOnlyElements).length,
+    handleRevealAll,
     syncing,
     hasUnsyncedChanges,
     lastSyncedAt,

--- a/src/components/ui/campaign/location-map/DmLocationEditor.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.tsx
@@ -32,6 +32,10 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
     selectedElementId,
     isDmOnly,
     handleToggleDmOnly,
+    hiddenPlacementActive,
+    handleToggleHiddenPlacement,
+    hiddenElementCount,
+    handleRevealAll,
     syncing,
     hasUnsyncedChanges,
     lastSyncedAt,
@@ -95,6 +99,10 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
             selectedElementId={selectedElementId}
             isDmOnly={isDmOnly}
             onToggleDmOnly={handleToggleDmOnly}
+            hiddenPlacementActive={hiddenPlacementActive}
+            onToggleHiddenPlacement={handleToggleHiddenPlacement}
+            hiddenElementCount={hiddenElementCount}
+            onRevealAll={handleRevealAll}
             mode={mode}
             onOpenTvDisplay={handleOpenTvDisplay}
             syncStatus={syncStatus}

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
@@ -247,17 +247,20 @@ export default function DmLocationToolbar({
               <EyeOff size={14} />
               {hiddenPlacementActive ? 'Placing hidden' : 'Place hidden'}
             </Button>
-            {hiddenElementCount > 0 && (
-              <Button
-                variant="ghost"
-                onClick={onRevealAll}
-                title={`Reveal all ${hiddenElementCount} hidden element${hiddenElementCount === 1 ? '' : 's'} to players`}
-                className="flex items-center gap-1.5 px-2 py-1 text-xs"
-              >
-                <Eye size={14} />
-                Reveal all ({hiddenElementCount})
-              </Button>
-            )}
+            <Button
+              variant="ghost"
+              onClick={onRevealAll}
+              disabled={hiddenElementCount === 0}
+              title={
+                hiddenElementCount === 0
+                  ? 'No hidden elements to reveal'
+                  : `Reveal all ${hiddenElementCount} hidden element${hiddenElementCount === 1 ? '' : 's'} to players`
+              }
+              className="flex items-center gap-1.5 px-2 py-1 text-xs"
+            >
+              <Eye size={14} />
+              Reveal all ({hiddenElementCount})
+            </Button>
           </>
         )}
 

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
@@ -24,6 +24,8 @@ import {
   Move,
   RotateCcw,
   RotateCw,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
 import { useActiveTool, useHistory, useSelectionOps } from '@fieldnotes/react';
 import { Button } from '@/components/ui/forms/button';
@@ -82,6 +84,10 @@ export default function DmLocationToolbar({
   selectedElementId,
   isDmOnly,
   onToggleDmOnly,
+  hiddenPlacementActive,
+  onToggleHiddenPlacement,
+  hiddenElementCount,
+  onRevealAll,
   mode,
   onOpenTvDisplay,
   syncStatus,
@@ -225,6 +231,36 @@ export default function DmLocationToolbar({
 
       {/* Right group */}
       <div className="ml-auto flex items-center gap-1">
+        {mode === 'battlemap' && (
+          <>
+            <Button
+              variant={hiddenPlacementActive ? 'warning' : 'ghost'}
+              onClick={onToggleHiddenPlacement}
+              title={
+                hiddenPlacementActive
+                  ? 'New elements are hidden from players'
+                  : 'New elements are visible to players'
+              }
+              aria-pressed={hiddenPlacementActive}
+              className="flex items-center gap-1.5 px-2 py-1 text-xs"
+            >
+              <EyeOff size={14} />
+              {hiddenPlacementActive ? 'Placing hidden' : 'Place hidden'}
+            </Button>
+            {hiddenElementCount > 0 && (
+              <Button
+                variant="ghost"
+                onClick={onRevealAll}
+                title={`Reveal all ${hiddenElementCount} hidden element${hiddenElementCount === 1 ? '' : 's'} to players`}
+                className="flex items-center gap-1.5 px-2 py-1 text-xs"
+              >
+                <Eye size={14} />
+                Reveal all ({hiddenElementCount})
+              </Button>
+            )}
+          </>
+        )}
+
         {/* DM-only toggle — only shown when a single element is selected */}
         {selectedElementId != null && (
           <DmOnlyToggle isDmOnly={isDmOnly} onToggle={onToggleDmOnly} />

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.types.ts
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.types.ts
@@ -24,6 +24,10 @@ export interface DmLocationToolbarProps {
   selectedElementId: string | null;
   isDmOnly: boolean;
   onToggleDmOnly: () => void;
+  hiddenPlacementActive: boolean;
+  onToggleHiddenPlacement: () => void;
+  hiddenElementCount: number;
+  onRevealAll: () => void;
   /** Whether canvas has changed since last sync */
   hasUnsyncedChanges: boolean;
   /** ISO timestamp of last successful sync, or null if never synced */

--- a/src/components/ui/campaign/location-map/__tests__/DmLocationToolbar.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/DmLocationToolbar.test.tsx
@@ -62,6 +62,10 @@ const baseProps: DmLocationToolbarProps = {
   selectedElementId: null,
   isDmOnly: false,
   onToggleDmOnly: vi.fn(),
+  hiddenPlacementActive: false,
+  onToggleHiddenPlacement: vi.fn(),
+  hiddenElementCount: 0,
+  onRevealAll: vi.fn(),
   mode: 'battlemap',
   syncStatus: 'disabled',
 };
@@ -111,5 +115,26 @@ describe('DmLocationToolbar rotation buttons', () => {
   it('renders the Align trigger in the center group', () => {
     render(<DmLocationToolbar {...baseProps} />);
     expect(screen.getByTitle('Align & distribute')).toBeInTheDocument();
+  });
+
+  it('shows hidden-placement state and reveals all hidden elements', () => {
+    const onToggle = vi.fn();
+    const onRevealAll = vi.fn();
+    render(
+      <DmLocationToolbar
+        {...baseProps}
+        hiddenPlacementActive
+        onToggleHiddenPlacement={onToggle}
+        hiddenElementCount={3}
+        onRevealAll={onRevealAll}
+      />
+    );
+
+    const placement = screen.getByRole('button', { name: 'Placing hidden' });
+    expect(placement).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(placement);
+    fireEvent.click(screen.getByRole('button', { name: 'Reveal all (3)' }));
+    expect(onToggle).toHaveBeenCalledOnce();
+    expect(onRevealAll).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
- add a session-local Place hidden toggle to battlemap setup and play modes
- mark every locally created element DM-only before its first live-sync upsert
- ignore remote/player-created elements when hidden placement is enabled
- add Reveal all controls that immediately publish existing hidden elements
- preserve the existing per-selected-element DM-only control

## Verification
- npm run type-check
- npx vitest run src/components/ui/campaign/location-map/__tests__/DmLocationToolbar.test.tsx src/components/ui/campaign/location-map/__tests__/DmLocationEditor.hooks.test.ts src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx src/components/ui/campaign/dm-vtt/__tests__/DmVttScreen.hooks.test.ts
- pre-commit Prettier and ESLint hooks