### PR TITLE
refactor(battlemap): use Fieldnotes transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@3d-dice/dice-box": "^1.1.3",
         "@3d-dice/dice-ui": "^0.5.2",
         "@aws-sdk/client-s3": "^3.922.0",
-        "@fieldnotes/core": "^0.52.2",
+        "@fieldnotes/core": "^0.53.0",
         "@fieldnotes/react": "^0.8.0",
         "@fieldnotes/sync": "^0.7.1",
         "@radix-ui/react-checkbox": "^1.3.2",
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/@fieldnotes/core": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.52.2.tgz",
-      "integrity": "sha512-eXF2su/1nymGRjpdtR9yFMnFOTjIudEQ+gg2jxTZCEUgN/e+0bo0N2F+6CM9/Z7TUu4gS0MefClwt7AGiiDApA==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.53.0.tgz",
+      "integrity": "sha512-kimNTHIBJXEJehZBGUwUkTtdZZaVSzH5Peujj2Ep7Vzl3cV8r22PcCobItmF17yEzVdgCHMBPcyKR7qfdMR/5w==",
       "license": "MIT"
     },
     "node_modules/@fieldnotes/react": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@3d-dice/dice-box": "^1.1.3",
     "@3d-dice/dice-ui": "^0.5.2",
     "@aws-sdk/client-s3": "^3.922.0",
-    "@fieldnotes/core": "^0.52.2",
+    "@fieldnotes/core": "^0.53.0",
     "@fieldnotes/react": "^0.8.0",
     "@fieldnotes/sync": "^0.7.1",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "rollkeeper-battlemap-relay",
       "version": "0.1.0",
       "dependencies": {
-        "@fieldnotes/core": "0.52.2",
+        "@fieldnotes/core": "0.53.0",
         "@fieldnotes/sync": "0.7.1",
         "@fieldnotes/sync-server": "0.10.1",
         "redis": "^4.7.0"
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/@fieldnotes/core": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.52.2.tgz",
-      "integrity": "sha512-eXF2su/1nymGRjpdtR9yFMnFOTjIudEQ+gg2jxTZCEUgN/e+0bo0N2F+6CM9/Z7TUu4gS0MefClwt7AGiiDApA==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.53.0.tgz",
+      "integrity": "sha512-kimNTHIBJXEJehZBGUwUkTtdZZaVSzH5Peujj2Ep7Vzl3cV8r22PcCobItmF17yEzVdgCHMBPcyKR7qfdMR/5w==",
       "license": "MIT"
     },
     "node_modules/@fieldnotes/sync": {

--- a/relay/package.json
+++ b/relay/package.json
@@ -14,7 +14,7 @@
     "type-check": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@fieldnotes/core": "0.52.2",
+    "@fieldnotes/core": "0.53.0",
     "@fieldnotes/sync": "0.7.1",
     "@fieldnotes/sync-server": "0.10.1",
     "redis": "^4.7.0"

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -48,11 +48,6 @@ export interface DmBattleMapCanvasProps {
   tokenInfoToggle: { mode: TokenInfoMode | null; onCycle: () => void };
 }
 
-/** Viewport exposes historyRecorder at runtime for batched store ops. */
-type ViewportHistoryAccess = {
-  historyRecorder: { begin: () => void; commit: () => void };
-};
-
 const DRAWING_TYPES = new Set(['stroke', 'arrow', 'template']);
 
 export interface DmBattleMapCanvasState {
@@ -287,13 +282,7 @@ export function useDmBattleMapCanvas({
     if (!window.confirm('Clear all drawings (pencil, arrows, templates)?')) {
       return;
     }
-    const { historyRecorder } = viewport as unknown as ViewportHistoryAccess;
-    historyRecorder.begin();
-    for (const id of ids) {
-      viewport.store.remove(id);
-    }
-    historyRecorder.commit();
-    viewport.requestRender();
+    viewport.removeElements(ids);
   }, [viewport]);
 
   const handleToggleHiddenPlacement = useCallback(() => {

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -62,11 +62,6 @@ function proxyUrl(url: string): string {
   return url;
 }
 
-/** Viewport exposes historyRecorder at runtime for batched store ops */
-type ViewportHistoryAccess = {
-  historyRecorder: { begin: () => void; commit: () => void };
-};
-
 /** Upload to S3 via /api/assets/upload; base64 data-URL fallback when S3 is
  *  not configured. Returns the canonical (non-proxied) src to store. */
 async function uploadCanvasImage(file: File): Promise<string> {
@@ -680,13 +675,7 @@ export function useDmLocationEditor(
       vp.store.getById(id)
     );
     if (ids.length === 0) return;
-    const { historyRecorder } = vp as unknown as ViewportHistoryAccess;
-    historyRecorder.begin();
-    for (const id of ids) {
-      vp.store.remove(id);
-    }
-    historyRecorder.commit();
-    vp.requestRender();
+    vp.removeElements(ids);
     setSelectedElementId(null);
   }, [getVp]);
 

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -85,11 +85,6 @@ interface PlayerBattleMapCanvasProps {
   tokenInfoToggle?: { mode: TokenInfoMode | null; onCycle: () => void };
 }
 
-/** Viewport exposes historyRecorder at runtime for batched store ops. */
-type ViewportHistoryAccess = {
-  historyRecorder: { begin: () => void; commit: () => void };
-};
-
 const PLAYER_TOOLS: {
   name: string;
   label: string;
@@ -340,14 +335,8 @@ export function PlayerBattleMapCanvas({
     if (!selectTool) return;
     const ids = selectTool.selectedIds.filter(id => vp.store.getById(id));
     if (ids.length === 0) return;
-    const { historyRecorder } = vp as unknown as ViewportHistoryAccess;
-    historyRecorder.begin();
-    for (const id of ids) {
-      vp.store.remove(id);
-    }
-    historyRecorder.commit();
+    vp.removeElements(ids);
     selectTool.setSelection([]);
-    vp.requestRender();
   }, [viewport]);
 
   useEffect(() => () => connectionRef.current?.stop(), []);

--- a/src/components/ui/campaign/location-map/__tests__/DmLocationEditor.hooks.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/DmLocationEditor.hooks.test.ts
@@ -64,6 +64,15 @@ function makeStubViewport() {
     removeGrid: vi.fn(),
     addGrid: vi.fn(),
     updateGrid: vi.fn(),
+    removeElements: vi.fn((ids: Iterable<string>) => {
+      let removed = 0;
+      for (const id of new Set(ids)) {
+        if (!store.getById(id)) continue;
+        store.remove(id);
+        removed += 1;
+      }
+      return removed;
+    }),
     requestRender: vi.fn(),
   };
   return { vp: vp as unknown as Viewport, store, elementId };
@@ -104,7 +113,7 @@ async function setup(mode: 'location' | 'battlemap') {
   });
   // Sanity: syncSelection picked up the stub's single selected element.
   expect(result.current.selectedElementId).toBe(elementId);
-  return { store, result, elementId };
+  return { vp, store, result, elementId };
 }
 
 describe('useDmLocationEditor — handleToggleDmOnly mode gating', () => {
@@ -120,6 +129,17 @@ describe('useDmLocationEditor — handleToggleDmOnly mode gating', () => {
       process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL = savedRelayUrl;
     }
     vi.clearAllMocks();
+  });
+
+  it('deletes the selection through the public Fieldnotes batch API', async () => {
+    const { vp, store, result, elementId } = await setup('location');
+
+    act(() => {
+      result.current.handleDeleteSelected();
+    });
+
+    expect(vp.removeElements).toHaveBeenCalledWith([elementId]);
+    expect(store.getById(elementId)).toBeUndefined();
   });
 
   it('location mode: toggling visibility does NOT touch the canvas store (no dirty/save side effects)', async () => {

--- a/src/prototypes/notes-module/FieldNotesDemoPanels.tsx
+++ b/src/prototypes/notes-module/FieldNotesDemoPanels.tsx
@@ -86,11 +86,6 @@ const TOOL_DEFS: {
   { name: 'laser', icon: Zap, label: 'Laser Pointer' },
 ];
 
-/** Viewport exposes historyRecorder for batched deletes (same as keyboard). */
-type ViewportHistoryAccess = {
-  historyRecorder: { begin: () => void; commit: () => void };
-};
-
 const ALIGN_BUTTONS: {
   edge: AlignEdge;
   icon: typeof AlignStartHorizontal;
@@ -374,13 +369,7 @@ export function FieldNotesDemoToolbar({
 
   const handleDeleteSelected = () => {
     if (selectedIds.length === 0) return;
-    const { historyRecorder } = viewport as unknown as ViewportHistoryAccess;
-    historyRecorder.begin();
-    for (const id of selectedIds) {
-      viewport.store.remove(id);
-    }
-    historyRecorder.commit();
-    viewport.requestRender();
+    viewport.removeElements(selectedIds);
   };
 
   const handleExport = () => {


### PR DESCRIPTION
## Summary

Adopts the public Fieldnotes transaction API released in `@fieldnotes/core@0.53.0`.

This replaces all four private `historyRecorder` casts with `Viewport.removeElements()` in:

- Player battle maps.
- DM location maps.
- DM VTT battle maps.
- The Fieldnotes prototype.

Both npm lockfiles resolve the published registry release.

## Paired Fieldnotes change

- Fieldnotes PR: IrakliDevelop/fieldnotes#135
- Published package: `@fieldnotes/core@0.53.0`

## Tests

- Added focused RollKeeper unit coverage proving deletion delegates to `removeElements()`.
- RollKeeper type-check passed.
- RollKeeper unit suite passed: 3,579 passed and 1 skipped.
- Relay type-check passed.
- Relay suite passed: 45/45.
- Prettier and diff checks passed.
