### PR TITLE
fix(relay): adopt server presence broadcast

### DIFF
--- a/relay/README.md
+++ b/relay/README.md
@@ -6,13 +6,18 @@ Auth = short-lived HMAC tokens minted by the Next.js app (`/api/campaign/[code]/
 
 ## Env
 
-| Var | Required | Notes |
-|---|---|---|
+| Var                      | Required | Notes                                                                                           |
+| ------------------------ | -------- | ----------------------------------------------------------------------------------------------- |
 | `BATTLEMAP_RELAY_SECRET` | yes | must equal the Vercel app's value |
 | `PORT` | no | Railway injects it; default 8787 |
-| `REDIS_URL` | no | e.g. `rediss://default:<pass>@<host>:6379` (Upstash TCP). Unset → in-memory |
+| `REDIS_URL` | no | Upstash TCP URL; enables buffered persistence and cross-instance ephemeral presence/poke fan-out |
 | `FLUSH_INTERVAL_MS` | no | default 3000 |
 | `ROOM_TTL_SECONDS` | no | default 172800 (2 days) |
+
+When Redis is enabled, the relay opens one backend connection plus dedicated publish and subscribe
+connections. Fan-out is intentionally limited to presence traffic because the buffered backend is
+memory-first and not a shared canonical backend. Durable canvas operations remain instance-local;
+server pokes, client presence, and disconnect presence leave events cross relay instances.
 
 ## Local dev
 

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@fieldnotes/core": "0.53.0",
         "@fieldnotes/sync": "0.7.1",
-        "@fieldnotes/sync-server": "0.10.2",
+        "@fieldnotes/sync-redis": "0.3.2",
+        "@fieldnotes/sync-server": "0.11.0",
         "redis": "^4.7.0"
       },
       "devDependencies": {
@@ -482,10 +483,19 @@
         "@fieldnotes/core": ">=0.46.0 <1.0.0"
       }
     },
+    "node_modules/@fieldnotes/sync-redis": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync-redis/-/sync-redis-0.3.2.tgz",
+      "integrity": "sha512-O98mLte63KfAsMaWoH5mnTbdYswK6X29Ul0sJgIZddZnwORON5HrIAl9Nf1UHRGSRqHa4jgHCX1StoK7g4HpgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fieldnotes/sync": "0.7.1"
+      }
+    },
     "node_modules/@fieldnotes/sync-server": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync-server/-/sync-server-0.10.2.tgz",
-      "integrity": "sha512-VZLNoeph2S2M6lZnoOKc6qM6buePDD0J/2SaqwzxgRG4+1eQFNBRI8Og/GGX0p9syiID5aNFyd8R568GAXXrrQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync-server/-/sync-server-0.11.0.tgz",
+      "integrity": "sha512-d4UX5OwzdVc1rfGHhVI3FMs7Km49+koCv3owyoNeIFWyDJE0aWmbxikGjYC2cogysVCeZiPeg9lX5Ra8TxE6kw==",
       "license": "MIT",
       "dependencies": {
         "@fieldnotes/sync": "0.7.1",

--- a/relay/package.json
+++ b/relay/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@fieldnotes/core": "0.53.0",
     "@fieldnotes/sync": "0.7.1",
-    "@fieldnotes/sync-server": "0.10.2",
+    "@fieldnotes/sync-redis": "0.3.2",
+    "@fieldnotes/sync-server": "0.11.0",
     "redis": "^4.7.0"
   },
   "devDependencies": {

--- a/relay/src/ephemeral-fanout.test.ts
+++ b/relay/src/ephemeral-fanout.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { InMemoryHubFanout } from '@fieldnotes/sync-server';
+import { EphemeralHubFanout } from './ephemeral-fanout.js';
+
+const payload = (kind: string): string => JSON.stringify({ op: { kind } });
+
+describe('EphemeralHubFanout', () => {
+  it('publishes presence and leave while dropping durable and malformed payloads', () => {
+    const inner = new InMemoryHubFanout();
+    const fanout = new EphemeralHubFanout(inner);
+    const seen = vi.fn();
+    inner.subscribe(seen);
+
+    fanout.publish(payload('presence'));
+    fanout.publish(payload('presence-leave'));
+    fanout.publish(payload('upsert'));
+    fanout.publish('not json');
+
+    expect(
+      seen.mock.calls.map(([message]) => JSON.parse(message).op.kind)
+    ).toEqual(['presence', 'presence-leave']);
+  });
+
+  it('filters inbound payloads before notifying hub subscribers', () => {
+    const inner = new InMemoryHubFanout();
+    const fanout = new EphemeralHubFanout(inner);
+    const seen = vi.fn();
+    fanout.subscribe(seen);
+
+    inner.publish(payload('clear'));
+    inner.publish(payload('presence'));
+
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(seen.mock.calls[0]?.[0] as string).op.kind).toBe(
+      'presence'
+    );
+  });
+});

--- a/relay/src/ephemeral-fanout.ts
+++ b/relay/src/ephemeral-fanout.ts
@@ -1,0 +1,35 @@
+import type { HubFanout } from '@fieldnotes/sync-server';
+
+function isEphemeralPayload(payload: string): boolean {
+  try {
+    const value = JSON.parse(payload) as { op?: { kind?: unknown } };
+    return value.op?.kind === 'presence' || value.op?.kind === 'presence-leave';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Restricts a shared fan-out to ephemeral traffic. RollKeeper's buffered Redis
+ * backend is intentionally memory-first and not a shared canonical backend, so
+ * durable operations must not be forwarded across instances until that backend
+ * contract is replaced.
+ */
+export class EphemeralHubFanout implements HubFanout {
+  constructor(private readonly inner: HubFanout) {}
+
+  publish(payload: string): void | Promise<void> {
+    if (!isEphemeralPayload(payload)) return;
+    return this.inner.publish(payload);
+  }
+
+  subscribe(handler: (payload: string) => void): () => void {
+    return this.inner.subscribe(payload => {
+      if (isEphemeralPayload(payload)) handler(payload);
+    });
+  }
+
+  close(): void {
+    this.inner.close?.();
+  }
+}

--- a/relay/src/poke.test.ts
+++ b/relay/src/poke.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import type { SyncHub } from '@fieldnotes/sync-server';
+import { InMemoryHubFanout, SyncHub } from '@fieldnotes/sync-server';
 import WebSocket from 'ws';
 import { pokeRoom, handlePokeRequest } from './poke.js';
 import { signBattleMapToken } from './token.js';
@@ -9,22 +9,16 @@ import { startRelay, type RelayHandle } from './server.js';
 const SECRET = 'test-secret';
 const ROOM = 'CAMP1:map-42';
 
-/** Mirrors the real `SyncHub` shape: `rooms` maps room -> connection ids,
- * and the actual connection objects (with `send`) live in `conns`. */
 function fakeHub(rooms: Record<string, { send: (m: string) => void }[]>) {
-  const conns = new Map<string, { send: (m: string) => void }>();
-  const roomMap = new Map<string, Set<string>>();
+  const hub = new SyncHub();
   let counter = 0;
   for (const [room, list] of Object.entries(rooms)) {
-    const ids = new Set<string>();
     for (const conn of list) {
       const id = `c${++counter}`;
-      conns.set(id, conn);
-      ids.add(id);
+      hub.addConnection({ id, room, send: conn.send });
     }
-    roomMap.set(room, ids);
   }
-  return { rooms: roomMap, conns } as unknown as SyncHub;
+  return hub;
 }
 
 /** Minimal async-iterable POST request carrying a JSON body. */
@@ -69,7 +63,7 @@ describe('pokeRoom', () => {
 
     expect(sent).toBe(2);
     const expected = JSON.stringify({
-      from: '@poke',
+      from: 'hub',
       op: { kind: 'presence', data: { kind: 'poke', feature: 'initiative' } },
     });
     expect(a.send).toHaveBeenCalledWith(expected);
@@ -232,9 +226,78 @@ describe('poke integration (real relay)', () => {
               'poke'
         );
       expect(pokeMessage).toEqual({
-        from: '@poke',
+        from: 'hub',
         op: { kind: 'presence', data: { kind: 'poke', feature: 'initiative' } },
       });
     });
+  });
+});
+
+describe('cross-instance poke integration (real relays)', () => {
+  const handles: RelayHandle[] = [];
+  let socket: WebSocket | null = null;
+
+  afterEach(async () => {
+    socket?.close();
+    socket = null;
+    await Promise.all(handles.splice(0).map(handle => handle.close()));
+  });
+
+  it('fans a poke from one relay to a room member on another relay', async () => {
+    const fanout = new InMemoryHubFanout();
+    const origin = await startRelay({ secret: SECRET, port: 0, fanout });
+    const remote = await startRelay({ secret: SECRET, port: 0, fanout });
+    handles.push(origin, remote);
+    socket = new WebSocket(
+      `ws://127.0.0.1:${remote.address().port}?room=${encodeURIComponent(ROOM)}&token=${encodeURIComponent(
+        signBattleMapToken(
+          {
+            userId: 'p1',
+            role: 'player',
+            room: ROOM,
+            exp: Date.now() + 30_000,
+          },
+          SECRET
+        )
+      )}`
+    );
+    const messages: Envelope[] = [];
+    socket.on('message', data =>
+      messages.push(JSON.parse(String(data)) as Envelope)
+    );
+    await vi.waitFor(() => expect(socket?.readyState).toBe(WebSocket.OPEN));
+    socket.send(
+      JSON.stringify({ from: 'ready-remote', op: { kind: 'request-snapshot' } })
+    );
+    await vi.waitFor(() =>
+      expect(
+        messages.some(
+          message =>
+            message.op.kind === 'snapshot' && message.op.to === 'ready-remote'
+        )
+      ).toBe(true)
+    );
+    messages.length = 0;
+
+    const response = await fetch(
+      `http://127.0.0.1:${origin.address().port}/poke`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          room: ROOM,
+          feature: 'roster',
+          token: dmToken(),
+        }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ sent: 0 });
+    await vi.waitFor(() =>
+      expect(messages).toContainEqual({
+        from: 'hub',
+        op: { kind: 'presence', data: { kind: 'poke', feature: 'roster' } },
+      })
+    );
   });
 });

--- a/relay/src/poke.ts
+++ b/relay/src/poke.ts
@@ -2,47 +2,13 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { SyncHub } from '@fieldnotes/sync-server';
 import { verifyBattleMapToken } from './token.js';
 
-/** Narrow structural view of the hub's private registries — same
- * private-access workaround. `rooms` maps room -> connection
- * ids; the actual connection objects (with `send`) live in `conns`. */
-interface RoomConnection {
-  send(message: string): void;
-}
-interface HubInternals {
-  rooms: Map<string, Set<string>>;
-  conns: Map<string, RoomConnection>;
-}
-
 /**
- * Broadcasts a content-free poke to every socket in a room as a synthetic
- * presence message. Bypasses `broadcastPresence` deliberately: that method
- * records `presenceIds` (driving presence-leave on disconnect) and skips the
- * sender connection — neither applies to a server-originated poke.
- * The sync client's presence dispatch is stateless, so `from: '@poke'`
- * pollutes no client-side bookkeeping.
- * NOTE: broadcasts only to locally-connected sockets (bypasses hub fanout) — fine for single-instance deploy; revisit if relay runs multiple instances.
+ * Broadcasts a content-free poke as server-owned ephemeral presence. The
+ * returned count covers this relay instance; configured hub fan-out delivers
+ * the same poke to room members connected to other instances.
  */
 export function pokeRoom(hub: SyncHub, room: string, feature: string): number {
-  const internals = hub as unknown as HubInternals;
-  const memberIds = internals.rooms.get(room);
-  if (!memberIds || memberIds.size === 0) return 0;
-  const message = JSON.stringify({
-    from: '@poke',
-    op: { kind: 'presence', data: { kind: 'poke', feature } },
-  });
-  let sent = 0;
-  for (const id of memberIds) {
-    const conn = internals.conns.get(id);
-    if (!conn) continue;
-    try {
-      conn.send(message);
-      sent++;
-    } catch (err) {
-      // dead socket — the heartbeat reaps it; poke is best-effort
-      console.warn('[poke] send failed:', err);
-    }
-  }
-  return sent;
+  return hub.broadcastPresence(room, { kind: 'poke', feature });
 }
 
 const MAX_BODY_BYTES = 4096;

--- a/relay/src/reservedSenders.test.ts
+++ b/relay/src/reservedSenders.test.ts
@@ -120,8 +120,7 @@ describe('server-owned presence senders (real relay)', () => {
     );
     expect(forged?.from).toEqual(expect.stringMatching(/^c\d+-/));
 
-    // 3) A real server poke must still be delivered — pokeRoom bypasses
-    // broadcastPresence entirely, so it must be unaffected by the patch.
+    // 3) A real server poke uses the hub's server-owned presence identity.
     const response = await fetch(`http://127.0.0.1:${port}/poke`, {
       method: 'POST',
       body: JSON.stringify({
@@ -136,12 +135,12 @@ describe('server-owned presence senders (real relay)', () => {
     await vi.waitFor(() => {
       const pokeMessage = bMessages.find(
         m =>
-          m.from === '@poke' &&
+          m.from === 'hub' &&
           (m as { op?: { data?: { kind?: unknown } } }).op?.data?.kind ===
             'poke'
       );
       expect(pokeMessage).toEqual({
-        from: '@poke',
+        from: 'hub',
         op: { kind: 'presence', data: { kind: 'poke', feature: 'initiative' } },
       });
     });

--- a/relay/src/server.ts
+++ b/relay/src/server.ts
@@ -2,9 +2,11 @@ import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { createClient } from 'redis';
 import { createSyncServer } from '@fieldnotes/sync-server';
-import type { HubBackend, SyncHub } from '@fieldnotes/sync-server';
+import type { HubBackend, HubFanout, SyncHub } from '@fieldnotes/sync-server';
+import { RedisHubFanout } from '@fieldnotes/sync-redis';
 import { makePolicies } from './policies.js';
 import { BufferedRedisBackend } from './backend.js';
+import { EphemeralHubFanout } from './ephemeral-fanout.js';
 import { handlePokeRequest } from './poke.js';
 
 export interface StartRelayOptions {
@@ -13,6 +15,8 @@ export interface StartRelayOptions {
   port?: number;
   /** Override the storage backend (e.g. MemoryHubBackend in tests). */
   backend?: HubBackend;
+  /** Cross-instance ephemeral and durable-operation fan-out. */
+  fanout?: HubFanout;
 }
 
 export interface RelayHandle {
@@ -55,6 +59,7 @@ export async function startRelay(
     server,
     ...policies,
     ...(opts.backend ? { backend: opts.backend } : {}),
+    ...(opts.fanout ? { fanout: opts.fanout } : {}),
   });
 
   pokeHandler = (req, res) =>
@@ -87,6 +92,9 @@ async function main(): Promise<void> {
 
   let backend: BufferedRedisBackend | undefined;
   let redisClient: ReturnType<typeof createClient> | undefined;
+  let fanoutPublisher: ReturnType<typeof createClient> | undefined;
+  let fanoutSubscriber: ReturnType<typeof createClient> | undefined;
+  let fanout: RedisHubFanout | undefined;
   if (process.env.REDIS_URL) {
     redisClient = createClient({ url: process.env.REDIS_URL });
     redisClient.on('error', err => console.error('[redis]', err));
@@ -95,20 +103,41 @@ async function main(): Promise<void> {
       flushIntervalMs: Number(process.env.FLUSH_INTERVAL_MS ?? 3000),
       roomTtlSeconds: Number(process.env.ROOM_TTL_SECONDS ?? 172800),
     });
-    console.log('[relay] using buffered Redis backend');
+    fanoutPublisher = redisClient.duplicate();
+    fanoutSubscriber = redisClient.duplicate();
+    fanoutPublisher.on('error', err =>
+      console.error('[redis:fanout:publish]', err)
+    );
+    fanoutSubscriber.on('error', err =>
+      console.error('[redis:fanout:subscribe]', err)
+    );
+    await Promise.all([fanoutPublisher.connect(), fanoutSubscriber.connect()]);
+    fanout = new RedisHubFanout(fanoutPublisher, fanoutSubscriber, {
+      onError: err => console.error('[redis:fanout]', err),
+    });
+    console.log(
+      '[relay] using buffered Redis backend and cross-instance presence fanout'
+    );
   } else {
     console.log(
       '[relay] REDIS_URL not set — in-memory rooms (state lost on restart)'
     );
   }
 
-  const { close } = await startRelay({ secret, port, backend });
+  const { close } = await startRelay({
+    secret,
+    port,
+    backend,
+    fanout: fanout ? new EphemeralHubFanout(fanout) : undefined,
+  });
   console.log(`[relay] listening on :${port}`);
 
   const shutdown = async (): Promise<void> => {
     console.log('[relay] shutting down…');
     await close();
     await backend?.stopAndFlush();
+    await fanoutSubscriber?.quit();
+    await fanoutPublisher?.quit();
     await redisClient?.quit();
     process.exit(0);
   };

--- a/src/lib/__tests__/battlemapPokeListener.test.ts
+++ b/src/lib/__tests__/battlemapPokeListener.test.ts
@@ -16,7 +16,7 @@ const mockMint = vi.mocked(mintBattleMapToken);
 
 const pokeEnvelope = (feature: string): string =>
   JSON.stringify({
-    from: '@poke',
+    from: 'hub',
     op: { kind: 'presence', data: { kind: 'poke', feature } },
   });
 

--- a/src/lib/__tests__/battlemapSync.poke.test.ts
+++ b/src/lib/__tests__/battlemapSync.poke.test.ts
@@ -7,7 +7,7 @@ import {
 import type { ElementStore } from '@fieldnotes/core';
 
 const POKE_RAW = JSON.stringify({
-  from: '@poke',
+  from: 'hub',
   op: { kind: 'presence', data: { kind: 'poke', feature: 'initiative' } },
 });
 
@@ -27,13 +27,13 @@ describe('pokeFeatureFromEnvelope', () => {
     ).toBeNull();
     expect(
       pokeFeatureFromEnvelope(
-        JSON.stringify({ from: '@poke', op: { kind: 'upsert' } })
+        JSON.stringify({ from: 'hub', op: { kind: 'upsert' } })
       )
     ).toBeNull();
     expect(pokeFeatureFromEnvelope('not json')).toBeNull();
     expect(
       pokeFeatureFromEnvelope(
-        JSON.stringify({ from: '@poke', op: { kind: 'presence', data: {} } })
+        JSON.stringify({ from: 'hub', op: { kind: 'presence', data: {} } })
       )
     ).toBeNull();
   });

--- a/src/lib/battlemapSync.ts
+++ b/src/lib/battlemapSync.ts
@@ -42,7 +42,7 @@ export function computeSeedIds(
   return local.filter(el => !presentIds.has(el.id)).map(el => el.id);
 }
 
-/** Parses a relay poke envelope: `{from:'@poke', op:{kind:'presence', data:{kind:'poke', feature}}}`. */
+/** Parses a server-owned relay poke presence envelope. */
 export function pokeFeatureFromEnvelope(raw: string): string | null {
   let env: {
     from?: string;
@@ -53,7 +53,7 @@ export function pokeFeatureFromEnvelope(raw: string): string | null {
   } catch {
     return null;
   }
-  if (env?.from !== '@poke') return null;
+  if (env?.from !== 'hub') return null;
   const op = env.op;
   if (op?.kind !== 'presence' || op.data?.kind !== 'poke') return null;
   return typeof op.data.feature === 'string' ? op.data.feature : null;


### PR DESCRIPTION
## Outcome
- update relay to published `@fieldnotes/sync-server@0.11.0`
- add published `@fieldnotes/sync-redis@0.3.2` for Redis pub/sub
- replace all private `SyncHub` room/connection access in `relay/src/poke.ts` with `hub.broadcastPresence`
- switch product poke parsing from the synthetic `@poke` sender to server-owned `hub`
- configure cross-instance Redis presence fan-out when `REDIS_URL` is set
- keep durable mutation fan-out disabled because RollKeeper’s buffered backend is memory-first, not a shared canonical backend

Paired with Fieldnotes PR #137 and manual npm release `@fieldnotes/sync-server@0.11.0`.

## Verification
- focused real two-relay poke integration passes, including remote delivery when origin reports `{ sent: 0 }`
- ephemeral fan-out publish/subscribe filtering: 2/2 passed
- relay: 48/48 tests passed
- relay build and type-check passed
- RollKeeper: 3,579 tests passed, 1 skipped
- RollKeeper type-check passed
- changed-file formatting and `git diff --check` passed

Desktop/touch checks are N/A because this is server transport and message parsing behavior with real WebSocket integration coverage.