### PR TITLE
refactor(battlemap): adopt managed sync lifecycle from @fieldnotes/sync 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/client-s3": "^3.922.0",
         "@fieldnotes/core": "^0.53.0",
         "@fieldnotes/react": "^0.8.0",
-        "@fieldnotes/sync": "^0.7.1",
+        "@fieldnotes/sync": "^0.8.0",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "1.1.15",
         "@radix-ui/react-form": "^0.1.7",
@@ -2193,9 +2193,9 @@
       }
     },
     "node_modules/@fieldnotes/sync": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.7.1.tgz",
-      "integrity": "sha512-gpnErIhWe/ClJX9sgOwRQscFMbjSwNhYp7IimtT9HyuYuyMdy27ETtgoskYyHvKwDley++PrQGL+tLGkjkNE8g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.8.0.tgz",
+      "integrity": "sha512-ZXpV7kLVjaWfqfOqJ9kEF6BuYYnRpuO6du+jTrJ1rUdC6qddO2R5CA/GHuY7ozMgSHQmK9LhNi44g1CAJcvvSw==",
       "license": "MIT",
       "peerDependencies": {
         "@fieldnotes/core": ">=0.46.0 <1.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@aws-sdk/client-s3": "^3.922.0",
     "@fieldnotes/core": "^0.53.0",
     "@fieldnotes/react": "^0.8.0",
-    "@fieldnotes/sync": "^0.7.1",
+    "@fieldnotes/sync": "^0.8.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-form": "^0.1.7",

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fieldnotes/core": "0.53.0",
-        "@fieldnotes/sync": "0.7.1",
+        "@fieldnotes/sync": "0.8.0",
         "@fieldnotes/sync-redis": "0.3.2",
         "@fieldnotes/sync-server": "0.11.0",
         "redis": "^4.7.0"
@@ -475,9 +475,9 @@
       "license": "MIT"
     },
     "node_modules/@fieldnotes/sync": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.7.1.tgz",
-      "integrity": "sha512-gpnErIhWe/ClJX9sgOwRQscFMbjSwNhYp7IimtT9HyuYuyMdy27ETtgoskYyHvKwDley++PrQGL+tLGkjkNE8g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.8.0.tgz",
+      "integrity": "sha512-ZXpV7kLVjaWfqfOqJ9kEF6BuYYnRpuO6du+jTrJ1rUdC6qddO2R5CA/GHuY7ozMgSHQmK9LhNi44g1CAJcvvSw==",
       "license": "MIT",
       "peerDependencies": {
         "@fieldnotes/core": ">=0.46.0 <1.0.0"
@@ -492,6 +492,15 @@
         "@fieldnotes/sync": "0.7.1"
       }
     },
+    "node_modules/@fieldnotes/sync-redis/node_modules/@fieldnotes/sync": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.7.1.tgz",
+      "integrity": "sha512-gpnErIhWe/ClJX9sgOwRQscFMbjSwNhYp7IimtT9HyuYuyMdy27ETtgoskYyHvKwDley++PrQGL+tLGkjkNE8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fieldnotes/core": ">=0.46.0 <1.0.0"
+      }
+    },
     "node_modules/@fieldnotes/sync-server": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@fieldnotes/sync-server/-/sync-server-0.11.0.tgz",
@@ -500,6 +509,15 @@
       "dependencies": {
         "@fieldnotes/sync": "0.7.1",
         "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@fieldnotes/sync-server/node_modules/@fieldnotes/sync": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.7.1.tgz",
+      "integrity": "sha512-gpnErIhWe/ClJX9sgOwRQscFMbjSwNhYp7IimtT9HyuYuyMdy27ETtgoskYyHvKwDley++PrQGL+tLGkjkNE8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fieldnotes/core": ">=0.46.0 <1.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {

--- a/relay/package.json
+++ b/relay/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@fieldnotes/core": "0.53.0",
-    "@fieldnotes/sync": "0.7.1",
+    "@fieldnotes/sync": "0.8.0",
     "@fieldnotes/sync-redis": "0.3.2",
     "@fieldnotes/sync-server": "0.11.0",
     "redis": "^4.7.0"

--- a/src/lib/battlemapSync.test.ts
+++ b/src/lib/battlemapSync.test.ts
@@ -7,15 +7,9 @@ import {
   type BattleMapTransport,
 } from '@/lib/battlemapSync';
 
-// SyncClient internals are not under test — stub it (and the never-constructed
-// WebSocketTransport, since tests inject transportFactory).
-vi.mock('@fieldnotes/sync', () => ({
-  // constructible stub (arrow functions cannot be `new`-ed)
-  SyncClient: vi.fn().mockImplementation(function (this: unknown) {
-    return { start: vi.fn(), stop: vi.fn() };
-  }),
-  WebSocketTransport: vi.fn(),
-}));
+// No @fieldnotes/sync mocking: the real managed lifecycle + SyncClient run
+// against an injected fake transport, so these tests exercise the actual
+// adoption seam (RollKeeper glue over createManagedSyncConnection).
 
 const el = (id: string) => ({ id }) as CanvasElement;
 
@@ -35,6 +29,7 @@ describe('computeSeedIds', () => {
 
 class FakeTransport implements BattleMapTransport {
   sent: string[] = [];
+  closed = false;
   private msgHandlers = new Set<(message: string) => void>();
   private reconnectHandlers = new Set<() => void>();
   private closeHandlers = new Set<(code: number, reason: string) => void>();
@@ -54,10 +49,18 @@ class FakeTransport implements BattleMapTransport {
     this.closeHandlers.add(handler);
     return () => this.closeHandlers.delete(handler);
   }
-  close(): void {}
+  close(): void {
+    this.closed = true;
+    this.msgHandlers.clear();
+    this.reconnectHandlers.clear();
+    this.closeHandlers.clear();
+  }
 
   emitMessage(message: string): void {
     for (const h of [...this.msgHandlers]) h(message);
+  }
+  emitClose(code: number): void {
+    for (const h of [...this.closeHandlers]) h(code, '');
   }
 }
 
@@ -66,6 +69,9 @@ interface FakeStore {
   getById: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
   add: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+  clear: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
   /** test helper: simulate SyncClient's destructive reconcile deleting an id */
   simulateRemove: (id: string) => void;
 }
@@ -79,6 +85,14 @@ function makeFakeStore(initial: CanvasElement[]): FakeStore {
     add: vi.fn((element: CanvasElement) => {
       elements.push(element);
     }),
+    remove: vi.fn((id: string) => {
+      elements = elements.filter(e => e.id !== id);
+    }),
+    clear: vi.fn(() => {
+      elements = [];
+    }),
+    // the real SyncClient subscribes to store mutations on start()
+    on: vi.fn(() => () => {}),
     simulateRemove: (id: string) => {
       elements = elements.filter(e => e.id !== id);
     },
@@ -95,27 +109,32 @@ const snapshotEnvelope = (to: string, ids: string[]): string =>
 const flush = (): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, 0));
 
-describe('createManagedBattleMapConnection snapshot watcher', () => {
+describe('createManagedBattleMapConnection', () => {
   let fakeTransport: FakeTransport;
+  let transportUrls: string[];
   let statuses: BattleMapConnectionStatus[];
+  let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     fakeTransport = new FakeTransport();
+    transportUrls = [];
     statuses = [];
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ token: 'test-token' }),
-      })
-    );
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: 'test-token' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  const startConnection = async (store: FakeStore, seedLocal = true) => {
+  const startConnection = async (
+    store: FakeStore,
+    seedLocal = true,
+    onPoke?: (feature: string) => void
+  ) => {
     const conn = createManagedBattleMapConnection({
       relayUrl: 'wss://relay.example',
       campaignCode: 'CODE',
@@ -125,19 +144,46 @@ describe('createManagedBattleMapConnection snapshot watcher', () => {
       tokenRequest: { role: 'dm', battleMapId: 'map-1', dmId: 'dm-1' },
       seedLocal,
       onStatus: s => statuses.push(s),
-      transportFactory: () => fakeTransport,
+      onPoke,
+      transportFactory: url => {
+        transportUrls.push(url);
+        return fakeTransport;
+      },
     });
     // let the async connect() (token fetch) finish and wire the transport
     await flush();
     return conn;
   };
 
+  it('mints via the campaign token route and connects with a room+token URL', async () => {
+    const store = makeFakeStore([]);
+    const conn = await startConnection(store);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/campaign/CODE/battlemap-token',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(transportUrls).toEqual([
+      'wss://relay.example?room=CODE%3Amap-1&token=test-token',
+    ]);
+    // the SyncClient announces itself with the stable clientId
+    const first = JSON.parse(fakeTransport.sent[0]) as {
+      from: string;
+      op: { kind: string };
+    };
+    expect(first.from).toBe('dm-1');
+    expect(first.op.kind).toBe('request-snapshot');
+
+    conn.stop();
+  });
+
   it('goes live and seeds missing local elements on a snapshot addressed to us', async () => {
     const store = makeFakeStore([el('a'), el('b'), el('c')]);
     const conn = await startConnection(store);
+    expect(statuses).toEqual(['connecting']);
 
     fakeTransport.emitMessage(snapshotEnvelope('dm-1', ['b']));
-    expect(statuses).toContain('live');
+    expect(statuses).toEqual(['connecting', 'live']);
 
     await flush(); // run the deferred seed
     expect(store.update).toHaveBeenCalledWith('a', {});
@@ -193,7 +239,7 @@ describe('createManagedBattleMapConnection snapshot watcher', () => {
     const before = [...statuses];
 
     fakeTransport.emitMessage(
-      JSON.stringify({ from: 'peer', op: { kind: 'upsert', element: el('x') } })
+      JSON.stringify({ from: 'peer', op: { kind: 'presence', data: {} } })
     );
     await flush();
 
@@ -202,5 +248,85 @@ describe('createManagedBattleMapConnection snapshot watcher', () => {
     expect(store.add).not.toHaveBeenCalled();
 
     conn.stop();
+  });
+
+  it('delivers hub pokes to onPoke and ignores non-hub or non-poke frames', async () => {
+    const store = makeFakeStore([]);
+    const pokes: string[] = [];
+    const conn = await startConnection(store, false, f => pokes.push(f));
+
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'hub',
+        op: { kind: 'presence', data: { kind: 'poke', feature: 'initiative' } },
+      })
+    );
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'someone-else',
+        op: { kind: 'presence', data: { kind: 'poke', feature: 'roster' } },
+      })
+    );
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'hub',
+        op: { kind: 'presence', data: { kind: 'cursor' } },
+      })
+    );
+
+    expect(pokes).toEqual(['initiative']);
+    conn.stop();
+  });
+
+  it('reports denied after bounded consecutive 4401 closes (token no longer accepted)', async () => {
+    vi.useFakeTimers();
+    try {
+      const store = makeFakeStore([]);
+      const conn = createManagedBattleMapConnection({
+        relayUrl: 'wss://relay.example',
+        campaignCode: 'CODE',
+        battleMapId: 'map-1',
+        store: store as unknown as ElementStore,
+        clientId: 'dm-1',
+        tokenRequest: { role: 'dm', battleMapId: 'map-1', dmId: 'dm-1' },
+        onStatus: s => statuses.push(s),
+        transportFactory: url => {
+          transportUrls.push(url);
+          return fakeTransport;
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0); // token mint 1 resolves
+
+      // Each terminal auth close tears the connection down; the managed
+      // lifecycle re-mints and rebuilds until the auth budget (4) is
+      // exhausted, then settles on terminal denied.
+      for (let i = 0; i < 3; i += 1) {
+        fakeTransport.emitClose(4401);
+        expect(statuses[statuses.length - 1]).toBe('offline');
+        await vi.advanceTimersByTimeAsync(20_000); // backoff + next mint
+      }
+      fakeTransport.emitClose(4401); // 4th consecutive auth failure
+
+      expect(statuses[statuses.length - 1]).toBe('denied');
+      expect(transportUrls).toHaveLength(4); // one mint per auth attempt
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(transportUrls).toHaveLength(4); // denied is terminal — no re-mint
+      conn.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stop() prevents the deferred seed from mutating the store', async () => {
+    const store = makeFakeStore([el('a')]);
+    const conn = await startConnection(store);
+
+    fakeTransport.emitMessage(snapshotEnvelope('dm-1', []));
+    conn.stop(); // before the deferred seed macrotask runs
+    await flush();
+
+    expect(store.update).not.toHaveBeenCalled();
+    expect(store.add).not.toHaveBeenCalled();
+    expect(fakeTransport.closed).toBe(true);
   });
 });

--- a/src/lib/battlemapSync.ts
+++ b/src/lib/battlemapSync.ts
@@ -1,12 +1,12 @@
-import { SyncClient, WebSocketTransport } from '@fieldnotes/sync';
+import {
+  createManagedSyncConnection,
+  type ManagedSyncStatus,
+  type ManagedSyncTransport,
+} from '@fieldnotes/sync';
 import type { ElementStore, CanvasElement } from '@fieldnotes/core';
 import type { BattleMapRole } from '@/lib/battlemapToken';
 
-export type BattleMapConnectionStatus =
-  | 'connecting'
-  | 'live'
-  | 'offline'
-  | 'denied';
+export type BattleMapConnectionStatus = ManagedSyncStatus;
 
 export interface BattleMapTokenRequest {
   role: BattleMapRole;
@@ -59,11 +59,8 @@ export function pokeFeatureFromEnvelope(raw: string): string | null {
   return typeof op.data.feature === 'string' ? op.data.feature : null;
 }
 
-/** Transport surface the connection manager relies on (WebSocketTransport-compatible). */
-export type BattleMapTransport = Pick<
-  WebSocketTransport,
-  'send' | 'onMessage' | 'onReconnect' | 'onClose' | 'close'
->;
+/** Transport surface the connection relies on (WebSocketTransport-compatible). */
+export type BattleMapTransport = ManagedSyncTransport;
 
 export interface ManagedConnectionOptions {
   relayUrl: string;
@@ -79,161 +76,97 @@ export interface ManagedConnectionOptions {
   onStatus?: (s: BattleMapConnectionStatus) => void;
   /** Fires when the relay pokes this room (e.g. initiative changed → refetch /shared). */
   onPoke?: (feature: string) => void;
-  /** DI seam for tests; defaults to `url => new WebSocketTransport(url)`. */
+  /** DI seam for tests; defaults to the SDK's WebSocketTransport. */
   transportFactory?: (url: string) => BattleMapTransport;
 }
 
-const MAX_AUTH_FAILURES = 4;
-const RETRY_CAP_MS = 15000;
-
 /**
- * Owns the mint-token → transport → SyncClient lifecycle.
- * WebSocketTransport's URL (and its embedded token) is frozen at construction
- * and app-range close codes (4000-4999) terminate it, so token rotation and
- * auth retries require tearing down and rebuilding both transport and client.
- * Transient network drops are left to the transport's built-in reconnect.
+ * Battle-map sync connection: token minting via the campaign token route plus
+ * RollKeeper-owned message parsing, layered over the Fieldnotes managed
+ * lifecycle (`createManagedSyncConnection`), which owns status transitions,
+ * transient reconnect, token refresh after terminal auth closes (4401), and
+ * bounded auth retry ending in `denied`.
  */
 export function createManagedBattleMapConnection(
   opts: ManagedConnectionOptions
 ): { stop: () => void } {
   let stopped = false;
-  let client: SyncClient | null = null;
-  let transport: BattleMapTransport | null = null;
-  const transportFactory =
-    opts.transportFactory ?? ((url: string) => new WebSocketTransport(url));
-  let retryTimer: ReturnType<typeof setTimeout> | null = null;
-  let attempt = 0;
-  let authFailures = 0;
   const room = `${opts.campaignCode}:${opts.battleMapId}`;
 
-  const scheduleRetry = (): void => {
-    if (stopped) return;
-    opts.onStatus?.('offline');
-    const delay = Math.min(RETRY_CAP_MS, 1000 * 2 ** Math.min(attempt, 4));
-    attempt += 1;
-    retryTimer = setTimeout(() => void connect(), delay);
+  // Handles EVERY snapshot addressed to us (not just the first): on a
+  // transport-internal reconnect SyncClient re-requests a snapshot and runs a
+  // destructive reconcile that deletes local elements absent from the hub —
+  // each resync needs a fresh reseed or those elements are lost. This runs on
+  // the raw frame BEFORE the SyncClient applies the merge (the managed
+  // lifecycle subscribes onTransportMessage first), so local state is captured
+  // synchronously and the deferred seed runs after the merge/reconcile.
+  // Temporary workaround until Fieldnotes ships explicit
+  // authoritative-bootstrap/reconcile hooks.
+  const seedFromSnapshot = (raw: string): void => {
+    let env: {
+      from?: string;
+      op?: { kind?: string; to?: string; elements?: { id: string }[] };
+    };
+    try {
+      env = JSON.parse(raw) as typeof env;
+    } catch {
+      return; // non-JSON frame — ignore
+    }
+    const op = env?.op;
+    if (!op || op.kind !== 'snapshot') return;
+    // Snapshots are addressed; ignore ones targeted at other clients.
+    if (op.to !== opts.clientId) return;
+    // Capture local state SYNCHRONOUSLY, before SyncClient's own handler
+    // (subscribed after us) applies the merge/reconcile for this snapshot.
+    const localBefore = opts.store.snapshot();
+    const present = new Set((op.elements ?? []).map(e => e.id));
+    setTimeout(() => {
+      if (stopped) return;
+      const missing = new Set(computeSeedIds(localBefore, present));
+      for (const el of localBefore) {
+        if (!missing.has(el.id)) continue;
+        if (opts.store.getById(el.id)) {
+          // no-op update re-emits the element as a local upsert
+          opts.store.update(el.id, {});
+        } else {
+          // reconcile just deleted it — re-adding re-emits it as a
+          // local upsert so it gets pushed back to the hub
+          opts.store.add(el);
+        }
+      }
+    }, 0);
   };
 
-  const connect = async (): Promise<void> => {
-    if (stopped) return;
-    opts.onStatus?.('connecting');
-    const token = await mintBattleMapToken(
-      opts.campaignCode,
-      opts.tokenRequest
-    );
-    if (stopped) return;
-    if (!token) {
-      scheduleRetry();
-      return;
-    }
-
-    const url = `${opts.relayUrl}?room=${encodeURIComponent(room)}&token=${encodeURIComponent(token)}`;
-    const t = transportFactory(url);
-    transport = t;
-
-    // Subscribed BEFORE client.start() so this handler runs first;
-    // the deferred seed then runs after SyncClient has applied the merge.
-    // Handles EVERY snapshot addressed to us (not just the first): on a
-    // transport-internal reconnect SyncClient re-requests a snapshot and runs a
-    // destructive reconcile that deletes local elements absent from the hub —
-    // each resync needs a fresh reseed or those elements are lost.
-    const unsubMsg = t.onMessage(raw => {
-      let env: {
-        from?: string;
-        op?: { kind?: string; to?: string; elements?: { id: string }[] };
-      };
-      try {
-        // The sync library wraps every message as { from, op } (see
-        // SyncClient.sendOp) — the op payload lives under env.op.
-        env = JSON.parse(raw) as typeof env;
-      } catch {
-        // non-JSON frame — ignore
-        return;
-      }
-      const op = env?.op;
-      if (!op || op.kind !== 'snapshot') return;
-      // Snapshots are addressed; ignore ones targeted at other clients.
-      if (op.to !== opts.clientId) return;
-      attempt = 0;
-      authFailures = 0;
-      opts.onStatus?.('live');
-      if (opts.seedLocal) {
-        // Capture local state SYNCHRONOUSLY, before SyncClient's own handler
-        // (subscribed after us) applies the merge/reconcile for this snapshot.
-        const localBefore = opts.store.snapshot();
-        const present = new Set((op.elements ?? []).map(e => e.id));
-        setTimeout(() => {
-          if (stopped) return;
-          const missing = new Set(computeSeedIds(localBefore, present));
-          for (const el of localBefore) {
-            if (!missing.has(el.id)) continue;
-            if (opts.store.getById(el.id)) {
-              // no-op update re-emits the element as a local upsert
-              opts.store.update(el.id, {});
-            } else {
-              // reconcile just deleted it — re-adding re-emits it as a
-              // local upsert so it gets pushed back to the hub
-              opts.store.add(el);
+  const connection = createManagedSyncConnection({
+    store: opts.store,
+    clientId: opts.clientId,
+    resolveAudience: opts.resolveAudience,
+    resolveUrl: async () => {
+      const token = await mintBattleMapToken(
+        opts.campaignCode,
+        opts.tokenRequest
+      );
+      if (!token) return null;
+      return `${opts.relayUrl}?room=${encodeURIComponent(room)}&token=${encodeURIComponent(token)}`;
+    },
+    onStatus: opts.onStatus,
+    onTransportMessage:
+      opts.seedLocal || opts.onPoke
+        ? raw => {
+            if (opts.seedLocal) seedFromSnapshot(raw);
+            if (opts.onPoke) {
+              const feature = pokeFeatureFromEnvelope(raw);
+              if (feature) opts.onPoke(feature);
             }
           }
-        }, 0);
-      }
-    });
-
-    const unsubPoke = opts.onPoke
-      ? t.onMessage(raw => {
-          const feature = pokeFeatureFromEnvelope(raw);
-          if (feature) opts.onPoke!(feature);
-        })
-      : null;
-
-    t.onReconnect(() => {
-      if (!stopped) opts.onStatus?.('live');
-    });
-
-    t.onClose(code => {
-      if (stopped) return;
-      if (code >= 4000 && code <= 4999) {
-        // transport is now terminated — rebuild with a fresh token
-        unsubMsg();
-        unsubPoke?.();
-        client?.stop();
-        client = null;
-        transport = null;
-        if (code === 4401) {
-          authFailures += 1;
-          if (authFailures >= MAX_AUTH_FAILURES) {
-            opts.onStatus?.('denied');
-            return;
-          }
-        }
-        scheduleRetry();
-      } else {
-        // transport auto-reconnects with the same (frozen) token; if that
-        // token has expired the server will 4401 us into the branch above.
-        opts.onStatus?.('offline');
-      }
-    });
-
-    client = new SyncClient({
-      store: opts.store,
-      transport: t,
-      clientId: opts.clientId,
-      resolveAudience: opts.resolveAudience,
-    });
-    client.start();
-  };
-
-  void connect();
+        : undefined,
+    transportFactory: opts.transportFactory,
+  });
 
   return {
     stop: (): void => {
       stopped = true;
-      if (retryTimer) clearTimeout(retryTimer);
-      client?.stop();
-      transport?.close();
-      client = null;
-      transport = null;
+      connection.stop();
     },
   };
 }


### PR DESCRIPTION
## Summary

Adopts the managed authenticated sync lifecycle released in `@fieldnotes/sync@0.8.0` (paired with IrakliDevelop/fieldnotes#138), replacing the hand-rolled lifecycle glue in `src/lib/battlemapSync.ts`.

**Removed (now SDK-owned via `createManagedSyncConnection`):**
- mint → transport → `SyncClient` connect loop and rebuild-on-terminal-close
- exponential retry timer and backoff state
- the `connecting/live/offline/denied` status machine, 4401 counting, and `MAX_AUTH_FAILURES` bound (SDK default matches the previous 4; backoff cap matches the previous 15s)
- manual transport listener bookkeeping and stop() teardown ordering

**Kept (product-owned):**
- `mintBattleMapToken` against `/api/campaign/[code]/battlemap-token`, wrapped in the manager's async `resolveUrl`, so credential refresh after `4401` reuses the token route
- `clientId === authenticated userId` invariant, passed straight through to the SDK's stable-identity contract
- Poke parsing (`pokeFeatureFromEnvelope`) and the DM `seedLocal` snapshot interception/deferred reseed, now riding the manager's `onTransportMessage` hook — which is subscribed before the internal `SyncClient` on every transport, preserving the capture-before-merge ordering the workaround depends on. The `seedLocal` workaround intentionally stays until the Fieldnotes authoritative-bootstrap/reconcile roadmap item.
- `createManagedBattleMapConnection`'s public signature: all four call sites (DM VTT canvas, DM location editor, player canvas, TV display page) are unchanged.

**Behavior notes:**
- Status vocabulary and UX are unchanged. One refinement: `live` is now bound to an authoritative snapshot addressed to this client, so after a transport-level reconnect the status briefly reports `connecting` until the resync snapshot lands (previously it optimistically reported `live` on socket reopen). Consecutive duplicate statuses are no longer re-emitted.
- Wire envelopes, persistence, audience filtering (`resolveAudience`), correction privacy, and server-owned `from:"hub"` poke identity are untouched. Relay code is untouched apart from the version bump; the Redis channel remains presence-only.

## Dependencies

- `package.json` / `package-lock.json`: `@fieldnotes/sync` `^0.7.1` → `^0.8.0` (resolves published 0.8.0)
- `relay/package.json` / lockfile: `@fieldnotes/sync` `0.7.1` → `0.8.0`

## Tests

`src/lib/battlemapSync.test.ts` no longer mocks `@fieldnotes/sync`: the real managed lifecycle and `SyncClient` run against an injected fake transport, so the tests exercise the actual adoption seam. Coverage: token-route URL construction (room + token encoding, stable clientId in the first frame), live + seed on addressed snapshot, ignoring foreign-addressed snapshots, reconcile-race reseed on resync, non-snapshot frames not affecting status, hub-only poke filtering, bounded consecutive 4401 closes settling on terminal `denied` with one mint per attempt, and `stop()` cancelling the deferred seed.

## Verification

- Focused: `battlemapSync.test.ts` 11/11 passed.
- RollKeeper unit suite: 3,583 passed, 1 skipped (244 files); `tsc --noEmit` clean.
- Relay: 48/48 tests passed; type-check and build clean against sync 0.8.0.
- Lint: no new findings (one pre-existing unrelated `ChargePool` unused-var warning in `src/utils/weaponConversion.ts`).
- Changed files pass `prettier --check`.
- Desktop/touch interaction checks are N/A: connection lifecycle only, no interaction code changed. Real WebSocket auth/reconnect integration coverage lives in the SDK release (`packages/sync-server/src/managed-connection.e2e.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)