### PR TITLE
refactor(battlemap): adopt bootstrap/reconcile hooks from @fieldnotes/sync 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/client-s3": "^3.922.0",
         "@fieldnotes/core": "^0.53.0",
         "@fieldnotes/react": "^0.8.0",
-        "@fieldnotes/sync": "^0.8.0",
+        "@fieldnotes/sync": "^0.9.0",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "1.1.15",
         "@radix-ui/react-form": "^0.1.7",
@@ -2193,9 +2193,9 @@
       }
     },
     "node_modules/@fieldnotes/sync": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.8.0.tgz",
-      "integrity": "sha512-ZXpV7kLVjaWfqfOqJ9kEF6BuYYnRpuO6du+jTrJ1rUdC6qddO2R5CA/GHuY7ozMgSHQmK9LhNi44g1CAJcvvSw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.9.0.tgz",
+      "integrity": "sha512-TMauGN6rip9RHKrdrptAQxnJhoImsnBcaKan8LFw9aQs192Z9f+/8YnXA5ZAVltoAFLdD2x0KU+pyBUHDDomUA==",
       "license": "MIT",
       "peerDependencies": {
         "@fieldnotes/core": ">=0.46.0 <1.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@aws-sdk/client-s3": "^3.922.0",
     "@fieldnotes/core": "^0.53.0",
     "@fieldnotes/react": "^0.8.0",
-    "@fieldnotes/sync": "^0.8.0",
+    "@fieldnotes/sync": "^0.9.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-form": "^0.1.7",

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fieldnotes/core": "0.53.0",
-        "@fieldnotes/sync": "0.8.0",
+        "@fieldnotes/sync": "0.9.0",
         "@fieldnotes/sync-redis": "0.3.2",
         "@fieldnotes/sync-server": "0.11.0",
         "redis": "^4.7.0"
@@ -475,9 +475,9 @@
       "license": "MIT"
     },
     "node_modules/@fieldnotes/sync": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.8.0.tgz",
-      "integrity": "sha512-ZXpV7kLVjaWfqfOqJ9kEF6BuYYnRpuO6du+jTrJ1rUdC6qddO2R5CA/GHuY7ozMgSHQmK9LhNi44g1CAJcvvSw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.9.0.tgz",
+      "integrity": "sha512-TMauGN6rip9RHKrdrptAQxnJhoImsnBcaKan8LFw9aQs192Z9f+/8YnXA5ZAVltoAFLdD2x0KU+pyBUHDDomUA==",
       "license": "MIT",
       "peerDependencies": {
         "@fieldnotes/core": ">=0.46.0 <1.0.0"

--- a/relay/package.json
+++ b/relay/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@fieldnotes/core": "0.53.0",
-    "@fieldnotes/sync": "0.8.0",
+    "@fieldnotes/sync": "0.9.0",
     "@fieldnotes/sync-redis": "0.3.2",
     "@fieldnotes/sync-server": "0.11.0",
     "redis": "^4.7.0"

--- a/src/lib/battlemapSync.test.ts
+++ b/src/lib/battlemapSync.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { CanvasElement, ElementStore } from '@fieldnotes/core';
 import {
-  computeSeedIds,
+  ElementStore,
+  createShape,
+  type CanvasElement,
+} from '@fieldnotes/core';
+import {
   createManagedBattleMapConnection,
   type BattleMapConnectionStatus,
   type BattleMapTransport,
@@ -9,22 +12,13 @@ import {
 
 // No @fieldnotes/sync mocking: the real managed lifecycle + SyncClient run
 // against an injected fake transport, so these tests exercise the actual
-// adoption seam (RollKeeper glue over createManagedSyncConnection).
+// adoption seam (RollKeeper glue over createManagedSyncConnection and its
+// authoritative bootstrap/reconcile hooks).
 
-const el = (id: string) => ({ id }) as CanvasElement;
-
-describe('computeSeedIds', () => {
-  it('returns ids of local elements missing from the snapshot', () => {
-    expect(computeSeedIds([el('a'), el('b'), el('c')], new Set(['b']))).toEqual(
-      ['a', 'c']
-    );
-  });
-  it('returns empty when snapshot covers everything', () => {
-    expect(computeSeedIds([el('a')], new Set(['a']))).toEqual([]);
-  });
-  it('returns everything for an empty room', () => {
-    expect(computeSeedIds([el('a'), el('b')], new Set())).toEqual(['a', 'b']);
-  });
+/** Structurally valid element — the SDK validates snapshot elements. */
+const el = (id: string): CanvasElement => ({
+  ...createShape({ position: { x: 0, y: 0 }, size: { w: 1, h: 1 } }),
+  id,
 });
 
 class FakeTransport implements BattleMapTransport {
@@ -59,53 +53,29 @@ class FakeTransport implements BattleMapTransport {
   emitMessage(message: string): void {
     for (const h of [...this.msgHandlers]) h(message);
   }
+  emitReconnect(): void {
+    for (const h of [...this.reconnectHandlers]) h();
+  }
   emitClose(code: number): void {
     for (const h of [...this.closeHandlers]) h(code, '');
   }
 }
 
-interface FakeStore {
-  snapshot: ReturnType<typeof vi.fn>;
-  getById: ReturnType<typeof vi.fn>;
-  update: ReturnType<typeof vi.fn>;
-  add: ReturnType<typeof vi.fn>;
-  remove: ReturnType<typeof vi.fn>;
-  clear: ReturnType<typeof vi.fn>;
-  on: ReturnType<typeof vi.fn>;
-  /** test helper: simulate SyncClient's destructive reconcile deleting an id */
-  simulateRemove: (id: string) => void;
-}
-
-function makeFakeStore(initial: CanvasElement[]): FakeStore {
-  let elements = [...initial];
-  return {
-    snapshot: vi.fn(() => [...elements]),
-    getById: vi.fn((id: string) => elements.find(e => e.id === id)),
-    update: vi.fn(),
-    add: vi.fn((element: CanvasElement) => {
-      elements.push(element);
-    }),
-    remove: vi.fn((id: string) => {
-      elements = elements.filter(e => e.id !== id);
-    }),
-    clear: vi.fn(() => {
-      elements = [];
-    }),
-    // the real SyncClient subscribes to store mutations on start()
-    on: vi.fn(() => () => {}),
-    simulateRemove: (id: string) => {
-      elements = elements.filter(e => e.id !== id);
-    },
-  };
-}
-
 const snapshotEnvelope = (to: string, ids: string[]): string =>
   JSON.stringify({
     from: 'hub',
-    op: { kind: 'snapshot', to, elements: ids.map(id => ({ id })) },
+    op: { kind: 'snapshot', to, elements: ids.map(id => el(id)) },
   });
 
-/** Flush pending microtasks + one macrotask (covers the deferred seed). */
+const sentUpsertIds = (sent: string[]): string[] =>
+  sent
+    .map(
+      m => JSON.parse(m) as { op: { kind: string; element?: { id: string } } }
+    )
+    .filter(e => e.op.kind === 'upsert' && e.op.element)
+    .map(e => (e.op.element as { id: string }).id);
+
+/** Flush pending microtasks (token mint) — nothing here defers to macrotasks. */
 const flush = (): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, 0));
 
@@ -131,7 +101,7 @@ describe('createManagedBattleMapConnection', () => {
   });
 
   const startConnection = async (
-    store: FakeStore,
+    store: ElementStore,
     seedLocal = true,
     onPoke?: (feature: string) => void
   ) => {
@@ -139,7 +109,7 @@ describe('createManagedBattleMapConnection', () => {
       relayUrl: 'wss://relay.example',
       campaignCode: 'CODE',
       battleMapId: 'map-1',
-      store: store as unknown as ElementStore,
+      store,
       clientId: 'dm-1',
       tokenRequest: { role: 'dm', battleMapId: 'map-1', dmId: 'dm-1' },
       seedLocal,
@@ -156,7 +126,7 @@ describe('createManagedBattleMapConnection', () => {
   };
 
   it('mints via the campaign token route and connects with a room+token URL', async () => {
-    const store = makeFakeStore([]);
+    const store = new ElementStore();
     const conn = await startConnection(store);
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -177,81 +147,127 @@ describe('createManagedBattleMapConnection', () => {
     conn.stop();
   });
 
-  it('goes live and seeds missing local elements on a snapshot addressed to us', async () => {
-    const store = makeFakeStore([el('a'), el('b'), el('c')]);
+  it('goes live and synchronously re-pushes hub-unknown seed elements on the bootstrap snapshot', async () => {
+    const store = new ElementStore();
+    store.add(el('a'));
+    store.add(el('b'));
+    store.add(el('c'));
     const conn = await startConnection(store);
     expect(statuses).toEqual(['connecting']);
 
     fakeTransport.emitMessage(snapshotEnvelope('dm-1', ['b']));
-    expect(statuses).toEqual(['connecting', 'live']);
 
-    await flush(); // run the deferred seed
-    expect(store.update).toHaveBeenCalledWith('a', {});
-    expect(store.update).toHaveBeenCalledWith('c', {});
-    expect(store.update).not.toHaveBeenCalledWith('b', {});
-    expect(store.add).not.toHaveBeenCalled();
+    // No deferred macrotask: live + seed happen inside the snapshot dispatch.
+    expect(statuses).toEqual(['connecting', 'live']);
+    expect(sentUpsertIds(fakeTransport.sent).sort()).toEqual(['a', 'c']);
+    expect(store.getById('a')).toBeDefined();
+    expect(store.getById('b')).toBeDefined();
+    expect(store.getById('c')).toBeDefined();
 
     conn.stop();
   });
 
   it('ignores snapshots addressed to a different client', async () => {
-    const store = makeFakeStore([el('a')]);
+    const store = new ElementStore();
+    store.add(el('a'));
     const conn = await startConnection(store);
 
     fakeTransport.emitMessage(snapshotEnvelope('someone-else', []));
-    await flush();
 
     expect(statuses).not.toContain('live');
-    expect(store.update).not.toHaveBeenCalled();
-    expect(store.add).not.toHaveBeenCalled();
+    expect(sentUpsertIds(fakeTransport.sent)).toEqual([]);
+    expect(store.getById('a')).toBeDefined();
 
     conn.stop();
   });
 
-  it('re-adds elements deleted by reconcile before the deferred seed runs (resync)', async () => {
-    const store = makeFakeStore([el('a'), el('b')]);
-    const conn = await startConnection(store);
+  it('keeps hub-unknown local elements across a rebuild while hub-deleted elements stay deleted', async () => {
+    vi.useFakeTimers();
+    try {
+      const store = new ElementStore();
+      store.add(el('a'));
+      store.add(el('b'));
+      const conn = createManagedBattleMapConnection({
+        relayUrl: 'wss://relay.example',
+        campaignCode: 'CODE',
+        battleMapId: 'map-1',
+        store,
+        clientId: 'dm-1',
+        tokenRequest: { role: 'dm', battleMapId: 'map-1', dmId: 'dm-1' },
+        seedLocal: true,
+        onStatus: s => statuses.push(s),
+        transportFactory: url => {
+          transportUrls.push(url);
+          return fakeTransport;
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0); // token mint resolves
 
-    // first snapshot: hub already has everything
-    fakeTransport.emitMessage(snapshotEnvelope('dm-1', ['a', 'b']));
-    await flush();
-    expect(store.update).not.toHaveBeenCalled();
-    expect(store.add).not.toHaveBeenCalled();
+      // Bootstrap: the hub already knows both seeds — nothing to push.
+      fakeTransport.emitMessage(snapshotEnvelope('dm-1', ['a', 'b']));
+      expect(statuses).toEqual(['connecting', 'live']);
+      expect(sentUpsertIds(fakeTransport.sent)).toEqual([]);
 
-    // reconnect resync: hub lost 'b'; SyncClient's reconcile deletes it
-    // locally after our watcher captured localBefore but before the seed runs
-    fakeTransport.emitMessage(snapshotEnvelope('dm-1', ['a']));
-    store.simulateRemove('b');
-    await flush();
+      // Terminal auth close: the managed lifecycle tears the client down and
+      // re-mints. While no client is attached, the host loads a new
+      // local-authoritative element the hub has never seen.
+      fakeTransport.emitClose(4401);
+      const sendsWhileDown = fakeTransport.sent.length;
+      store.add(el('n'));
+      expect(fakeTransport.sent.length).toBe(sendsWhileDown); // detached — nothing sent
 
-    expect(store.add).toHaveBeenCalledTimes(1);
-    expect(store.add).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'b' })
-    );
-    expect(store.update).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(2_000); // backoff + re-mint + rebuild
+      expect(transportUrls).toHaveLength(2);
+      const sentBefore = fakeTransport.sent.length;
+
+      // The hub deleted 'b' while we were away.
+      fakeTransport.emitMessage(snapshotEnvelope('dm-1', ['a']));
+
+      expect(store.getById('a')).toBeDefined();
+      expect(store.getById('b')).toBeUndefined(); // deleted-while-away — no zombie
+      expect(store.getById('n')).toBeDefined(); // hub-unknown — preserved
+      expect(sentUpsertIds(fakeTransport.sent.slice(sentBefore))).toEqual([
+        'n',
+      ]);
+      conn.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not push local-only elements when seedLocal is off', async () => {
+    const store = new ElementStore();
+    store.add(el('x'));
+    const conn = await startConnection(store, false);
+
+    fakeTransport.emitMessage(snapshotEnvelope('dm-1', []));
+
+    expect(statuses).toEqual(['connecting', 'live']);
+    expect(sentUpsertIds(fakeTransport.sent)).toEqual([]);
+    expect(store.getById('x')).toBeDefined(); // bootstrap merge keeps it locally
 
     conn.stop();
   });
 
   it('does not change status on non-snapshot envelopes', async () => {
-    const store = makeFakeStore([el('a')]);
+    const store = new ElementStore();
+    store.add(el('a'));
     const conn = await startConnection(store);
     const before = [...statuses];
 
     fakeTransport.emitMessage(
       JSON.stringify({ from: 'peer', op: { kind: 'presence', data: {} } })
     );
-    await flush();
 
     expect(statuses).toEqual(before);
-    expect(store.update).not.toHaveBeenCalled();
-    expect(store.add).not.toHaveBeenCalled();
+    expect(store.getById('a')).toBeDefined();
+    expect(sentUpsertIds(fakeTransport.sent)).toEqual([]);
 
     conn.stop();
   });
 
   it('delivers hub pokes to onPoke and ignores non-hub or non-poke frames', async () => {
-    const store = makeFakeStore([]);
+    const store = new ElementStore();
     const pokes: string[] = [];
     const conn = await startConnection(store, false, f => pokes.push(f));
 
@@ -281,12 +297,12 @@ describe('createManagedBattleMapConnection', () => {
   it('reports denied after bounded consecutive 4401 closes (token no longer accepted)', async () => {
     vi.useFakeTimers();
     try {
-      const store = makeFakeStore([]);
+      const store = new ElementStore();
       const conn = createManagedBattleMapConnection({
         relayUrl: 'wss://relay.example',
         campaignCode: 'CODE',
         battleMapId: 'map-1',
-        store: store as unknown as ElementStore,
+        store,
         clientId: 'dm-1',
         tokenRequest: { role: 'dm', battleMapId: 'map-1', dmId: 'dm-1' },
         onStatus: s => statuses.push(s),
@@ -317,16 +333,16 @@ describe('createManagedBattleMapConnection', () => {
     }
   });
 
-  it('stop() prevents the deferred seed from mutating the store', async () => {
-    const store = makeFakeStore([el('a')]);
+  it('stop() closes the transport and detaches the store', async () => {
+    const store = new ElementStore();
     const conn = await startConnection(store);
-
     fakeTransport.emitMessage(snapshotEnvelope('dm-1', []));
-    conn.stop(); // before the deferred seed macrotask runs
-    await flush();
 
-    expect(store.update).not.toHaveBeenCalled();
-    expect(store.add).not.toHaveBeenCalled();
+    conn.stop();
     expect(fakeTransport.closed).toBe(true);
+
+    const sends = fakeTransport.sent.length;
+    store.add(el('late'));
+    expect(fakeTransport.sent.length).toBe(sends);
   });
 });

--- a/src/lib/battlemapSync.ts
+++ b/src/lib/battlemapSync.ts
@@ -2,6 +2,7 @@ import {
   createManagedSyncConnection,
   type ManagedSyncStatus,
   type ManagedSyncTransport,
+  type ResolveLocalOnly,
 } from '@fieldnotes/sync';
 import type { ElementStore, CanvasElement } from '@fieldnotes/core';
 import type { BattleMapRole } from '@/lib/battlemapToken';
@@ -34,13 +35,19 @@ export async function mintBattleMapToken(
   }
 }
 
-/** Local elements the hub doesn't know about yet (must be pushed by us). */
-export function computeSeedIds(
-  local: CanvasElement[],
-  presentIds: Set<string>
-): string[] {
-  return local.filter(el => !presentIds.has(el.id)).map(el => el.id);
-}
+/**
+ * DM seeding policy for the SDK's authoritative bootstrap/reconcile hooks:
+ * local-authoritative elements the hub has never seen (DB-loaded seeds,
+ * elements added while detached) are preserved and re-pushed through the
+ * normal local-upsert path, while hub-known absences are deliberate
+ * deletions and stay deleted — a DM reconnect can no longer discard seed
+ * elements, and deleted-while-away elements are not resurrected.
+ */
+const preserveHubUnknown: ResolveLocalOnly = context => ({
+  preserve: context.localOnly
+    .filter(entry => !entry.hubKnown)
+    .map(entry => entry.element.id),
+});
 
 /** Parses a server-owned relay poke presence envelope. */
 export function pokeFeatureFromEnvelope(raw: string): string | null {
@@ -71,7 +78,10 @@ export interface ManagedConnectionOptions {
   clientId: string;
   tokenRequest: BattleMapTokenRequest;
   resolveAudience?: (el: CanvasElement) => string | undefined;
-  /** DM only: push local elements missing from each snapshot. */
+  /**
+   * DM only: preserve and re-push local elements the hub does not know yet
+   * on every bootstrap/reconcile snapshot (SDK `resolveLocalOnly` hooks).
+   */
   seedLocal?: boolean;
   onStatus?: (s: BattleMapConnectionStatus) => void;
   /** Fires when the relay pokes this room (e.g. initiative changed → refetch /shared). */
@@ -90,57 +100,17 @@ export interface ManagedConnectionOptions {
 export function createManagedBattleMapConnection(
   opts: ManagedConnectionOptions
 ): { stop: () => void } {
-  let stopped = false;
   const room = `${opts.campaignCode}:${opts.battleMapId}`;
-
-  // Handles EVERY snapshot addressed to us (not just the first): on a
-  // transport-internal reconnect SyncClient re-requests a snapshot and runs a
-  // destructive reconcile that deletes local elements absent from the hub —
-  // each resync needs a fresh reseed or those elements are lost. This runs on
-  // the raw frame BEFORE the SyncClient applies the merge (the managed
-  // lifecycle subscribes onTransportMessage first), so local state is captured
-  // synchronously and the deferred seed runs after the merge/reconcile.
-  // Temporary workaround until Fieldnotes ships explicit
-  // authoritative-bootstrap/reconcile hooks.
-  const seedFromSnapshot = (raw: string): void => {
-    let env: {
-      from?: string;
-      op?: { kind?: string; to?: string; elements?: { id: string }[] };
-    };
-    try {
-      env = JSON.parse(raw) as typeof env;
-    } catch {
-      return; // non-JSON frame — ignore
-    }
-    const op = env?.op;
-    if (!op || op.kind !== 'snapshot') return;
-    // Snapshots are addressed; ignore ones targeted at other clients.
-    if (op.to !== opts.clientId) return;
-    // Capture local state SYNCHRONOUSLY, before SyncClient's own handler
-    // (subscribed after us) applies the merge/reconcile for this snapshot.
-    const localBefore = opts.store.snapshot();
-    const present = new Set((op.elements ?? []).map(e => e.id));
-    setTimeout(() => {
-      if (stopped) return;
-      const missing = new Set(computeSeedIds(localBefore, present));
-      for (const el of localBefore) {
-        if (!missing.has(el.id)) continue;
-        if (opts.store.getById(el.id)) {
-          // no-op update re-emits the element as a local upsert
-          opts.store.update(el.id, {});
-        } else {
-          // reconcile just deleted it — re-adding re-emits it as a
-          // local upsert so it gets pushed back to the hub
-          opts.store.add(el);
-        }
-      }
-    }, 0);
-  };
 
   const connection = createManagedSyncConnection({
     store: opts.store,
     clientId: opts.clientId,
     resolveAudience: opts.resolveAudience,
+    // Seeding rides the SDK's authoritative bootstrap/reconcile hooks: the
+    // managed lifecycle persists hub knowledge across credential rebuilds and
+    // calls the hook synchronously for every snapshot addressed to us, so no
+    // raw-frame parsing or deferred reseeding is needed.
+    resolveLocalOnly: opts.seedLocal ? preserveHubUnknown : undefined,
     resolveUrl: async () => {
       const token = await mintBattleMapToken(
         opts.campaignCode,
@@ -150,22 +120,17 @@ export function createManagedBattleMapConnection(
       return `${opts.relayUrl}?room=${encodeURIComponent(room)}&token=${encodeURIComponent(token)}`;
     },
     onStatus: opts.onStatus,
-    onTransportMessage:
-      opts.seedLocal || opts.onPoke
-        ? raw => {
-            if (opts.seedLocal) seedFromSnapshot(raw);
-            if (opts.onPoke) {
-              const feature = pokeFeatureFromEnvelope(raw);
-              if (feature) opts.onPoke(feature);
-            }
-          }
-        : undefined,
+    onTransportMessage: opts.onPoke
+      ? raw => {
+          const feature = pokeFeatureFromEnvelope(raw);
+          if (feature) opts.onPoke?.(feature);
+        }
+      : undefined,
     transportFactory: opts.transportFactory,
   });
 
   return {
     stop: (): void => {
-      stopped = true;
       connection.stop();
     },
   };


### PR DESCRIPTION
## Summary

Paired adoption PR for [IrakliDevelop/fieldnotes#139](https://github.com/IrakliDevelop/fieldnotes/pull/139) (published as `@fieldnotes/sync@0.9.0`).

- Deletes the `seedFromSnapshot` raw-frame interception and deferred `setTimeout` reseeding from `src/lib/battlemapSync.ts`, and removes the fully superseded `computeSeedIds`.
- `seedLocal` now maps to the SDK's `resolveLocalOnly` hook with a preserve-hub-unknown policy: local elements the hub has never seen (DB-loaded seeds, elements added while detached) are preserved and re-pushed through the normal local-upsert path (audience stamping and server-side filtering apply), while hub-known absences are deliberate deletions and stay deleted. A DM reconnect can no longer discard DM seed elements, and deleted-while-away elements are not resurrected — including across `4401` token-refresh rebuilds, since the managed lifecycle persists hub knowledge across cycles.
- Seeding is now synchronous inside snapshot dispatch — no macrotask timing anywhere.
- `createManagedBattleMapConnection` keeps its signature: the DM VTT, DM location editor, player canvas, and display call sites are unchanged, as are the `connecting/live/offline/denied` status UX, `clientId === authenticated userId`, and poke parsing on `onTransportMessage`.
- Dependencies: root `@fieldnotes/sync` `^0.9.0`, relay pinned `0.9.0`; both lockfiles resolve the published registry package.

## Verification

- `battlemapSync.test.ts` rewritten against the real managed lifecycle + `SyncClient` (no `@fieldnotes/sync` mocks) with a real `ElementStore` and structurally valid elements: 9/9 passed — token-route URL construction, synchronous bootstrap seeding of hub-unknown elements, foreign-snapshot filtering, a rebuild reconcile where a hub-unknown element is kept and re-pushed while a hub-deleted element stays deleted, seedLocal-off no-push, hub-only poke filtering, bounded 4401 denial, and stop() teardown.
- Full unit suite: 3,581 passed / 1 skipped (244 files). `tsc --noEmit` clean.
- Relay on sync 0.9.0: 48/48 tests, type-check and build clean.
- Changed-file Prettier and ESLint clean (`relay/package.json` has pre-existing Prettier drift on master; only its version pin changed here).
- Desktop/touch checks N/A — no interaction code changed. The real-WebSocket DM-reconnect integration path is covered upstream in fieldnotes#139's sync-server e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)