### PR TITLE
Fix battle map eraser and combat rest actions

### DIFF
--- a/src/components/__tests__/combatant-detail-vitals.test.tsx
+++ b/src/components/__tests__/combatant-detail-vitals.test.tsx
@@ -147,6 +147,20 @@ describe('DetailVitals', () => {
     expect(screen.getByText('synced')).toBeInTheDocument();
   });
 
+  it.each([
+    ['player', playerEntity],
+    ['NPC', npcEntity],
+  ])('does not offer rest actions for a %s in combat', (_label, entity) => {
+    render(<DetailVitals entity={entity} actions={makeActions()} />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Short Rest' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Long Rest' })
+    ).not.toBeInTheDocument();
+  });
+
   it('NPC death-save failure toggle calls onUpdate with incremented failures', async () => {
     const npcAtZeroHp: EncounterEntity = {
       ...npcEntity,

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -8,6 +8,7 @@ import {
   NoteTool,
   TextTool,
   ShapeTool,
+  EraserTool,
   AutoSave,
   type Tool,
   type Viewport,
@@ -134,6 +135,7 @@ export function useDmBattleMapCanvas({
         feetPerCell: 5,
         renderStyle: 'geometric',
       }),
+      new EraserTool({ radius: 12, mode: 'stroke' }),
       new DmTokenTool(tokenConfigRef),
     ];
   }, [tokenConfigRef]);

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -11,6 +11,7 @@ import {
   StickyNote,
   Shapes,
   Eraser,
+  Scissors,
   Eye,
   Minus,
   EyeOff,
@@ -31,6 +32,7 @@ const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
   { name: 'note', label: 'Sticky Note', Icon: StickyNote },
   { name: 'measure', label: 'Measure', Icon: Ruler },
   { name: 'template', label: 'Template', Icon: Circle },
+  { name: 'eraser', label: 'Eraser', Icon: Eraser },
 ];
 
 export interface DmVttToolbarProps {
@@ -152,7 +154,7 @@ export function DmVttToolbar({
           title="Clear drawings"
           aria-label="Clear drawings"
         >
-          <Eraser size={16} />
+          <Scissors size={16} />
         </Button>
         <Button
           variant="ghost"

--- a/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
@@ -10,6 +10,27 @@ vi.mock('@fieldnotes/react', () => ({
 describe('DmVttToolbar', () => {
   afterEach(() => cleanup());
 
+  it('offers a real eraser tool separately from clearing drawings', () => {
+    render(
+      <DmVttToolbar
+        onClearDrawings={vi.fn()}
+        tokenInfoToggle={{ mode: 'compact', onCycle: vi.fn() }}
+        hiddenPlacementActive={false}
+        onToggleHiddenPlacement={vi.fn()}
+        hiddenElementCount={0}
+        onRevealAll={vi.fn()}
+        selectedElementId={null}
+        selectedElementIsDmOnly={false}
+        onToggleSelectedDmOnly={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Eraser' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Clear drawings' })
+    ).toBeInTheDocument();
+  });
+
   it('always sits below the fixed top bar (top-16), never sharing its row', () => {
     // Regression pin for the wide-viewport overlap bug: a `min-[1350px]:top-3`
     // variant previously moved the toolbar into `DmVttTopBar`'s row at

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -11,6 +11,7 @@ import {
   TextTool,
   ShapeTool,
   TemplateTool,
+  EraserTool,
   AutoSave,
   type Tool,
   type Viewport,
@@ -242,7 +243,7 @@ export function useDmLocationEditor(
   const { sharedWithPlayers, handleToggleShareWithPlayers } =
     useShareWithPlayers(campaignCode, dmId, location, mode === 'battlemap');
 
-  // Build tools once — no PencilTool or EraserTool for the location editor
+  // Build tools once. Battle-map setup also supports FieldNotes' stroke eraser.
   const tools = useMemo<Tool[]>(() => {
     const baseTools: Tool[] = [
       new HandTool(),
@@ -271,6 +272,7 @@ export function useDmLocationEditor(
           renderStyle: 'geometric',
         })
       );
+      baseTools.push(new EraserTool({ radius: 12, mode: 'stroke' }));
     }
 
     return baseTools;

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
@@ -14,6 +14,7 @@ import {
   Redo2,
   Trash2,
   Eraser,
+  X,
   Download,
   Loader2,
   Check,
@@ -48,6 +49,7 @@ const BASE_TOOL_DEFS = [
 const BATTLEMAP_TOOL_DEFS = [
   { name: 'measure', icon: Ruler, label: 'Measure' },
   { name: 'template', icon: Sparkles, label: 'Template' },
+  { name: 'eraser', icon: Eraser, label: 'Eraser' },
 ] as const;
 
 function formatSyncTime(iso: string): string {
@@ -194,7 +196,7 @@ export default function DmLocationToolbar({
           title="Clear canvas"
           className="text-accent-red-text h-8 w-8 p-0"
         >
-          <Eraser size={15} />
+          <X size={15} />
         </Button>
       </div>
 

--- a/src/components/ui/campaign/location-map/__tests__/DmLocationToolbar.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/DmLocationToolbar.test.tsx
@@ -117,6 +117,13 @@ describe('DmLocationToolbar rotation buttons', () => {
     expect(screen.getByTitle('Align & distribute')).toBeInTheDocument();
   });
 
+  it('offers an eraser tool separately from clearing the canvas', () => {
+    render(<DmLocationToolbar {...baseProps} />);
+
+    expect(screen.getByTitle('Eraser')).toBeInTheDocument();
+    expect(screen.getByTitle('Clear canvas')).toBeInTheDocument();
+  });
+
   it('shows hidden-placement state and reveals all hidden elements', () => {
     const onToggle = vi.fn();
     const onRevealAll = vi.fn();

--- a/src/components/ui/encounter/combat-screen/detail/DetailVitals.tsx
+++ b/src/components/ui/encounter/combat-screen/detail/DetailVitals.tsx
@@ -196,24 +196,6 @@ export function DetailVitals({ entity, actions }: DetailSectionProps) {
           Spend Hit Die ({entity.hitDice?.dieType})
         </button>
       )}
-
-      {/* Rests */}
-      <div className="flex gap-2">
-        {!isPlayer && (
-          <button
-            onClick={() => actions.onShortRest(entity.id)}
-            className="border-divider text-muted hover:text-body hover:bg-surface-raised flex-1 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors"
-          >
-            Short Rest
-          </button>
-        )}
-        <button
-          onClick={() => actions.onLongRest(entity.id)}
-          className="border-divider text-muted hover:text-body hover:bg-surface-raised flex-1 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors"
-        >
-          Long Rest
-        </button>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add the FieldNotes stroke eraser to DM battle-map setup and play toolbars
- give bulk canvas/drawing clearing distinct X and scissors icons
- remove short and long rest actions from player and NPC combat details
- add regression coverage for toolbar actions and combat rest visibility

## Validation
- `npm run type-check`
- `npx vitest run --project unit src/components/__tests__/combatant-detail-vitals.test.tsx src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx src/components/ui/campaign/location-map/__tests__/DmLocationToolbar.test.tsx`
- focused Prettier check
- pre-commit ESLint and Prettier hooks