### PR TITLE
feat(battlemap): sync layer definitions via @fieldnotes/sync 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/client-s3": "^3.922.0",
         "@fieldnotes/core": "^0.53.0",
         "@fieldnotes/react": "^0.8.0",
-        "@fieldnotes/sync": "^0.9.0",
+        "@fieldnotes/sync": "^0.10.0",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "1.1.15",
         "@radix-ui/react-form": "^0.1.7",
@@ -2193,9 +2193,9 @@
       }
     },
     "node_modules/@fieldnotes/sync": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.9.0.tgz",
-      "integrity": "sha512-TMauGN6rip9RHKrdrptAQxnJhoImsnBcaKan8LFw9aQs192Z9f+/8YnXA5ZAVltoAFLdD2x0KU+pyBUHDDomUA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.10.0.tgz",
+      "integrity": "sha512-In0+d49tLFCTShu330OXl/Y6i1UmlM04fMwGGBOdtpN/h6ZUuQTUtdIdvyDsssdUzLh95gpTN1C7co6+if/aXg==",
       "license": "MIT",
       "peerDependencies": {
         "@fieldnotes/core": ">=0.46.0 <1.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@aws-sdk/client-s3": "^3.922.0",
     "@fieldnotes/core": "^0.53.0",
     "@fieldnotes/react": "^0.8.0",
-    "@fieldnotes/sync": "^0.9.0",
+    "@fieldnotes/sync": "^0.10.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-form": "^0.1.7",

--- a/relay/package-lock.json
+++ b/relay/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@fieldnotes/core": "0.53.0",
-        "@fieldnotes/sync": "0.9.0",
-        "@fieldnotes/sync-redis": "0.3.2",
-        "@fieldnotes/sync-server": "0.11.0",
+        "@fieldnotes/sync": "0.10.0",
+        "@fieldnotes/sync-redis": "0.4.0",
+        "@fieldnotes/sync-server": "0.12.0",
         "redis": "^4.7.0"
       },
       "devDependencies": {
@@ -475,49 +475,31 @@
       "license": "MIT"
     },
     "node_modules/@fieldnotes/sync": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.9.0.tgz",
-      "integrity": "sha512-TMauGN6rip9RHKrdrptAQxnJhoImsnBcaKan8LFw9aQs192Z9f+/8YnXA5ZAVltoAFLdD2x0KU+pyBUHDDomUA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.10.0.tgz",
+      "integrity": "sha512-In0+d49tLFCTShu330OXl/Y6i1UmlM04fMwGGBOdtpN/h6ZUuQTUtdIdvyDsssdUzLh95gpTN1C7co6+if/aXg==",
       "license": "MIT",
       "peerDependencies": {
         "@fieldnotes/core": ">=0.46.0 <1.0.0"
       }
     },
     "node_modules/@fieldnotes/sync-redis": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync-redis/-/sync-redis-0.3.2.tgz",
-      "integrity": "sha512-O98mLte63KfAsMaWoH5mnTbdYswK6X29Ul0sJgIZddZnwORON5HrIAl9Nf1UHRGSRqHa4jgHCX1StoK7g4HpgA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync-redis/-/sync-redis-0.4.0.tgz",
+      "integrity": "sha512-/a1N8MuqxehVPPIDkkRjhgd6jNez/uNDD4rrCKU0HV9cnQAfm4H47+PHjL1TGcDOvl9U1GtkYeXJns7NqJIPbA==",
       "license": "MIT",
       "dependencies": {
-        "@fieldnotes/sync": "0.7.1"
-      }
-    },
-    "node_modules/@fieldnotes/sync-redis/node_modules/@fieldnotes/sync": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.7.1.tgz",
-      "integrity": "sha512-gpnErIhWe/ClJX9sgOwRQscFMbjSwNhYp7IimtT9HyuYuyMdy27ETtgoskYyHvKwDley++PrQGL+tLGkjkNE8g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@fieldnotes/core": ">=0.46.0 <1.0.0"
+        "@fieldnotes/sync": "0.10.0"
       }
     },
     "node_modules/@fieldnotes/sync-server": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync-server/-/sync-server-0.11.0.tgz",
-      "integrity": "sha512-d4UX5OwzdVc1rfGHhVI3FMs7Km49+koCv3owyoNeIFWyDJE0aWmbxikGjYC2cogysVCeZiPeg9lX5Ra8TxE6kw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/sync-server/-/sync-server-0.12.0.tgz",
+      "integrity": "sha512-wya9Rg+hCGwqQvU7sYL+qu6yJSIJGlm3TcRLSk+5CDcstZW2fUpm+uFYxLudOE+1kbTNDtp87h5XnIlzntGuHQ==",
       "license": "MIT",
       "dependencies": {
-        "@fieldnotes/sync": "0.7.1",
+        "@fieldnotes/sync": "0.10.0",
         "ws": "^8.18.0"
-      }
-    },
-    "node_modules/@fieldnotes/sync-server/node_modules/@fieldnotes/sync": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/sync/-/sync-0.7.1.tgz",
-      "integrity": "sha512-gpnErIhWe/ClJX9sgOwRQscFMbjSwNhYp7IimtT9HyuYuyMdy27ETtgoskYyHvKwDley++PrQGL+tLGkjkNE8g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@fieldnotes/core": ">=0.46.0 <1.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {

--- a/relay/package.json
+++ b/relay/package.json
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "@fieldnotes/core": "0.53.0",
-    "@fieldnotes/sync": "0.9.0",
-    "@fieldnotes/sync-redis": "0.3.2",
-    "@fieldnotes/sync-server": "0.11.0",
+    "@fieldnotes/sync": "0.10.0",
+    "@fieldnotes/sync-redis": "0.4.0",
+    "@fieldnotes/sync-server": "0.12.0",
     "redis": "^4.7.0"
   },
   "devDependencies": {

--- a/relay/src/layer-sync.test.ts
+++ b/relay/src/layer-sync.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import WebSocket from 'ws';
+import { MemoryHubBackend } from '@fieldnotes/sync-server';
+import { startRelay, type RelayHandle } from './server.js';
+import { signBattleMapToken } from './token.js';
+
+/**
+ * Integration test for layer-definition sync through the real relay: the
+ * published, unpatched SyncHub with RollKeeper's authorizeLayer policy.
+ */
+
+const SECRET = 'layer-sync-test-secret';
+const ROOM = 'ROOM1:bm-layers';
+
+interface Envelope {
+  from: string;
+  op: {
+    kind: string;
+    [key: string]: unknown;
+  };
+}
+
+function tokenFor(userId: string, role: 'dm' | 'player' | 'display'): string {
+  return signBattleMapToken(
+    { userId, role, room: ROOM, exp: Date.now() + 60_000 },
+    SECRET
+  );
+}
+
+function connect(
+  role: 'dm' | 'player' | 'display',
+  userId: string,
+  port: number
+) {
+  const token = tokenFor(userId, role);
+  const ws = new WebSocket(
+    `ws://127.0.0.1:${port}/?room=${encodeURIComponent(ROOM)}&token=${token}`
+  );
+  const messages: Envelope[] = [];
+  ws.on('message', data => {
+    try {
+      messages.push(JSON.parse(String(data)) as Envelope);
+    } catch {
+      // ignore malformed frames
+    }
+  });
+  const opened = new Promise<void>((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+  const waitFor = (
+    predicate: (m: Envelope) => boolean,
+    timeoutMs = 2000
+  ): Promise<Envelope> =>
+    new Promise((resolve, reject) => {
+      const existing = messages.find(predicate);
+      if (existing) {
+        resolve(existing);
+        return;
+      }
+      const start = Date.now();
+      const interval = setInterval(() => {
+        const found = messages.find(predicate);
+        if (found) {
+          clearInterval(interval);
+          resolve(found);
+        } else if (Date.now() - start > timeoutMs) {
+          clearInterval(interval);
+          reject(
+            new Error(
+              `timeout waiting for message; received: ${JSON.stringify(messages)}`
+            )
+          );
+        }
+      }, 10);
+    });
+  return { ws, messages, opened, waitFor };
+}
+
+function layerDef(id: string, name = id, order = 200) {
+  return { id, name, visible: true, locked: false, order, opacity: 1 };
+}
+
+function layerUpsert(
+  from: string,
+  id: string,
+  version: number,
+  editor: string,
+  name = id
+): Envelope {
+  return {
+    from,
+    op: { kind: 'layer-upsert', layer: layerDef(id, name), version, editor },
+  };
+}
+
+describe('layer-definition sync (real relay)', () => {
+  let handle: RelayHandle;
+  let port: number;
+
+  beforeAll(async () => {
+    handle = await startRelay({
+      secret: SECRET,
+      backend: new MemoryHubBackend(),
+    });
+    port = handle.address().port;
+  });
+
+  afterAll(async () => {
+    await handle.close();
+  });
+
+  it('propagates DM layer definitions, enforces player ownership, and serves records to late joiners', async () => {
+    const dm = connect('dm', 'dm-1', port);
+    const player = connect('player', 'char1', port);
+    await Promise.all([dm.opened, player.opened]);
+
+    // DM defines a custom layer — the player receives it.
+    dm.ws.send(
+      JSON.stringify(layerUpsert('dm-1', 'layer-props', 1, 'dm-1', 'Props'))
+    );
+    const seen = await player.waitFor(m => m.op.kind === 'layer-upsert');
+    expect((seen.op.layer as { name: string }).name).toBe('Props');
+
+    // Player defines their own layer — allowed, DM receives it.
+    player.ws.send(
+      JSON.stringify(layerUpsert('char1', 'player-char1', 1, 'char1'))
+    );
+    await dm.waitFor(
+      m =>
+        m.op.kind === 'layer-upsert' &&
+        (m.op.layer as { id: string }).id === 'player-char1'
+    );
+
+    // Player tries to hijack the DM's layer — denied; the hub answers the
+    // sender with an authoritative correction carrying the current record,
+    // and the DM never sees the forged edit.
+    player.ws.send(
+      JSON.stringify(
+        layerUpsert('char1', 'layer-props', 5, 'char1', 'hijacked')
+      )
+    );
+    const correction = await player.waitFor(
+      m =>
+        m.from === 'hub' &&
+        m.op.kind === 'layer-upsert' &&
+        (m.op.layer as { id: string }).id === 'layer-props'
+    );
+    expect((correction.op.layer as { name: string }).name).toBe('Props');
+    expect(correction.op.version).toBe(1);
+    expect(
+      dm.messages.filter(
+        m =>
+          m.op.kind === 'layer-upsert' &&
+          (m.op.layer as { name?: string }).name === 'hijacked'
+      )
+    ).toEqual([]);
+
+    // A late joiner's snapshot carries both stored records.
+    const late = connect('player', 'char2', port);
+    await late.opened;
+    late.ws.send(
+      JSON.stringify({ from: 'char2', op: { kind: 'request-snapshot' } })
+    );
+    const snapshot = await late.waitFor(
+      m => m.op.kind === 'snapshot' && m.op.to === 'char2'
+    );
+    const records = (snapshot.op.layers ?? []) as {
+      id: string;
+      version: number;
+      definition?: { name: string };
+    }[];
+    const ids = records.map(r => r.id).sort();
+    expect(ids).toEqual(['layer-props', 'player-char1']);
+    expect(records.find(r => r.id === 'layer-props')?.definition?.name).toBe(
+      'Props'
+    );
+
+    dm.ws.close();
+    player.ws.close();
+    late.ws.close();
+  }, 10_000);
+
+  it('display connections are read-only for layer definitions', async () => {
+    const dm = connect('dm', 'dm-1', port);
+    const display = connect('display', 'display-1', port);
+    await Promise.all([dm.opened, display.opened]);
+
+    display.ws.send(
+      JSON.stringify(
+        layerUpsert('display-1', 'player-display-1', 1, 'display-1')
+      )
+    );
+    // Denied with no stored record: the hub reverts the sender with a
+    // tombstone, and the DM sees nothing.
+    const correction = await display.waitFor(
+      m => m.from === 'hub' && m.op.kind === 'layer-remove'
+    );
+    expect(correction.op.id).toBe('player-display-1');
+    expect(dm.messages.filter(m => m.op.kind === 'layer-upsert')).toEqual([]);
+
+    dm.ws.close();
+    display.ws.close();
+  }, 10_000);
+});

--- a/relay/src/policies.test.ts
+++ b/relay/src/policies.test.ts
@@ -6,7 +6,8 @@ import { signBattleMapToken } from './token.js';
 
 const SECRET = 'test-secret';
 const ROOM = 'ABC123:bm-1';
-const { authenticate, authorize, canRead } = makePolicies(SECRET);
+const { authenticate, authorize, authorizeLayer, canRead } =
+  makePolicies(SECRET);
 
 function req(url: string): { req: IncomingMessage; room: string } {
   return { req: { url } as IncomingMessage, room: ROOM };
@@ -222,5 +223,107 @@ describe('canRead', () => {
     expect(canRead({ ...base, role: 'display', audience: DM_AUDIENCE })).toBe(
       false
     );
+  });
+});
+
+describe('authorizeLayer', () => {
+  const layerDef = (id: string) => ({
+    id,
+    name: id,
+    visible: true,
+    locked: false,
+    order: 500,
+    opacity: 1,
+  });
+  const upsertOp = (id: string) =>
+    ({
+      kind: 'layer-upsert',
+      layer: layerDef(id),
+      version: 1,
+      editor: 'x',
+    }) as const;
+  const removeOp = (id: string) =>
+    ({ kind: 'layer-remove', id, version: 2, editor: 'x' }) as const;
+  const base = { room: ROOM };
+
+  it('dm may edit any layer definition', () => {
+    expect(
+      authorizeLayer({
+        ...base,
+        userId: 'dm1',
+        role: 'dm',
+        op: upsertOp('layer-props'),
+      })
+    ).toBe(true);
+    expect(
+      authorizeLayer({
+        ...base,
+        userId: 'dm1',
+        role: 'dm',
+        op: removeOp('player-p1'),
+      })
+    ).toBe(true);
+  });
+
+  it('a player may only define or remove their own player layer', () => {
+    expect(
+      authorizeLayer({
+        ...base,
+        userId: 'p1',
+        role: 'player',
+        op: upsertOp('player-p1'),
+      })
+    ).toBe(true);
+    expect(
+      authorizeLayer({
+        ...base,
+        userId: 'p1',
+        role: 'player',
+        op: removeOp('player-p1'),
+      })
+    ).toBe(true);
+    expect(
+      authorizeLayer({
+        ...base,
+        userId: 'p1',
+        role: 'player',
+        op: upsertOp('player-p2'),
+      })
+    ).toBe(false);
+    expect(
+      authorizeLayer({
+        ...base,
+        userId: 'p1',
+        role: 'player',
+        op: upsertOp('layer-annotations'),
+      })
+    ).toBe(false);
+    expect(
+      authorizeLayer({
+        ...base,
+        userId: 'p1',
+        role: 'player',
+        op: removeOp('layer-map'),
+      })
+    ).toBe(false);
+  });
+
+  it('display and unknown roles are read-only; missing userId fails closed', () => {
+    expect(
+      authorizeLayer({
+        ...base,
+        userId: 'd1',
+        role: 'display',
+        op: upsertOp('player-d1'),
+      })
+    ).toBe(false);
+    expect(
+      authorizeLayer({
+        ...base,
+        userId: undefined,
+        role: 'player',
+        op: upsertOp('player-undefined'),
+      })
+    ).toBe(false);
   });
 });

--- a/relay/src/policies.ts
+++ b/relay/src/policies.ts
@@ -1,6 +1,7 @@
 import type {
   Authenticate,
   Authorize,
+  AuthorizeLayer,
   CanRead,
   OwnedElement,
 } from '@fieldnotes/sync-server';
@@ -9,12 +10,15 @@ import { verifyBattleMapToken } from './token.js';
 export const DM_AUDIENCE = 'dm';
 
 /**
- * The whole security model of the live battle map lives in these three hooks.
+ * The whole security model of the live battle map lives in these hooks.
  * They run on the relay; clients never see elements canRead filters out.
+ * Layer definitions are presentation-only (never element bytes), so
+ * authorizeLayer guards edit ownership, not privacy.
  */
 export function makePolicies(secret: string): {
   authenticate: Authenticate;
   authorize: Authorize;
+  authorizeLayer: AuthorizeLayer;
   canRead: CanRead;
 } {
   const authenticate: Authenticate = ({ req, room }) => {
@@ -55,5 +59,15 @@ export function makePolicies(secret: string): {
   const canRead: CanRead = ({ role, audience }) =>
     audience !== DM_AUDIENCE || role === 'dm';
 
-  return { authenticate, authorize, canRead };
+  // The DM owns the scene; a player may only define/edit their own
+  // player-<characterId> layer; the display is read-only. A denied edit is
+  // answered by the hub with an authoritative correction to the sender.
+  const authorizeLayer: AuthorizeLayer = ({ role, userId, op }) => {
+    if (role === 'dm') return true;
+    if (role !== 'player') return false;
+    const layerId = op.kind === 'layer-upsert' ? op.layer.id : op.id;
+    return userId !== undefined && layerId === `player-${userId}`;
+  };
+
+  return { authenticate, authorize, authorizeLayer, canRead };
 }

--- a/src/app/dm/campaign/[code]/battlemaps/[id]/display/page.tsx
+++ b/src/app/dm/campaign/[code]/battlemaps/[id]/display/page.tsx
@@ -9,6 +9,8 @@ import {
   createManagedBattleMapConnection,
   type BattleMapConnectionStatus,
 } from '@/lib/battlemapSync';
+import { ensureCanonicalLayers } from '@/components/ui/campaign/location-map/layerContract';
+import { makeApplyRemoteLayer } from '@/components/ui/campaign/location-map/layerSync';
 
 function DisplayCanvas() {
   const params = useParams();
@@ -26,6 +28,10 @@ function DisplayCanvas() {
 
   const handleReady = (vp: Viewport) => {
     viewportRef.current = vp;
+    // Canonical bands so map/annotation elements stack correctly; custom and
+    // player layer definitions arrive over layer sync. Read-only view — the
+    // 'player' lock stance is irrelevant here.
+    ensureCanonicalLayers(vp, 'player');
     if (!relayUrl || !displayKey) return;
     connectionRef.current?.stop();
     connectionRef.current = createManagedBattleMapConnection({
@@ -35,6 +41,11 @@ function DisplayCanvas() {
       store: vp.store,
       clientId: `display-${code}`,
       tokenRequest: { role: 'display', battleMapId: id, displayKey },
+      layers: {
+        applyLayer: makeApplyRemoteLayer(vp, 'display', {
+          onApplied: () => vp.requestRender(),
+        }),
+      },
       onStatus: s => {
         setStatus(s);
         if (s === 'live') {

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -26,9 +26,12 @@ import {
 } from '@/components/ui/campaign/dm-vtt/combatantToken';
 import {
   migrateCanvasToContract,
-  attachUnknownLayerMirror,
   subscribePinCanonicalLayers,
 } from '@/components/ui/campaign/location-map/layerContract';
+import {
+  makeApplyRemoteLayer,
+  publishOwnedLayers,
+} from '@/components/ui/campaign/location-map/layerSync';
 
 import type { TokenInfoMode } from '@/components/ui/campaign/token-overlay';
 
@@ -207,11 +210,6 @@ export function useDmBattleMapCanvas({
           .setDmOnly(campaignCode, battleMapId, element.id, true);
       });
 
-      // Mirror unknown remote layers (player tokens) into the player band —
-      // without this they sort at layer order 0, under DM-added images.
-      // Covers both new elements (add) and relay snapshot reconcile
-      // re-applying remote elements as full updates (including layerId).
-      attachUnknownLayerMirror(vp, 'dm', () => vp.requestRender());
       pinUnsubRef.current?.();
       // Play canvas never arranges maps — the annotations layer (DM tokens,
       // notes, text) must stay unlocked, repairing any state persisted locked
@@ -233,7 +231,7 @@ export function useDmBattleMapCanvas({
       const relayUrl = process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
       if (relayUrl) {
         connectionRef.current?.stop();
-        connectionRef.current = createManagedBattleMapConnection({
+        const connection = createManagedBattleMapConnection({
           relayUrl,
           campaignCode,
           battleMapId,
@@ -246,12 +244,25 @@ export function useDmBattleMapCanvas({
               ?.dmOnlyElements[el.id]
               ? 'dm'
               : undefined,
+          // Layer definitions sync (replaces the unknown-layer mirror):
+          // winning remote records apply through history-transparent *Direct
+          // calls; the pin subscription above re-pins bands on every change.
+          layers: {
+            applyLayer: makeApplyRemoteLayer(vp, 'dm', {
+              onApplied: () => vp.requestRender(),
+            }),
+          },
           onStatus: s => {
             setStatus(s);
             onStatusProp?.(s);
           },
           onPoke: feature => onPokeRef.current?.(feature),
         });
+        connectionRef.current = connection;
+        // Teach peers and late joiners the custom layers persisted in this
+        // canvas (created before layer sync, or on another device). Ledger
+        // buffers until the first snapshot if the socket is still connecting.
+        publishOwnedLayers(vp, 'dm', def => connection.publishLayerUpsert(def));
       }
 
       onViewportReady?.(vp);

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -13,6 +13,7 @@ import {
   TemplateTool,
   EraserTool,
   AutoSave,
+  type Layer,
   type Tool,
   type Viewport,
 } from '@fieldnotes/core';
@@ -21,6 +22,7 @@ import { useLocationStore } from '@/store/locationStore';
 import { useBattleMapStore } from '@/store/battleMapStore';
 import {
   createManagedBattleMapConnection,
+  type BattleMapConnection,
   type BattleMapConnectionStatus,
 } from '@/lib/battlemapSync';
 import { openTvDisplay } from '@/lib/openTvDisplay';
@@ -28,10 +30,10 @@ import { useShareWithPlayers } from './useShareWithPlayers';
 import {
   ensureCanonicalLayers,
   migrateCanvasToContract,
-  attachUnknownLayerMirror,
   subscribePinCanonicalLayers,
   MAP_LAYER_ID,
 } from './layerContract';
+import { makeApplyRemoteLayer, publishOwnedLayers } from './layerSync';
 import { pinGridToMapLayer } from './gridPin';
 import { nextMapImagePosition } from './mapImagePlacement';
 import {
@@ -158,6 +160,10 @@ export interface DmLocationEditorState {
   // Arrange maps (battlemap mode only)
   arrangeMapsActive: boolean;
   handleToggleArrangeMaps: () => void;
+
+  // Layer sync (battlemap mode; no-ops when live sync is off)
+  publishLayerUpsert: (definition: Layer) => void;
+  publishLayerRemove: (id: string) => void;
 }
 
 export function useDmLocationEditor(
@@ -170,7 +176,7 @@ export function useDmLocationEditor(
   const fileInputRef = useRef<HTMLInputElement>(null);
   const mapImageInputRef = useRef<HTMLInputElement>(null);
   const autoSaveRef = useRef<AutoSave | null>(null);
-  const connectionRef = useRef<{ stop: () => void } | null>(null);
+  const connectionRef = useRef<BattleMapConnection | null>(null);
   const pinUnsubRef = useRef<(() => void) | null>(null);
   const hiddenPlacementUnsubRef = useRef<(() => void) | null>(null);
   const [syncStatus, setSyncStatus] = useState<
@@ -376,13 +382,6 @@ export function useDmLocationEditor(
           .setDmOnly(campaignCode, location.id, element.id, true);
       });
 
-      // Layers aren't synced: player tokens arrive referencing player-*
-      // layer ids that don't exist on this canvas and would sort at layer
-      // order 0 — UNDER the annotations layer where DM-added images live.
-      // Mirror unknown layers into their canonical band instead. Covers both
-      // new elements (add) and relay snapshot reconcile re-applying remote
-      // elements as full updates (including layerId) on reconnect.
-      attachUnknownLayerMirror(vp, 'dm', () => vp.requestRender());
       pinUnsubRef.current?.();
       pinUnsubRef.current = subscribePinCanonicalLayers(vp, () => ({
         mapUnlocked: arrangeActiveRef.current,
@@ -395,7 +394,7 @@ export function useDmLocationEditor(
       // getState() (a captured snapshot would go stale after the first toggle).
       if (mode === 'battlemap' && process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL) {
         connectionRef.current?.stop();
-        connectionRef.current = createManagedBattleMapConnection({
+        const connection = createManagedBattleMapConnection({
           relayUrl: process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL,
           campaignCode,
           battleMapId: location.id,
@@ -408,8 +407,20 @@ export function useDmLocationEditor(
               ?.dmOnlyElements[el.id]
               ? 'dm'
               : undefined,
+          // Layer definitions sync (replaces the unknown-layer mirror):
+          // winning remote records apply through history-transparent *Direct
+          // calls; the pin subscription above re-pins bands on every change.
+          layers: {
+            applyLayer: makeApplyRemoteLayer(vp, 'dm', {
+              onApplied: () => vp.requestRender(),
+            }),
+          },
           onStatus: setSyncStatus,
         });
+        connectionRef.current = connection;
+        // Teach peers and late joiners the custom layers persisted in this
+        // canvas (created before layer sync, or on another device).
+        publishOwnedLayers(vp, 'dm', def => connection.publishLayerUpsert(def));
       }
     },
     [location, onSave, mode, campaignCode, dmId]
@@ -947,6 +958,15 @@ export function useDmLocationEditor(
     if (vp) _fitCameraToMap(vp, location.mapImageSize);
   }, [getVp, location.mapImageSize]);
 
+  // Stable across renders; reads the live connection so the layers panel can
+  // broadcast panel edits. Setup mode has no connection — silently local.
+  const publishLayerUpsert = useCallback((definition: Layer) => {
+    connectionRef.current?.publishLayerUpsert(definition);
+  }, []);
+  const publishLayerRemove = useCallback((id: string) => {
+    connectionRef.current?.publishLayerRemove(id);
+  }, []);
+
   return {
     mode,
     canvasRef,
@@ -992,5 +1012,7 @@ export function useDmLocationEditor(
     handleFitToMap,
     arrangeMapsActive,
     handleToggleArrangeMaps,
+    publishLayerUpsert,
+    publishLayerRemove,
   };
 }

--- a/src/components/ui/campaign/location-map/DmLocationEditor.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.tsx
@@ -57,6 +57,8 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
     handleFitToMap,
     arrangeMapsActive,
     handleToggleArrangeMaps,
+    publishLayerUpsert,
+    publishLayerRemove,
   } = useDmLocationEditor(props);
 
   return (
@@ -158,6 +160,8 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
                 unlinkEncounter(props.campaignCode, props.location.id, id)
               }
               onClose={() => setLayersPanelOpen(false)}
+              publishLayerUpsert={publishLayerUpsert}
+              publishLayerRemove={publishLayerRemove}
             />
           )}
 

--- a/src/components/ui/campaign/location-map/DmLocationLayersPanel.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationLayersPanel.tsx
@@ -10,6 +10,7 @@ import {
   PLAYER_LAYER_PREFIX,
 } from './layerContract';
 import type { EditorMode } from './DmLocationEditor.types';
+import type { Layer } from '@fieldnotes/core';
 
 interface DmLocationLayersPanelProps {
   mode: EditorMode;
@@ -18,6 +19,9 @@ interface DmLocationLayersPanelProps {
   onLinkEncounter: (id: string) => void;
   onUnlinkEncounter: (id: string) => void;
   onClose: () => void;
+  /** Battlemap mode: broadcast panel edits over layer sync (custom layers only). */
+  publishLayerUpsert?: (definition: Layer) => void;
+  publishLayerRemove?: (id: string) => void;
 }
 
 export default function DmLocationLayersPanel({
@@ -27,6 +31,8 @@ export default function DmLocationLayersPanel({
   onLinkEncounter,
   onUnlinkEncounter,
   onClose,
+  publishLayerUpsert,
+  publishLayerRemove,
 }: DmLocationLayersPanelProps) {
   const viewport = useViewport();
   const {
@@ -40,6 +46,14 @@ export default function DmLocationLayersPanel({
   } = useLayers();
   const allElements = useElements();
 
+  // Canonical bands are locally pinned per role and never broadcast; only
+  // custom layer definitions ride layer sync.
+  const publishIfCustom = (id: string) => {
+    if (id === MAP_LAYER_ID || id === ANNOTATIONS_LAYER_ID) return;
+    const layer = viewport.layerManager.getLayer(id);
+    if (layer) publishLayerUpsert?.(layer);
+  };
+
   return (
     <div className="border-divider bg-surface-raised flex w-52 flex-col border-l">
       <div className="border-divider flex items-center justify-between border-b px-3 py-2">
@@ -49,7 +63,8 @@ export default function DmLocationLayersPanel({
             variant="ghost"
             className="h-6 w-6 p-0"
             onClick={() => {
-              createLayer();
+              const layer = createLayer();
+              publishIfCustom(layer.id);
               viewport.requestRender();
             }}
             title="Add layer"
@@ -113,6 +128,7 @@ export default function DmLocationLayersPanel({
                   onClick={e => {
                     e.stopPropagation();
                     setVisible(layer.id, !layer.visible);
+                    publishIfCustom(layer.id);
                     viewport.requestRender();
                   }}
                   title={layer.visible ? 'Hide layer' : 'Show layer'}
@@ -133,6 +149,7 @@ export default function DmLocationLayersPanel({
                     onClick={e => {
                       e.stopPropagation();
                       setLocked(layer.id, !layer.locked);
+                      publishIfCustom(layer.id);
                       viewport.requestRender();
                     }}
                     title={layer.locked ? 'Unlock layer' : 'Lock layer'}
@@ -154,6 +171,12 @@ export default function DmLocationLayersPanel({
                     onClick={e => {
                       e.stopPropagation();
                       removeLayer(layer.id);
+                      if (
+                        layer.id !== MAP_LAYER_ID &&
+                        layer.id !== ANNOTATIONS_LAYER_ID
+                      ) {
+                        publishLayerRemove?.(layer.id);
+                      }
                       viewport.requestRender();
                     }}
                     className="text-muted hover:text-accent-red-text shrink-0"

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -44,12 +44,12 @@ import {
   type BattleMapConnectionStatus,
 } from '@/lib/battlemapSync';
 import DmLocationToolOptions from './DmLocationToolOptions';
-import { ensurePlayerLayer } from './playerLayer';
+import { ensurePlayerLayer, playerLayerId } from './playerLayer';
 import {
   ensureCanonicalLayers,
-  attachUnknownLayerMirror,
   subscribePinCanonicalLayers,
 } from './layerContract';
+import { makeApplyRemoteLayer, publishOwnedLayers } from './layerSync';
 import {
   PlayerTokenTool,
   PlayerTemplateTool,
@@ -286,15 +286,6 @@ export function PlayerBattleMapCanvas({
     // writes to it anyway).
     subscribePinCanonicalLayers(vp, () => ({ annotationsLocked: true }));
 
-    // Layers aren't synced: remote elements can reference layer ids that
-    // don't exist here (old clients, other players). Mirror each unknown
-    // layer locked into its band — hit-test and marquee skip remote content
-    // (the relay rejects player writes to it anyway), and stacking matches
-    // the DM's view. Covers both new elements (add) and relay snapshot
-    // reconcile re-applying remote elements as full updates (including
-    // layerId) on reconnect.
-    attachUnknownLayerMirror(vp, 'player', () => vp.requestRender());
-
     // Selection state for the touch-friendly delete button.
     const selectTool = vp.toolManager.getTool<SelectTool>('select');
     if (selectTool) {
@@ -312,13 +303,24 @@ export function PlayerBattleMapCanvas({
     const relayUrl = process.env.NEXT_PUBLIC_BATTLEMAP_RELAY_URL;
     if (!relayUrl) return;
     connectionRef.current?.stop();
-    connectionRef.current = createManagedBattleMapConnection({
+    const ownLayerId = playerLayerId(characterId);
+    const connection = createManagedBattleMapConnection({
       relayUrl,
       campaignCode,
       battleMapId,
       store: vp.store,
       clientId: characterId,
       tokenRequest: { role: 'player', battleMapId, playerId: characterId },
+      // Layer definitions sync (replaces the unknown-layer mirror): remote
+      // layers apply locked for players — hit-test and marquee skip content
+      // they cannot edit (the relay rejects their writes to it anyway) —
+      // while their own layer is never locked or removed by remote records.
+      layers: {
+        applyLayer: makeApplyRemoteLayer(vp, 'player', {
+          ownLayerId,
+          onApplied: () => vp.requestRender(),
+        }),
+      },
       onStatus: s => {
         setStatus(s);
         onStatusProp?.(s);
@@ -326,6 +328,15 @@ export function PlayerBattleMapCanvas({
       },
       onPoke: feature => onPokeRef.current?.(feature),
     });
+    connectionRef.current = connection;
+    // Teach the room this player's own layer (the relay only accepts a
+    // player's writes to player-<characterId>).
+    publishOwnedLayers(
+      vp,
+      'player',
+      def => connection.publishLayerUpsert(def),
+      ownLayerId
+    );
   };
 
   const handleDeleteSelected = useCallback(() => {

--- a/src/components/ui/campaign/location-map/__tests__/layerContract.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/layerContract.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   ElementStore,
   LayerManager,
@@ -15,11 +15,10 @@ import {
   ensureCanonicalLayers,
   pinCanonicalLayers,
   subscribePinCanonicalLayers,
-  mirrorUnknownLayer,
-  attachUnknownLayerMirror,
   migrateCanvasToContract,
   type ViewportLike,
 } from '@/components/ui/campaign/location-map/layerContract';
+import { makeApplyRemoteLayer } from '@/components/ui/campaign/location-map/layerSync';
 
 function makeVp(): ViewportLike {
   const store = new ElementStore();
@@ -204,80 +203,6 @@ describe('subscribePinCanonicalLayers', () => {
   });
 });
 
-describe('mirrorUnknownLayer', () => {
-  it('puts player-* ids in the player band, locked for role player', () => {
-    const vp = makeCleanVp('player');
-    mirrorUnknownLayer(vp, 'player-remote', 'player');
-    expect(layer(vp, 'player-remote').order).toBe(PLAYER_BAND_ORDER);
-    expect(layer(vp, 'player-remote').locked).toBe(true);
-  });
-
-  it('is unlocked for role dm and no-ops on a known layer', () => {
-    const vp = makeCleanVp();
-    mirrorUnknownLayer(vp, 'player-remote', 'dm');
-    expect(layer(vp, 'player-remote').locked).toBe(false);
-    const before = layer(vp, 'player-remote');
-    mirrorUnknownLayer(vp, 'player-remote', 'dm');
-    expect(layer(vp, 'player-remote')).toEqual(before);
-  });
-
-  it('puts non-player unknown ids in the custom band', () => {
-    const vp = makeCleanVp();
-    mirrorUnknownLayer(vp, 'layer-oldclient', 'dm');
-    expect(layer(vp, 'layer-oldclient').order).toBe(CUSTOM_BAND_ORDER);
-  });
-});
-
-describe('attachUnknownLayerMirror', () => {
-  it('mirrors an unknown layerId on add', () => {
-    const vp = makeCleanVp();
-    const onMirrored = vi.fn();
-    attachUnknownLayerMirror(vp, 'dm', onMirrored);
-    addImageOn(vp, 'player-remote');
-    expect(vp.layerManager.getLayer('player-remote')).toBeDefined();
-    expect(onMirrored).toHaveBeenCalledTimes(1);
-  });
-
-  it('mirrors an unknown layerId when an existing element is moved via update (relay snapshot reconcile regression)', () => {
-    // Regression for C1: relay snapshot reconcile re-applies remote elements
-    // via store.update(id, el) — a full replace including layerId — not
-    // store.add. An add-only mirror misses this and the element ends up
-    // referencing a layer this canvas no longer has.
-    const vp = makeCleanVp();
-    const elId = addImageOn(vp, ANNOTATIONS_LAYER_ID);
-    const onMirrored = vi.fn();
-    attachUnknownLayerMirror(vp, 'dm', onMirrored);
-    vp.store.update(elId, { layerId: 'player-ghost' });
-    expect(vp.layerManager.getLayer('player-ghost')).toBeDefined();
-    expect(layer(vp, 'player-ghost').order).toBe(PLAYER_BAND_ORDER);
-    expect(onMirrored).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not create a layer when an update targets a known layer', () => {
-    const vp = makeCleanVp();
-    const elId = addImageOn(vp, ANNOTATIONS_LAYER_ID);
-    const before = vp.layerManager.getLayers().length;
-    const onMirrored = vi.fn();
-    attachUnknownLayerMirror(vp, 'dm', onMirrored);
-    vp.store.update(elId, { zIndex: 5 });
-    expect(vp.layerManager.getLayers().length).toBe(before);
-    expect(onMirrored).not.toHaveBeenCalled();
-  });
-
-  it('unsubscribe stops both the add and update mirror paths', () => {
-    const vp = makeCleanVp();
-    const elId = addImageOn(vp, ANNOTATIONS_LAYER_ID);
-    const unsubscribe = attachUnknownLayerMirror(vp, 'dm');
-    unsubscribe();
-    addImageOn(vp, 'player-after-unsub-add');
-    vp.store.update(elId, { layerId: 'player-after-unsub-update' });
-    expect(vp.layerManager.getLayer('player-after-unsub-add')).toBeUndefined();
-    expect(
-      vp.layerManager.getLayer('player-after-unsub-update')
-    ).toBeUndefined();
-  });
-});
-
 describe('migrateCanvasToContract', () => {
   function legacyVp(): { vp: ViewportLike; bgId: string; annId: string } {
     const vp = makeVp();
@@ -414,8 +339,27 @@ describe('bug regression: DM-added image vs player token', () => {
     const vp = makeVp();
     ensureCanonicalLayers(vp, 'dm');
     const imageId = addImageOn(vp, ANNOTATIONS_LAYER_ID, 0);
-    // Remote token arrives referencing a layer this canvas has never seen.
-    mirrorUnknownLayer(vp, 'player-char1', 'dm');
+    // The player layer definition now arrives over layer sync before the
+    // token that references it (snapshots apply layers first).
+    makeApplyRemoteLayer(
+      vp,
+      'dm'
+    )({
+      source: 'op',
+      record: {
+        id: 'player-char1',
+        version: 1,
+        editor: 'char1',
+        definition: {
+          id: 'player-char1',
+          name: 'My elements',
+          visible: true,
+          locked: false,
+          order: PLAYER_BAND_ORDER,
+          opacity: 1,
+        },
+      },
+    });
     const tokenId = addImageOn(vp, 'player-char1', 1000);
     const order = vp.store.getAll().map(el => el.id);
     expect(order.indexOf(tokenId)).toBeGreaterThan(order.indexOf(imageId));

--- a/src/components/ui/campaign/location-map/__tests__/layerSync.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/layerSync.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ElementStore, LayerManager, type Layer } from '@fieldnotes/core';
+import type { RemoteLayerUpdate } from '@fieldnotes/sync';
+import {
+  MAP_LAYER_ID,
+  ANNOTATIONS_LAYER_ID,
+  ANNOTATIONS_LAYER_ORDER,
+  CUSTOM_BAND_ORDER,
+  PLAYER_BAND_ORDER,
+  ensureCanonicalLayers,
+  migrateCanvasToContract,
+  subscribePinCanonicalLayers,
+  type ViewportLike,
+} from '@/components/ui/campaign/location-map/layerContract';
+import {
+  makeApplyRemoteLayer,
+  publishOwnedLayers,
+} from '@/components/ui/campaign/location-map/layerSync';
+
+function makeVp(role: 'dm' | 'player' = 'dm'): ViewportLike {
+  const store = new ElementStore();
+  const layerManager = new LayerManager(store);
+  const vp = { store, layerManager };
+  ensureCanonicalLayers(vp, role);
+  migrateCanvasToContract(vp, role);
+  return vp;
+}
+
+function def(id: string, overrides: Partial<Layer> = {}): Layer {
+  return {
+    id,
+    name: id,
+    visible: true,
+    locked: false,
+    order: CUSTOM_BAND_ORDER,
+    opacity: 1,
+    ...overrides,
+  };
+}
+
+function upsert(definition: Layer, version = 1): RemoteLayerUpdate {
+  return {
+    source: 'op',
+    record: { id: definition.id, version, editor: 'remote', definition },
+  };
+}
+
+function tombstone(id: string, version = 2): RemoteLayerUpdate {
+  return { source: 'op', record: { id, version, editor: 'remote' } };
+}
+
+describe('makeApplyRemoteLayer', () => {
+  it('creates a missing layer from a remote definition and reports it', () => {
+    const vp = makeVp();
+    const onApplied = vi.fn();
+    const apply = makeApplyRemoteLayer(vp, 'dm', { onApplied });
+    apply(upsert(def('layer-tokens', { name: 'Tokens', opacity: 0.8 })));
+    const created = vp.layerManager.getLayer('layer-tokens');
+    expect(created?.name).toBe('Tokens');
+    expect(created?.opacity).toBe(0.8);
+    expect(onApplied).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates an existing layer in place', () => {
+    const vp = makeVp();
+    const apply = makeApplyRemoteLayer(vp, 'dm');
+    apply(upsert(def('layer-tokens')));
+    apply(upsert(def('layer-tokens', { name: 'Renamed', visible: false }), 2));
+    const updated = vp.layerManager.getLayer('layer-tokens');
+    expect(updated?.name).toBe('Renamed');
+    expect(updated?.visible).toBe(false);
+    expect(
+      vp.layerManager.getLayers().filter(l => l.id === 'layer-tokens')
+    ).toHaveLength(1);
+  });
+
+  it('ignores remote records for the canonical bands so role locks are never stomped', () => {
+    const vp = makeVp('player');
+    const apply = makeApplyRemoteLayer(vp, 'player');
+    // A DM's copy of annotations is unlocked; applying it here would unlock
+    // DM content for this player.
+    apply(upsert(def(ANNOTATIONS_LAYER_ID, { locked: false, order: 7 })));
+    apply(tombstone(MAP_LAYER_ID));
+    expect(vp.layerManager.getLayer(ANNOTATIONS_LAYER_ID)?.locked).toBe(true);
+    expect(vp.layerManager.getLayer(ANNOTATIONS_LAYER_ID)?.order).toBe(
+      ANNOTATIONS_LAYER_ORDER
+    );
+    expect(vp.layerManager.getLayer(MAP_LAYER_ID)).toBeDefined();
+  });
+
+  it('locks every remote layer for players except their own', () => {
+    const vp = makeVp('player');
+    const own = 'player-me';
+    vp.layerManager.addLayerDirect(def(own, { order: PLAYER_BAND_ORDER }));
+    const apply = makeApplyRemoteLayer(vp, 'player', { ownLayerId: own });
+
+    apply(
+      upsert(def('player-other', { order: PLAYER_BAND_ORDER, locked: false }))
+    );
+    apply(upsert(def('layer-dm-custom', { locked: false })));
+    // Own-layer definition arriving from the hub (e.g. same character on
+    // another device) must not lock the owner out.
+    apply(upsert(def(own, { order: PLAYER_BAND_ORDER, locked: false }), 3));
+
+    expect(vp.layerManager.getLayer('player-other')?.locked).toBe(true);
+    expect(vp.layerManager.getLayer('layer-dm-custom')?.locked).toBe(true);
+    expect(vp.layerManager.getLayer(own)?.locked).toBe(false);
+  });
+
+  it('applies lock state as-is for the DM and always locked for the display', () => {
+    const dmVp = makeVp();
+    makeApplyRemoteLayer(
+      dmVp,
+      'dm'
+    )(upsert(def('player-char1', { order: PLAYER_BAND_ORDER, locked: false })));
+    expect(dmVp.layerManager.getLayer('player-char1')?.locked).toBe(false);
+
+    const displayVp = makeVp('player');
+    makeApplyRemoteLayer(
+      displayVp,
+      'display'
+    )(upsert(def('layer-x', { locked: false })));
+    expect(displayVp.layerManager.getLayer('layer-x')?.locked).toBe(true);
+  });
+
+  it('removes a layer on a tombstone and repairs a dangling active layer', () => {
+    const vp = makeVp();
+    const apply = makeApplyRemoteLayer(vp, 'dm');
+    apply(upsert(def('layer-tokens')));
+    vp.layerManager.setActiveLayer('layer-tokens');
+
+    apply(tombstone('layer-tokens'));
+    expect(vp.layerManager.getLayer('layer-tokens')).toBeUndefined();
+    expect(vp.layerManager.activeLayerId).toBe(ANNOTATIONS_LAYER_ID);
+  });
+
+  it('never removes the player own layer and ignores tombstones for unknown ids', () => {
+    const vp = makeVp('player');
+    const own = 'player-me';
+    vp.layerManager.addLayerDirect(def(own, { order: PLAYER_BAND_ORDER }));
+    const onApplied = vi.fn();
+    const apply = makeApplyRemoteLayer(vp, 'player', {
+      ownLayerId: own,
+      onApplied,
+    });
+
+    apply(tombstone(own));
+    apply(tombstone('never-seen'));
+    expect(vp.layerManager.getLayer(own)).toBeDefined();
+    expect(onApplied).not.toHaveBeenCalled();
+  });
+
+  it('keeps bands pinned when combined with the pin subscription', () => {
+    const vp = makeVp();
+    subscribePinCanonicalLayers(vp, () => ({ annotationsLocked: false }));
+    const apply = makeApplyRemoteLayer(vp, 'dm');
+    // Remote order lands inside its band even if the record carries a raw value.
+    apply(upsert(def('layer-tokens', { order: 42 })));
+    apply(upsert(def('player-char1', { order: 999 })));
+    expect(vp.layerManager.getLayer('layer-tokens')?.order).toBe(
+      CUSTOM_BAND_ORDER
+    );
+    expect(vp.layerManager.getLayer('player-char1')?.order).toBe(
+      PLAYER_BAND_ORDER
+    );
+  });
+});
+
+describe('publishOwnedLayers', () => {
+  it('dm publishes custom layers only — never canonical or player layers', () => {
+    const vp = makeVp();
+    vp.layerManager.addLayerDirect(
+      def('layer-props', { order: CUSTOM_BAND_ORDER })
+    );
+    vp.layerManager.addLayerDirect(
+      def('player-char1', { order: PLAYER_BAND_ORDER })
+    );
+    const published: string[] = [];
+    publishOwnedLayers(vp, 'dm', d => published.push(d.id));
+    expect(published).toEqual(['layer-props']);
+  });
+
+  it('player publishes exactly their own layer', () => {
+    const vp = makeVp('player');
+    vp.layerManager.addLayerDirect(
+      def('player-me', { order: PLAYER_BAND_ORDER })
+    );
+    vp.layerManager.addLayerDirect(
+      def('player-other', { order: PLAYER_BAND_ORDER })
+    );
+    const published: string[] = [];
+    publishOwnedLayers(vp, 'player', d => published.push(d.id), 'player-me');
+    expect(published).toEqual(['player-me']);
+  });
+
+  it('player publishes nothing when the own layer does not exist yet', () => {
+    const vp = makeVp('player');
+    const published: string[] = [];
+    publishOwnedLayers(vp, 'player', d => published.push(d.id), 'player-me');
+    expect(published).toEqual([]);
+  });
+});

--- a/src/components/ui/campaign/location-map/layerContract.ts
+++ b/src/components/ui/campaign/location-map/layerContract.ts
@@ -3,9 +3,11 @@ import type { ElementStore, LayerManager } from '@fieldnotes/core';
 /**
  * Canonical layer bands shared by ALL battlemap canvases (DM setup editor,
  * DM play canvas, player canvas). The FieldNotes SDK paints elements sorted
- * by (layerOrder, zIndex) with zIndex compared only WITHIN a layer, and
- * layers are not synced between clients — so stacking is only deterministic
- * if every canvas assigns the same order band to the same layer id:
+ * by (layerOrder, zIndex) with zIndex compared only WITHIN a layer — so
+ * stacking is only deterministic if every canvas assigns the same order band
+ * to the same layer id. Custom and player layer definitions now sync between
+ * clients (`layerSync.ts` over `@fieldnotes/sync` layer records); the bands
+ * below remain RollKeeper policy, re-pinned locally on every layer change:
  *
  *   layer-map (0, locked)            map images + grid
  *   layer-annotations (100)          DM annotations + combatant tokens
@@ -154,60 +156,6 @@ export function subscribePinCanonicalLayers(
       pinning = false;
     }
   });
-}
-
-/**
- * Layers don't sync: a remote element can reference a layer id this canvas
- * has never seen (old clients mid-rollout, other players' layers). Mirror it
- * locally into the right band so stacking stays deterministic. Locked for
- * players (can't touch remote content anyway); unlocked for the DM (keeps
- * the DM able to drag player tokens).
- */
-export function mirrorUnknownLayer(
-  vp: ViewportLike,
-  layerId: string,
-  role: CanvasRole
-): void {
-  if (!layerId || vp.layerManager.getLayer(layerId)) return;
-  const isPlayerLayer = layerId.startsWith(PLAYER_LAYER_PREFIX);
-  vp.layerManager.addLayerDirect({
-    id: layerId,
-    name: 'Remote layer',
-    visible: true,
-    locked: role === 'player',
-    order: isPlayerLayer ? PLAYER_BAND_ORDER : CUSTOM_BAND_ORDER,
-    opacity: 1,
-  });
-  pinCanonicalLayers(vp);
-}
-
-/**
- * Register the unknown-layer mirror on a store. Both 'add' AND 'update' must
- * be covered: relay snapshot reconcile re-applies remote elements as full
- * updates (including layerId), so a layerId referencing a layer this canvas
- * no longer has (e.g. pre-migration legacy ids restored from the relay's
- * persisted room state) can arrive on either event. Returns an unsubscribe
- * for both listeners.
- */
-export function attachUnknownLayerMirror(
-  vp: ViewportLike,
-  role: CanvasRole,
-  onMirrored?: () => void
-): () => void {
-  const check = (layerId: string | undefined) => {
-    if (layerId && !vp.layerManager.getLayer(layerId)) {
-      mirrorUnknownLayer(vp, layerId, role);
-      onMirrored?.();
-    }
-  };
-  const unsubAdd = vp.store.on('add', el => check(el.layerId));
-  const unsubUpdate = vp.store.on('update', ({ current }) =>
-    check(current.layerId)
-  );
-  return () => {
-    unsubAdd();
-    unsubUpdate();
-  };
 }
 
 /**

--- a/src/components/ui/campaign/location-map/layerSync.ts
+++ b/src/components/ui/campaign/location-map/layerSync.ts
@@ -1,0 +1,126 @@
+import type { Layer } from '@fieldnotes/core';
+import type { RemoteLayerUpdate } from '@fieldnotes/sync';
+import {
+  MAP_LAYER_ID,
+  ANNOTATIONS_LAYER_ID,
+  PLAYER_LAYER_PREFIX,
+  type ViewportLike,
+} from './layerContract';
+
+/**
+ * Roles a synced battle-map canvas can play. `display` is the read-only TV
+ * view: definitions apply verbatim but always locked, and it never publishes.
+ */
+export type LayerSyncRole = 'dm' | 'player' | 'display';
+
+export interface ApplyRemoteLayerOptions {
+  /**
+   * The player's own `player-<characterId>` layer. It is never locked or
+   * removed by remote records — the owner must always keep control of their
+   * elements, whatever another client's copy of the definition says.
+   */
+  ownLayerId?: string;
+  /** Called after a record actually changed local layer state (e.g. requestRender). */
+  onApplied?: () => void;
+}
+
+/**
+ * Builds the `applyLayer` hook for a battle-map connection. The SDK calls it
+ * only for records that win the deterministic (version, editor) ordering;
+ * this hook owns RollKeeper policy on top:
+ *
+ * - Canonical bands (`layer-map`, `layer-annotations`) are locally owned and
+ *   pinned by `subscribePinCanonicalLayers`; remote definitions for them are
+ *   ignored outright so role lock rules are never stomped.
+ * - Players get every remote layer locked except their own (hit-testing and
+ *   marquee must skip content they cannot edit — the relay rejects their
+ *   writes to it anyway). The DM applies lock state as-is; the display locks
+ *   everything.
+ * - Application uses `LayerManager` `*Direct` calls, so remote layer changes
+ *   never enter local undo history.
+ * - Band renumbering stays with the existing pin subscription, which fires on
+ *   every layer change these applications emit.
+ */
+export function makeApplyRemoteLayer(
+  vp: ViewportLike,
+  role: LayerSyncRole,
+  opts: ApplyRemoteLayerOptions = {}
+): (update: RemoteLayerUpdate) => void {
+  return update => {
+    const { record } = update;
+    const id = record.id;
+    if (id === MAP_LAYER_ID || id === ANNOTATIONS_LAYER_ID) return;
+    if (id === opts.ownLayerId && record.definition === undefined) return;
+    const lm = vp.layerManager;
+
+    if (!record.definition) {
+      if (!lm.getLayer(id)) return;
+      lm.removeLayerDirect(id);
+      // removeLayerDirect does not repair a dangling active layer.
+      if (!lm.getLayer(lm.activeLayerId)) {
+        const fallback =
+          opts.ownLayerId && lm.getLayer(opts.ownLayerId)
+            ? opts.ownLayerId
+            : ANNOTATIONS_LAYER_ID;
+        if (lm.getLayer(fallback)) lm.setActiveLayer(fallback);
+      }
+      opts.onApplied?.();
+      return;
+    }
+
+    const def = record.definition;
+    const locked =
+      role === 'display'
+        ? true
+        : role === 'player' && id !== opts.ownLayerId
+          ? true
+          : def.locked;
+    const existing = lm.getLayer(id);
+    if (existing) {
+      lm.updateLayerDirect(id, {
+        name: def.name,
+        visible: def.visible,
+        locked,
+        order: def.order,
+        opacity: def.opacity,
+      });
+    } else {
+      lm.addLayerDirect({ ...def, locked });
+    }
+    opts.onApplied?.();
+  };
+}
+
+/**
+ * Publishes the layers this client owns, once per canvas ready, so peers and
+ * late joiners get definitions even for layers created before layer sync
+ * shipped (persisted in `canvasState` only):
+ *
+ * - DM canvases own the custom (non-canonical, non-player) layers.
+ * - A player canvas owns exactly its `player-<characterId>` layer.
+ * - Canonical bands are never published — every canvas creates and pins them
+ *   locally with role-dependent lock state.
+ *
+ * The connection ledger stamps versions; while the socket is still
+ * connecting, edits land in the ledger and are re-pushed after the first
+ * authoritative snapshot.
+ */
+export function publishOwnedLayers(
+  vp: ViewportLike,
+  role: 'dm' | 'player',
+  publish: (definition: Layer) => void,
+  ownLayerId?: string
+): void {
+  if (role === 'player') {
+    const own = ownLayerId ? vp.layerManager.getLayer(ownLayerId) : undefined;
+    if (own) publish(own);
+    return;
+  }
+  for (const layer of vp.layerManager.getLayers()) {
+    if (layer.id === MAP_LAYER_ID || layer.id === ANNOTATIONS_LAYER_ID) {
+      continue;
+    }
+    if (layer.id.startsWith(PLAYER_LAYER_PREFIX)) continue;
+    publish(layer);
+  }
+}

--- a/src/lib/battlemapSync.test.ts
+++ b/src/lib/battlemapSync.test.ts
@@ -1,14 +1,29 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   ElementStore,
+  LayerManager,
   createShape,
   type CanvasElement,
+  type Layer,
 } from '@fieldnotes/core';
 import {
   createManagedBattleMapConnection,
   type BattleMapConnectionStatus,
   type BattleMapTransport,
 } from '@/lib/battlemapSync';
+import {
+  ANNOTATIONS_LAYER_ID,
+  CUSTOM_BAND_ORDER,
+  PLAYER_BAND_ORDER,
+  ensureCanonicalLayers,
+  migrateCanvasToContract,
+  subscribePinCanonicalLayers,
+  type ViewportLike,
+} from '@/components/ui/campaign/location-map/layerContract';
+import {
+  makeApplyRemoteLayer,
+  publishOwnedLayers,
+} from '@/components/ui/campaign/location-map/layerSync';
 
 // No @fieldnotes/sync mocking: the real managed lifecycle + SyncClient run
 // against an injected fake transport, so these tests exercise the actual
@@ -344,5 +359,301 @@ describe('createManagedBattleMapConnection', () => {
     const sends = fakeTransport.sent.length;
     store.add(el('late'));
     expect(fakeTransport.sent.length).toBe(sends);
+  });
+});
+
+describe('createManagedBattleMapConnection layer sync (call-site wiring)', () => {
+  let fakeTransport: FakeTransport;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fakeTransport = new FakeTransport();
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: 'test-token' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const flushMicro = (): Promise<void> =>
+    new Promise(resolve => setTimeout(resolve, 0));
+
+  function makeCanvas(role: 'dm' | 'player'): ViewportLike {
+    const store = new ElementStore();
+    const layerManager = new LayerManager(store);
+    const vp = { store, layerManager };
+    ensureCanonicalLayers(vp, role);
+    migrateCanvasToContract(vp, role);
+    return vp;
+  }
+
+  function layerDef(id: string, overrides: Partial<Layer> = {}): Layer {
+    return {
+      id,
+      name: id,
+      visible: true,
+      locked: false,
+      order: CUSTOM_BAND_ORDER,
+      opacity: 1,
+      ...overrides,
+    };
+  }
+
+  function record(definition: Layer, version = 1, editor = 'remote') {
+    return { id: definition.id, version, editor, definition };
+  }
+
+  const sentLayerOps = (
+    sent: string[]
+  ): { kind: string; layer?: Layer; version?: number; editor?: string }[] =>
+    sent
+      .map(m => JSON.parse(m) as { op: { kind: string } })
+      .map(e => e.op as { kind: string; layer?: Layer; version?: number })
+      .filter(op => op.kind === 'layer-upsert' || op.kind === 'layer-remove');
+
+  function connect(
+    vp: ViewportLike,
+    roleWiring: 'dm' | 'player' | 'display',
+    clientId: string,
+    ownLayerId?: string
+  ) {
+    return createManagedBattleMapConnection({
+      relayUrl: 'wss://relay.example',
+      campaignCode: 'CODE',
+      battleMapId: 'map-1',
+      store: vp.store as ElementStore,
+      clientId,
+      tokenRequest: { role: 'dm', battleMapId: 'map-1', dmId: clientId },
+      seedLocal: roleWiring === 'dm',
+      layers: {
+        applyLayer: makeApplyRemoteLayer(vp, roleWiring, { ownLayerId }),
+      },
+      transportFactory: () => fakeTransport,
+    });
+  }
+
+  it('DM canvas: join snapshot applies layer records before elements, bands pinned (VTT/editor wiring)', async () => {
+    const vp = makeCanvas('dm');
+    subscribePinCanonicalLayers(vp, () => ({ annotationsLocked: false }));
+    const events: string[] = [];
+    vp.layerManager.on('create', l => events.push(`layer:${l.id}`));
+    vp.store.on('add', element => events.push(`el:${element.id}`));
+
+    const conn = connect(vp, 'dm', 'dm-1');
+    await flushMicro();
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'hub',
+        op: {
+          kind: 'snapshot',
+          to: 'dm-1',
+          elements: [
+            { ...el('img'), layerId: ANNOTATIONS_LAYER_ID },
+            { ...el('tok'), layerId: 'player-char9' },
+          ],
+          layers: [
+            record(
+              layerDef('player-char9', { order: PLAYER_BAND_ORDER }),
+              1,
+              'char9'
+            ),
+            record(layerDef('layer-props', { order: 42 }), 1, 'dm-other'),
+          ],
+        },
+      })
+    );
+
+    // The token's layer exists before the token itself lands.
+    expect(events.indexOf('layer:player-char9')).toBeGreaterThanOrEqual(0);
+    expect(events.indexOf('layer:player-char9')).toBeLessThan(
+      events.indexOf('el:tok')
+    );
+    // Bands re-pinned by the subscription, even for a raw record order.
+    expect(vp.layerManager.getLayer('layer-props')?.order).toBe(
+      CUSTOM_BAND_ORDER
+    );
+    expect(vp.layerManager.getLayer('player-char9')?.order).toBe(
+      PLAYER_BAND_ORDER
+    );
+    // DM keeps player layers unlocked (can drag player tokens).
+    expect(vp.layerManager.getLayer('player-char9')?.locked).toBe(false);
+    conn.stop();
+  });
+
+  it('DM canvas: connect-time publishOwnedLayers teaches peers pre-existing custom layers', async () => {
+    const vp = makeCanvas('dm');
+    vp.layerManager.addLayerDirect(layerDef('layer-props'));
+
+    const conn = connect(vp, 'dm', 'dm-1');
+    // Production publishes immediately after creating the connection, while
+    // the token mint is still in flight — the ledger must buffer it.
+    publishOwnedLayers(vp, 'dm', def => conn.publishLayerUpsert(def));
+    await flushMicro();
+    fakeTransport.emitMessage(snapshotEnvelope('dm-1', []));
+
+    const ops = sentLayerOps(fakeTransport.sent);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]?.kind).toBe('layer-upsert');
+    expect(ops[0]?.layer?.id).toBe('layer-props');
+    expect(ops[0]?.editor).toBe('dm-1');
+    conn.stop();
+  });
+
+  it('DM canvas: an offline layer edit survives a 4401 rebuild and beats a stale reconcile record', async () => {
+    vi.useFakeTimers();
+    try {
+      const vp = makeCanvas('dm');
+      const applied: string[] = [];
+      const conn = createManagedBattleMapConnection({
+        relayUrl: 'wss://relay.example',
+        campaignCode: 'CODE',
+        battleMapId: 'map-1',
+        store: vp.store as ElementStore,
+        clientId: 'dm-1',
+        tokenRequest: { role: 'dm', battleMapId: 'map-1', dmId: 'dm-1' },
+        seedLocal: true,
+        layers: {
+          applyLayer: update => {
+            applied.push(update.record.definition?.name ?? 'tombstone');
+            makeApplyRemoteLayer(vp, 'dm')(update);
+          },
+        },
+        transportFactory: () => fakeTransport,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      fakeTransport.emitMessage(
+        JSON.stringify({
+          from: 'hub',
+          op: {
+            kind: 'snapshot',
+            to: 'dm-1',
+            elements: [],
+            layers: [record(layerDef('layer-props', { name: 'v1' }), 1)],
+          },
+        })
+      );
+      expect(applied).toEqual(['v1']);
+
+      // Token expires; the DM renames the layer while detached.
+      fakeTransport.emitClose(4401);
+      conn.publishLayerUpsert(
+        layerDef('layer-props', { name: 'renamed offline' })
+      );
+      await vi.advanceTimersByTimeAsync(2_000); // re-mint + rebuild
+
+      const sentBefore = fakeTransport.sent.length;
+      // Reconcile snapshot still carries the stale v1 record.
+      fakeTransport.emitMessage(
+        JSON.stringify({
+          from: 'hub',
+          op: {
+            kind: 'snapshot',
+            to: 'dm-1',
+            elements: [],
+            layers: [record(layerDef('layer-props', { name: 'v1' }), 1)],
+          },
+        })
+      );
+
+      // Stale record must not fire the hook again; the newer offline edit is re-pushed.
+      expect(applied).toEqual(['v1']);
+      const repushed = sentLayerOps(fakeTransport.sent.slice(sentBefore));
+      expect(repushed).toHaveLength(1);
+      expect(repushed[0]?.layer?.name).toBe('renamed offline');
+      expect(repushed[0]?.version).toBe(2);
+      conn.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('player canvas: publishes its own layer, applies remote layers locked, own layer never locked or removed', async () => {
+    const vp = makeCanvas('player');
+    const ownLayerId = 'player-char1';
+    vp.layerManager.addLayerDirect(
+      layerDef(ownLayerId, { name: 'My elements', order: PLAYER_BAND_ORDER })
+    );
+    vp.layerManager.setActiveLayer(ownLayerId);
+    subscribePinCanonicalLayers(vp, () => ({ annotationsLocked: true }));
+
+    const conn = connect(vp, 'player', 'char1', ownLayerId);
+    publishOwnedLayers(
+      vp,
+      'player',
+      def => conn.publishLayerUpsert(def),
+      ownLayerId
+    );
+    await flushMicro();
+    fakeTransport.emitMessage(snapshotEnvelope('char1', []));
+
+    const ops = sentLayerOps(fakeTransport.sent);
+    expect(ops.map(op => op.layer?.id)).toEqual([ownLayerId]);
+
+    // DM custom layer arrives: locked for the player.
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'relay-conn',
+        op: {
+          kind: 'layer-upsert',
+          layer: layerDef('layer-props', { locked: false }),
+          version: 1,
+          editor: 'dm-1',
+        },
+      })
+    );
+    expect(vp.layerManager.getLayer('layer-props')?.locked).toBe(true);
+
+    // A rogue tombstone for the own layer is ignored.
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'relay-conn',
+        op: {
+          kind: 'layer-remove',
+          id: ownLayerId,
+          version: 9,
+          editor: 'dm-1',
+        },
+      })
+    );
+    expect(vp.layerManager.getLayer(ownLayerId)).toBeDefined();
+    expect(vp.layerManager.getLayer(ownLayerId)?.locked).toBe(false);
+    conn.stop();
+  });
+
+  it('display canvas: applies snapshot layer records locked and publishes nothing', async () => {
+    const vp = makeCanvas('player'); // display also ensures canonical bands
+    const conn = connect(vp, 'display', 'display-CODE');
+    await flushMicro();
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'hub',
+        op: {
+          kind: 'snapshot',
+          to: 'display-CODE',
+          elements: [{ ...el('tok'), layerId: 'player-char9' }],
+          layers: [
+            record(
+              layerDef('player-char9', {
+                order: PLAYER_BAND_ORDER,
+                locked: false,
+              }),
+              1,
+              'char9'
+            ),
+          ],
+        },
+      })
+    );
+
+    expect(vp.layerManager.getLayer('player-char9')?.locked).toBe(true);
+    expect(vp.layerManager.getLayer('player-char9')?.order).toBe(
+      PLAYER_BAND_ORDER
+    );
+    expect(sentLayerOps(fakeTransport.sent)).toEqual([]);
+    conn.stop();
   });
 });

--- a/src/lib/battlemapSync.ts
+++ b/src/lib/battlemapSync.ts
@@ -2,10 +2,13 @@ import {
   createManagedSyncConnection,
   type ManagedSyncStatus,
   type ManagedSyncTransport,
+  type RemoteLayerUpdate,
   type ResolveLocalOnly,
 } from '@fieldnotes/sync';
-import type { ElementStore, CanvasElement } from '@fieldnotes/core';
+import type { ElementStore, CanvasElement, Layer } from '@fieldnotes/core';
 import type { BattleMapRole } from '@/lib/battlemapToken';
+
+export type { RemoteLayerUpdate };
 
 export type BattleMapConnectionStatus = ManagedSyncStatus;
 
@@ -83,6 +86,15 @@ export interface ManagedConnectionOptions {
    * on every bootstrap/reconcile snapshot (SDK `resolveLocalOnly` hooks).
    */
   seedLocal?: boolean;
+  /**
+   * Opt into versioned layer-definition sync (SDK `layers` option). The hook
+   * receives only records that win the deterministic (version, editor)
+   * ordering; RollKeeper applies them through history-transparent
+   * `LayerManager` `*Direct` calls with role policy overlaid (see
+   * `layerSync.ts`). Publishing stays explicit via the returned
+   * `publishLayerUpsert`/`publishLayerRemove`.
+   */
+  layers?: { applyLayer: (update: RemoteLayerUpdate) => void };
   onStatus?: (s: BattleMapConnectionStatus) => void;
   /** Fires when the relay pokes this room (e.g. initiative changed → refetch /shared). */
   onPoke?: (feature: string) => void;
@@ -97,9 +109,21 @@ export interface ManagedConnectionOptions {
  * transient reconnect, token refresh after terminal auth closes (4401), and
  * bounded auth retry ending in `denied`.
  */
+export interface BattleMapConnection {
+  stop: () => void;
+  /**
+   * Publishes a layer definition edit (stamped and versioned by the SDK).
+   * While disconnected the edit lands in the connection's ledger and is
+   * re-pushed after the next authoritative snapshot. Throws when the
+   * connection was created without the `layers` option.
+   */
+  publishLayerUpsert: (definition: Layer) => void;
+  publishLayerRemove: (id: string) => void;
+}
+
 export function createManagedBattleMapConnection(
   opts: ManagedConnectionOptions
-): { stop: () => void } {
+): BattleMapConnection {
   const room = `${opts.campaignCode}:${opts.battleMapId}`;
 
   const connection = createManagedSyncConnection({
@@ -111,6 +135,7 @@ export function createManagedBattleMapConnection(
     // calls the hook synchronously for every snapshot addressed to us, so no
     // raw-frame parsing or deferred reseeding is needed.
     resolveLocalOnly: opts.seedLocal ? preserveHubUnknown : undefined,
+    layers: opts.layers,
     resolveUrl: async () => {
       const token = await mintBattleMapToken(
         opts.campaignCode,
@@ -132,6 +157,12 @@ export function createManagedBattleMapConnection(
   return {
     stop: (): void => {
       connection.stop();
+    },
+    publishLayerUpsert: (definition: Layer): void => {
+      connection.publishLayerUpsert(definition);
+    },
+    publishLayerRemove: (id: string): void => {
+      connection.publishLayerRemove(id);
     },
   };
 }


### PR DESCRIPTION
## Why

Paired adoption PR for Fieldnotes [#140](https://github.com/IrakliDevelop/fieldnotes/pull/140) (`@fieldnotes/sync@0.10.0`, `@fieldnotes/sync-server@0.12.0`, `@fieldnotes/sync-redis@0.4.0`, all published). Layers were client-local, so every canvas mirrored unknown remote layer ids into hard-coded bands (`attachUnknownLayerMirror`) — remote-elements-referencing-unseen-layers was the workaround this roadmap item exists to delete. Map, annotation, custom, and player layer ordering now survives join and reconnect on all four call sites without local mirroring.

## What

**Dependencies / relay**
- Root `@fieldnotes/sync` `^0.10.0`; relay pins sync `0.10.0`, sync-server `0.12.0`, sync-redis `0.4.0`; both lockfiles resolve the published packages.
- `BufferedRedisBackend` unchanged — the new `HubBackend` layer methods are optional and the hub's per-room memory fallback covers the relay's memory-first design. `EphemeralHubFanout` still forwards presence only; layer ops (like durable element ops) do not cross instances, consistent with the existing single-canonical-instance model.
- New relay `authorizeLayer` policy: DM edits any definition; a player only their own `player-<characterId>` layer; display read-only. Denied/stale edits get an authoritative hub correction to the sender only.

**Adoption seam**
- `battlemapSync.ts` forwards the SDK `layers` option and exposes `publishLayerUpsert`/`publishLayerRemove` (ledger-buffered while disconnected, re-pushed after the next authoritative snapshot).
- New `layerSync.ts`:
  - `makeApplyRemoteLayer(vp, role, {ownLayerId})` — the host hook. Winning records apply via history-transparent `*Direct` calls (never undo history). Canonical bands (`layer-map`, `layer-annotations`) are ignored outright so role lock rules are never stomped. Players get every remote layer locked except their own, which is also never locked or removed by remote records; the display locks everything; the DM applies lock state as-is. Band renumbering stays with `subscribePinCanonicalLayers`.
  - `publishOwnedLayers` — connect-time publish of the layers a client owns (DM: custom layers; player: own layer), so definitions exist even for layers created before this feature.

**Call sites**
- DM VTT + DM location editor: apply as `dm`, publish customs on connect; layers-panel create/remove/visible/lock edits broadcast (canonical bands never published).
- Player canvas: publishes its own layer, applies remote layers locked.
- TV display: now ensures canonical bands and applies definitions read-only.
- Deleted: `attachUnknownLayerMirror`/`mirrorUnknownLayer`. Kept product-owned: band policy, `ensureCanonicalLayers`/`pinCanonicalLayers`/`subscribePinCanonicalLayers`, `migrateCanvasToContract`.

## Behavior notes

- Layer definitions are presentation only — element privacy stays entirely on relay-side `canRead`/audience filtering; layer records carry no element bytes.
- Rooms with stale pre-contract element layer ids (no definition published, DM absent) render those elements without a band until the DM opens the map, where migration rewrites them through the relay — same healing path as before, minus the local mirror.
- Relay restart loses in-memory layer records (fallback storage); DM/player connect-time publishing re-teaches the room on next join.

## Verification

- Full unit suite: **3,594 passed / 1 skipped**; `tsc --noEmit` clean.
- New `layerSync.test.ts` (11 tests): apply/create/update, canonical-band protection, player lock overlay + own-layer immunity, tombstone + dangling-active-layer repair, band pinning with the pin subscription, publish ownership rules.
- `battlemapSync.test.ts` (+5, now 14): real managed lifecycle + `SyncClient` over a fake transport per call-site wiring — DM join snapshot applies layer records before the elements referencing them with bands pinned; connect-time `publishOwnedLayers` buffers through the ledger during token mint; an offline layer edit survives a 4401 rebuild and out-versions a stale reconcile record; player publishes own layer, applies remote layers locked, ignores rogue own-layer tombstones; display applies locked and publishes nothing.
- `layerContract.test.ts` regression (DM image vs player token) now proves the layer-sync path instead of the mirror.
- Relay: **53/53** on the published packages, including new real-WebSocket e2e (`layer-sync.test.ts`): DM definition propagation, player ownership enforcement with authoritative correction on hijack attempt, late-joiner snapshot records, display read-only tombstone correction; plus `authorizeLayer` unit cases. Relay build + type-check clean.
- ESLint on touched areas: 0 errors, warnings pre-existing on master.
- Desktop/touch: N/A — no pointer/interaction code changed.

SDK PR: IrakliDevelop/fieldnotes#140 (merged `bfc7751`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)