### PR TITLE
fix(battlemap): allow laser color selection

### DIFF
--- a/src/components/ui/campaign/location-map/DmLocationToolOptions.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolOptions.tsx
@@ -3,6 +3,7 @@
 import type { ShapeKind } from '@fieldnotes/core';
 import type {
   ArrowToolOptions,
+  LaserToolOptions,
   MeasureToolOptions,
   NoteToolOptions,
   PencilToolOptions,
@@ -83,6 +84,9 @@ export default function DmLocationToolOptions({
   const [templateOpts, setTemplateOpts] = useToolOptions<
     TemplateToolOptions & Record<string, unknown>
   >('template');
+  const [laserOpts, setLaserOpts] = useToolOptions<
+    LaserToolOptions & Record<string, unknown>
+  >('laser');
 
   const showOptionsBar =
     (activeTool === 'pencil' && pencilOpts !== undefined) ||
@@ -91,7 +95,9 @@ export default function DmLocationToolOptions({
     activeTool === 'text' ||
     activeTool === 'shape' ||
     (mode === 'battlemap' &&
-      (activeTool === 'measure' || activeTool === 'template'));
+      (activeTool === 'measure' ||
+        activeTool === 'template' ||
+        (activeTool === 'laser' && laserOpts !== undefined)));
 
   if (!showOptionsBar) return null;
 
@@ -104,11 +110,13 @@ export default function DmLocationToolOptions({
         ? textOpts?.color
         : activeTool === 'note'
           ? noteOpts?.backgroundColor
-          : activeTool === 'arrow'
-            ? arrowOpts?.color
-            : activeTool === 'pencil'
-              ? pencilOpts?.color
-              : '#334155';
+          : activeTool === 'laser'
+            ? laserOpts?.color
+            : activeTool === 'arrow'
+              ? arrowOpts?.color
+              : activeTool === 'pencil'
+                ? pencilOpts?.color
+                : '#334155';
 
   const handleColorChange = (color: string) => {
     if (activeTool === 'shape') setShapeOpts({ strokeColor: color });
@@ -117,6 +125,7 @@ export default function DmLocationToolOptions({
     else if (activeTool === 'arrow') setArrowOpts({ color });
     else if (activeTool === 'pencil') setPencilOpts({ color });
     else if (activeTool === 'template') setTemplateOpts({ strokeColor: color });
+    else if (activeTool === 'laser') setLaserOpts({ color });
   };
 
   return (

--- a/src/components/ui/campaign/location-map/__tests__/DmLocationToolOptions.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/DmLocationToolOptions.test.tsx
@@ -42,6 +42,25 @@ describe('DmLocationToolOptions pencil options', () => {
     });
   });
 
+  it('shows laser colors in battle-map mode and updates the laser tool', () => {
+    mockActiveTool = 'laser';
+    mockToolOptions = { laser: { color: '#F4C430', width: 3 } };
+    render(<DmLocationToolOptions mode="battlemap" />);
+
+    fireEvent.click(screen.getByTitle('#ef4444'));
+    expect(setOptionsSpies['laser']).toHaveBeenCalledWith({
+      color: '#ef4444',
+    });
+  });
+
+  it('does not show laser options outside battle-map mode', () => {
+    mockActiveTool = 'laser';
+    mockToolOptions = { laser: { color: '#F4C430', width: 3 } };
+    const { container } = render(<DmLocationToolOptions mode="location" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('renders nothing when no pencil tool is registered (location editor)', () => {
     mockToolOptions = { pencil: undefined };
     const { container } = render(<DmLocationToolOptions mode="location" />);


### PR DESCRIPTION
## Summary
- show the shared color options bar when the laser tool is active in battle-map play mode
- apply palette and custom-picker colors directly to the laser tool
- add regression coverage for battle-map and location-map visibility

## Verification
- pnpm exec tsc --noEmit --pretty false
- pnpm test -- --run src/components/ui/campaign/location-map/__tests__/DmLocationToolOptions.test.tsx (full unit project: 3,607 passed, 1 skipped)
- commit hooks: Prettier and ESLint