### PR TITLE
fix: preserve published location details

### DIFF
--- a/src/app/api/assets/proxy/__tests__/route.test.ts
+++ b/src/app/api/assets/proxy/__tests__/route.test.ts
@@ -1,0 +1,66 @@
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET } from '../route';
+
+describe('GET /api/assets/proxy', () => {
+  beforeEach(() => {
+    process.env.AWS_S3_BUCKET_NAME = 'rollkeeper-test';
+    process.env.AWS_S3_REGION = 'us-west-2';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.AWS_S3_BUCKET_NAME;
+    delete process.env.AWS_S3_REGION;
+  });
+
+  it('proxies an image from the configured bucket and region', async () => {
+    const upstream = new Response(new Uint8Array([1, 2, 3]), {
+      headers: { 'content-type': 'image/png' },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(upstream);
+    vi.stubGlobal('fetch', fetchMock);
+    const assetUrl =
+      'https://rollkeeper-test.s3.us-west-2.amazonaws.com/notes-assets/map.png';
+    const request = new NextRequest(
+      `http://localhost/api/assets/proxy?url=${encodeURIComponent(assetUrl)}`
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('image/png');
+    expect(fetchMock).toHaveBeenCalledWith(assetUrl);
+  });
+
+  it('rejects a URL from a different region', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const assetUrl =
+      'https://rollkeeper-test.s3.eu-central-1.amazonaws.com/map.png';
+    const request = new NextRequest(
+      `http://localhost/api/assets/proxy?url=${encodeURIComponent(assetUrl)}`
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a lookalike hostname', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const assetUrl =
+      'https://rollkeeper-test.s3.us-west-2.amazonaws.com.attacker.test/map.png';
+    const request = new NextRequest(
+      `http://localhost/api/assets/proxy?url=${encodeURIComponent(assetUrl)}`
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/assets/proxy/route.ts
+++ b/src/app/api/assets/proxy/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const ALLOWED_HOST_SUFFIX = '.s3.eu-central-1.amazonaws.com';
 const MAX_PROXY_SIZE = 50 * 1024 * 1024; // 50 MB
+
+function configuredS3Hostname(): string | null {
+  const bucket = process.env.AWS_S3_BUCKET_NAME;
+  const region = process.env.AWS_S3_REGION;
+
+  if (!bucket || !region) return null;
+  return `${bucket}.s3.${region}.amazonaws.com`;
+}
 
 /**
  * Proxies an S3 image through our own origin so the browser never
@@ -27,9 +34,17 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
   }
 
-  if (!parsed.hostname.endsWith(ALLOWED_HOST_SUFFIX)) {
+  const allowedHostname = configuredS3Hostname();
+  if (!allowedHostname) {
     return NextResponse.json(
-      { error: 'URL not allowed — only S3 images can be proxied' },
+      { error: 'S3 is not configured' },
+      { status: 503 }
+    );
+  }
+
+  if (parsed.protocol !== 'https:' || parsed.hostname !== allowedHostname) {
+    return NextResponse.json(
+      { error: 'URL not allowed — only configured S3 images can be proxied' },
       { status: 403 }
     );
   }

--- a/src/app/api/campaign/[code]/locations/[id]/route.ts
+++ b/src/app/api/campaign/[code]/locations/[id]/route.ts
@@ -19,6 +19,29 @@ export async function GET(
     const raw = await redis.get<SyncedLocation>(campaignLocationKey(code, id));
     await refreshCampaignTTL(redis, code);
     if (!raw) {
+      // Older deployments refreshed only the list key, allowing a detail key
+      // to expire while its metadata remained. Return the original map as a
+      // degraded fallback until the DM republishes the full location.
+      const metadataRaw = await redis.get<LocationMetadata[]>(
+        campaignLocationsKey(code)
+      );
+      const locations: LocationMetadata[] = metadataRaw
+        ? Array.isArray(metadataRaw)
+          ? metadataRaw
+          : (JSON.parse(metadataRaw as unknown as string) as LocationMetadata[])
+        : [];
+      const metadata = locations.find(location => location.id === id);
+
+      if (metadata) {
+        const fallback: SyncedLocation = {
+          ...metadata,
+          mapImageSize: { w: 0, h: 0 },
+          canvasState: '',
+          gridEnabled: false,
+        };
+        return NextResponse.json({ location: fallback });
+      }
+
       return NextResponse.json(
         { error: 'Location not found' },
         { status: 404 }

--- a/src/app/api/campaign/[code]/locations/__tests__/route.test.ts
+++ b/src/app/api/campaign/[code]/locations/__tests__/route.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { createNextRequest, createRouteParams } from '@/test/helpers';
+import { mockRedis, resetRedis, seedRedis } from '@/test/mocks/redis';
+import { GET as getLocations } from '../route';
+import { GET as getLocation } from '../[id]/route';
+
+const metadata = {
+  id: 'location-1',
+  name: 'Barovia',
+  mapImageUrl: 'https://maps.example/barovia.webp',
+  updatedAt: '2026-05-17T11:38:32.869Z',
+};
+
+describe('location TTL consistency', () => {
+  beforeEach(() => {
+    resetRedis();
+    mockRedis.expire.mockClear();
+  });
+
+  it('refreshes each detail key when the location list is fetched', async () => {
+    seedRedis('campaign:FNLRC6:locations', [metadata]);
+    const request = createNextRequest('/api/campaign/FNLRC6/locations');
+
+    const response = await getLocations(
+      request as NextRequest,
+      createRouteParams({ code: 'FNLRC6' })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockRedis.expire).toHaveBeenCalledWith(
+      'campaign:FNLRC6:location:location-1',
+      60 * 24 * 60 * 60
+    );
+  });
+
+  it('falls back to metadata when an old detail key has expired', async () => {
+    seedRedis('campaign:FNLRC6:locations', [metadata]);
+    const request = createNextRequest(
+      '/api/campaign/FNLRC6/locations/location-1'
+    );
+
+    const response = await getLocation(
+      request as NextRequest,
+      createRouteParams({ code: 'FNLRC6', id: 'location-1' })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.location).toMatchObject({
+      ...metadata,
+      canvasState: '',
+      gridEnabled: false,
+    });
+  });
+
+  it('still returns 404 when neither detail nor metadata exists', async () => {
+    const request = createNextRequest('/api/campaign/FNLRC6/locations/missing');
+
+    const response = await getLocation(
+      request as NextRequest,
+      createRouteParams({ code: 'FNLRC6', id: 'missing' })
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/api/campaign/[code]/locations/route.ts
+++ b/src/app/api/campaign/[code]/locations/route.ts
@@ -2,7 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import {
   getRedis,
   campaignLocationsKey,
+  campaignLocationKey,
   refreshCampaignTTL,
+  SLIDING_TTL_SECONDS,
 } from '@/lib/redis';
 import type { LocationMetadata } from '@/types/location';
 
@@ -14,8 +16,25 @@ export async function GET(
     const { code } = await params;
     const redis = getRedis();
     const raw = await redis.get<LocationMetadata[]>(campaignLocationsKey(code));
-    await refreshCampaignTTL(redis, code);
-    return NextResponse.json({ locations: raw ?? [] });
+    const locations: LocationMetadata[] = raw
+      ? Array.isArray(raw)
+        ? raw
+        : (JSON.parse(raw as unknown as string) as LocationMetadata[])
+      : [];
+
+    // The list and each full location are stored under separate keys. Keep the
+    // detail keys alive whenever the player-facing list is active so the list
+    // cannot outlive the records it points to.
+    await Promise.all([
+      refreshCampaignTTL(redis, code),
+      ...locations.map(location =>
+        redis.expire(
+          campaignLocationKey(code, location.id),
+          SLIDING_TTL_SECONDS
+        )
+      ),
+    ]);
+    return NextResponse.json({ locations });
   } catch (error) {
     console.error('Failed to fetch locations:', error);
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- refresh individual location detail TTLs whenever players fetch the location list
- fall back to the original map metadata when a legacy detail record has already expired
- validate proxied S3 assets against the configured bucket and region
- add regression coverage for location TTL consistency and proxy host validation

## Testing
- pnpm exec vitest run --project unit src/app/api/campaign/[code]/locations/__tests__/route.test.ts src/app/api/assets/proxy/__tests__/route.test.ts
- pnpm type-check
- pre-commit Prettier and ESLint checks