### PR TITLE
feat(battlemap): adopt map pings (look here) from core 0.55.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@3d-dice/dice-box": "^1.1.3",
         "@3d-dice/dice-ui": "^0.5.2",
         "@aws-sdk/client-s3": "^3.922.0",
-        "@fieldnotes/core": "^0.54.0",
+        "@fieldnotes/core": "^0.55.0",
         "@fieldnotes/react": "^0.8.0",
         "@fieldnotes/sync": "^0.11.0",
         "@radix-ui/react-checkbox": "^1.3.2",
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/@fieldnotes/core": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.54.0.tgz",
-      "integrity": "sha512-6KI3C2FUW5diWuLQsV74LQFwLbwQXiviukDhX16sejOZ9GhIZIwJegcjzTdklqPQFq3gCFo6JMbFjL1dCAcFIA==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.55.0.tgz",
+      "integrity": "sha512-R0uqYZV/oeuu0F2RLuusIhCjOBkDW6NaFD9A/4RMpHaGMgGmW38rWhYNGU3Llq+l9uj4hLz/LEij6EZwLbSwPQ==",
       "license": "MIT"
     },
     "node_modules/@fieldnotes/react": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@3d-dice/dice-box": "^1.1.3",
     "@3d-dice/dice-ui": "^0.5.2",
     "@aws-sdk/client-s3": "^3.922.0",
-    "@fieldnotes/core": "^0.54.0",
+    "@fieldnotes/core": "^0.55.0",
     "@fieldnotes/react": "^0.8.0",
     "@fieldnotes/sync": "^0.11.0",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/src/app/dm/campaign/[code]/battlemaps/[id]/display/page.tsx
+++ b/src/app/dm/campaign/[code]/battlemaps/[id]/display/page.tsx
@@ -12,6 +12,7 @@ import {
 import { ensureCanonicalLayers } from '@/components/ui/campaign/location-map/layerContract';
 import { makeApplyRemoteLayer } from '@/components/ui/campaign/location-map/layerSync';
 import { attachRemoteLaserTrails } from '@/components/ui/campaign/location-map/laserSync';
+import { attachRemotePings } from '@/components/ui/campaign/location-map/pingSync';
 
 function DisplayCanvas() {
   const params = useParams();
@@ -57,9 +58,15 @@ function DisplayCanvas() {
       },
     });
     connectionRef.current = connection;
-    // Render remote laser trails (DM pointer) on the TV view.
+    // Render remote laser trails + map pings (DM pointer) on the TV view.
     laserCleanupRef.current?.();
-    laserCleanupRef.current = attachRemoteLaserTrails(vp, connection);
+    const presenceCleanups = [
+      attachRemoteLaserTrails(vp, connection),
+      attachRemotePings(vp, connection),
+    ];
+    laserCleanupRef.current = () => {
+      for (const cleanup of presenceCleanups) cleanup();
+    };
   };
 
   useEffect(

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -10,6 +10,7 @@ import {
   ShapeTool,
   EraserTool,
   LaserTool,
+  PingTool,
   AutoSave,
   type Tool,
   type Viewport,
@@ -37,6 +38,10 @@ import {
   attachLaserBroadcast,
   attachRemoteLaserTrails,
 } from '@/components/ui/campaign/location-map/laserSync';
+import {
+  attachPingBroadcast,
+  attachRemotePings,
+} from '@/components/ui/campaign/location-map/pingSync';
 
 import type { TokenInfoMode } from '@/components/ui/campaign/token-overlay';
 
@@ -148,6 +153,9 @@ export function useDmBattleMapCanvas({
       // Ephemeral pointer in the DM accent color; trails broadcast as
       // presence when the room connection is up (see attachLaserBroadcast).
       new LaserTool({ color: '#F4C430', width: 3 }),
+      // Ephemeral "look here" pulse; taps broadcast as presence when the
+      // room connection is up (see attachPingBroadcast).
+      new PingTool({ color: '#F4C430' }),
       new DmTokenTool(tokenConfigRef),
     ];
   }, [tokenConfigRef]);
@@ -273,12 +281,20 @@ export function useDmBattleMapCanvas({
         // buffers until the first snapshot if the socket is still connecting.
         publishOwnedLayers(vp, 'dm', def => connection.publishLayerUpsert(def));
 
-        // Laser pointer: broadcast this DM's trails, render everyone else's.
+        // Laser pointer + map pings: broadcast this DM's, render everyone
+        // else's.
         laserCleanupRef.current?.();
-        const laserCleanups = [attachRemoteLaserTrails(vp, connection)];
+        const laserCleanups = [
+          attachRemoteLaserTrails(vp, connection),
+          attachRemotePings(vp, connection),
+        ];
         const laserTool = vp.toolManager.getTool<LaserTool>('laser');
         if (laserTool) {
           laserCleanups.push(attachLaserBroadcast(laserTool, connection));
+        }
+        const pingTool = vp.toolManager.getTool<PingTool>('ping');
+        if (pingTool) {
+          laserCleanups.push(attachPingBroadcast(pingTool, connection));
         }
         laserCleanupRef.current = () => {
           for (const cleanup of laserCleanups) cleanup();

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -16,6 +16,7 @@ import {
   Minus,
   EyeOff,
   Zap,
+  MapPin,
 } from 'lucide-react';
 import { useActiveTool } from '@fieldnotes/react';
 
@@ -35,6 +36,7 @@ const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
   { name: 'template', label: 'Template', Icon: Circle },
   { name: 'eraser', label: 'Eraser', Icon: Eraser },
   { name: 'laser', label: 'Laser pointer', Icon: Zap },
+  { name: 'ping', label: 'Ping (look here)', Icon: MapPin },
 ];
 
 export interface DmVttToolbarProps {

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -13,6 +13,7 @@ import {
   TemplateTool,
   EraserTool,
   LaserTool,
+  PingTool,
   AutoSave,
   type Layer,
   type Tool,
@@ -36,6 +37,7 @@ import {
 } from './layerContract';
 import { makeApplyRemoteLayer, publishOwnedLayers } from './layerSync';
 import { attachLaserBroadcast, attachRemoteLaserTrails } from './laserSync';
+import { attachPingBroadcast, attachRemotePings } from './pingSync';
 import { pinGridToMapLayer } from './gridPin';
 import { nextMapImagePosition } from './mapImagePlacement';
 import {
@@ -285,6 +287,9 @@ export function useDmLocationEditor(
       // Ephemeral pointer; trails broadcast as presence while the battlemap
       // room connection is up (see attachLaserBroadcast).
       baseTools.push(new LaserTool({ color: '#F4C430', width: 3 }));
+      // Ephemeral "look here" pulse; taps broadcast as presence while the
+      // battlemap room connection is up (see attachPingBroadcast).
+      baseTools.push(new PingTool({ color: '#F4C430' }));
     }
 
     return baseTools;
@@ -428,12 +433,20 @@ export function useDmLocationEditor(
         // canvas (created before layer sync, or on another device).
         publishOwnedLayers(vp, 'dm', def => connection.publishLayerUpsert(def));
 
-        // Laser pointer: broadcast this DM's trails, render everyone else's.
+        // Laser pointer + map pings: broadcast this DM's, render everyone
+        // else's.
         laserCleanupRef.current?.();
-        const laserCleanups = [attachRemoteLaserTrails(vp, connection)];
+        const laserCleanups = [
+          attachRemoteLaserTrails(vp, connection),
+          attachRemotePings(vp, connection),
+        ];
         const laserTool = vp.toolManager.getTool<LaserTool>('laser');
         if (laserTool) {
           laserCleanups.push(attachLaserBroadcast(laserTool, connection));
+        }
+        const pingTool = vp.toolManager.getTool<PingTool>('ping');
+        if (pingTool) {
+          laserCleanups.push(attachPingBroadcast(pingTool, connection));
         }
         laserCleanupRef.current = () => {
           for (const cleanup of laserCleanups) cleanup();

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
@@ -28,6 +28,7 @@ import {
   Eye,
   EyeOff,
   Zap,
+  MapPin,
 } from 'lucide-react';
 import { useActiveTool, useHistory, useSelectionOps } from '@fieldnotes/react';
 import { Button } from '@/components/ui/forms/button';
@@ -52,6 +53,7 @@ const BATTLEMAP_TOOL_DEFS = [
   { name: 'template', icon: Sparkles, label: 'Template' },
   { name: 'eraser', icon: Eraser, label: 'Eraser' },
   { name: 'laser', icon: Zap, label: 'Laser pointer' },
+  { name: 'ping', icon: MapPin, label: 'Ping (look here)' },
 ] as const;
 
 function formatSyncTime(iso: string): string {

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -51,6 +51,7 @@ import {
 } from './layerContract';
 import { makeApplyRemoteLayer, publishOwnedLayers } from './layerSync';
 import { attachRemoteLaserTrails } from './laserSync';
+import { attachRemotePings } from './pingSync';
 import {
   PlayerTokenTool,
   PlayerTemplateTool,
@@ -339,11 +340,17 @@ export function PlayerBattleMapCanvas({
       def => connection.publishLayerUpsert(def),
       ownLayerId
     );
-    // Render remote laser trails (DM pointer). Players do not broadcast —
-    // product policy today; the wiring is role-based so enabling them later
-    // is configuration, not code.
+    // Render remote laser trails + map pings (DM pointer). Players do not
+    // broadcast — product policy today; the wiring is role-based so enabling
+    // them later is configuration, not code.
     laserCleanupRef.current?.();
-    laserCleanupRef.current = attachRemoteLaserTrails(vp, connection);
+    const presenceCleanups = [
+      attachRemoteLaserTrails(vp, connection),
+      attachRemotePings(vp, connection),
+    ];
+    laserCleanupRef.current = () => {
+      for (const cleanup of presenceCleanups) cleanup();
+    };
   };
 
   const handleDeleteSelected = useCallback(() => {

--- a/src/components/ui/campaign/location-map/pingSync.test.ts
+++ b/src/components/ui/campaign/location-map/pingSync.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PingTool, type Camera, type OverlayRenderer } from '@fieldnotes/core';
+import type { ToolContext, PointerState } from '@fieldnotes/core';
+import { attachPingBroadcast, attachRemotePings } from './pingSync';
+
+// Deterministic raf: callbacks run only when explicitly flushed (unused by
+// pings' assertions but keeps overlay animation loops inert).
+let rafCallbacks: FrameRequestCallback[];
+
+beforeEach(() => {
+  rafCallbacks = [];
+  let id = 0;
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn((cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return ++id;
+    })
+  );
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function toolCtx(): ToolContext {
+  return {
+    // Identity camera: screen coords are world coords.
+    camera: {
+      screenToWorld: (p: { x: number; y: number }) => ({ ...p }),
+    } as unknown as Camera,
+    store: {} as ToolContext['store'],
+    requestRender: vi.fn(),
+  };
+}
+
+const pt = (x: number, y: number): PointerState => ({
+  x,
+  y,
+  pressure: 0.5,
+  pointerType: 'mouse',
+  shiftKey: false,
+});
+
+describe('attachPingBroadcast', () => {
+  it('forwards accepted taps as validated ping presence', () => {
+    const tool = new PingTool({
+      color: '#F4C430',
+      durationMs: 1500,
+      radius: 40,
+    });
+    const sent: unknown[] = [];
+    attachPingBroadcast(tool, { sendPresence: data => sent.push(data) });
+
+    tool.onPointerDown(pt(10, 20), toolCtx());
+
+    expect(sent).toEqual([
+      {
+        kind: 'ping',
+        x: 10,
+        y: 20,
+        color: '#F4C430',
+        durationMs: 1500,
+        radius: 40,
+      },
+    ]);
+  });
+
+  it('rate-limited taps broadcast nothing', () => {
+    const tool = new PingTool({ minIntervalMs: 10_000 });
+    const sent: unknown[] = [];
+    attachPingBroadcast(tool, { sendPresence: data => sent.push(data) });
+
+    const ctx = toolCtx();
+    tool.onPointerDown(pt(1, 1), ctx);
+    tool.onPointerDown(pt(2, 2), ctx); // inside the interval — dropped
+    expect(sent).toHaveLength(1);
+  });
+
+  it('unsubscribe stops broadcasting', () => {
+    const tool = new PingTool();
+    const sent: unknown[] = [];
+    const unsubscribe = attachPingBroadcast(tool, {
+      sendPresence: data => sent.push(data),
+    });
+    unsubscribe();
+
+    tool.onPointerDown(pt(1, 1), toolCtx());
+    expect(sent).toEqual([]);
+  });
+});
+
+describe('attachRemotePings', () => {
+  function makeViewport() {
+    const overlays: OverlayRenderer[] = [];
+    let unregisterCalls = 0;
+    return {
+      overlays,
+      get unregisterCalls() {
+        return unregisterCalls;
+      },
+      registerOverlay(draw: OverlayRenderer): () => void {
+        overlays.push(draw);
+        return () => {
+          unregisterCalls += 1;
+          const index = overlays.indexOf(draw);
+          if (index >= 0) overlays.splice(index, 1);
+        };
+      },
+      requestRender: vi.fn(),
+    };
+  }
+
+  function makeConnection() {
+    const presenceHandlers = new Set<(from: string, data: unknown) => void>();
+    const leaveHandlers = new Set<(from: string) => void>();
+    return {
+      presenceHandlers,
+      leaveHandlers,
+      onPresence(handler: (from: string, data: unknown) => void): () => void {
+        presenceHandlers.add(handler);
+        return () => presenceHandlers.delete(handler);
+      },
+      onPresenceLeave(handler: (from: string) => void): () => void {
+        leaveHandlers.add(handler);
+        return () => leaveHandlers.delete(handler);
+      },
+      emitPresence(from: string, data: unknown): void {
+        for (const h of [...presenceHandlers]) h(from, data);
+      },
+      emitLeave(from: string): void {
+        for (const h of [...leaveHandlers]) h(from);
+      },
+    };
+  }
+
+  const ping = (x: number, y: number) => ({ kind: 'ping', x, y });
+
+  /** Count distinct pings the registered overlay draws (one fill = one ping
+   * center dot on a mock 2d context). */
+  function drawnPings(overlay: OverlayRenderer | undefined): number {
+    let fills = 0;
+    const ctx = {
+      save: vi.fn(),
+      restore: vi.fn(),
+      beginPath: vi.fn(),
+      arc: vi.fn(),
+      stroke: vi.fn(),
+      fill: vi.fn(() => {
+        fills += 1;
+      }),
+      globalAlpha: 1,
+      strokeStyle: '',
+      fillStyle: '',
+      lineWidth: 0,
+    } as unknown as CanvasRenderingContext2D;
+    overlay?.(ctx);
+    return fills;
+  }
+
+  it('registers an overlay that renders ping presence and ignores pokes and lasers', () => {
+    const vp = makeViewport();
+    const connection = makeConnection();
+    attachRemotePings(vp, connection);
+    expect(vp.overlays).toHaveLength(1);
+
+    // Hub pokes and laser trails must not create a ping.
+    connection.emitPresence('hub', { kind: 'poke', feature: 'players' });
+    connection.emitPresence('conn-1', {
+      kind: 'laser',
+      points: [{ x: 0, y: 0 }],
+    });
+    expect(drawnPings(vp.overlays[0])).toBe(0);
+    expect(vp.requestRender).not.toHaveBeenCalled();
+
+    connection.emitPresence('conn-1', ping(0, 0));
+    expect(vp.requestRender).toHaveBeenCalled();
+    expect(drawnPings(vp.overlays[0])).toBe(1);
+  });
+
+  it('removes a sender ping immediately on presence-leave', () => {
+    const vp = makeViewport();
+    const connection = makeConnection();
+    attachRemotePings(vp, connection);
+
+    connection.emitPresence('conn-1', ping(0, 0));
+    connection.emitPresence('conn-2', ping(10, 10));
+    expect(drawnPings(vp.overlays[0])).toBe(2);
+
+    connection.emitLeave('conn-1');
+    expect(drawnPings(vp.overlays[0])).toBe(1);
+  });
+
+  it('cleanup unsubscribes handlers and disposes the overlay', () => {
+    const vp = makeViewport();
+    const connection = makeConnection();
+    const cleanup = attachRemotePings(vp, connection);
+
+    cleanup();
+    expect(vp.overlays).toHaveLength(0);
+    expect(vp.unregisterCalls).toBe(1);
+    expect(connection.presenceHandlers.size).toBe(0);
+    expect(connection.leaveHandlers.size).toBe(0);
+  });
+
+  it('coexists with a laser overlay on the same connection — each renders only its kind', () => {
+    const vp = makeViewport();
+    const connection = makeConnection();
+    attachRemotePings(vp, connection);
+
+    // Simulate the laser attachment sharing the connection: both handler sets
+    // receive every frame; the ping overlay must only react to pings.
+    const seenByOther: unknown[] = [];
+    connection.onPresence((_from, data) => seenByOther.push(data));
+
+    connection.emitPresence('conn-1', ping(5, 5));
+    connection.emitPresence('conn-1', {
+      kind: 'laser',
+      points: [{ x: 1, y: 1 }],
+    });
+    connection.emitPresence('hub', { kind: 'poke', feature: 'players' });
+
+    expect(drawnPings(vp.overlays[0])).toBe(1); // only the ping
+    expect(seenByOther).toHaveLength(3); // other subscribers see everything
+  });
+});

--- a/src/components/ui/campaign/location-map/pingSync.ts
+++ b/src/components/ui/campaign/location-map/pingSync.ts
@@ -1,0 +1,67 @@
+import {
+  RemotePingOverlay,
+  toPingPresence,
+  type PingTool,
+  type RemotePingOverlayHost,
+} from '@fieldnotes/core';
+
+/**
+ * Map ping ("look here") wiring over battle-map presence. Ping traffic is
+ * ephemeral by contract: presence frames only — never elements, undo
+ * history, `canvasState`/autosave, or the durable operation queue — and it
+ * is room-visible (element `canRead` filtering is unrelated). Pings never
+ * move the viewer's camera. Broadcast is role-based product policy: today
+ * only DM canvases attach the broadcast side; every synced canvas attaches
+ * the receiving side, so enabling player pings later is configuration, not
+ * code.
+ */
+
+/** The presence surface `createManagedBattleMapConnection` exposes. */
+export interface PingPresenceConnection {
+  sendPresence: (data: unknown) => void;
+  onPresence: (handler: (from: string, data: unknown) => void) => () => void;
+  onPresenceLeave: (handler: (from: string) => void) => () => void;
+}
+
+/**
+ * Broadcasts the local `PingTool`'s accepted taps as ping presence. The tool
+ * already rate-limits taps (`minIntervalMs`), and sends while not live are
+ * dropped by the connection (never queued), matching the ephemerality
+ * contract. Returns unsubscribe.
+ */
+export function attachPingBroadcast(
+  tool: PingTool,
+  connection: Pick<PingPresenceConnection, 'sendPresence'>
+): () => void {
+  return tool.onPing(emission => {
+    connection.sendPresence(toPingPresence(emission));
+  });
+}
+
+/**
+ * Renders remote map pings on a synced canvas, whatever tool the viewer
+ * holds. The presence `from` (the relay's server-owned connection id) is
+ * used purely as an opaque per-sender key; `RemotePingOverlay.apply`
+ * validates payloads, so hub pokes (`data.kind === 'poke'`), laser trails
+ * (`data.kind === 'laser'`), and any other presence traffic are ignored
+ * here and their own handlers stay undisturbed. A sender's pings expire on
+ * their own and disappear immediately on presence-leave. Returns a cleanup
+ * that unsubscribes and disposes the overlay.
+ */
+export function attachRemotePings(
+  vp: RemotePingOverlayHost,
+  connection: Pick<PingPresenceConnection, 'onPresence' | 'onPresenceLeave'>
+): () => void {
+  const overlay = new RemotePingOverlay(vp);
+  const unsubscribePresence = connection.onPresence((from, data) => {
+    overlay.apply(from, data);
+  });
+  const unsubscribeLeave = connection.onPresenceLeave(from => {
+    overlay.remove(from);
+  });
+  return () => {
+    unsubscribePresence();
+    unsubscribeLeave();
+    overlay.dispose();
+  };
+}

--- a/src/lib/battlemapSync.test.ts
+++ b/src/lib/battlemapSync.test.ts
@@ -772,6 +772,119 @@ describe('createManagedBattleMapConnection presence (laser)', () => {
     conn.stop();
   });
 
+  it('poke + laser + ping presence coexist over the real attachments: each overlay renders only its kind, nothing persists, leave clears both', async () => {
+    // RemotePingOverlay/RemoteLaserOverlay animate via raf; keep them inert.
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 1)
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+    const { attachRemotePings } = await import(
+      '@/components/ui/campaign/location-map/pingSync'
+    );
+    const { attachRemoteLaserTrails } = await import(
+      '@/components/ui/campaign/location-map/laserSync'
+    );
+
+    const overlays: ((ctx: CanvasRenderingContext2D) => void)[] = [];
+    const vp = {
+      registerOverlay(draw: (ctx: CanvasRenderingContext2D) => void) {
+        overlays.push(draw);
+        return () => {
+          const index = overlays.indexOf(draw);
+          if (index >= 0) overlays.splice(index, 1);
+        };
+      },
+      requestRender: vi.fn(),
+    };
+
+    const store = new ElementStore();
+    const pokes: string[] = [];
+    const conn = createManagedBattleMapConnection({
+      relayUrl: 'wss://relay.example',
+      campaignCode: 'CODE',
+      battleMapId: 'map-1',
+      store,
+      clientId: 'player-1',
+      tokenRequest: { role: 'player', battleMapId: 'map-1', playerId: 'p1' },
+      onStatus: s => statuses.push(s),
+      onPoke: feature => pokes.push(feature),
+      transportFactory: () => fakeTransport,
+    });
+    await flushMicro();
+    const cleanupPings = attachRemotePings(vp, conn);
+    const cleanupLasers = attachRemoteLaserTrails(vp, conn);
+    fakeTransport.emitMessage(snapshotEnvelope('player-1', []));
+
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'hub',
+        op: { kind: 'presence', data: { kind: 'poke', feature: 'players' } },
+      })
+    );
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'conn-dm',
+        op: { kind: 'presence', data: laserPayload },
+      })
+    );
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'conn-dm',
+        op: {
+          kind: 'presence',
+          data: { kind: 'ping', x: 100, y: 200, color: '#F4C430' },
+        },
+      })
+    );
+
+    // Count what each overlay draws: pings fill a center dot, lasers stroke
+    // segments — a mock 2d context distinguishes them.
+    const counts = () => {
+      let fills = 0;
+      let strokes = 0;
+      const ctx = {
+        save: vi.fn(),
+        restore: vi.fn(),
+        beginPath: vi.fn(),
+        arc: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        stroke: vi.fn(() => (strokes += 1)),
+        fill: vi.fn(() => (fills += 1)),
+        globalAlpha: 1,
+        strokeStyle: '',
+        fillStyle: '',
+        lineWidth: 0,
+        lineCap: '',
+        lineJoin: '',
+      } as unknown as CanvasRenderingContext2D;
+      for (const draw of [...overlays]) draw(ctx);
+      return { fills, strokes };
+    };
+
+    expect(pokes).toEqual(['players']); // poke parsing undisturbed
+    const drawn = counts();
+    expect(drawn.fills).toBe(1); // exactly one ping pulse
+    expect(drawn.strokes).toBeGreaterThan(0); // laser trail rendered
+    // Ephemerality: presence never touches the element store.
+    expect(store.snapshot()).toEqual([]);
+
+    // Presence-leave clears both overlays for that sender immediately.
+    fakeTransport.emitMessage(
+      JSON.stringify({ from: 'conn-dm', op: { kind: 'presence-leave' } })
+    );
+    const afterLeave = counts();
+    expect(afterLeave.fills).toBe(0);
+    expect(afterLeave.strokes).toBe(0);
+
+    cleanupPings();
+    cleanupLasers();
+    expect(overlays).toHaveLength(0);
+    conn.stop();
+  });
+
   it('presence unsubscribe stops delivery', async () => {
     const seen: unknown[] = [];
     const conn = await startConnection();


### PR DESCRIPTION
## Summary

RollKeeper adoption of the map-ping primitives released in `@fieldnotes/core@0.55.0` (paired SDK PR: IrakliDevelop/fieldnotes#142). Second Phase 2 roadmap item.

- **DM VTT + DM location editor (battlemap mode)**: register `PingTool({ color: '#F4C430' })` with a 📍 "Ping (look here)" toolbar button; taps broadcast as presence and render the local pulse via the tool itself.
- **Player canvas + TV display**: receive-only — `RemotePingOverlay` renders remote pulses whatever tool the viewer holds. DM-only send is product policy; wiring is role-based, so enabling player pings later is configuration, not code.
- New `location-map/pingSync.ts` mirrors `laserSync.ts`: `attachPingBroadcast` (`onPing` → `toPingPresence` → `sendPresence`; sends while not live are dropped, never queued) and `attachRemotePings` (`RemotePingOverlay` keyed by presence `from`, removed immediately on presence-leave; payload guard ignores pokes and lasers so poke parsing and laser trails stay untouched).
- Dependencies: root `@fieldnotes/core ^0.55.0`; lockfile resolves the published 0.55.0. Relay pins unchanged (core-only SDK release; no server change).

### Contract

Pings are ephemeral: presence frames only — never elements, undo history, `canvasState`/autosave, or the durable operation queue — and they never move the viewer's camera (camera focus-pulling is the Phase 3 bookmarks item). Ping presence is room-visible; element `canRead` filtering is unrelated and unchanged.

## Verification

- Full unit suite: **3,621 passed / 1 skipped** (was 3,605)
- New `pingSync.test.ts`: 7 tests — broadcast payload correctness, tool-level rate limit, unsubscribe, overlay renders pings only (poke/laser ignored), presence-leave removal, cleanup/dispose, laser+ping shared-connection coexistence
- `battlemapSync.test.ts`: +1 integration test over the real managed lifecycle and real attachments — poke + laser + ping presence on one connection: `onPoke` fires, each overlay renders only its kind, element store stays empty (nothing persists), presence-leave clears both overlays; 18/18 in file
- `tsc --noEmit` clean; ESLint 0 errors on changed files (3 warnings pre-existing on master)
- Committed blobs prettier-clean (worktree CRLF via `core.autocrlf`)
- Relay untouched: no relay-side change, pins unchanged
- Desktop/touch interaction: SDK side carries desktop + iPad-emulation e2e (10/10 in fieldnotes#142); RollKeeper wiring is connection glue with integration coverage above

## Follow-ups

- `PingInput` (Foundry-style long-press-to-ping with any tool + ping-at-cursor for a product-owned "P" hotkey) was designed but **not** in core 0.55.0 — it is the next Fieldnotes core PR; RollKeeper wiring lands in that adoption cycle.
- Carried over: manual touch-device pass on the DM laser tool still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)