### PR TITLE
feat(campaign): show projected player XP to DMs

### DIFF
--- a/src/app/api/campaign/[code]/players/__tests__/route.test.ts
+++ b/src/app/api/campaign/[code]/players/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import {
+  resetRedis,
+  seedRedis,
+  seedRedisList,
+  seedRedisSet,
+} from '@/test/mocks/redis';
+import { createMockPlayerData, createRouteParams } from '@/test/helpers';
+import { GET } from '../route';
+
+const CODE = 'PROJECTED';
+const PLAYER_ID = 'player-1';
+
+beforeEach(() => {
+  resetRedis();
+  seedRedis(`campaign:${CODE}`, {
+    dmId: 'dm-1',
+    campaignName: 'Test campaign',
+    createdAt: '2026-08-04T00:00:00.000Z',
+  });
+  seedRedisSet(`campaign:${CODE}:players`, [PLAYER_ID]);
+  const player = createMockPlayerData({ playerId: PLAYER_ID });
+  player.characterData.experience = 1200;
+  seedRedis(`campaign:${CODE}:player:${PLAYER_ID}`, player);
+});
+
+describe('GET campaign players projected XP', () => {
+  it('folds queued add and set awards over the synced snapshot', async () => {
+    seedRedisList(`campaign:${CODE}:xp:${PLAYER_ID}`, [
+      JSON.stringify({
+        id: 'add-1',
+        mode: 'add',
+        amount: 300,
+        awardedAt: '2026-08-04T00:00:00.000Z',
+      }),
+      JSON.stringify({
+        id: 'set-1',
+        mode: 'set',
+        amount: 900,
+        awardedAt: '2026-08-04T00:01:00.000Z',
+      }),
+      JSON.stringify({
+        id: 'add-2',
+        mode: 'add',
+        amount: 50,
+        awardedAt: '2026-08-04T00:02:00.000Z',
+      }),
+      // A retry may enqueue the same delivery twice after a lost response.
+      JSON.stringify({
+        id: 'add-2',
+        mode: 'add',
+        amount: 50,
+        awardedAt: '2026-08-04T00:02:00.000Z',
+      }),
+    ]);
+
+    const response = await GET(
+      new NextRequest(`http://localhost/api/campaign/${CODE}/players`),
+      createRouteParams({ code: CODE })
+    );
+    const body = await response.json();
+
+    expect(body.players[0].characterData.experience).toBe(1200);
+    expect(body.players[0].projectedExperience).toBe(950);
+    expect(body.players[0].pendingXpAwardCount).toBe(3);
+  });
+
+  it('reports synced XP when no awards are pending', async () => {
+    const response = await GET(
+      new NextRequest(`http://localhost/api/campaign/${CODE}/players`),
+      createRouteParams({ code: CODE })
+    );
+    const body = await response.json();
+
+    expect(body.players[0].projectedExperience).toBe(1200);
+    expect(body.players[0].pendingXpAwardCount).toBe(0);
+  });
+});

--- a/src/app/api/campaign/[code]/players/route.ts
+++ b/src/app/api/campaign/[code]/players/route.ts
@@ -4,8 +4,15 @@ import {
   campaignKey,
   campaignPlayersKey,
   campaignPlayerKey,
+  campaignXpKey,
+  getRawRedis,
   refreshCampaignTTL,
 } from '@/lib/redis';
+import {
+  countUniqueXpAwards,
+  projectXpFromAwards,
+  readXpAwards,
+} from '@/lib/xpAwardQueue';
 import { CampaignData, CampaignPlayerData } from '@/types/campaign';
 
 export async function GET(
@@ -50,6 +57,21 @@ export async function GET(
           players.push(parsed);
         }
       }
+
+      await Promise.all(
+        players.map(async player => {
+          const pending = await readXpAwards(
+            getRawRedis(),
+            campaignXpKey(code, player.playerId)
+          );
+          const awards = pending.map(entry => entry.award);
+          player.projectedExperience = projectXpFromAwards(
+            player.characterData.experience ?? 0,
+            awards
+          );
+          player.pendingXpAwardCount = countUniqueXpAwards(awards);
+        })
+      );
 
       players.sort((a, b) => a.playerId.localeCompare(b.playerId));
     }

--- a/src/app/dm/campaign/[code]/page.tsx
+++ b/src/app/dm/campaign/[code]/page.tsx
@@ -106,6 +106,10 @@ export default function CampaignViewPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [selectedPlayer, setSelectedPlayer] =
     useState<CampaignPlayerData | null>(null);
+  const currentSelectedPlayer = selectedPlayer
+    ? (players.find(player => player.playerId === selectedPlayer.playerId) ??
+      selectedPlayer)
+    : null;
   const [editingCounterLabel, setEditingCounterLabel] = useState(false);
   const [counterLabelInput, setCounterLabelInput] = useState('');
   const [messageTarget, setMessageTarget] = useState<
@@ -715,25 +719,29 @@ export default function CampaignViewPage() {
       </main>
 
       {/* Player Detail Dialog */}
-      {selectedPlayer && (
+      {currentSelectedPlayer && (
         <PlayerDetailDialog
-          open={!!selectedPlayer}
+          open={!!currentSelectedPlayer}
           onOpenChange={open => {
             if (!open) setSelectedPlayer(null);
           }}
-          player={selectedPlayer}
+          player={currentSelectedPlayer}
           customCounterLabel={customCounterLabel}
           counterValue={
-            localCampaign?.playerCounters?.[selectedPlayer.playerId] ?? 0
+            localCampaign?.playerCounters?.[currentSelectedPlayer.playerId] ?? 0
           }
           onAdjustCounter={
             customCounterLabel
               ? delta =>
-                  adjustPlayerCounter(code, selectedPlayer.playerId, delta)
+                  adjustPlayerCounter(
+                    code,
+                    currentSelectedPlayer.playerId,
+                    delta
+                  )
               : undefined
           }
           onSendMessage={() => {
-            setMessageTarget(selectedPlayer);
+            setMessageTarget(currentSelectedPlayer);
             setSelectedPlayer(null);
           }}
           campaignCode={code}

--- a/src/components/__tests__/xp-award-dm-ui.test.tsx
+++ b/src/components/__tests__/xp-award-dm-ui.test.tsx
@@ -40,9 +40,15 @@ describe('XpAwardControl', () => {
         dmId="dm-1"
         playerId="p-1"
         lastSyncedXp={1200}
+        currentLevel={3}
       />
     );
-    expect(screen.getByText(/last synced: 1,200 xp/i)).toBeTruthy();
+    expect(screen.getByText('1,200')).toBeTruthy();
+    expect(screen.getByText('1,500 XP')).toBeTruthy();
+    expect(screen.getByText('16.7% to Level 4')).toBeTruthy();
+    expect(
+      screen.getByRole('progressbar', { name: /xp progress to level 4/i })
+    ).toHaveAttribute('aria-valuenow', '16.7');
 
     await user.type(screen.getByLabelText('XP to add'), '300');
     await user.click(screen.getByRole('button', { name: /send/i }));
@@ -54,6 +60,32 @@ describe('XpAwardControl', () => {
     expect(body.data.playerId).toBe('p-1');
     expect(body.data.award).toMatchObject({ mode: 'add', amount: 300 });
     expect(body.data.award.id).toBeTruthy();
+    expect(screen.getByText('1,500')).toBeTruthy();
+    expect(screen.getByText(/projected · 1 pending/i)).toBeTruthy();
+  });
+
+  it('starts from the persisted projection and applies set awards immediately', async () => {
+    const user = userEvent.setup();
+    render(
+      <XpAwardControl
+        campaignCode="ABC"
+        dmId="dm-1"
+        playerId="p-1"
+        lastSyncedXp={1200}
+        projectedXp={1500}
+        pendingAwardCount={1}
+        currentLevel={3}
+      />
+    );
+
+    expect(screen.getByText('1,500')).toBeTruthy();
+    await user.click(screen.getByLabelText(/toggle between add and set xp/i));
+    await user.type(screen.getByLabelText('Total XP'), '900');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('900')).toBeTruthy();
+    expect(screen.getByText(/projected · 2 pending/i)).toBeTruthy();
   });
 
   it('retry re-posts the ORIGINAL award with the same id', async () => {
@@ -69,6 +101,7 @@ describe('XpAwardControl', () => {
         dmId="dm-1"
         playerId="p-1"
         lastSyncedXp={0}
+        currentLevel={1}
       />
     );
     await user.type(screen.getByLabelText('XP to add'), '100');
@@ -95,6 +128,7 @@ describe('XpAwardControl', () => {
         dmId="dm-1"
         playerId="p-1"
         lastSyncedXp={0}
+        currentLevel={1}
       />
     );
 

--- a/src/components/shared/character/XPTracker.tsx
+++ b/src/components/shared/character/XPTracker.tsx
@@ -87,9 +87,7 @@ export function XPTracker({
       {/* Current XP and Level Display */}
       <div
         className={
-          compact
-            ? 'flex items-center justify-between'
-            : 'grid grid-cols-2 gap-4'
+          compact ? 'grid grid-cols-2 gap-3' : 'grid grid-cols-2 gap-4'
         }
       >
         <div className="text-center">
@@ -130,10 +128,15 @@ export function XPTracker({
             )}
           </div>
           <div
-            className={`bg-bg-tertiary w-full rounded-full ${compact ? 'h-2' : 'h-3'}`}
+            className={`bg-divider-strong w-full overflow-hidden rounded-full ring-1 ring-black/10 dark:ring-white/10 ${compact ? 'h-2.5' : 'h-3'}`}
+            role="progressbar"
+            aria-label={`XP progress to level ${currentLevel + 1}`}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Number(progress.toFixed(1))}
           >
             <div
-              className={`rounded-full bg-gradient-to-r from-blue-500 to-purple-500 transition-all duration-500 ease-out ${compact ? 'h-2' : 'h-3'}`}
+              className={`rounded-full bg-gradient-to-r from-indigo-500 to-purple-500 shadow-sm transition-all duration-500 ease-out ${compact ? 'h-2.5' : 'h-3'}`}
               style={{ width: `${progress}%` }}
             />
           </div>

--- a/src/components/ui/campaign/PlayerDetailDialog/OverviewTab.tsx
+++ b/src/components/ui/campaign/PlayerDetailDialog/OverviewTab.tsx
@@ -95,6 +95,8 @@ interface OverviewTabProps {
   campaignCode?: string;
   dmId?: string;
   playerId?: string;
+  projectedExperience?: number;
+  pendingXpAwardCount?: number;
 }
 
 export function OverviewTab({
@@ -105,6 +107,8 @@ export function OverviewTab({
   campaignCode,
   dmId,
   playerId,
+  projectedExperience,
+  pendingXpAwardCount,
 }: OverviewTabProps) {
   const currentHp = char.hitPoints?.current ?? 0;
   const maxHp = char.hitPoints?.max ?? 0;
@@ -170,6 +174,9 @@ export function OverviewTab({
             dmId={dmId}
             playerId={playerId}
             lastSyncedXp={char.experience ?? 0}
+            currentLevel={level}
+            projectedXp={projectedExperience}
+            pendingAwardCount={pendingXpAwardCount}
           />
         </div>
       )}

--- a/src/components/ui/campaign/PlayerDetailDialog/index.tsx
+++ b/src/components/ui/campaign/PlayerDetailDialog/index.tsx
@@ -143,6 +143,8 @@ export function PlayerDetailDialog({
               campaignCode={campaignCode}
               dmId={dmId}
               playerId={player.playerId}
+              projectedExperience={player.projectedExperience}
+              pendingXpAwardCount={player.pendingXpAwardCount}
             />
           )}
           {activeTab === 'spells' && showSpellsTab && <SpellsTab char={char} />}

--- a/src/components/ui/campaign/XpAwardControl.tsx
+++ b/src/components/ui/campaign/XpAwardControl.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { TrendingUp } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { NumberInput } from '@/components/ui/forms/NumberInput';
 import { Switch } from '@/components/ui/forms/switch';
+import { XPTracker } from '@/components/shared/character';
 import type { DmXpAward } from '@/types/sharedState';
+import { projectXpFromAwards } from '@/lib/xpAwardQueue';
 
 interface XpAwardControlProps {
   campaignCode: string;
@@ -13,6 +15,10 @@ interface XpAwardControlProps {
   playerId: string;
   /** XP from the player's last synced snapshot — may be stale. */
   lastSyncedXp: number;
+  /** Level from the same synced snapshot, used for XP progress. */
+  currentLevel: number;
+  projectedXp?: number;
+  pendingAwardCount?: number;
 }
 
 export async function postXpAward(
@@ -37,6 +43,9 @@ export function XpAwardControl({
   dmId,
   playerId,
   lastSyncedXp,
+  currentLevel,
+  projectedXp: serverProjectedXp,
+  pendingAwardCount: serverPendingAwardCount = 0,
 }: XpAwardControlProps) {
   const [mode, setMode] = useState<'add' | 'set'>('add');
   const [amount, setAmount] = useState<number | undefined>(undefined);
@@ -46,6 +55,17 @@ export function XpAwardControl({
   // Retained on failure so Retry re-sends the ORIGINAL award (same id) — a
   // lost response may still have enqueued it; the player dedupes by id.
   const [failedAward, setFailedAward] = useState<DmXpAward | null>(null);
+  const [displayedXp, setDisplayedXp] = useState(
+    serverProjectedXp ?? lastSyncedXp
+  );
+  const [pendingAwardCount, setPendingAwardCount] = useState(
+    serverPendingAwardCount
+  );
+
+  useEffect(() => {
+    setDisplayedXp(serverProjectedXp ?? lastSyncedXp);
+    setPendingAwardCount(serverPendingAwardCount);
+  }, [lastSyncedXp, serverProjectedXp, serverPendingAwardCount]);
 
   const minAmount = mode === 'add' ? 1 : 0;
   const valid = amount !== undefined && amount >= minAmount;
@@ -56,6 +76,8 @@ export function XpAwardControl({
     setSent(false);
     try {
       await postXpAward(campaignCode, dmId, playerId, award);
+      setDisplayedXp(current => projectXpFromAwards(current, [award]));
+      setPendingAwardCount(current => current + 1);
       setFailedAward(null);
       setAmount(undefined);
       setSent(true);
@@ -78,81 +100,92 @@ export function XpAwardControl({
   };
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <span className="text-heading flex items-center gap-1.5 text-sm font-medium">
-          <TrendingUp size={14} />
-          Award XP
-        </span>
-        <span className="text-faint text-xs">
-          Last synced: {lastSyncedXp.toLocaleString()} XP
-        </span>
-      </div>
-      <div className="flex items-center gap-2">
-        <span
-          className={`text-xs font-medium ${mode === 'add' ? 'text-heading' : 'text-muted'}`}
-        >
-          Add
-        </span>
-        <Switch
-          checked={mode === 'set'}
-          onCheckedChange={checked => setMode(checked ? 'set' : 'add')}
-          size="sm"
-          aria-label="Toggle between add and set XP"
-          disabled={sending || failedAward !== null}
-        />
-        <span
-          className={`text-xs font-medium ${mode === 'set' ? 'text-heading' : 'text-muted'}`}
-        >
-          Set
-        </span>
-        <NumberInput
-          value={amount}
-          onChange={setAmount}
-          min={minAmount}
-          allowEmpty
-          placeholder={mode === 'add' ? 'XP to add...' : 'Total XP...'}
-          aria-label={mode === 'add' ? 'XP to add' : 'Total XP'}
-          className="flex-1"
-          disabled={sending || failedAward !== null}
-        />
-        {failedAward ? (
-          <Button
-            variant="warning"
-            size="sm"
-            onClick={() => send(failedAward)}
-            disabled={sending}
+    <div className="grid items-start gap-4 lg:grid-cols-[minmax(16rem,22rem)_minmax(0,1fr)]">
+      <XPTracker
+        currentXP={displayedXp}
+        currentLevel={currentLevel}
+        readonly
+        compact
+        hideLevelUpAlert
+      />
+      <div className="space-y-3 lg:pt-1">
+        <div className="flex items-center justify-between">
+          <span className="text-heading flex items-center gap-1.5 text-sm font-medium">
+            <TrendingUp size={14} />
+            Award XP
+          </span>
+          <span className="text-faint text-right text-xs">
+            {pendingAwardCount > 0
+              ? `Projected · ${pendingAwardCount} pending`
+              : 'Synced XP'}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className={`text-xs font-medium ${mode === 'add' ? 'text-heading' : 'text-muted'}`}
           >
-            {sending ? 'Sending...' : 'Retry'}
-          </Button>
-        ) : (
-          <Button
-            variant="primary"
+            Add
+          </span>
+          <Switch
+            checked={mode === 'set'}
+            onCheckedChange={checked => setMode(checked ? 'set' : 'add')}
             size="sm"
-            onClick={handleSend}
-            disabled={!valid || sending}
+            aria-label="Toggle between add and set XP"
+            disabled={sending || failedAward !== null}
+          />
+          <span
+            className={`text-xs font-medium ${mode === 'set' ? 'text-heading' : 'text-muted'}`}
           >
-            {sending ? 'Sending...' : 'Send'}
-          </Button>
+            Set
+          </span>
+          <NumberInput
+            value={amount}
+            onChange={setAmount}
+            min={minAmount}
+            allowEmpty
+            placeholder={mode === 'add' ? 'XP to add...' : 'Total XP...'}
+            aria-label={mode === 'add' ? 'XP to add' : 'Total XP'}
+            className="flex-1"
+            disabled={sending || failedAward !== null}
+          />
+          {failedAward ? (
+            <Button
+              variant="warning"
+              size="sm"
+              onClick={() => send(failedAward)}
+              disabled={sending}
+            >
+              {sending ? 'Sending...' : 'Retry'}
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleSend}
+              disabled={!valid || sending}
+            >
+              {sending ? 'Sending...' : 'Send'}
+            </Button>
+          )}
+        </div>
+        {failedAward && (
+          <p className="text-accent-amber-text text-xs">
+            Retry will resend the original{' '}
+            {failedAward.mode === 'add' ? 'add' : 'set'} award of{' '}
+            {failedAward.amount.toLocaleString()} XP with the same delivery ID.
+          </p>
+        )}
+        {mode === 'set' && (
+          <p className="text-faint text-xs">
+            Sets the player&apos;s total XP — overwrites changes they made since
+            the last sync.
+          </p>
+        )}
+        {error && <p className="text-accent-red-text text-xs">{error}</p>}
+        {sent && !error && (
+          <p className="text-accent-emerald-text text-xs">XP award sent.</p>
         )}
       </div>
-      {failedAward && (
-        <p className="text-accent-amber-text text-xs">
-          Retry will resend the original{' '}
-          {failedAward.mode === 'add' ? 'add' : 'set'} award of{' '}
-          {failedAward.amount.toLocaleString()} XP with the same delivery ID.
-        </p>
-      )}
-      {mode === 'set' && (
-        <p className="text-faint text-xs">
-          Sets the player&apos;s total XP — overwrites changes they made since
-          the last sync.
-        </p>
-      )}
-      {error && <p className="text-accent-red-text text-xs">{error}</p>}
-      {sent && !error && (
-        <p className="text-accent-emerald-text text-xs">XP award sent.</p>
-      )}
     </div>
   );
 }

--- a/src/lib/xpAwardQueue.ts
+++ b/src/lib/xpAwardQueue.ts
@@ -6,6 +6,28 @@ export const XP_QUEUE_CAP = 100;
 const XP_AWARD_ID_MAX_LENGTH = 64;
 const XP_AWARD_DATE_MAX_LENGTH = 40;
 
+/** Apply pending DM awards to a synced XP baseline without mutating it. */
+export function projectXpFromAwards(
+  syncedXp: number,
+  awards: readonly DmXpAward[]
+): number {
+  const appliedIds = new Set<string>();
+  return awards.reduce(
+    (xp, award) => {
+      if (appliedIds.has(award.id)) return xp;
+      appliedIds.add(award.id);
+      return award.mode === 'set'
+        ? Math.max(0, award.amount)
+        : Math.max(0, xp + award.amount);
+    },
+    Math.max(0, syncedXp)
+  );
+}
+
+export function countUniqueXpAwards(awards: readonly DmXpAward[]): number {
+  return new Set(awards.map(award => award.id)).size;
+}
+
 // Atomic capped enqueue: cap check, append, and expiry refresh in one script
 // so concurrent requests can never both observe length 99 and overshoot.
 // KEYS[1] = queue key; ARGV[1] = serialized award; ARGV[2] = cap; ARGV[3] = ttl.

--- a/src/types/campaign.ts
+++ b/src/types/campaign.ts
@@ -13,6 +13,10 @@ export interface CampaignPlayerData {
   characterName: string;
   characterData: CharacterState;
   lastSynced: string;
+  /** XP after applying queued DM awards to characterData.experience. */
+  projectedExperience?: number;
+  /** Number of DM XP awards not yet consumed by the player. */
+  pendingXpAwardCount?: number;
 }
 
 export interface CampaignInfo {


### PR DESCRIPTION
## Summary
- reuse the shared XP tracker in the DM player overview
- derive projected XP from the last synced snapshot and pending Redis awards
- update the projection immediately after successful DM awards
- deduplicate retried award IDs to match player-side application
- improve progress-bar layout, contrast, and accessibility

## Validation
- 44 focused unit tests pass
- npm run type-check passes