### PR TITLE
fix(campaign): prioritize XP progress width

### DIFF
--- a/src/components/ui/campaign/XpAwardControl.tsx
+++ b/src/components/ui/campaign/XpAwardControl.tsx
@@ -100,7 +100,7 @@ export function XpAwardControl({
   };
 
   return (
-    <div className="grid items-start gap-4 lg:grid-cols-[minmax(16rem,22rem)_minmax(0,1fr)]">
+    <div className="grid items-start gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,22rem)]">
       <XPTracker
         currentXP={displayedXp}
         currentLevel={currentLevel}


### PR DESCRIPTION
## Summary
- give the XP progress tracker the flexible wide column
- constrain the Award XP controls to the smaller column
- preserve the existing stacked mobile layout

## Validation
- XP award UI tests pass
- npm run type-check passes