### PR TITLE
fix(campaign): move DM XP below skills

### DIFF
--- a/src/components/ui/campaign/PlayerDetailDialog/OverviewTab.tsx
+++ b/src/components/ui/campaign/PlayerDetailDialog/OverviewTab.tsx
@@ -167,20 +167,6 @@ export function OverviewTab({
         />
       </div>
 
-      {campaignCode && dmId && playerId && (
-        <div className="bg-surface-secondary rounded-lg p-3">
-          <XpAwardControl
-            campaignCode={campaignCode}
-            dmId={dmId}
-            playerId={playerId}
-            lastSyncedXp={char.experience ?? 0}
-            currentLevel={level}
-            projectedXp={projectedExperience}
-            pendingAwardCount={pendingXpAwardCount}
-          />
-        </div>
-      )}
-
       {/* ── Inspiration & Custom Counter ── */}
       <div className="flex flex-wrap gap-3">
         {/* Inspiration — golden star boxes like character page */}
@@ -288,7 +274,7 @@ export function OverviewTab({
       </div>
 
       <div className="grid gap-6 lg:grid-cols-2">
-        {/* ── Left Column: Skills + Encumbrance ── */}
+        {/* ── Left Column: Skills ── */}
         <div className="space-y-4">
           <div>
             <SectionTitle icon={<Scroll size={14} />}>Skills</SectionTitle>
@@ -341,7 +327,40 @@ export function OverviewTab({
               </div>
             </div>
           </div>
+        </div>
 
+        {/* ── Right Column: Conditions, Defenses, Senses, Attunement ── */}
+        <div className="space-y-4">
+          <ConditionsSection char={char} />
+          <DefensesSection char={char} />
+          <SensesSection char={char} />
+          <LanguagesSection char={char} />
+
+          {attunement && (
+            <div>
+              <SectionTitle icon={<Link2 size={14} />}>Attunement</SectionTitle>
+              <div className="text-body text-sm">
+                {attunement.used} / {attunement.max} slots used
+              </div>
+            </div>
+          )}
+        </div>
+
+        {campaignCode && dmId && playerId && (
+          <div className="bg-surface-secondary rounded-lg p-3 lg:col-span-2">
+            <XpAwardControl
+              campaignCode={campaignCode}
+              dmId={dmId}
+              playerId={playerId}
+              lastSyncedXp={char.experience ?? 0}
+              currentLevel={level}
+              projectedXp={projectedExperience}
+              pendingAwardCount={pendingXpAwardCount}
+            />
+          </div>
+        )}
+
+        <div className="space-y-4">
           {/* Encumbrance */}
           <div>
             <SectionTitle icon={<Weight size={14} />}>Encumbrance</SectionTitle>
@@ -364,23 +383,6 @@ export function OverviewTab({
           </div>
 
           <CurrencySection char={char} />
-        </div>
-
-        {/* ── Right Column: Conditions, Defenses, Senses, Attunement ── */}
-        <div className="space-y-4">
-          <ConditionsSection char={char} />
-          <DefensesSection char={char} />
-          <SensesSection char={char} />
-          <LanguagesSection char={char} />
-
-          {attunement && (
-            <div>
-              <SectionTitle icon={<Link2 size={14} />}>Attunement</SectionTitle>
-              <div className="text-body text-sm">
-                {attunement.used} / {attunement.max} slots used
-              </div>
-            </div>
-          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move the DM XP progress and award section below the Skills/details row
- let the XP section span the full modal width
- keep Encumbrance and Currency beneath it in their existing left column
- retain the wide XP tracker and compact award-control proportions

## Validation
- XP award UI tests pass
- npm run type-check passes