### PR TITLE
feat(battlemap): adopt PingInput from @fieldnotes/core 0.56.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@3d-dice/dice-box": "^1.1.3",
         "@3d-dice/dice-ui": "^0.5.2",
         "@aws-sdk/client-s3": "^3.922.0",
-        "@fieldnotes/core": "^0.55.0",
+        "@fieldnotes/core": "^0.56.0",
         "@fieldnotes/react": "^0.8.0",
         "@fieldnotes/sync": "^0.11.0",
         "@radix-ui/react-checkbox": "^1.3.2",
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/@fieldnotes/core": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.55.0.tgz",
-      "integrity": "sha512-R0uqYZV/oeuu0F2RLuusIhCjOBkDW6NaFD9A/4RMpHaGMgGmW38rWhYNGU3Llq+l9uj4hLz/LEij6EZwLbSwPQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.56.0.tgz",
+      "integrity": "sha512-lCNBdtZ0eWp+eppORF7qhpd80fMyTgNlRTIWNxcU2hv7okq5dfeC1wnjZHfBRik5jW5afAu5JscBFVNW8J+MYw==",
       "license": "MIT"
     },
     "node_modules/@fieldnotes/react": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@3d-dice/dice-box": "^1.1.3",
     "@3d-dice/dice-ui": "^0.5.2",
     "@aws-sdk/client-s3": "^3.922.0",
-    "@fieldnotes/core": "^0.55.0",
+    "@fieldnotes/core": "^0.56.0",
     "@fieldnotes/react": "^0.8.0",
     "@fieldnotes/sync": "^0.11.0",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/src/app/dm/campaign/[code]/battlemaps/[id]/display/page.tsx
+++ b/src/app/dm/campaign/[code]/battlemaps/[id]/display/page.tsx
@@ -62,7 +62,7 @@ function DisplayCanvas() {
     laserCleanupRef.current?.();
     const presenceCleanups = [
       attachRemoteLaserTrails(vp, connection),
-      attachRemotePings(vp, connection),
+      attachRemotePings(vp, connection).dispose,
     ];
     laserCleanupRef.current = () => {
       for (const cleanup of presenceCleanups) cleanup();

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -40,6 +40,7 @@ import {
 } from '@/components/ui/campaign/location-map/laserSync';
 import {
   attachPingBroadcast,
+  attachPingInput,
   attachRemotePings,
 } from '@/components/ui/campaign/location-map/pingSync';
 
@@ -284,9 +285,10 @@ export function useDmBattleMapCanvas({
         // Laser pointer + map pings: broadcast this DM's, render everyone
         // else's.
         laserCleanupRef.current?.();
+        const remotePings = attachRemotePings(vp, connection);
         const laserCleanups = [
           attachRemoteLaserTrails(vp, connection),
-          attachRemotePings(vp, connection),
+          remotePings.dispose,
         ];
         const laserTool = vp.toolManager.getTool<LaserTool>('laser');
         if (laserTool) {
@@ -296,6 +298,16 @@ export function useDmBattleMapCanvas({
         if (pingTool) {
           laserCleanups.push(attachPingBroadcast(pingTool, connection));
         }
+        // Always-available DM pings: long-press with any tool + "P" at the
+        // cursor, self-pulse through the shared receive overlay. The veto
+        // skips the ping tool, whose own tap already pinged on pointer down.
+        laserCleanups.push(
+          attachPingInput(vp, remotePings.overlay, connection, {
+            color: '#F4C430',
+            hotkey: 'p',
+            shouldPing: () => vp.toolManager.activeTool?.name !== 'ping',
+          })
+        );
         laserCleanupRef.current = () => {
           for (const cleanup of laserCleanups) cleanup();
         };

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -304,6 +304,8 @@ export function useDmBattleMapCanvas({
         laserCleanups.push(
           attachPingInput(vp, remotePings.overlay, connection, {
             color: '#F4C430',
+            // Options-bar swatch changes restyle long-press/hotkey pings too.
+            ...(pingTool ? { followTool: pingTool } : {}),
             hotkey: 'p',
             shouldPing: () => vp.toolManager.activeTool?.name !== 'ping',
           })

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -459,6 +459,8 @@ export function useDmLocationEditor(
         laserCleanups.push(
           attachPingInput(vp, remotePings.overlay, connection, {
             color: '#F4C430',
+            // Options-bar swatch changes restyle long-press/hotkey pings too.
+            ...(pingTool ? { followTool: pingTool } : {}),
             hotkey: 'p',
             shouldPing: () => vp.toolManager.activeTool?.name !== 'ping',
           })

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -37,7 +37,11 @@ import {
 } from './layerContract';
 import { makeApplyRemoteLayer, publishOwnedLayers } from './layerSync';
 import { attachLaserBroadcast, attachRemoteLaserTrails } from './laserSync';
-import { attachPingBroadcast, attachRemotePings } from './pingSync';
+import {
+  attachPingBroadcast,
+  attachPingInput,
+  attachRemotePings,
+} from './pingSync';
 import { pinGridToMapLayer } from './gridPin';
 import { nextMapImagePosition } from './mapImagePlacement';
 import {
@@ -436,9 +440,10 @@ export function useDmLocationEditor(
         // Laser pointer + map pings: broadcast this DM's, render everyone
         // else's.
         laserCleanupRef.current?.();
+        const remotePings = attachRemotePings(vp, connection);
         const laserCleanups = [
           attachRemoteLaserTrails(vp, connection),
-          attachRemotePings(vp, connection),
+          remotePings.dispose,
         ];
         const laserTool = vp.toolManager.getTool<LaserTool>('laser');
         if (laserTool) {
@@ -448,6 +453,16 @@ export function useDmLocationEditor(
         if (pingTool) {
           laserCleanups.push(attachPingBroadcast(pingTool, connection));
         }
+        // Always-available DM pings: long-press with any tool + "P" at the
+        // cursor, self-pulse through the shared receive overlay. The veto
+        // skips the ping tool, whose own tap already pinged on pointer down.
+        laserCleanups.push(
+          attachPingInput(vp, remotePings.overlay, connection, {
+            color: '#F4C430',
+            hotkey: 'p',
+            shouldPing: () => vp.toolManager.activeTool?.name !== 'ping',
+          })
+        );
         laserCleanupRef.current = () => {
           for (const cleanup of laserCleanups) cleanup();
         };

--- a/src/components/ui/campaign/location-map/DmLocationToolOptions.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolOptions.tsx
@@ -7,6 +7,7 @@ import type {
   MeasureToolOptions,
   NoteToolOptions,
   PencilToolOptions,
+  PingToolOptions,
   ShapeToolOptions,
   TemplateRenderStyle,
   TemplateShape,
@@ -87,6 +88,9 @@ export default function DmLocationToolOptions({
   const [laserOpts, setLaserOpts] = useToolOptions<
     LaserToolOptions & Record<string, unknown>
   >('laser');
+  const [pingOpts, setPingOpts] = useToolOptions<
+    PingToolOptions & Record<string, unknown>
+  >('ping');
 
   const showOptionsBar =
     (activeTool === 'pencil' && pencilOpts !== undefined) ||
@@ -97,7 +101,8 @@ export default function DmLocationToolOptions({
     (mode === 'battlemap' &&
       (activeTool === 'measure' ||
         activeTool === 'template' ||
-        (activeTool === 'laser' && laserOpts !== undefined)));
+        (activeTool === 'laser' && laserOpts !== undefined) ||
+        (activeTool === 'ping' && pingOpts !== undefined)));
 
   if (!showOptionsBar) return null;
 
@@ -112,11 +117,13 @@ export default function DmLocationToolOptions({
           ? noteOpts?.backgroundColor
           : activeTool === 'laser'
             ? laserOpts?.color
-            : activeTool === 'arrow'
-              ? arrowOpts?.color
-              : activeTool === 'pencil'
-                ? pencilOpts?.color
-                : '#334155';
+            : activeTool === 'ping'
+              ? pingOpts?.color
+              : activeTool === 'arrow'
+                ? arrowOpts?.color
+                : activeTool === 'pencil'
+                  ? pencilOpts?.color
+                  : '#334155';
 
   const handleColorChange = (color: string) => {
     if (activeTool === 'shape') setShapeOpts({ strokeColor: color });
@@ -126,6 +133,7 @@ export default function DmLocationToolOptions({
     else if (activeTool === 'pencil') setPencilOpts({ color });
     else if (activeTool === 'template') setTemplateOpts({ strokeColor: color });
     else if (activeTool === 'laser') setLaserOpts({ color });
+    else if (activeTool === 'ping') setPingOpts({ color });
   };
 
   return (

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -346,7 +346,7 @@ export function PlayerBattleMapCanvas({
     laserCleanupRef.current?.();
     const presenceCleanups = [
       attachRemoteLaserTrails(vp, connection),
-      attachRemotePings(vp, connection),
+      attachRemotePings(vp, connection).dispose,
     ];
     laserCleanupRef.current = () => {
       for (const cleanup of presenceCleanups) cleanup();

--- a/src/components/ui/campaign/location-map/__tests__/DmLocationToolOptions.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/DmLocationToolOptions.test.tsx
@@ -66,4 +66,22 @@ describe('DmLocationToolOptions pencil options', () => {
     const { container } = render(<DmLocationToolOptions mode="location" />);
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('shows ping colors in battle-map mode and updates the ping tool', () => {
+    mockActiveTool = 'ping';
+    mockToolOptions = { ping: { color: '#F4C430' } };
+    render(<DmLocationToolOptions mode="battlemap" />);
+
+    fireEvent.click(screen.getByTitle('#3b82f6'));
+    expect(setOptionsSpies['ping']).toHaveBeenCalledWith({
+      color: '#3b82f6',
+    });
+  });
+
+  it('does not show ping options outside battle-map mode', () => {
+    mockActiveTool = 'ping';
+    mockToolOptions = { ping: { color: '#F4C430' } };
+    const { container } = render(<DmLocationToolOptions mode="location" />);
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/src/components/ui/campaign/location-map/pingSync.test.ts
+++ b/src/components/ui/campaign/location-map/pingSync.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { PingTool, type Camera, type OverlayRenderer } from '@fieldnotes/core';
+import {
+  PingTool,
+  RemotePingOverlay,
+  type Camera,
+  type OverlayRenderer,
+} from '@fieldnotes/core';
 import type { ToolContext, PointerState } from '@fieldnotes/core';
-import { attachPingBroadcast, attachRemotePings } from './pingSync';
+import {
+  attachPingBroadcast,
+  attachPingInput,
+  attachRemotePings,
+} from './pingSync';
 
 // Deterministic raf: callbacks run only when explicitly flushed (unused by
 // pings' assertions but keeps overlay animation loops inert).
@@ -192,16 +201,25 @@ describe('attachRemotePings', () => {
     expect(drawnPings(vp.overlays[0])).toBe(1);
   });
 
-  it('cleanup unsubscribes handlers and disposes the overlay', () => {
+  it('dispose unsubscribes handlers and disposes the overlay', () => {
     const vp = makeViewport();
     const connection = makeConnection();
-    const cleanup = attachRemotePings(vp, connection);
+    const remotePings = attachRemotePings(vp, connection);
 
-    cleanup();
+    remotePings.dispose();
     expect(vp.overlays).toHaveLength(0);
     expect(vp.unregisterCalls).toBe(1);
     expect(connection.presenceHandlers.size).toBe(0);
     expect(connection.leaveHandlers.size).toBe(0);
+  });
+
+  it('exposes its overlay so the DM self-pulse can share it', () => {
+    const vp = makeViewport();
+    const connection = makeConnection();
+    const remotePings = attachRemotePings(vp, connection);
+
+    remotePings.overlay.apply('self', ping(3, 4));
+    expect(drawnPings(vp.overlays[0])).toBe(1);
   });
 
   it('coexists with a laser overlay on the same connection — each renders only its kind', () => {
@@ -223,5 +241,191 @@ describe('attachRemotePings', () => {
 
     expect(drawnPings(vp.overlays[0])).toBe(1); // only the ping
     expect(seenByOther).toHaveLength(3); // other subscribers see everything
+  });
+});
+
+describe('attachPingInput', () => {
+  function makeViewport() {
+    const overlays: OverlayRenderer[] = [];
+    return {
+      overlays,
+      registerOverlay(draw: OverlayRenderer): () => void {
+        overlays.push(draw);
+        return () => {
+          const index = overlays.indexOf(draw);
+          if (index >= 0) overlays.splice(index, 1);
+        };
+      },
+      requestRender: vi.fn(),
+    };
+  }
+
+  /** Real DOM: container div wrapping a domLayer div, like the Viewport DOM. */
+  function makeDom() {
+    const container = document.createElement('div');
+    const domLayer = document.createElement('div');
+    container.appendChild(domLayer);
+    document.body.appendChild(container);
+    return { container, domLayer };
+  }
+
+  // Identity camera: screen coords are world coords.
+  const camera = {
+    screenToWorld: (p: { x: number; y: number }) => ({ ...p }),
+  };
+
+  function fire(
+    el: HTMLElement,
+    type: string,
+    opts: PointerEventInit & { clientX?: number; clientY?: number } = {}
+  ): void {
+    el.dispatchEvent(
+      new PointerEvent(type, {
+        bubbles: true,
+        pointerId: 1,
+        pointerType: 'touch',
+        button: 0,
+        ...opts,
+      })
+    );
+  }
+
+  function drawnPings(overlay: OverlayRenderer | undefined): number {
+    let fills = 0;
+    const ctx = {
+      save: vi.fn(),
+      restore: vi.fn(),
+      beginPath: vi.fn(),
+      arc: vi.fn(),
+      stroke: vi.fn(),
+      fill: vi.fn(() => {
+        fills += 1;
+      }),
+      globalAlpha: 1,
+      strokeStyle: '',
+      fillStyle: '',
+      lineWidth: 0,
+    } as unknown as CanvasRenderingContext2D;
+    overlay?.(ctx);
+    return fills;
+  }
+
+  function setup(options: Parameters<typeof attachPingInput>[3] = {}) {
+    const vp = makeViewport();
+    const { container, domLayer } = makeDom();
+    const overlay = new RemotePingOverlay(vp);
+    const sent: unknown[] = [];
+    const cleanup = attachPingInput(
+      { domLayer, camera },
+      overlay,
+      { sendPresence: data => sent.push(data) },
+      options
+    );
+    return { vp, container, domLayer, overlay, sent, cleanup };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('a long-press broadcasts presence and renders the self pulse on the shared overlay', () => {
+    const { vp, container, sent } = setup({ color: '#F4C430' });
+
+    fire(container, 'pointerdown', { clientX: 30, clientY: 40 });
+    vi.advanceTimersByTime(600);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      kind: 'ping',
+      x: 30,
+      y: 40,
+      color: '#F4C430',
+    });
+    expect(drawnPings(vp.overlays[0])).toBe(1);
+  });
+
+  it('a drag past the slop never pings', () => {
+    const { container, sent } = setup();
+
+    fire(container, 'pointerdown', { clientX: 30, clientY: 40 });
+    fire(container, 'pointermove', { clientX: 90, clientY: 40 });
+    vi.advanceTimersByTime(600);
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it('the shouldPing veto suppresses the long-press (active ping tool)', () => {
+    const { container, sent } = setup({ shouldPing: () => false });
+
+    fire(container, 'pointerdown', { clientX: 30, clientY: 40 });
+    vi.advanceTimersByTime(600);
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it('the hotkey pings at the hovered position, but not while typing', () => {
+    const { vp, container, sent } = setup({ hotkey: 'p' });
+
+    fire(container, 'pointermove', { clientX: 12, clientY: 34 });
+
+    // Typing "p" into a form control must not ping.
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'p', bubbles: true })
+    );
+    expect(sent).toHaveLength(0);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ kind: 'ping', x: 12, y: 34 });
+    expect(drawnPings(vp.overlays[0])).toBe(1);
+  });
+
+  it('modified or repeated hotkey presses are ignored', () => {
+    const { container, sent } = setup({ hotkey: 'p' });
+    fire(container, 'pointermove', { clientX: 1, clientY: 2 });
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'p', ctrlKey: true })
+    );
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'p', repeat: true })
+    );
+    expect(sent).toHaveLength(0);
+  });
+
+  it('cleanup removes the long-press and hotkey listeners', () => {
+    const { container, sent, cleanup } = setup({ hotkey: 'p' });
+    fire(container, 'pointermove', { clientX: 1, clientY: 2 });
+
+    cleanup();
+
+    fire(container, 'pointerdown', { clientX: 30, clientY: 40 });
+    vi.advanceTimersByTime(600);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+    expect(sent).toHaveLength(0);
+  });
+
+  it('a detached domLayer (no parent element) attaches nothing and cleans up as a no-op', () => {
+    const vp = makeViewport();
+    const overlay = new RemotePingOverlay(vp);
+    const domLayer = document.createElement('div'); // no parent
+    const sent: unknown[] = [];
+    const cleanup = attachPingInput(
+      { domLayer, camera },
+      overlay,
+      { sendPresence: data => sent.push(data) },
+      { hotkey: 'p' }
+    );
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+    expect(sent).toHaveLength(0);
+    expect(() => cleanup()).not.toThrow();
   });
 });

--- a/src/components/ui/campaign/location-map/pingSync.test.ts
+++ b/src/components/ui/campaign/location-map/pingSync.test.ts
@@ -412,6 +412,41 @@ describe('attachPingInput', () => {
     expect(sent).toHaveLength(0);
   });
 
+  it('followTool mirrors the ping tool color at attach time', () => {
+    const tool = new PingTool({ color: '#F4C430' });
+    const { container, sent } = setup({ followTool: tool, hotkey: 'p' });
+
+    fire(container, 'pointermove', { clientX: 1, clientY: 2 });
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+
+    expect(sent[0]).toMatchObject({ kind: 'ping', color: '#F4C430' });
+  });
+
+  it('followTool tracks ping tool color changes (the options-bar swatches)', () => {
+    const tool = new PingTool({ color: '#F4C430' });
+    const { container, sent } = setup({ followTool: tool, hotkey: 'p' });
+
+    tool.setOptions({ color: '#3b82f6' }); // DM picks a swatch
+    fire(container, 'pointermove', { clientX: 1, clientY: 2 });
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+
+    expect(sent[0]).toMatchObject({ kind: 'ping', color: '#3b82f6' });
+  });
+
+  it('cleanup unsubscribes from followTool option changes', () => {
+    const tool = new PingTool({ color: '#F4C430' });
+    const { container, sent, cleanup } = setup({
+      followTool: tool,
+      hotkey: 'p',
+    });
+    cleanup();
+
+    expect(() => tool.setOptions({ color: '#3b82f6' })).not.toThrow();
+    fire(container, 'pointermove', { clientX: 1, clientY: 2 });
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+    expect(sent).toHaveLength(0);
+  });
+
   it('a detached domLayer (no parent element) attaches nothing and cleans up as a no-op', () => {
     const vp = makeViewport();
     const overlay = new RemotePingOverlay(vp);

--- a/src/components/ui/campaign/location-map/pingSync.ts
+++ b/src/components/ui/campaign/location-map/pingSync.ts
@@ -1,6 +1,8 @@
 import {
+  PingInput,
   RemotePingOverlay,
   toPingPresence,
+  type PingInputHost,
   type PingTool,
   type RemotePingOverlayHost,
 } from '@fieldnotes/core';
@@ -38,6 +40,17 @@ export function attachPingBroadcast(
   });
 }
 
+/** The receiving side of ping presence plus the overlay it renders through. */
+export interface RemotePingHandle {
+  /**
+   * The overlay every remote sender renders through. Exposed so the DM's own
+   * `PingInput` pulses can share it under the `'self'` sender key instead of
+   * growing a second drawing path.
+   */
+  overlay: RemotePingOverlay;
+  dispose: () => void;
+}
+
 /**
  * Renders remote map pings on a synced canvas, whatever tool the viewer
  * holds. The presence `from` (the relay's server-owned connection id) is
@@ -45,13 +58,13 @@ export function attachPingBroadcast(
  * validates payloads, so hub pokes (`data.kind === 'poke'`), laser trails
  * (`data.kind === 'laser'`), and any other presence traffic are ignored
  * here and their own handlers stay undisturbed. A sender's pings expire on
- * their own and disappear immediately on presence-leave. Returns a cleanup
- * that unsubscribes and disposes the overlay.
+ * their own and disappear immediately on presence-leave. `dispose`
+ * unsubscribes and disposes the overlay.
  */
 export function attachRemotePings(
   vp: RemotePingOverlayHost,
   connection: Pick<PingPresenceConnection, 'onPresence' | 'onPresenceLeave'>
-): () => void {
+): RemotePingHandle {
   const overlay = new RemotePingOverlay(vp);
   const unsubscribePresence = connection.onPresence((from, data) => {
     overlay.apply(from, data);
@@ -59,9 +72,91 @@ export function attachRemotePings(
   const unsubscribeLeave = connection.onPresenceLeave(from => {
     overlay.remove(from);
   });
+  return {
+    overlay,
+    dispose: () => {
+      unsubscribePresence();
+      unsubscribeLeave();
+      overlay.dispose();
+    },
+  };
+}
+
+/** The sender key `attachPingInput` renders the local DM's pulses under. */
+const SELF_SENDER = 'self';
+
+export interface AttachPingInputOptions {
+  /** Emission color (the DM accent, matching the `PingTool` registration). */
+  color?: string;
+  /**
+   * Product hotkey for ping-at-cursor (the SDK ships no binding). Ignored
+   * while focus is in a form control or contenteditable; modifier chords and
+   * key repeat never ping.
+   */
+  hotkey?: string;
+  /** Veto, e.g. exclude the active ping tool to avoid double pings. */
+  shouldPing?: () => boolean;
+}
+
+/**
+ * Always-available DM pings alongside the active tool: long-press (mouse,
+ * touch, or pen — `longPressEnabled` opt-in) plus an optional ping-at-cursor
+ * hotkey. Emissions broadcast as the same ping presence `attachPingBroadcast`
+ * sends AND render locally through the shared receive overlay under the
+ * `'self'` key, so local and remote pulses stay pixel-identical. DM-only is
+ * call-site policy: only DM canvases attach this. `PingInput` is passive by
+ * contract — it never blocks or captures pointers, so tools, panning, and
+ * pinch navigation are unaffected. Returns a cleanup.
+ */
+export function attachPingInput(
+  vp: { domLayer: HTMLElement; camera: PingInputHost },
+  overlay: RemotePingOverlay,
+  connection: Pick<PingPresenceConnection, 'sendPresence'>,
+  options: AttachPingInputOptions = {}
+): () => void {
+  // The wrapper around the canvas stack is the element the Viewport's own
+  // input listens on; PingInput needs the same origin for screen coords.
+  const element = vp.domLayer.parentElement;
+  if (!element) return () => {};
+
+  const input = new PingInput(element, vp.camera, {
+    longPressEnabled: true,
+    ...(options.color !== undefined ? { color: options.color } : {}),
+    ...(options.shouldPing !== undefined
+      ? { shouldPing: options.shouldPing }
+      : {}),
+  });
+  const unsubscribe = input.onPing(emission => {
+    const presence = toPingPresence(emission);
+    connection.sendPresence(presence);
+    overlay.apply(SELF_SENDER, presence);
+  });
+
+  let removeHotkey: (() => void) | undefined;
+  if (options.hotkey !== undefined) {
+    const hotkey = options.hotkey.toLowerCase();
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat || e.ctrlKey || e.metaKey || e.altKey) return;
+      if (e.key.toLowerCase() !== hotkey) return;
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.isContentEditable ||
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLTextAreaElement ||
+          target instanceof HTMLSelectElement)
+      ) {
+        return;
+      }
+      input.pingAtPointer();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    removeHotkey = () => document.removeEventListener('keydown', onKeyDown);
+  }
+
   return () => {
-    unsubscribePresence();
-    unsubscribeLeave();
-    overlay.dispose();
+    removeHotkey?.();
+    unsubscribe();
+    input.dispose();
   };
 }

--- a/src/components/ui/campaign/location-map/pingSync.ts
+++ b/src/components/ui/campaign/location-map/pingSync.ts
@@ -86,8 +86,14 @@ export function attachRemotePings(
 const SELF_SENDER = 'self';
 
 export interface AttachPingInputOptions {
-  /** Emission color (the DM accent, matching the `PingTool` registration). */
+  /** Emission color fallback when no `followTool` is given. */
   color?: string;
+  /**
+   * Keep the input's color mirrored to this `PingTool`'s (initial value and
+   * every option change), so the options-bar swatches restyle long-press and
+   * hotkey pings together with tool taps. Takes precedence over `color`.
+   */
+  followTool?: PingTool;
   /**
    * Product hotkey for ping-at-cursor (the SDK ships no binding). Ignored
    * while focus is in a form control or contenteditable; modifier chords and
@@ -119,9 +125,10 @@ export function attachPingInput(
   const element = vp.domLayer.parentElement;
   if (!element) return () => {};
 
+  const initialColor = options.followTool?.getOptions().color ?? options.color;
   const input = new PingInput(element, vp.camera, {
     longPressEnabled: true,
-    ...(options.color !== undefined ? { color: options.color } : {}),
+    ...(initialColor !== undefined ? { color: initialColor } : {}),
     ...(options.shouldPing !== undefined
       ? { shouldPing: options.shouldPing }
       : {}),
@@ -131,6 +138,15 @@ export function attachPingInput(
     connection.sendPresence(presence);
     overlay.apply(SELF_SENDER, presence);
   });
+
+  let unsubscribeToolOptions: (() => void) | undefined;
+  const followTool = options.followTool;
+  if (followTool) {
+    unsubscribeToolOptions = followTool.onOptionsChange(() => {
+      const color = followTool.getOptions().color;
+      if (color !== undefined) input.setOptions({ color });
+    });
+  }
 
   let removeHotkey: (() => void) | undefined;
   if (options.hotkey !== undefined) {
@@ -156,6 +172,7 @@ export function attachPingInput(
 
   return () => {
     removeHotkey?.();
+    unsubscribeToolOptions?.();
     unsubscribe();
     input.dispose();
   };

--- a/src/lib/battlemapSync.test.ts
+++ b/src/lib/battlemapSync.test.ts
@@ -780,7 +780,7 @@ describe('createManagedBattleMapConnection presence (laser)', () => {
     );
     vi.stubGlobal('cancelAnimationFrame', vi.fn());
 
-    const { attachRemotePings } = await import(
+    const { attachRemotePings, attachPingInput } = await import(
       '@/components/ui/campaign/location-map/pingSync'
     );
     const { attachRemoteLaserTrails } = await import(
@@ -813,7 +813,7 @@ describe('createManagedBattleMapConnection presence (laser)', () => {
       transportFactory: () => fakeTransport,
     });
     await flushMicro();
-    const cleanupPings = attachRemotePings(vp, conn);
+    const remotePings = attachRemotePings(vp, conn);
     const cleanupLasers = attachRemoteLaserTrails(vp, conn);
     fakeTransport.emitMessage(snapshotEnvelope('player-1', []));
 
@@ -879,7 +879,49 @@ describe('createManagedBattleMapConnection presence (laser)', () => {
     expect(afterLeave.fills).toBe(0);
     expect(afterLeave.strokes).toBe(0);
 
-    cleanupPings();
+    // DM PingInput (ping-at-cursor path) over the same live connection:
+    // one presence frame on the wire + a self pulse on the shared overlay.
+    const container = document.createElement('div');
+    const domLayer = document.createElement('div');
+    container.appendChild(domLayer);
+    document.body.appendChild(container);
+    const cleanupPingInput = attachPingInput(
+      { domLayer, camera: { screenToWorld: p => ({ ...p }) } },
+      remotePings.overlay,
+      conn,
+      { color: '#F4C430', hotkey: 'p' }
+    );
+    const sentBefore = fakeTransport.sent.length;
+    container.dispatchEvent(
+      new PointerEvent('pointermove', {
+        bubbles: true,
+        pointerId: 1,
+        pointerType: 'mouse',
+        clientX: 40,
+        clientY: 50,
+      })
+    );
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+
+    const pingFrames = fakeTransport.sent
+      .slice(sentBefore)
+      .map(
+        frame => JSON.parse(frame) as { op: { kind: string; data?: unknown } }
+      )
+      .filter(envelope => envelope.op.kind === 'presence');
+    expect(pingFrames).toHaveLength(1);
+    expect(pingFrames[0]?.op.data).toMatchObject({
+      kind: 'ping',
+      x: 40,
+      y: 50,
+      color: '#F4C430',
+    });
+    expect(counts().fills).toBe(1); // the self pulse, on the shared overlay
+    expect(store.snapshot()).toEqual([]); // still nothing persisted
+
+    cleanupPingInput();
+    container.remove();
+    remotePings.dispose();
     cleanupLasers();
     expect(overlays).toHaveLength(0);
     conn.stop();


### PR DESCRIPTION
## Summary

Paired adoption PR for `IrakliDevelop/fieldnotes#143` (published `@fieldnotes/core@0.56.0`): always-available DM pings on the battle map — long-press with any tool plus a "P" ping-at-cursor hotkey.

- **Dependency:** root `@fieldnotes/core` `^0.56.0` (lockfile resolves published 0.56.0). Relay pins unchanged — core-only release, no server changes.
- **`pingSync.ts`:**
  - `attachRemotePings` now returns a `RemotePingHandle` (`{ overlay, dispose }`) so the DM's own pulses can share the receive overlay instead of growing a second drawing path.
  - New `attachPingInput(vp, overlay, connection, options)`: constructs a `PingInput` (`longPressEnabled: true` — the SDK default is off) on the viewport wrapper, broadcasts emissions as the existing ping presence AND applies them locally under a `'self'` sender key, and optionally binds a product hotkey (ignored in form controls/contenteditable; modifier chords and key repeat never ping). Passive by contract: never blocks or captures pointers, so tools/pan/pinch are untouched.
- **DM call sites** (DM VTT + DM location editor, battlemap mode): attach `attachPingInput` with the DM accent color `#F4C430`, hotkey `p`, and a `shouldPing` veto excluding the active ping tool (its own tap already pings on pointer down). DM-only remains call-site policy.
- **Player canvas + display:** adopt the new handle shape only; behavior unchanged (receive-only).

### Rider (`7fb5eed`): ping color selection

Ping joins the laser/pencil color pattern in the tool options bar: battlemap-mode swatches + custom color via `useToolOptions('ping')` in `DmLocationToolOptions` (shared by DM VTT and the location editor; hidden outside battlemap mode and wherever no ping tool is registered). `attachPingInput` gains `followTool`, so a swatch change restyles long-press and hotkey pings together with tool taps (initial color mirrored at attach; subscription removed on cleanup; `color` stays as fallback when no tool is present).

## Verification

- Full unit suite: **3,637 passed / 1 skipped** (was 3,621 — +16).
- `pingSync.test.ts` **18 tests** (+11): handle exposure, long-press broadcast + self pulse on the shared overlay, slop-drag never pings, `shouldPing` veto, hotkey at hovered position, hotkey ignored while typing / with modifiers / on repeat, cleanup removes both listener sets, detached-domLayer no-op, `followTool` initial mirror + swatch-change tracking + unsubscribe on cleanup.
- `DmLocationToolOptions.test.tsx` +2: ping swatches update the ping tool in battlemap mode; hidden outside battlemap mode.
- `battlemapSync.test.ts` coexistence test extended over the **real managed lifecycle**: DM `PingInput` ping-at-cursor sends exactly one presence frame on the wire while live, renders the self pulse through the shared overlay, and the element store stays empty (ephemerality).
- `tsc --noEmit` clean; ESLint 0 errors (3 warnings pre-existing); committed blobs prettier-clean; relay untouched.

## Notes

- Long-press default-off in the SDK was a deliberate product decision (2026-08-04); RollKeeper opts in explicitly on DM canvases.
- Carried-over follow-up: manual touch-device pass on the DM laser AND ping tools (incl. this long-press) still outstanding — SDK has desktop + iPad-emulation e2e only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
