### PR TITLE
feat(vtt): unify responsive DM command dock

### DIFF
--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -50,6 +50,8 @@ export interface DmBattleMapCanvasProps {
   campaignCode: string;
   battleMapId: string;
   dmId: string;
+  /** Map/session controls rendered as the command dock's first row. */
+  sessionControls?: React.ReactNode;
   /** Chrome rendered inside the ViewportContext.Provider. */
   children?: React.ReactNode;
   onStatus?: (status: BattleMapConnectionStatus) => void;

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { FieldNotesCanvas, ViewportContext } from '@fieldnotes/react';
-import DmLocationToolOptions from '@/components/ui/campaign/location-map/DmLocationToolOptions';
 import { DmVttToolbar } from './DmVttToolbar';
 import {
   useDmBattleMapCanvas,
@@ -18,7 +17,7 @@ export type { DmBattleMapCanvasProps };
  * init/persistence/connection wiring.
  */
 export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
-  const { children, tokenInfoToggle } = props;
+  const { children, sessionControls, tokenInfoToggle } = props;
   const {
     viewport,
     tools,
@@ -45,6 +44,7 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
         />
         {viewport && (
           <DmVttToolbar
+            sessionControls={sessionControls}
             onClearDrawings={handleClearDrawings}
             tokenInfoToggle={tokenInfoToggle}
             hiddenPlacementActive={hiddenPlacementActive}
@@ -55,11 +55,6 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
             selectedElementIsDmOnly={selectedElementIsDmOnly}
             onToggleSelectedDmOnly={handleToggleSelectedDmOnly}
           />
-        )}
-        {viewport && (
-          <div className="border-divider absolute top-[8.25rem] left-1/2 z-10 max-w-[92vw] -translate-x-1/2 overflow-hidden rounded-xl border shadow-lg">
-            <DmLocationToolOptions mode="battlemap" />
-          </div>
         )}
         {viewport && children}
       </div>

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -68,6 +68,19 @@ export function DmVttScreen({
       tokenConfigRef={vtt.tokenConfigRef}
       onSelectionChange={vtt.onSelectionChange}
       tokenInfoToggle={{ mode: tokenInfoMode, onCycle: cycleTokenInfo }}
+      sessionControls={
+        <DmVttTopBar
+          campaignCode={campaignCode}
+          battleMapId={battleMapId}
+          dmId={dmId}
+          mapName={vtt.battleMap?.name ?? 'Battle Map'}
+          status={vtt.status}
+          gridMode={gridMode}
+          onSetGridMode={vtt.setGridMode}
+          mode={mode}
+          onModeChange={onModeChange}
+        />
+      }
     >
       <TokenDecorationLayer decorations={decorations} mode={tokenInfoMode} />
       <TokenPlacementController
@@ -82,17 +95,6 @@ export function DmVttScreen({
         />
       )}
       <div className="pointer-events-none absolute inset-0 z-10">
-        <DmVttTopBar
-          campaignCode={campaignCode}
-          battleMapId={battleMapId}
-          dmId={dmId}
-          mapName={vtt.battleMap?.name ?? 'Battle Map'}
-          status={vtt.status}
-          gridMode={gridMode}
-          onSetGridMode={vtt.setGridMode}
-          mode={mode}
-          onModeChange={onModeChange}
-        />
         <RosterTray
           entities={vtt.linkedEntities}
           placedIndex={vtt.placedIndex}

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -21,6 +21,9 @@ import {
 import { useActiveTool } from '@fieldnotes/react';
 
 import { Button } from '@/components/ui/forms/button';
+import DmLocationToolOptions from '@/components/ui/campaign/location-map/DmLocationToolOptions';
+
+import { useEffect, useRef, type ReactNode } from 'react';
 
 import type { TokenInfoMode } from '@/components/ui/campaign/token-overlay';
 
@@ -40,6 +43,7 @@ const DM_TOOLS: { name: string; label: string; Icon: typeof Hand }[] = [
 ];
 
 export interface DmVttToolbarProps {
+  sessionControls?: ReactNode;
   onClearDrawings: () => void;
   tokenInfoToggle: { mode: TokenInfoMode | null; onCycle: () => void };
   hiddenPlacementActive: boolean;
@@ -63,12 +67,17 @@ const TOKEN_INFO_LABEL: Record<TokenInfoMode, string> = {
   off: 'Token info: hidden',
 };
 
-/** Top-center tool pill for the DM battle-map canvas — structurally mirrors
+/** Unified DM command dock. Session controls, canvas tools, and contextual
+ * tool options share one self-sizing surface so responsive rows cannot
+ * collide. The player toolbar deliberately remains independent.
+ *
+ * The canvas tools structurally mirror
  * `PlayerBattleMapCanvas`'s `PlayerToolbar`, minus the token tool (placed via
  * the roster in Task 8, never through this toolbar) plus a Clear-drawings
  * action. The connection-status chip lives solely in `DmVttTopBar` now (see
  * P7c) — this toolbar no longer duplicates it. */
 export function DmVttToolbar({
+  sessionControls,
   onClearDrawings,
   tokenInfoToggle,
   hiddenPlacementActive,
@@ -81,94 +90,135 @@ export function DmVttToolbar({
 }: DmVttToolbarProps) {
   const [activeTool, setTool] = useActiveTool();
   const TokenInfoIcon = TOKEN_INFO_ICON[tokenInfoToggle.mode ?? 'compact'];
+  const dockRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const dock = dockRef.current;
+    if (!dock) return;
+
+    const updatePanelTop = () => {
+      const bottom = Math.ceil(dock.getBoundingClientRect().bottom + 12);
+      document.documentElement.style.setProperty(
+        '--dm-vtt-panel-top',
+        `${bottom}px`
+      );
+    };
+    updatePanelTop();
+    const observer =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(updatePanelTop);
+    observer?.observe(dock);
+    window.addEventListener('resize', updatePanelTop);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener('resize', updatePanelTop);
+      document.documentElement.style.removeProperty('--dm-vtt-panel-top');
+    };
+  }, []);
+
   return (
-    <div className="bg-surface-raised border-divider absolute top-20 left-1/2 z-10 flex max-w-[94vw] -translate-x-1/2 items-center gap-3 overflow-x-auto rounded-xl border p-1 shadow-lg">
-      <div className="flex items-center gap-1">
-        {DM_TOOLS.map(({ name, label, Icon }) => (
+    <div
+      ref={dockRef}
+      className="bg-surface-raised border-divider pointer-events-auto fixed top-3 left-1/2 z-20 flex w-fit max-w-[calc(100%-2rem)] -translate-x-1/2 flex-col overflow-hidden rounded-2xl border shadow-xl min-[1512px]:max-w-[1480px]"
+      data-testid="dm-vtt-command-dock"
+    >
+      {sessionControls}
+      <div className="border-divider flex flex-wrap items-center justify-center gap-x-3 gap-y-1 border-t p-1">
+        <div className="flex flex-wrap items-center justify-center gap-1">
+          {DM_TOOLS.map(({ name, label, Icon }) => (
+            <Button
+              key={name}
+              variant={activeTool === name ? 'primary' : 'ghost'}
+              onClick={() => setTool(name)}
+              className="min-h-[44px] min-w-[44px] p-0"
+              title={label}
+              aria-label={label}
+            >
+              <Icon size={16} />
+            </Button>
+          ))}
+        </div>
+        <div className="border-divider flex flex-wrap items-center justify-center gap-1 border-l pl-3">
           <Button
-            key={name}
-            variant={activeTool === name ? 'primary' : 'ghost'}
-            onClick={() => setTool(name)}
-            className="min-h-[44px] min-w-[44px] p-0"
-            title={label}
-            aria-label={label}
-          >
-            <Icon size={16} />
-          </Button>
-        ))}
-      </div>
-      <div className="flex items-center gap-1">
-        <Button
-          variant={hiddenPlacementActive ? 'warning' : 'ghost'}
-          onClick={onToggleHiddenPlacement}
-          className="min-h-[44px] px-2"
-          title={
-            hiddenPlacementActive
-              ? 'New elements are hidden from players'
-              : 'New elements are visible to players'
-          }
-          aria-label="Place hidden elements"
-          aria-pressed={hiddenPlacementActive}
-        >
-          <EyeOff size={16} />
-          <span className="ml-1.5 hidden text-xs xl:inline">
-            {hiddenPlacementActive ? 'Placing hidden' : 'Place hidden'}
-          </span>
-        </Button>
-        <Button
-          variant="ghost"
-          onClick={onRevealAll}
-          disabled={hiddenElementCount === 0}
-          className="min-h-[44px] px-2"
-          title={
-            hiddenElementCount === 0
-              ? 'No hidden elements to reveal'
-              : `Reveal all ${hiddenElementCount} hidden element${hiddenElementCount === 1 ? '' : 's'}`
-          }
-          aria-label={`Reveal all hidden elements (${hiddenElementCount})`}
-        >
-          <Eye size={16} />
-          <span className="ml-1.5 hidden text-xs xl:inline">
-            Reveal all ({hiddenElementCount})
-          </span>
-        </Button>
-        {selectedElementId && (
-          <Button
-            variant={selectedElementIsDmOnly ? 'warning' : 'ghost'}
-            onClick={onToggleSelectedDmOnly}
+            variant={hiddenPlacementActive ? 'warning' : 'ghost'}
+            onClick={onToggleHiddenPlacement}
             className="min-h-[44px] px-2"
             title={
-              selectedElementIsDmOnly
-                ? 'Reveal selected element to players'
-                : 'Hide selected element from players'
+              hiddenPlacementActive
+                ? 'New elements are hidden from players'
+                : 'New elements are visible to players'
             }
-            aria-label={
-              selectedElementIsDmOnly
-                ? 'Reveal selected element'
-                : 'Hide selected element'
-            }
+            aria-label="Place hidden elements"
+            aria-pressed={hiddenPlacementActive}
           >
-            {selectedElementIsDmOnly ? <Eye size={16} /> : <EyeOff size={16} />}
+            <EyeOff size={16} />
+            <span className="ml-1.5 hidden text-xs xl:inline">
+              {hiddenPlacementActive ? 'Placing hidden' : 'Place hidden'}
+            </span>
           </Button>
-        )}
-        <Button
-          variant="ghost"
-          onClick={onClearDrawings}
-          className="min-h-[44px] min-w-[44px] p-0"
-          title="Clear drawings"
-          aria-label="Clear drawings"
-        >
-          <Scissors size={16} />
-        </Button>
-        <Button
-          variant="ghost"
-          onClick={tokenInfoToggle.onCycle}
-          className="min-h-[44px] min-w-[44px] p-0"
-          title={TOKEN_INFO_LABEL[tokenInfoToggle.mode ?? 'compact']}
-          aria-label={TOKEN_INFO_LABEL[tokenInfoToggle.mode ?? 'compact']}
-        >
-          <TokenInfoIcon size={16} />
-        </Button>
+          <Button
+            variant="ghost"
+            onClick={onRevealAll}
+            disabled={hiddenElementCount === 0}
+            className="min-h-[44px] px-2"
+            title={
+              hiddenElementCount === 0
+                ? 'No hidden elements to reveal'
+                : `Reveal all ${hiddenElementCount} hidden element${hiddenElementCount === 1 ? '' : 's'}`
+            }
+            aria-label={`Reveal all hidden elements (${hiddenElementCount})`}
+          >
+            <Eye size={16} />
+            <span className="ml-1.5 hidden text-xs xl:inline">
+              Reveal all ({hiddenElementCount})
+            </span>
+          </Button>
+          {selectedElementId && (
+            <Button
+              variant={selectedElementIsDmOnly ? 'warning' : 'ghost'}
+              onClick={onToggleSelectedDmOnly}
+              className="min-h-[44px] px-2"
+              title={
+                selectedElementIsDmOnly
+                  ? 'Reveal selected element to players'
+                  : 'Hide selected element from players'
+              }
+              aria-label={
+                selectedElementIsDmOnly
+                  ? 'Reveal selected element'
+                  : 'Hide selected element'
+              }
+            >
+              {selectedElementIsDmOnly ? (
+                <Eye size={16} />
+              ) : (
+                <EyeOff size={16} />
+              )}
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            onClick={onClearDrawings}
+            className="min-h-[44px] min-w-[44px] p-0"
+            title="Clear drawings"
+            aria-label="Clear drawings"
+          >
+            <Scissors size={16} />
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={tokenInfoToggle.onCycle}
+            className="min-h-[44px] min-w-[44px] p-0"
+            title={TOKEN_INFO_LABEL[tokenInfoToggle.mode ?? 'compact']}
+            aria-label={TOKEN_INFO_LABEL[tokenInfoToggle.mode ?? 'compact']}
+          >
+            <TokenInfoIcon size={16} />
+          </Button>
+        </div>
+      </div>
+      <div className="border-divider border-t empty:hidden">
+        <DmLocationToolOptions mode="battlemap" />
       </div>
     </div>
   );

--- a/src/components/ui/campaign/dm-vtt/DmVttTopBar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttTopBar.tsx
@@ -35,7 +35,7 @@ const MODE_OPTIONS: { key: DmVttMode; label: string }[] = [
 ];
 
 /**
- * Top chrome bar for the DM VTT play screen: back link, map name, grid
+ * Session-controls row for the DM VTT command dock: back link, map name, grid
  * segmented control (mirrors `useDmVttGrid`'s `setGridMode`), TV display
  * launcher (Task 1's `openTvDisplay` helper), a live-status chip (the
  * chip's single home — the Play toolbar no longer duplicates it), and the
@@ -53,13 +53,13 @@ export function DmVttTopBar({
   onModeChange,
 }: DmVttTopBarProps) {
   return (
-    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-3 left-4 flex min-h-[44px] items-center gap-3 rounded-2xl border px-3 py-1.5 shadow-xl">
+    <div className="flex min-h-[44px] min-w-0 items-center justify-center gap-2 px-2 py-1 sm:gap-3 sm:px-3">
       <Link href={`/dm/campaign/${campaignCode}/battlemaps`}>
         <Button variant="ghost" size="lg" aria-label="Back to battle maps">
           <ArrowLeft size={18} />
         </Button>
       </Link>
-      <span className="text-heading max-w-[160px] truncate text-sm font-semibold">
+      <span className="text-heading min-w-0 flex-1 truncate text-sm font-semibold sm:max-w-[160px] sm:flex-none">
         {mapName}
       </span>
       <div className="border-divider flex items-center gap-0.5 rounded-lg border p-0.5">
@@ -79,12 +79,13 @@ export function DmVttTopBar({
         size="lg"
         leftIcon={<Monitor size={16} />}
         onClick={() => openTvDisplay(campaignCode, battleMapId, dmId)}
-        className="text-xs"
+        className="min-h-[44px] min-w-[44px] px-2 text-xs lg:px-3"
+        aria-label="Open display"
       >
-        Open Display
+        <span className="hidden lg:inline">Open Display</span>
       </Button>
       <span
-        className={`rounded-full px-2 py-0.5 text-xs ${
+        className={`h-2.5 w-2.5 shrink-0 rounded-full sm:h-auto sm:w-auto sm:px-2 sm:py-0.5 sm:text-xs ${
           status === 'live'
             ? 'bg-accent-emerald-bg text-accent-emerald-text'
             : status === 'denied'
@@ -92,11 +93,13 @@ export function DmVttTopBar({
               : 'bg-accent-amber-bg text-accent-amber-text'
         }`}
       >
-        {status === 'live'
-          ? 'Live'
-          : status === 'denied'
-            ? 'Access denied'
-            : 'Connecting…'}
+        <span className="sr-only sm:not-sr-only">
+          {status === 'live'
+            ? 'Live'
+            : status === 'denied'
+              ? 'Access denied'
+              : 'Connecting…'}
+        </span>
       </span>
       <div className="border-divider flex items-center gap-0.5 rounded-lg border p-0.5">
         {MODE_OPTIONS.map(({ key, label }) => (

--- a/src/components/ui/campaign/dm-vtt/PlacementBanner.tsx
+++ b/src/components/ui/campaign/dm-vtt/PlacementBanner.tsx
@@ -14,7 +14,7 @@ export function PlacementBanner({
   onCancel,
 }: PlacementBannerProps) {
   return (
-    <div className="pointer-events-auto fixed top-16 left-1/2 z-20 -translate-x-1/2">
+    <div className="pointer-events-auto fixed top-[var(--dm-vtt-panel-top,8rem)] left-1/2 z-20 -translate-x-1/2">
       <div className="bg-accent-blue-bg border-accent-blue-border flex min-h-[44px] items-center gap-2 rounded-xl border px-3 py-1.5 shadow-lg">
         <span className="text-accent-blue-text text-sm font-medium">
           📍 Click the map to place {entityName}

--- a/src/components/ui/campaign/dm-vtt/RosterTray.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterTray.tsx
@@ -50,7 +50,7 @@ export function RosterTray({
       <button
         onClick={onToggleCollapsed}
         title="Expand roster"
-        className="bg-surface-raised border-divider text-heading pointer-events-auto fixed top-[78px] left-4 flex min-h-[44px] items-center gap-1.5 rounded-2xl border px-3 text-xs font-bold tracking-wider shadow-xl"
+        className="bg-surface-raised border-divider text-heading pointer-events-auto fixed top-[var(--dm-vtt-panel-top,8rem)] left-4 flex min-h-[44px] items-center gap-1.5 rounded-2xl border px-3 text-xs font-bold tracking-wider shadow-xl"
       >
         <span aria-hidden>👥</span> ROSTER
       </button>
@@ -60,7 +60,7 @@ export function RosterTray({
   const groups = groupRosterEntities(entities);
 
   return (
-    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-[78px] left-4 flex max-h-[calc(100vh-102px)] w-[180px] flex-col overflow-hidden rounded-2xl border shadow-xl">
+    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-[var(--dm-vtt-panel-top,8rem)] left-4 flex max-h-[calc(100vh-var(--dm-vtt-panel-top,8rem)-1.5rem)] w-[180px] flex-col overflow-hidden rounded-2xl border shadow-xl">
       <div className="border-divider flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2.5">
         <span className="text-heading text-sm font-semibold">👥 Roster</span>
         <Button

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
@@ -62,7 +62,7 @@ export function StudioPanel({
       <button
         onClick={onToggleCollapsed}
         title="Expand combat panel"
-        className="bg-surface-raised border-divider text-heading pointer-events-auto fixed top-[78px] right-4 flex min-h-[44px] items-center gap-1.5 rounded-2xl border px-3 text-xs font-bold tracking-wider shadow-xl"
+        className="bg-surface-raised border-divider text-heading pointer-events-auto fixed top-[var(--dm-vtt-panel-top,8rem)] right-4 flex min-h-[44px] items-center gap-1.5 rounded-2xl border px-3 text-xs font-bold tracking-wider shadow-xl"
       >
         <span aria-hidden>📋</span> COMBAT
       </button>
@@ -74,7 +74,7 @@ export function StudioPanel({
   );
 
   return (
-    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-[78px] right-4 flex max-h-[calc(100vh-102px)] w-[390px] flex-col overflow-hidden rounded-2xl border shadow-xl">
+    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-[var(--dm-vtt-panel-top,8rem)] right-4 flex max-h-[calc(100vh-var(--dm-vtt-panel-top,8rem)-1.5rem)] w-[min(390px,calc(100vw-2rem))] flex-col overflow-hidden rounded-2xl border shadow-xl">
       <div className="border-divider flex shrink-0 items-center justify-between gap-2 border-b px-2 py-1.5">
         <div className="flex items-center gap-1">
           {TABS.map(({ key, icon, label }) => (

--- a/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
@@ -5,6 +5,7 @@ import { DmVttToolbar } from '@/components/ui/campaign/dm-vtt/DmVttToolbar';
 
 vi.mock('@fieldnotes/react', () => ({
   useActiveTool: () => ['select', vi.fn()] as const,
+  useToolOptions: () => [undefined, vi.fn()] as const,
 }));
 
 describe('DmVttToolbar', () => {
@@ -31,11 +32,7 @@ describe('DmVttToolbar', () => {
     ).toBeInTheDocument();
   });
 
-  it('always sits below the fixed top bar (top-16), never sharing its row', () => {
-    // Regression pin for the wide-viewport overlap bug: a `min-[1350px]:top-3`
-    // variant previously moved the toolbar into `DmVttTopBar`'s row at
-    // >=1350px, hiding the drawing tools behind the top bar's controls. The
-    // toolbar must stay at `top-16` at every width.
+  it('uses one wrapping command dock instead of an independently positioned tool strip', () => {
     const { container } = render(
       <DmVttToolbar
         onClearDrawings={vi.fn()}
@@ -49,12 +46,13 @@ describe('DmVttToolbar', () => {
         onToggleSelectedDmOnly={vi.fn()}
       />
     );
-    const toolbar = container.firstChild as HTMLElement;
-    const classes = toolbar.className.split(/\s+/);
-    expect(classes).toContain('top-20');
-    expect(classes).not.toEqual(
-      expect.arrayContaining([expect.stringMatching(/^min-\[1350px\]:top-3$/)])
-    );
+    const dock = container.firstChild as HTMLElement;
+    expect(dock).toHaveAttribute('data-testid', 'dm-vtt-command-dock');
+    expect(dock.className).toContain('flex-col');
+    expect(dock.className).toContain('w-fit');
+    expect(dock.className).toContain('max-w-[calc(100%-2rem)]');
+    expect(dock.className).not.toContain('overflow-x-auto');
+    expect(dock.querySelector('.flex-wrap')).toBeInTheDocument();
   });
 
   it('toggles hidden placement and offers reveal all', () => {


### PR DESCRIPTION
## Summary
- combine DM battle-map session controls, canvas tools, and contextual options into one command dock
- make the dock shrink to its content, widen as tools appear, and wrap within the viewport
- dynamically position the roster, studio panel, and placement banner below the dock
- compact secondary labels and connection status for laptop-sized and narrower screens
- leave the player battle-map toolbar unchanged

## Validation
- pnpm type-check
- focused Vitest suite: 43 tests passed
- focused ESLint checks
- git diff --check