### PR TITLE
feat: shared live ruler (fieldnotes core 0.57.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@3d-dice/dice-box": "^1.1.3",
         "@3d-dice/dice-ui": "^0.5.2",
         "@aws-sdk/client-s3": "^3.922.0",
-        "@fieldnotes/core": "^0.56.0",
+        "@fieldnotes/core": "^0.57.0",
         "@fieldnotes/react": "^0.8.0",
         "@fieldnotes/sync": "^0.11.0",
         "@radix-ui/react-checkbox": "^1.3.2",
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/@fieldnotes/core": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.56.0.tgz",
-      "integrity": "sha512-lCNBdtZ0eWp+eppORF7qhpd80fMyTgNlRTIWNxcU2hv7okq5dfeC1wnjZHfBRik5jW5afAu5JscBFVNW8J+MYw==",
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.57.0.tgz",
+      "integrity": "sha512-41fF5BJTPIomNL9iqtP1U7dXJHbEhy0cfGSyOAXVbfFH5S9mLzdthVM/wEQx9Ee2IeMFWtLzCYOoyjBFK7wQkg==",
       "license": "MIT"
     },
     "node_modules/@fieldnotes/react": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@3d-dice/dice-box": "^1.1.3",
     "@3d-dice/dice-ui": "^0.5.2",
     "@aws-sdk/client-s3": "^3.922.0",
-    "@fieldnotes/core": "^0.56.0",
+    "@fieldnotes/core": "^0.57.0",
     "@fieldnotes/react": "^0.8.0",
     "@fieldnotes/sync": "^0.11.0",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/src/app/dm/campaign/[code]/battlemaps/[id]/display/page.tsx
+++ b/src/app/dm/campaign/[code]/battlemaps/[id]/display/page.tsx
@@ -13,6 +13,7 @@ import { ensureCanonicalLayers } from '@/components/ui/campaign/location-map/lay
 import { makeApplyRemoteLayer } from '@/components/ui/campaign/location-map/layerSync';
 import { attachRemoteLaserTrails } from '@/components/ui/campaign/location-map/laserSync';
 import { attachRemotePings } from '@/components/ui/campaign/location-map/pingSync';
+import { attachRemoteMeasurements } from '@/components/ui/campaign/location-map/measureSync';
 
 function DisplayCanvas() {
   const params = useParams();
@@ -63,6 +64,7 @@ function DisplayCanvas() {
     const presenceCleanups = [
       attachRemoteLaserTrails(vp, connection),
       attachRemotePings(vp, connection).dispose,
+      attachRemoteMeasurements(vp, connection).dispose,
     ];
     laserCleanupRef.current = () => {
       for (const cleanup of presenceCleanups) cleanup();

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -43,6 +43,11 @@ import {
   attachPingInput,
   attachRemotePings,
 } from '@/components/ui/campaign/location-map/pingSync';
+import {
+  attachMeasureBroadcast,
+  attachRemoteMeasurements,
+  type MeasureBroadcastHandle,
+} from '@/components/ui/campaign/location-map/measureSync';
 
 import type { TokenInfoMode } from '@/components/ui/campaign/token-overlay';
 
@@ -80,6 +85,8 @@ export interface DmBattleMapCanvasState {
   selectedElementId: string | null;
   selectedElementIsDmOnly: boolean;
   handleToggleSelectedDmOnly: () => void;
+  measureSharing: boolean;
+  handleSetMeasureSharing: (enabled: boolean) => void;
 }
 
 /**
@@ -111,6 +118,16 @@ export function useDmBattleMapCanvas({
   const [selectedElementId, setSelectedElementId] = useState<string | null>(
     null
   );
+  const [measureSharing, setMeasureSharing] = useState(false);
+  const measureSharingRef = useRef(false);
+  const measureBroadcastRef = useRef<MeasureBroadcastHandle | null>(null);
+
+  const handleSetMeasureSharing = useCallback((enabled: boolean) => {
+    measureSharingRef.current = enabled;
+    setMeasureSharing(enabled);
+    measureBroadcastRef.current?.setSharing(enabled);
+  }, []);
+
   const hiddenElementCount = useBattleMapStore(
     state =>
       Object.keys(
@@ -288,9 +305,11 @@ export function useDmBattleMapCanvas({
         // else's.
         laserCleanupRef.current?.();
         const remotePings = attachRemotePings(vp, connection);
+        const remoteMeasures = attachRemoteMeasurements(vp, connection);
         const laserCleanups = [
           attachRemoteLaserTrails(vp, connection),
           remotePings.dispose,
+          remoteMeasures.dispose,
         ];
         const laserTool = vp.toolManager.getTool<LaserTool>('laser');
         if (laserTool) {
@@ -299,6 +318,22 @@ export function useDmBattleMapCanvas({
         const pingTool = vp.toolManager.getTool<PingTool>('ping');
         if (pingTool) {
           laserCleanups.push(attachPingBroadcast(pingTool, connection));
+        }
+        const measureTool = vp.toolManager.getTool<MeasureTool>('measure');
+        if (measureTool) {
+          const measureBroadcast = attachMeasureBroadcast(
+            measureTool,
+            connection
+          );
+          // Reattachment (viewport/connection rebuild) must not silently
+          // revert to private while the toggle still says shared — apply the
+          // latest value now.
+          measureBroadcast.setSharing(measureSharingRef.current);
+          measureBroadcastRef.current = measureBroadcast;
+          laserCleanups.push(() => {
+            measureBroadcastRef.current = null;
+            measureBroadcast.dispose();
+          });
         }
         // Always-available DM pings: long-press with any tool + "P" at the
         // cursor, self-pulse through the shared receive overlay. The veto
@@ -397,5 +432,7 @@ export function useDmBattleMapCanvas({
     selectedElementId,
     selectedElementIsDmOnly,
     handleToggleSelectedDmOnly,
+    measureSharing,
+    handleSetMeasureSharing,
   };
 }

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -30,6 +30,8 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
     selectedElementId,
     selectedElementIsDmOnly,
     handleToggleSelectedDmOnly,
+    measureSharing,
+    handleSetMeasureSharing,
   } = useDmBattleMapCanvas(props);
 
   return (
@@ -54,6 +56,10 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
             selectedElementId={selectedElementId}
             selectedElementIsDmOnly={selectedElementIsDmOnly}
             onToggleSelectedDmOnly={handleToggleSelectedDmOnly}
+            measureSharing={{
+              enabled: measureSharing,
+              onChange: handleSetMeasureSharing,
+            }}
           />
         )}
         {viewport && children}

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -21,7 +21,9 @@ import {
 import { useActiveTool } from '@fieldnotes/react';
 
 import { Button } from '@/components/ui/forms/button';
-import DmLocationToolOptions from '@/components/ui/campaign/location-map/DmLocationToolOptions';
+import DmLocationToolOptions, {
+  type MeasureSharingControl,
+} from '@/components/ui/campaign/location-map/DmLocationToolOptions';
 
 import { useEffect, useRef, type ReactNode } from 'react';
 
@@ -53,6 +55,7 @@ export interface DmVttToolbarProps {
   selectedElementId: string | null;
   selectedElementIsDmOnly: boolean;
   onToggleSelectedDmOnly: () => void;
+  measureSharing?: MeasureSharingControl;
 }
 
 const TOKEN_INFO_ICON: Record<TokenInfoMode, typeof Eye> = {
@@ -87,6 +90,7 @@ export function DmVttToolbar({
   selectedElementId,
   selectedElementIsDmOnly,
   onToggleSelectedDmOnly,
+  measureSharing,
 }: DmVttToolbarProps) {
   const [activeTool, setTool] = useActiveTool();
   const TokenInfoIcon = TOKEN_INFO_ICON[tokenInfoToggle.mode ?? 'compact'];
@@ -218,7 +222,10 @@ export function DmVttToolbar({
         </div>
       </div>
       <div className="border-divider border-t empty:hidden">
-        <DmLocationToolOptions mode="battlemap" />
+        <DmLocationToolOptions
+          mode="battlemap"
+          measureSharing={measureSharing}
+        />
       </div>
     </div>
   );

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -42,6 +42,11 @@ import {
   attachPingInput,
   attachRemotePings,
 } from './pingSync';
+import {
+  attachMeasureBroadcast,
+  attachRemoteMeasurements,
+  type MeasureBroadcastHandle,
+} from './measureSync';
 import { pinGridToMapLayer } from './gridPin';
 import { nextMapImagePosition } from './mapImagePlacement';
 import {
@@ -172,6 +177,10 @@ export interface DmLocationEditorState {
   // Layer sync (battlemap mode; no-ops when live sync is off)
   publishLayerUpsert: (definition: Layer) => void;
   publishLayerRemove: (id: string) => void;
+
+  // Shared live ruler (battlemap mode; no-ops when live sync is off)
+  measureSharing: boolean;
+  handleSetMeasureSharing: (enabled: boolean) => void;
 }
 
 export function useDmLocationEditor(
@@ -245,6 +254,15 @@ export function useDmLocationEditor(
       : false;
   const [hiddenPlacementActive, setHiddenPlacementActive] = useState(false);
   const hiddenPlacementActiveRef = useRef(false);
+  const [measureSharing, setMeasureSharing] = useState(false);
+  const measureSharingRef = useRef(false);
+  const measureBroadcastRef = useRef<MeasureBroadcastHandle | null>(null);
+
+  const handleSetMeasureSharing = useCallback((enabled: boolean) => {
+    measureSharingRef.current = enabled;
+    setMeasureSharing(enabled);
+    measureBroadcastRef.current?.setSharing(enabled);
+  }, []);
 
   // Loading states
   const [syncing, setSyncing] = useState(false);
@@ -441,9 +459,11 @@ export function useDmLocationEditor(
         // else's.
         laserCleanupRef.current?.();
         const remotePings = attachRemotePings(vp, connection);
+        const remoteMeasures = attachRemoteMeasurements(vp, connection);
         const laserCleanups = [
           attachRemoteLaserTrails(vp, connection),
           remotePings.dispose,
+          remoteMeasures.dispose,
         ];
         const laserTool = vp.toolManager.getTool<LaserTool>('laser');
         if (laserTool) {
@@ -452,6 +472,22 @@ export function useDmLocationEditor(
         const pingTool = vp.toolManager.getTool<PingTool>('ping');
         if (pingTool) {
           laserCleanups.push(attachPingBroadcast(pingTool, connection));
+        }
+        const measureTool = vp.toolManager.getTool<MeasureTool>('measure');
+        if (measureTool) {
+          const measureBroadcast = attachMeasureBroadcast(
+            measureTool,
+            connection
+          );
+          // Reattachment (viewport/connection rebuild) must not silently
+          // revert to private while the toggle still says shared — apply the
+          // latest value now.
+          measureBroadcast.setSharing(measureSharingRef.current);
+          measureBroadcastRef.current = measureBroadcast;
+          laserCleanups.push(() => {
+            measureBroadcastRef.current = null;
+            measureBroadcast.dispose();
+          });
         }
         // Always-available DM pings: long-press with any tool + "P" at the
         // cursor, self-pulse through the shared receive overlay. The veto
@@ -1062,5 +1098,7 @@ export function useDmLocationEditor(
     handleToggleArrangeMaps,
     publishLayerUpsert,
     publishLayerRemove,
+    measureSharing,
+    handleSetMeasureSharing,
   };
 }

--- a/src/components/ui/campaign/location-map/DmLocationEditor.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.tsx
@@ -59,6 +59,8 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
     handleToggleArrangeMaps,
     publishLayerUpsert,
     publishLayerRemove,
+    measureSharing,
+    handleSetMeasureSharing,
   } = useDmLocationEditor(props);
 
   return (
@@ -115,7 +117,15 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
           />
         )}
 
-        {viewport && <DmLocationToolOptions mode={mode} />}
+        {viewport && (
+          <DmLocationToolOptions
+            mode={mode}
+            measureSharing={{
+              enabled: measureSharing,
+              onChange: handleSetMeasureSharing,
+            }}
+          />
+        )}
 
         <div className="relative flex min-h-0 flex-1 overflow-hidden">
           {arrangeMapsActive && (

--- a/src/components/ui/campaign/location-map/DmLocationToolOptions.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolOptions.tsx
@@ -15,6 +15,7 @@ import type {
   TextToolOptions,
 } from '@fieldnotes/core';
 import { useActiveTool, useToolOptions } from '@fieldnotes/react';
+import { Switch } from '@/components/ui/forms/switch';
 import type { EditorMode } from './DmLocationEditor.types';
 
 const COLOR_SWATCHES = [
@@ -56,12 +57,19 @@ const TEMPLATE_RENDER_STYLES: {
   },
 ];
 
+export interface MeasureSharingControl {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+}
+
 interface DmLocationToolOptionsProps {
   mode?: EditorMode;
+  measureSharing?: MeasureSharingControl;
 }
 
 export default function DmLocationToolOptions({
   mode = 'location',
+  measureSharing,
 }: DmLocationToolOptionsProps) {
   const [activeTool] = useActiveTool();
   const [pencilOpts, setPencilOpts] = useToolOptions<
@@ -123,7 +131,9 @@ export default function DmLocationToolOptions({
                 ? arrowOpts?.color
                 : activeTool === 'pencil'
                   ? pencilOpts?.color
-                  : '#334155';
+                  : activeTool === 'measure'
+                    ? measureOpts?.color
+                    : '#334155';
 
   const handleColorChange = (color: string) => {
     if (activeTool === 'shape') setShapeOpts({ strokeColor: color });
@@ -134,6 +144,7 @@ export default function DmLocationToolOptions({
     else if (activeTool === 'template') setTemplateOpts({ strokeColor: color });
     else if (activeTool === 'laser') setLaserOpts({ color });
     else if (activeTool === 'ping') setPingOpts({ color });
+    else if (activeTool === 'measure') setMeasureOpts({ color });
   };
 
   return (
@@ -347,6 +358,19 @@ export default function DmLocationToolOptions({
           <span className="text-muted w-8 text-xs">
             {measureOpts.feetPerCell ?? 5}
           </span>
+          {measureSharing && (
+            <>
+              <div className="bg-divider h-6 w-px" />
+              <label className="text-muted flex items-center gap-2 text-xs font-medium">
+                Share with players
+                <Switch
+                  checked={measureSharing.enabled}
+                  onCheckedChange={measureSharing.onChange}
+                  aria-label="Share with players"
+                />
+              </label>
+            </>
+          )}
         </>
       )}
 

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -52,6 +52,7 @@ import {
 import { makeApplyRemoteLayer, publishOwnedLayers } from './layerSync';
 import { attachRemoteLaserTrails } from './laserSync';
 import { attachRemotePings } from './pingSync';
+import { attachRemoteMeasurements } from './measureSync';
 import {
   PlayerTokenTool,
   PlayerTemplateTool,
@@ -347,6 +348,7 @@ export function PlayerBattleMapCanvas({
     const presenceCleanups = [
       attachRemoteLaserTrails(vp, connection),
       attachRemotePings(vp, connection).dispose,
+      attachRemoteMeasurements(vp, connection).dispose,
     ];
     laserCleanupRef.current = () => {
       for (const cleanup of presenceCleanups) cleanup();

--- a/src/components/ui/campaign/location-map/__tests__/DmLocationToolOptions.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/DmLocationToolOptions.test.tsx
@@ -85,3 +85,65 @@ describe('DmLocationToolOptions pencil options', () => {
     expect(container).toBeEmptyDOMElement();
   });
 });
+
+describe('DmLocationToolOptions measure sharing control', () => {
+  beforeEach(() => {
+    mockActiveTool = 'measure';
+    mockToolOptions = { measure: { color: '#FF5722', feetPerCell: 5 } };
+    for (const key of Object.keys(setOptionsSpies)) delete setOptionsSpies[key];
+  });
+
+  afterEach(() => cleanup());
+
+  it('renders no share control when measureSharing is not provided', () => {
+    render(<DmLocationToolOptions mode="battlemap" />);
+
+    expect(screen.queryByLabelText(/share with players/i)).toBeNull();
+  });
+
+  it('renders the share toggle unchecked by default state and fires onChange', () => {
+    const onChange = vi.fn();
+    render(
+      <DmLocationToolOptions
+        mode="battlemap"
+        measureSharing={{ enabled: false, onChange }}
+      />
+    );
+
+    const toggle = screen.getByLabelText(/share with players/i);
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('reflects enabled sharing state', () => {
+    const onChange = vi.fn();
+    render(
+      <DmLocationToolOptions
+        mode="battlemap"
+        measureSharing={{ enabled: true, onChange }}
+      />
+    );
+
+    const toggle = screen.getByLabelText(/share with players/i);
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('sets measureOpts.color when a swatch is clicked', () => {
+    render(<DmLocationToolOptions mode="battlemap" />);
+
+    fireEvent.click(screen.getByTitle('#22c55e'));
+    expect(setOptionsSpies['measure']).toHaveBeenCalledWith({
+      color: '#22c55e',
+    });
+  });
+
+  it('reflects measureOpts.color as the active color for the measure tool', () => {
+    mockToolOptions = { measure: { color: '#3b82f6', feetPerCell: 5 } };
+    render(<DmLocationToolOptions mode="battlemap" />);
+
+    const swatch = screen.getByTitle('#3b82f6');
+    expect(swatch.className).toContain('border-accent-blue-border');
+  });
+});

--- a/src/components/ui/campaign/location-map/measureSync.test.ts
+++ b/src/components/ui/campaign/location-map/measureSync.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  MeasureTool,
+  type Camera,
+  type OverlayRenderer,
+  type ToolContext,
+  type PointerState,
+} from '@fieldnotes/core';
+import {
+  attachMeasureBroadcast,
+  attachRemoteMeasurements,
+} from './measureSync';
+
+// Deterministic raf: callbacks run only when flushFrame() is called.
+let rafCallbacks: FrameRequestCallback[];
+
+beforeEach(() => {
+  rafCallbacks = [];
+  let id = 0;
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn((cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return ++id;
+    })
+  );
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function flushFrame(): void {
+  const cbs = rafCallbacks;
+  rafCallbacks = [];
+  for (const cb of cbs) cb(0);
+}
+
+function toolCtx(): ToolContext {
+  return {
+    // Identity camera: screen coords are world coords.
+    camera: {
+      screenToWorld: (p: { x: number; y: number }) => ({ ...p }),
+    } as unknown as Camera,
+    store: {} as ToolContext['store'],
+    requestRender: vi.fn(),
+  };
+}
+
+const pt = (x: number, y: number): PointerState => ({
+  x,
+  y,
+  pressure: 0.5,
+  pointerType: 'mouse',
+  shiftKey: false,
+});
+
+// With the identity camera and no grid, start/end pass through unsnapped, so
+// a (0,0)->(3,4) drag always yields worldDistance 5 / cells 5 / feet 25 with
+// the default MeasureTool color.
+const activeFrame = (
+  start: { x: number; y: number },
+  end: { x: number; y: number }
+) => ({
+  kind: 'measure',
+  start,
+  end,
+  cells: 5,
+  feet: 25,
+  color: '#FF5722',
+});
+const clearedFrame = { kind: 'measure', cleared: true };
+
+describe('attachMeasureBroadcast', () => {
+  it('default (sharing off) suppresses all frames', () => {
+    const tool = new MeasureTool();
+    const sendPresence = vi.fn();
+    attachMeasureBroadcast(tool, { sendPresence });
+
+    const ctx = toolCtx();
+    tool.onPointerDown(pt(0, 0), ctx);
+    tool.onPointerMove(pt(3, 4), ctx);
+    flushFrame();
+    tool.onPointerUp(pt(3, 4), ctx);
+
+    expect(sendPresence).not.toHaveBeenCalled();
+  });
+
+  it('setSharing(true) then drag: active frames sent, cleared on release', () => {
+    const tool = new MeasureTool();
+    const sendPresence = vi.fn();
+    const handle = attachMeasureBroadcast(tool, { sendPresence });
+    handle.setSharing(true);
+
+    const ctx = toolCtx();
+    tool.onPointerDown(pt(10, 20), ctx);
+    tool.onPointerMove(pt(13, 24), ctx);
+    flushFrame();
+    expect(sendPresence).toHaveBeenNthCalledWith(
+      1,
+      activeFrame({ x: 10, y: 20 }, { x: 13, y: 24 })
+    );
+
+    tool.onPointerUp(pt(13, 24), ctx);
+    expect(sendPresence).toHaveBeenNthCalledWith(2, clearedFrame);
+    expect(sendPresence).toHaveBeenCalledTimes(2);
+  });
+
+  it('setSharing(false) after an active frame (no release) sends exactly one extra cleared frame', () => {
+    const tool = new MeasureTool();
+    const sendPresence = vi.fn();
+    const handle = attachMeasureBroadcast(tool, { sendPresence });
+    handle.setSharing(true);
+
+    const ctx = toolCtx();
+    tool.onPointerDown(pt(0, 0), ctx);
+    tool.onPointerMove(pt(3, 4), ctx);
+    flushFrame();
+    expect(sendPresence).toHaveBeenCalledTimes(1);
+
+    handle.setSharing(false);
+    expect(sendPresence).toHaveBeenCalledTimes(2);
+    expect(sendPresence).toHaveBeenLastCalledWith(clearedFrame);
+
+    handle.setSharing(false); // redundant: no extra send
+    expect(sendPresence).toHaveBeenCalledTimes(2);
+  });
+
+  it('setSharing(false) after a natural release (clear already sent) sends nothing extra', () => {
+    const tool = new MeasureTool();
+    const sendPresence = vi.fn();
+    const handle = attachMeasureBroadcast(tool, { sendPresence });
+    handle.setSharing(true);
+
+    const ctx = toolCtx();
+    tool.onPointerDown(pt(0, 0), ctx);
+    tool.onPointerMove(pt(3, 4), ctx);
+    flushFrame();
+    tool.onPointerUp(pt(3, 4), ctx);
+    expect(sendPresence).toHaveBeenCalledTimes(2); // active + cleared
+
+    handle.setSharing(false);
+    expect(sendPresence).toHaveBeenCalledTimes(2);
+  });
+
+  it('setSharing(true) mid-suppression resumes on the next emission', () => {
+    const tool = new MeasureTool();
+    const sendPresence = vi.fn();
+    const handle = attachMeasureBroadcast(tool, { sendPresence });
+
+    const ctx = toolCtx();
+    tool.onPointerDown(pt(10, 20), ctx);
+    tool.onPointerMove(pt(11, 21), ctx);
+    flushFrame();
+    expect(sendPresence).not.toHaveBeenCalled();
+
+    handle.setSharing(true);
+    tool.onPointerMove(pt(13, 24), ctx);
+    flushFrame();
+    expect(sendPresence).toHaveBeenCalledTimes(1);
+    expect(sendPresence).toHaveBeenLastCalledWith(
+      activeFrame({ x: 10, y: 20 }, { x: 13, y: 24 })
+    );
+  });
+
+  it('redundant setSharing(true) twice causes no duplicate behavior', () => {
+    const tool = new MeasureTool();
+    const sendPresence = vi.fn();
+    const handle = attachMeasureBroadcast(tool, { sendPresence });
+    handle.setSharing(true);
+    handle.setSharing(true);
+
+    const ctx = toolCtx();
+    tool.onPointerDown(pt(0, 0), ctx);
+    tool.onPointerMove(pt(3, 4), ctx);
+    flushFrame();
+    expect(sendPresence).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispose() after an active frame sends one final cleared frame; further calls/emissions send nothing', () => {
+    const tool = new MeasureTool();
+    const sendPresence = vi.fn();
+    const handle = attachMeasureBroadcast(tool, { sendPresence });
+    handle.setSharing(true);
+
+    const ctx = toolCtx();
+    tool.onPointerDown(pt(0, 0), ctx);
+    tool.onPointerMove(pt(3, 4), ctx);
+    flushFrame();
+    expect(sendPresence).toHaveBeenCalledTimes(1);
+
+    handle.dispose();
+    expect(sendPresence).toHaveBeenCalledTimes(2);
+    expect(sendPresence).toHaveBeenLastCalledWith(clearedFrame);
+
+    handle.dispose(); // idempotent
+    expect(sendPresence).toHaveBeenCalledTimes(2);
+
+    tool.onPointerMove(pt(5, 5), ctx);
+    flushFrame();
+    expect(sendPresence).toHaveBeenCalledTimes(2);
+  });
+
+  it('replacement-handle contract: a fresh handle keeps sharing on across reattachment', () => {
+    const tool = new MeasureTool();
+    const sentA: unknown[] = [];
+    const handleA = attachMeasureBroadcast(tool, {
+      sendPresence: d => sentA.push(d),
+    });
+    handleA.setSharing(true);
+    handleA.dispose(); // no frame emitted yet, so no cleared send here
+    expect(sentA).toEqual([]);
+
+    const sentB: unknown[] = [];
+    const handleB = attachMeasureBroadcast(tool, {
+      sendPresence: d => sentB.push(d),
+    });
+    handleB.setSharing(true);
+
+    const ctx = toolCtx();
+    tool.onPointerDown(pt(1, 1), ctx);
+    tool.onPointerMove(pt(4, 5), ctx);
+    flushFrame();
+
+    expect(sentB).toEqual([activeFrame({ x: 1, y: 1 }, { x: 4, y: 5 })]);
+    expect(sentA).toEqual([]);
+  });
+});
+
+describe('attachRemoteMeasurements', () => {
+  function makeHost() {
+    const overlays: OverlayRenderer[] = [];
+    return {
+      overlays,
+      registerOverlay(draw: OverlayRenderer): () => void {
+        overlays.push(draw);
+        return () => {
+          const index = overlays.indexOf(draw);
+          if (index >= 0) overlays.splice(index, 1);
+        };
+      },
+      requestRender: vi.fn(),
+    };
+  }
+
+  function makeConnection() {
+    const presenceHandlers = new Set<(from: string, data: unknown) => void>();
+    const leaveHandlers = new Set<(from: string) => void>();
+    return {
+      presenceHandlers,
+      leaveHandlers,
+      onPresence(handler: (from: string, data: unknown) => void): () => void {
+        presenceHandlers.add(handler);
+        return () => presenceHandlers.delete(handler);
+      },
+      onPresenceLeave(handler: (from: string) => void): () => void {
+        leaveHandlers.add(handler);
+        return () => leaveHandlers.delete(handler);
+      },
+      emitPresence(from: string, data: unknown): void {
+        for (const h of [...presenceHandlers]) h(from, data);
+      },
+      emitLeave(from: string): void {
+        for (const h of [...leaveHandlers]) h(from);
+      },
+    };
+  }
+
+  const measure = (x: number, y: number) => ({
+    kind: 'measure',
+    start: { x, y },
+    end: { x: x + 5, y },
+    cells: 5,
+    feet: 25,
+  });
+
+  it('applies measure payloads keyed by sender and ignores foreign kinds', () => {
+    const host = makeHost();
+    const connection = makeConnection();
+    const handle = attachRemoteMeasurements(host, connection);
+
+    connection.emitPresence('hub', { kind: 'poke', feature: 'players' });
+    connection.emitPresence('conn-1', {
+      kind: 'laser',
+      points: [{ x: 0, y: 0 }],
+    });
+    connection.emitPresence('conn-1', { kind: 'ping', x: 0, y: 0 });
+    expect(handle.overlay.activeSenderCount).toBe(0);
+
+    connection.emitPresence('conn-1', measure(0, 0));
+    expect(handle.overlay.activeSenderCount).toBe(1);
+  });
+
+  it('presence-leave removes the sender immediately', () => {
+    const host = makeHost();
+    const connection = makeConnection();
+    const handle = attachRemoteMeasurements(host, connection);
+
+    connection.emitPresence('conn-1', measure(0, 0));
+    expect(handle.overlay.activeSenderCount).toBe(1);
+
+    connection.emitLeave('conn-1');
+    expect(handle.overlay.activeSenderCount).toBe(0);
+  });
+
+  it('dispose() unsubscribes both handlers and disposes the overlay', () => {
+    const host = makeHost();
+    const connection = makeConnection();
+    const handle = attachRemoteMeasurements(host, connection);
+
+    handle.dispose();
+
+    expect(connection.presenceHandlers.size).toBe(0);
+    expect(connection.leaveHandlers.size).toBe(0);
+    expect(handle.overlay.apply('conn-1', measure(0, 0))).toBe(false);
+  });
+});

--- a/src/components/ui/campaign/location-map/measureSync.ts
+++ b/src/components/ui/campaign/location-map/measureSync.ts
@@ -1,0 +1,112 @@
+import {
+  RemoteMeasureOverlay,
+  toMeasurePresence,
+  type MeasureTool,
+  type RemoteMeasureOverlayHost,
+} from '@fieldnotes/core';
+
+/**
+ * Shared-ruler wiring over battle-map presence. Measure traffic is ephemeral
+ * by contract: presence frames only — never elements, undo history,
+ * `canvasState`/autosave, or the durable operation queue — and it is
+ * room-visible (element `canRead` filtering is unrelated). Broadcast is
+ * role-based product policy: today only DM canvases attach the broadcast
+ * side; every synced canvas attaches the receiving side, so enabling player
+ * rulers later is configuration, not code.
+ */
+
+/** The presence surface `createManagedBattleMapConnection` exposes. */
+export interface MeasurePresenceConnection {
+  sendPresence: (data: unknown) => void;
+  onPresence: (handler: (from: string, data: unknown) => void) => () => void;
+  onPresenceLeave: (handler: (from: string) => void) => () => void;
+}
+
+export interface MeasureBroadcastHandle {
+  /**
+   * Push-based sharing switch. Turning sharing off sends one cleared frame
+   * immediately when the last broadcast frame was an active measurement — a
+   * pull-based check could not react while the pointer is stationary, and a
+   * remote ruler must never stick after the DM goes private.
+   */
+  setSharing(enabled: boolean): void;
+  dispose(): void;
+}
+
+/**
+ * Broadcasts the local `MeasureTool`'s per-frame coalesced measurement
+ * emissions as shared-ruler presence, gated by `setSharing`. Sends while not
+ * sharing (or not live) are dropped by the connection (never queued),
+ * matching the ephemerality contract.
+ */
+export function attachMeasureBroadcast(
+  tool: MeasureTool,
+  connection: Pick<MeasurePresenceConnection, 'sendPresence'>
+): MeasureBroadcastHandle {
+  let sharing = false;
+  let lastFrameActive = false;
+  let disposed = false;
+
+  const sendClearIfActive = () => {
+    if (!lastFrameActive) return;
+    lastFrameActive = false;
+    connection.sendPresence(toMeasurePresence(null));
+  };
+
+  const unsubscribe = tool.onMeasurement(emission => {
+    if (disposed || !sharing) return;
+    connection.sendPresence(toMeasurePresence(emission));
+    lastFrameActive = emission !== null;
+  });
+
+  return {
+    setSharing(enabled: boolean) {
+      if (disposed || sharing === enabled) return;
+      sharing = enabled;
+      if (!enabled) sendClearIfActive();
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      unsubscribe();
+      sendClearIfActive();
+    },
+  };
+}
+
+/** The receiving side of measure presence plus the overlay it renders through. */
+export interface RemoteMeasureHandle {
+  overlay: RemoteMeasureOverlay;
+  dispose: () => void;
+}
+
+/**
+ * Renders remote shared-ruler measurements on a synced canvas, whatever tool
+ * the viewer holds. The presence `from` (the relay's server-owned connection
+ * id) is used purely as an opaque per-sender key; `RemoteMeasureOverlay.apply`
+ * validates payloads, so hub pokes (`data.kind === 'poke'`), laser trails
+ * (`data.kind === 'laser'`), map pings (`data.kind === 'ping'`), and any
+ * other presence traffic are ignored here and their own handlers stay
+ * undisturbed. A sender's ruler disappears on fade and immediately on
+ * presence-leave. `dispose` unsubscribes and disposes the overlay.
+ */
+export function attachRemoteMeasurements(
+  vp: RemoteMeasureOverlayHost,
+  connection: Pick<MeasurePresenceConnection, 'onPresence' | 'onPresenceLeave'>
+): RemoteMeasureHandle {
+  const overlay = new RemoteMeasureOverlay(vp);
+  const unsubscribePresence = connection.onPresence((from, data) => {
+    overlay.apply(from, data);
+  });
+  const unsubscribeLeave = connection.onPresenceLeave(from => {
+    overlay.remove(from);
+  });
+  return {
+    overlay,
+    dispose: () => {
+      unsubscribePresence();
+      unsubscribeLeave();
+      overlay.dispose();
+    },
+  };
+}

--- a/src/lib/battlemapSync.test.ts
+++ b/src/lib/battlemapSync.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   ElementStore,
   LayerManager,
+  MeasureTool,
   createShape,
   type CanvasElement,
   type Layer,
+  type PointerState,
 } from '@fieldnotes/core';
 import {
   createManagedBattleMapConnection,
@@ -923,6 +925,205 @@ describe('createManagedBattleMapConnection presence (laser)', () => {
     container.remove();
     remotePings.dispose();
     cleanupLasers();
+    expect(overlays).toHaveLength(0);
+    conn.stop();
+  });
+
+  it('poke + laser + ping + measure presence coexist over the real attachments: measure sends exactly one presence frame, the remote overlay applies it presence-only, leave clears every overlay', async () => {
+    // MeasureTool's onMeasurement is raf-coalesced (see measureSync.test.ts):
+    // callbacks are captured and only run on an explicit flushFrame(). The
+    // ping/laser overlays above never have their raf callback invoked either
+    // way, so a capturing stub is a compatible drop-in for this test.
+    let rafCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb);
+        return 1;
+      })
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    const flushFrame = () => {
+      const cbs = rafCallbacks;
+      rafCallbacks = [];
+      for (const cb of cbs) cb(0);
+    };
+    const pt = (x: number, y: number): PointerState => ({
+      x,
+      y,
+      pressure: 0.5,
+      pointerType: 'mouse',
+      shiftKey: false,
+    });
+
+    const { attachRemotePings } = await import(
+      '@/components/ui/campaign/location-map/pingSync'
+    );
+    const { attachRemoteLaserTrails } = await import(
+      '@/components/ui/campaign/location-map/laserSync'
+    );
+    const { attachMeasureBroadcast, attachRemoteMeasurements } = await import(
+      '@/components/ui/campaign/location-map/measureSync'
+    );
+
+    // Ping/laser overlays share this host, mirroring the sibling test above
+    // (their draw functions are exercised through a mock 2D context).
+    const overlays: ((ctx: CanvasRenderingContext2D) => void)[] = [];
+    const vp = {
+      registerOverlay(draw: (ctx: CanvasRenderingContext2D) => void) {
+        overlays.push(draw);
+        return () => {
+          const index = overlays.indexOf(draw);
+          if (index >= 0) overlays.splice(index, 1);
+        };
+      },
+      requestRender: vi.fn(),
+    };
+    // The measure overlay gets its own host: RemoteMeasureOverlay's real
+    // draw calls (setLineDash/roundRect/fillText/measureText) don't fit the
+    // slim ping/laser canvas mock below, and this test asserts remote-side
+    // state via activeSenderCount rather than drawing it.
+    const measureHost = {
+      registerOverlay: (draw: (ctx: CanvasRenderingContext2D) => void) => {
+        void draw;
+        return () => {};
+      },
+      requestRender: vi.fn(),
+    };
+
+    const store = new ElementStore();
+    const pokes: string[] = [];
+    const conn = createManagedBattleMapConnection({
+      relayUrl: 'wss://relay.example',
+      campaignCode: 'CODE',
+      battleMapId: 'map-1',
+      store,
+      clientId: 'player-1',
+      tokenRequest: { role: 'player', battleMapId: 'map-1', playerId: 'p1' },
+      onStatus: s => statuses.push(s),
+      onPoke: feature => pokes.push(feature),
+      transportFactory: () => fakeTransport,
+    });
+    await flushMicro();
+    const remotePings = attachRemotePings(vp, conn);
+    const cleanupLasers = attachRemoteLaserTrails(vp, conn);
+    const remoteMeasurements = attachRemoteMeasurements(measureHost, conn);
+    const measureTool = new MeasureTool();
+    const measureHandle = attachMeasureBroadcast(measureTool, conn);
+    fakeTransport.emitMessage(snapshotEnvelope('player-1', []));
+
+    const counts = () => {
+      let fills = 0;
+      let strokes = 0;
+      const ctx = {
+        save: vi.fn(),
+        restore: vi.fn(),
+        beginPath: vi.fn(),
+        arc: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        stroke: vi.fn(() => (strokes += 1)),
+        fill: vi.fn(() => (fills += 1)),
+        globalAlpha: 1,
+        strokeStyle: '',
+        fillStyle: '',
+        lineWidth: 0,
+        lineCap: '',
+        lineJoin: '',
+      } as unknown as CanvasRenderingContext2D;
+      for (const draw of [...overlays]) draw(ctx);
+      return { fills, strokes };
+    };
+
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'hub',
+        op: { kind: 'presence', data: { kind: 'poke', feature: 'players' } },
+      })
+    );
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'conn-dm',
+        op: { kind: 'presence', data: laserPayload },
+      })
+    );
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'conn-dm',
+        op: {
+          kind: 'presence',
+          data: { kind: 'ping', x: 100, y: 200, color: '#F4C430' },
+        },
+      })
+    );
+    // Remote receive path: a shared-ruler frame from the same foreign
+    // sender. The overlay applies it (presence-only — nothing persists).
+    fakeTransport.emitMessage(
+      JSON.stringify({
+        from: 'conn-dm',
+        op: {
+          kind: 'presence',
+          data: {
+            kind: 'measure',
+            start: { x: 0, y: 0 },
+            end: { x: 30, y: 40 },
+            cells: 10,
+            feet: 50,
+            color: '#F4C430',
+          },
+        },
+      })
+    );
+
+    expect(pokes).toEqual(['players']); // poke parsing undisturbed
+    const drawn = counts();
+    expect(drawn.fills).toBe(1); // exactly one ping pulse
+    expect(drawn.strokes).toBeGreaterThan(0); // laser trail rendered
+    expect(remoteMeasurements.overlay.activeSenderCount).toBe(1); // remote ruler applied
+    expect(store.snapshot()).toEqual([]); // presence-only: nothing persisted
+
+    // Local broadcast path: enable sharing, drive one measurement, flush the
+    // coalesced raf emission — exactly one presence frame reaches the wire.
+    measureHandle.setSharing(true);
+    const sentBeforeMeasure = fakeTransport.sent.length;
+    const measureCtx = {
+      camera: { screenToWorld: (p: { x: number; y: number }) => ({ ...p }) },
+      store: {} as ElementStore,
+      requestRender: vi.fn(),
+    } as unknown as Parameters<MeasureTool['onPointerDown']>[1];
+    measureTool.onPointerDown(pt(10, 20), measureCtx);
+    measureTool.onPointerMove(pt(13, 24), measureCtx);
+    flushFrame();
+
+    const measureFrames = fakeTransport.sent
+      .slice(sentBeforeMeasure)
+      .map(
+        frame => JSON.parse(frame) as { op: { kind: string; data?: unknown } }
+      )
+      .filter(envelope => envelope.op.kind === 'presence');
+    expect(measureFrames).toHaveLength(1);
+    const measurePayload = measureFrames[0]?.op.data as {
+      kind: string;
+      feet: number;
+    };
+    expect(measurePayload.kind).toBe('measure');
+    expect(Number.isFinite(measurePayload.feet)).toBe(true);
+    expect(store.snapshot()).toEqual([]); // still nothing persisted
+
+    // Presence-leave clears every overlay for that sender immediately.
+    fakeTransport.emitMessage(
+      JSON.stringify({ from: 'conn-dm', op: { kind: 'presence-leave' } })
+    );
+    const afterLeave = counts();
+    expect(afterLeave.fills).toBe(0);
+    expect(afterLeave.strokes).toBe(0);
+    expect(remoteMeasurements.overlay.activeSenderCount).toBe(0);
+    expect(store.snapshot()).toEqual([]); // presence-only, end to end
+
+    measureHandle.dispose();
+    remotePings.dispose();
+    cleanupLasers();
+    remoteMeasurements.dispose();
     expect(overlays).toHaveLength(0);
     conn.stop();
   });


### PR DESCRIPTION
## Summary

Adopts `@fieldnotes/core@0.57.0` (IrakliDevelop/fieldnotes#144) — players see the DM's measured path and distance live. Presence-only: no elements, no undo history, no canvasState/autosave, no durable queue, no camera moves. Relay pins deliberately untouched (core-only SDK release).

- **`measureSync.ts`** (mirrors `laserSync`/`pingSync`): `attachMeasureBroadcast(tool, connection)` returns a push-based `{ setSharing(enabled), dispose }` handle — sharing starts **false (private by default)**; turning sharing off sends exactly one cleared frame immediately (stationary pointer included) so a remote ruler can never stick after the DM goes private; `dispose()` sends the same final clear when a broadcast measurement was live. `attachRemoteMeasurements(vp, connection)` returns `{ overlay, dispose }` keyed by presence `from`, removed on presence-leave; payload guard ignores poke/laser/ping on the same connection.
- **DM "Share with players" toggle**: new optional `measureSharing` prop on `DmLocationToolOptions` (control renders only when provided — player canvas passes nothing and never sees it); state lifted into both DM canvas owners; reattachment applies the latest sharing value immediately after every attach, so a connection rebuild can't silently revert to private while the UI says shared. Toggling never rebuilds the connection.
- **Measure color rider**: the previously dead generic palette now works for the measure tool (`measureOpts.color` in the `activeColor` chain + `setMeasureOpts({ color })` branch); emissions carry the color so the shared ruler follows the swatch.
- **Call sites**: DM VTT + DM location editor (battlemap mode) broadcast + receive; player canvas + display receive-only. Player-local measuring stays private (structurally unattached, not gated).

## Verification

- Full suite 3654 passed / 1 skipped (stable across two runs): measureSync.test.ts 11 (incl. exact-one-cleared-frame gating and the replacement-handle reattachment contract), DmLocationToolOptions +5 (toggle absence/presence, swatch wiring), battlemapSync.test.ts +1 real-managed-lifecycle coexistence test (poke + laser + ping + measure on one connection; exactly one presence frame per emission; element store empty throughout; presence-leave clears all overlays).
- `tsc --noEmit` clean; eslint 0 errors; relay untouched.
- Final whole-branch review: READY_WITH_NOTES — go-private guarantee verified end-to-end (stationary toggle-off, rebuild-while-enabled, unmount-mid-measurement: cleanup disposes broadcast before `connection.stop()` so the final clear rides the live connection); offline-drop paths recover via relay presence-leave or receiver `maxAgeMs` 30s per spec.

Closes the RollKeeper side of the paired delivery for Fieldnotes PR #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)