### PR TITLE
Make the DM command rail responsive and edge-to-edge

### DIFF
--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -124,12 +124,16 @@ export function DmVttToolbar({
   return (
     <div
       ref={dockRef}
-      className="bg-surface-raised border-divider pointer-events-auto fixed top-3 left-1/2 z-20 flex w-fit max-w-[calc(100%-2rem)] -translate-x-1/2 flex-col overflow-hidden rounded-2xl border shadow-xl min-[1512px]:max-w-[1480px]"
+      className="bg-surface-raised border-divider pointer-events-auto fixed inset-x-0 top-0 z-20 flex w-full flex-col overflow-hidden border-b shadow-xl 2xl:flex-row 2xl:flex-wrap"
       data-testid="dm-vtt-command-dock"
     >
-      {sessionControls}
-      <div className="border-divider flex flex-wrap items-center justify-center gap-x-3 gap-y-1 border-t p-1">
-        <div className="flex flex-wrap items-center justify-center gap-1">
+      {sessionControls && (
+        <div className="border-divider min-w-0 shrink-0 border-b 2xl:border-r 2xl:border-b-0">
+          {sessionControls}
+        </div>
+      )}
+      <div className="scrollbar-thin flex min-w-0 flex-1 items-center gap-3 overflow-x-auto overscroll-x-contain px-2 py-1">
+        <div className="flex shrink-0 items-center gap-1">
           {DM_TOOLS.map(({ name, label, Icon }) => (
             <Button
               key={name}
@@ -143,7 +147,7 @@ export function DmVttToolbar({
             </Button>
           ))}
         </div>
-        <div className="border-divider flex flex-wrap items-center justify-center gap-1 border-l pl-3">
+        <div className="border-divider flex shrink-0 items-center gap-1 border-l pl-3">
           <Button
             variant={hiddenPlacementActive ? 'warning' : 'ghost'}
             onClick={onToggleHiddenPlacement}
@@ -221,7 +225,7 @@ export function DmVttToolbar({
           </Button>
         </div>
       </div>
-      <div className="border-divider border-t empty:hidden">
+      <div className="border-divider w-full border-t empty:hidden">
         <DmLocationToolOptions
           mode="battlemap"
           measureSharing={measureSharing}

--- a/src/components/ui/campaign/dm-vtt/DmVttTopBar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttTopBar.tsx
@@ -53,16 +53,19 @@ export function DmVttTopBar({
   onModeChange,
 }: DmVttTopBarProps) {
   return (
-    <div className="flex min-h-[44px] min-w-0 items-center justify-center gap-2 px-2 py-1 sm:gap-3 sm:px-3">
-      <Link href={`/dm/campaign/${campaignCode}/battlemaps`}>
+    <div className="scrollbar-thin flex min-h-[52px] min-w-0 items-center justify-start gap-2 overflow-x-auto overscroll-x-contain px-2 py-1 sm:gap-3 sm:px-3">
+      <Link
+        href={`/dm/campaign/${campaignCode}/battlemaps`}
+        className="shrink-0"
+      >
         <Button variant="ghost" size="lg" aria-label="Back to battle maps">
           <ArrowLeft size={18} />
         </Button>
       </Link>
-      <span className="text-heading min-w-0 flex-1 truncate text-sm font-semibold sm:max-w-[160px] sm:flex-none">
+      <span className="text-heading min-w-[5rem] flex-1 truncate text-sm font-semibold sm:max-w-[160px] sm:flex-none">
         {mapName}
       </span>
-      <div className="border-divider flex items-center gap-0.5 rounded-lg border p-0.5">
+      <div className="border-divider flex shrink-0 items-center gap-0.5 rounded-lg border p-0.5">
         {GRID_OPTIONS.map(({ key, label }) => (
           <Button
             key={key}
@@ -101,7 +104,7 @@ export function DmVttTopBar({
               : 'Connecting…'}
         </span>
       </span>
-      <div className="border-divider flex items-center gap-0.5 rounded-lg border p-0.5">
+      <div className="border-divider flex shrink-0 items-center gap-0.5 rounded-lg border p-0.5">
         {MODE_OPTIONS.map(({ key, label }) => (
           <Button
             key={key}

--- a/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/DmVttToolbar.test.tsx
@@ -32,7 +32,7 @@ describe('DmVttToolbar', () => {
     ).toBeInTheDocument();
   });
 
-  it('uses one wrapping command dock instead of an independently positioned tool strip', () => {
+  it('uses an edge-to-edge responsive command rail', () => {
     const { container } = render(
       <DmVttToolbar
         onClearDrawings={vi.fn()}
@@ -49,10 +49,10 @@ describe('DmVttToolbar', () => {
     const dock = container.firstChild as HTMLElement;
     expect(dock).toHaveAttribute('data-testid', 'dm-vtt-command-dock');
     expect(dock.className).toContain('flex-col');
-    expect(dock.className).toContain('w-fit');
-    expect(dock.className).toContain('max-w-[calc(100%-2rem)]');
-    expect(dock.className).not.toContain('overflow-x-auto');
-    expect(dock.querySelector('.flex-wrap')).toBeInTheDocument();
+    expect(dock.className).toContain('inset-x-0');
+    expect(dock.className).toContain('w-full');
+    expect(dock.className).toContain('2xl:flex-row');
+    expect(dock.querySelector('.overflow-x-auto')).toBeInTheDocument();
   });
 
   it('toggles hidden placement and offers reveal all', () => {


### PR DESCRIPTION
## Summary
- replace the centered floating command dock with an edge-to-edge top rail
- use a single row on wide displays and compact stacked rows on smaller laptops
- keep session and tool controls touch-accessible with horizontal scrolling on narrow screens
- preserve dynamic side-panel positioning below the rail

## Verification
- Prettier check passed
- 36 focused DM VTT tests passed