### PR TITLE
Make DM battle-map panels content-sized

### DIFF
--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -63,7 +63,9 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
             }}
           />
         )}
-        {viewport && <BattleMapMinimap placement="bottom-left" />}
+        {viewport && (
+          <BattleMapMinimap placement="bottom-left" defaultCollapsed />
+        )}
         {viewport && children}
       </div>
     </ViewportContext.Provider>

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -63,7 +63,7 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
             }}
           />
         )}
-        {viewport && <BattleMapMinimap />}
+        {viewport && <BattleMapMinimap placement="bottom-left" />}
         {viewport && children}
       </div>
     </ViewportContext.Provider>

--- a/src/components/ui/campaign/dm-vtt/RosterTray.tsx
+++ b/src/components/ui/campaign/dm-vtt/RosterTray.tsx
@@ -60,7 +60,14 @@ export function RosterTray({
   const groups = groupRosterEntities(entities);
 
   return (
-    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-[var(--dm-vtt-panel-top,8rem)] bottom-0 left-0 flex w-[clamp(150px,16vw,180px)] flex-col overflow-hidden rounded-tr-2xl border shadow-xl">
+    <div
+      className="bg-surface-raised border-divider pointer-events-auto fixed top-[var(--dm-vtt-panel-top,8rem)] left-0 flex max-h-[70vh] w-[clamp(150px,16vw,180px)] flex-col overflow-hidden rounded-r-2xl border shadow-xl"
+      style={{
+        maxHeight:
+          'min(70dvh, calc(100dvh - var(--dm-vtt-panel-top, 8rem) - 12rem))',
+      }}
+      data-testid="dm-vtt-roster-panel"
+    >
       <div className="border-divider flex shrink-0 items-center justify-between gap-2 border-b px-3 py-2.5">
         <span className="text-heading text-sm font-semibold">👥 Roster</span>
         <Button
@@ -72,7 +79,7 @@ export function RosterTray({
           ▸
         </Button>
       </div>
-      <div className="flex-1 overflow-y-auto px-2 py-2">
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
         {!hasLinkedEncounter ? (
           <p className="text-muted px-1 py-2 text-xs">
             Link an encounter in Setup mode

--- a/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
+++ b/src/components/ui/campaign/dm-vtt/StudioPanel/index.tsx
@@ -72,9 +72,22 @@ export function StudioPanel({
   const selectedEntity = encounter?.entities.find(
     e => e.id === selectedEntityId
   );
+  const maxPanelHeight =
+    activeTab === 'initiative'
+      ? 'min(70dvh, calc(100dvh - var(--dm-vtt-panel-top, 8rem) - 0.75rem))'
+      : 'calc(100dvh - var(--dm-vtt-panel-top, 8rem) - 0.75rem)';
 
   return (
-    <div className="bg-surface-raised border-divider pointer-events-auto fixed top-[var(--dm-vtt-panel-top,8rem)] right-0 bottom-0 flex w-[min(390px,40vw)] flex-col overflow-hidden rounded-tl-2xl border shadow-xl">
+    <div
+      className={`bg-surface-raised border-divider pointer-events-auto fixed top-[var(--dm-vtt-panel-top,8rem)] right-0 flex w-[min(390px,40vw)] flex-col overflow-hidden rounded-l-2xl border shadow-xl ${
+        activeTab === 'initiative'
+          ? 'max-h-[70vh]'
+          : 'max-h-[calc(100vh-var(--dm-vtt-panel-top,8rem)-0.75rem)]'
+      }`}
+      style={{ maxHeight: maxPanelHeight }}
+      data-testid="dm-vtt-studio-panel"
+      data-active-tab={activeTab}
+    >
       <div className="border-divider flex shrink-0 items-center justify-between gap-2 border-b px-2 py-1.5">
         <div className="flex items-center gap-1">
           {TABS.map(({ key, icon, label }) => (
@@ -113,7 +126,7 @@ export function StudioPanel({
           {followNote}
         </p>
       )}
-      <div className="flex-1 overflow-y-auto">
+      <div className="min-h-0 flex-1 overflow-y-auto">
         {activeTab === 'initiative' ? (
           <InitiativeTab
             encounter={encounter}

--- a/src/components/ui/campaign/dm-vtt/__tests__/RosterTray.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/RosterTray.test.tsx
@@ -91,6 +91,15 @@ describe('RosterTray', () => {
     expect(screen.getByText('Goblin')).toBeInTheDocument();
   });
 
+  it('sizes to its content with a viewport-aware height cap', () => {
+    render(<RosterTray {...baseProps()} />);
+    const panel = screen.getByTestId('dm-vtt-roster-panel');
+
+    expect(panel.className).not.toContain('bottom-0');
+    expect(panel.className).toContain('max-h-[70vh]');
+    expect(panel.style.maxHeight).toContain('70dvh');
+  });
+
   it('dims a placed row and shows "On map"; clicking it calls onSelectEntity', () => {
     const onSelectEntity = vi.fn();
     const onArmPlacement = vi.fn();

--- a/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
+++ b/src/components/ui/campaign/dm-vtt/__tests__/StudioPanel.test.tsx
@@ -146,6 +146,29 @@ describe('StudioPanel', () => {
     ]);
   });
 
+  it('keeps initiative content-sized with a viewport-aware height cap', () => {
+    render(<StudioPanel {...baseProps()} />);
+    const panel = screen.getByTestId('dm-vtt-studio-panel');
+
+    expect(panel).toHaveAttribute('data-active-tab', 'initiative');
+    expect(panel.className).not.toContain('bottom-0');
+    expect(panel.className).toContain('max-h-[70vh]');
+    expect(panel.style.maxHeight).toContain('70dvh');
+  });
+
+  it('lets selected details use all remaining viewport height', () => {
+    render(
+      <StudioPanel
+        {...baseProps({ activeTab: 'selected', selectedEntityId: 'm1' })}
+      />
+    );
+    const panel = screen.getByTestId('dm-vtt-studio-panel');
+
+    expect(panel).toHaveAttribute('data-active-tab', 'selected');
+    expect(panel.style.maxHeight).not.toContain('min(70dvh');
+    expect(panel.style.maxHeight).toContain('100dvh');
+  });
+
   it('clicking a row calls onSelectEntity with that entity id', () => {
     const onSelectEntity = vi.fn();
     render(<StudioPanel {...baseProps({ onSelectEntity })} />);

--- a/src/components/ui/campaign/location-map/BattleMapMinimap.tsx
+++ b/src/components/ui/campaign/location-map/BattleMapMinimap.tsx
@@ -13,10 +13,12 @@ interface BattleMapMinimapProps {
  * Battle-map overview navigator. Rendered inside the canvas
  * ViewportContext by the DM VTT and player battle-map canvases.
  *
- * Player surfaces retain the bottom-center position, with `bottom-20`
- * clearing their lower product overlays. The DM surface opts into
- * bottom-left: its roster is content-sized and capped to leave that corner
- * available, while the right side may contain a tall selected-entity panel.
+ * Player surfaces use the true bottom-center with a small edge gutter. Their
+ * temporary prompts render later at a higher stacking level, so they can
+ * cover the minimap when attention is required without permanently pushing
+ * it upward. The DM surface opts into bottom-left: its roster is content-sized
+ * and capped to leave that corner available, while the right side may contain
+ * a tall selected-entity panel.
  *
  * Stacking: both host canvases render `<BattleMapMinimap />` as an EARLIER
  * sibling of `{viewport && children}`, both at the same `z-10`. Same-z-index
@@ -36,7 +38,7 @@ export function BattleMapMinimap({
       className={`absolute z-10 ${
         placement === 'bottom-left'
           ? 'bottom-3 left-3'
-          : 'bottom-20 left-1/2 -translate-x-1/2'
+          : 'bottom-3 left-1/2 -translate-x-1/2'
       }`}
       data-minimap-placement={placement}
     >

--- a/src/components/ui/campaign/location-map/BattleMapMinimap.tsx
+++ b/src/components/ui/campaign/location-map/BattleMapMinimap.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { Minimap } from '@fieldnotes/react';
+import { useEffect, useRef } from 'react';
+import { Minimap, useViewport } from '@fieldnotes/react';
+
+const ZOOM_SENSITIVITY = 1e-3;
 
 interface BattleMapMinimapProps {
   /** Player surfaces start collapsed (quiet player UI); DM starts open. */
@@ -33,8 +36,36 @@ export function BattleMapMinimap({
   defaultCollapsed = false,
   placement = 'bottom-center',
 }: BattleMapMinimapProps) {
+  const viewport = useViewport();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const visibleRect = viewport.getVisibleRect();
+      const currentZoom = viewport.camera.zoom;
+      const zoomFactor = Math.max(0.1, 1 - event.deltaY * ZOOM_SENSITIVITY);
+
+      // The gesture originates on the overview rather than the main canvas,
+      // so preserve the main viewport's center as the stable zoom anchor.
+      viewport.camera.zoomAt(currentZoom * zoomFactor, {
+        x: (visibleRect.w * currentZoom) / 2,
+        y: (visibleRect.h * currentZoom) / 2,
+      });
+    };
+
+    wrapper.addEventListener('wheel', handleWheel, { passive: false });
+    return () => wrapper.removeEventListener('wheel', handleWheel);
+  }, [viewport]);
+
   return (
     <div
+      ref={wrapperRef}
       className={`absolute z-10 ${
         placement === 'bottom-left'
           ? 'bottom-3 left-3'

--- a/src/components/ui/campaign/location-map/BattleMapMinimap.tsx
+++ b/src/components/ui/campaign/location-map/BattleMapMinimap.tsx
@@ -5,21 +5,18 @@ import { Minimap } from '@fieldnotes/react';
 interface BattleMapMinimapProps {
   /** Player surfaces start collapsed (quiet player UI); DM starts open. */
   defaultCollapsed?: boolean;
+  /** DM surfaces can use a free corner while the player layout stays centered. */
+  placement?: 'bottom-center' | 'bottom-left';
 }
 
 /**
- * Battle-map overview navigator, bottom-center. Rendered inside the canvas
+ * Battle-map overview navigator. Rendered inside the canvas
  * ViewportContext by the DM VTT and player battle-map canvases.
  *
- * Positioned bottom-center rather than the conventional bottom-right corner:
- * both call sites already reserve the full-height right edge for a
- * collapsible side panel (`StudioPanel` on the DM VTT, `CharacterDock` on
- * the player canvas — both `fixed ... right-0/right-4` spanning from just
- * below the top chrome down to near the viewport bottom), and the left edge
- * is similarly claimed (`RosterTray`, `CombatPanel`). A bottom-right minimap
- * would sit directly behind/in front of those panels whenever they're
- * expanded, which is their default state. `bottom-20` keeps clearance above
- * the bottom-center `TurnControl` pill (DM, active-encounter only).
+ * Player surfaces retain the bottom-center position, with `bottom-20`
+ * clearing their lower product overlays. The DM surface opts into
+ * bottom-left: its roster is content-sized and capped to leave that corner
+ * available, while the right side may contain a tall selected-entity panel.
  *
  * Stacking: both host canvases render `<BattleMapMinimap />` as an EARLIER
  * sibling of `{viewport && children}`, both at the same `z-10`. Same-z-index
@@ -32,9 +29,17 @@ interface BattleMapMinimapProps {
  */
 export function BattleMapMinimap({
   defaultCollapsed = false,
+  placement = 'bottom-center',
 }: BattleMapMinimapProps) {
   return (
-    <div className="absolute bottom-20 left-1/2 z-10 -translate-x-1/2">
+    <div
+      className={`absolute z-10 ${
+        placement === 'bottom-left'
+          ? 'bottom-3 left-3'
+          : 'bottom-20 left-1/2 -translate-x-1/2'
+      }`}
+      data-minimap-placement={placement}
+    >
       <Minimap
         defaultCollapsed={defaultCollapsed}
         className="border-divider bg-surface-raised overflow-hidden rounded-lg border shadow-lg"

--- a/src/components/ui/campaign/location-map/__tests__/BattleMapMinimap.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/BattleMapMinimap.test.tsx
@@ -80,6 +80,22 @@ describe('BattleMapMinimap', () => {
     ).toBeNull();
   });
 
+  it('places the player minimap at the bottom-center edge by default', () => {
+    render(
+      <FieldNotesCanvas>
+        <BattleMapMinimap />
+      </FieldNotesCanvas>
+    );
+
+    const wrapper = screen
+      .getByRole('button', { name: 'Collapse minimap' })
+      .closest('[data-minimap-placement]');
+    expect(wrapper).toHaveAttribute('data-minimap-placement', 'bottom-center');
+    expect(wrapper?.className).toContain('bottom-3');
+    expect(wrapper?.className).toContain('left-1/2');
+    expect(wrapper?.className).not.toContain('bottom-20');
+  });
+
   it('supports a bottom-left placement for the DM canvas', () => {
     render(
       <FieldNotesCanvas>

--- a/src/components/ui/campaign/location-map/__tests__/BattleMapMinimap.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/BattleMapMinimap.test.tsx
@@ -80,6 +80,22 @@ describe('BattleMapMinimap', () => {
     ).toBeNull();
   });
 
+  it('supports a bottom-left placement for the DM canvas', () => {
+    render(
+      <FieldNotesCanvas>
+        <BattleMapMinimap placement="bottom-left" />
+      </FieldNotesCanvas>
+    );
+
+    const wrapper = screen
+      .getByRole('button', { name: 'Collapse minimap' })
+      .closest('[data-minimap-placement]');
+    expect(wrapper).toHaveAttribute('data-minimap-placement', 'bottom-left');
+    expect(wrapper?.className).toContain('bottom-3');
+    expect(wrapper?.className).toContain('left-3');
+    expect(wrapper?.className).not.toContain('left-1/2');
+  });
+
   it('clicking expand from a collapsed state reveals the canvas (player flow: collapsed -> tap -> overview)', () => {
     const { container } = render(
       <FieldNotesCanvas>

--- a/src/components/ui/campaign/location-map/__tests__/BattleMapMinimap.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/BattleMapMinimap.test.tsx
@@ -112,6 +112,28 @@ describe('BattleMapMinimap', () => {
     expect(wrapper?.className).not.toContain('left-1/2');
   });
 
+  it('prevents browser zoom for wheel gestures over the minimap', () => {
+    render(
+      <FieldNotesCanvas>
+        <BattleMapMinimap />
+      </FieldNotesCanvas>
+    );
+
+    const wrapper = screen
+      .getByRole('button', { name: 'Collapse minimap' })
+      .closest('[data-minimap-placement]')!;
+    const wheel = new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaY: -100,
+      ctrlKey: true,
+    });
+
+    wrapper.dispatchEvent(wheel);
+
+    expect(wheel.defaultPrevented).toBe(true);
+  });
+
   it('clicking expand from a collapsed state reveals the canvas (player flow: collapsed -> tap -> overview)', () => {
     const { container } = render(
       <FieldNotesCanvas>


### PR DESCRIPTION
## Summary
- size the Roster and Initiative palettes to their content with viewport-aware caps
- let Selected details use all remaining height and scroll internally
- move the DM minimap to the bottom-left while preserving the player minimap layout
- reserve lower-left room for the minimap by scrolling long rosters

## Verification
- 40 focused unit tests passed
- targeted ESLint passed
- TypeScript no-emit check passed
- Prettier check passed