### PR TITLE
Add NPC duplication action

### DIFF
--- a/src/components/ui/campaign/NPCSection.tsx
+++ b/src/components/ui/campaign/NPCSection.tsx
@@ -16,6 +16,7 @@ import {
   Tag,
   Eye,
   Lightbulb,
+  Copy,
 } from 'lucide-react';
 import { useNPCStore } from '@/store/npcStore';
 import { useDmStore } from '@/store/dmStore';
@@ -41,6 +42,7 @@ export function NPCSection({
     getNPCsForCampaign,
     getNPC,
     createNPC,
+    duplicateNPC,
     updateNPC,
     deleteNPC,
     reorderNPCsSubset,
@@ -97,6 +99,10 @@ export function NPCSection({
       deleteNPC(campaignCode, npc.id);
       setSelectedNpc(null);
     }
+  };
+
+  const handleDuplicate = (npc: CampaignNPC) => {
+    duplicateNPC(campaignCode, npc.id);
   };
 
   const handleUpdateInventory = (
@@ -366,6 +372,7 @@ export function NPCSection({
                         <NPCCard
                           npc={npc}
                           onEdit={() => handleEdit(npc)}
+                          onDuplicate={() => handleDuplicate(npc)}
                           onDelete={() => handleDelete(npc)}
                           onClick={() => setSelectedNpc(npc)}
                         />
@@ -395,6 +402,7 @@ export function NPCSection({
                 <NPCCard
                   npc={npc}
                   onEdit={() => handleEdit(npc)}
+                  onDuplicate={() => handleDuplicate(npc)}
                   onDelete={() => handleDelete(npc)}
                   onClick={() => setSelectedNpc(npc)}
                 />
@@ -439,11 +447,13 @@ export function NPCSection({
 function NPCCard({
   npc,
   onEdit,
+  onDuplicate,
   onDelete,
   onClick,
 }: {
   npc: CampaignNPC;
   onEdit: () => void;
+  onDuplicate: () => void;
   onDelete: () => void;
   onClick: () => void;
 }) {
@@ -483,6 +493,17 @@ function NPCCard({
                 )}
               </div>
               <div className="flex shrink-0 items-center gap-0.5">
+                <button
+                  onClick={e => {
+                    e.stopPropagation();
+                    onDuplicate();
+                  }}
+                  className="text-muted hover:text-body rounded p-1 transition-colors"
+                  title="Duplicate NPC"
+                  aria-label={`Duplicate ${npc.name}`}
+                >
+                  <Copy size={13} />
+                </button>
                 <button
                   onClick={e => {
                     e.stopPropagation();
@@ -649,6 +670,17 @@ function NPCCard({
               )}
             </div>
             <div className="flex shrink-0 items-center gap-1">
+              <button
+                onClick={e => {
+                  e.stopPropagation();
+                  onDuplicate();
+                }}
+                className="text-muted hover:text-body rounded p-1 transition-colors"
+                title="Duplicate NPC"
+                aria-label={`Duplicate ${npc.name}`}
+              >
+                <Copy size={14} />
+              </button>
               <button
                 onClick={e => {
                   e.stopPropagation();

--- a/src/store/__tests__/npcStore.test.ts
+++ b/src/store/__tests__/npcStore.test.ts
@@ -65,6 +65,78 @@ describe('npcStore (campaign-scoped)', () => {
     });
   });
 
+  describe('duplicateNPC', () => {
+    it('copies all NPC data with a fresh identity and independent nested data', () => {
+      const id = useNPCStore.getState().createNPC(CAMPAIGN, {
+        name: 'Town Guard',
+        armorClass: '16 (chain mail)',
+        maxHp: 18,
+        currentHp: 11,
+        speed: '30 ft.',
+        tags: ['guard', 'human'],
+        inventory: [
+          { id: 'item-1', name: 'Spear', quantity: 1, equipped: true },
+        ],
+      });
+
+      const duplicateId = useNPCStore.getState().duplicateNPC(CAMPAIGN, id);
+      const [source, duplicate] = useNPCStore
+        .getState()
+        .getNPCsForCampaign(CAMPAIGN);
+
+      expect(duplicateId).toMatch(/^npc-/);
+      expect(duplicateId).not.toBe(id);
+      expect(duplicate).toMatchObject({
+        name: 'Town Guard (Copy)',
+        armorClass: source.armorClass,
+        maxHp: source.maxHp,
+        currentHp: source.currentHp,
+        speed: source.speed,
+        tags: source.tags,
+        inventory: source.inventory,
+      });
+      expect(duplicate.tags).not.toBe(source.tags);
+      expect(duplicate.inventory).not.toBe(source.inventory);
+      expect(duplicate.inventory?.[0]).not.toBe(source.inventory?.[0]);
+    });
+
+    it('numbers repeated copies without colliding with existing names', () => {
+      const id = useNPCStore.getState().createNPC(CAMPAIGN, {
+        name: 'Bandit',
+        armorClass: '12',
+        maxHp: 11,
+        speed: '30 ft.',
+      });
+
+      useNPCStore.getState().duplicateNPC(CAMPAIGN, id);
+      useNPCStore.getState().duplicateNPC(CAMPAIGN, id);
+      const copyId = useNPCStore
+        .getState()
+        .getNPCsForCampaign(CAMPAIGN)
+        .find(npc => npc.name === 'Bandit (Copy)')!.id;
+      useNPCStore.getState().duplicateNPC(CAMPAIGN, copyId);
+
+      expect(
+        useNPCStore
+          .getState()
+          .getNPCsForCampaign(CAMPAIGN)
+          .map(npc => npc.name)
+      ).toEqual([
+        'Bandit',
+        'Bandit (Copy)',
+        'Bandit (Copy 2)',
+        'Bandit (Copy 3)',
+      ]);
+    });
+
+    it('does nothing when the source NPC does not exist', () => {
+      expect(
+        useNPCStore.getState().duplicateNPC(CAMPAIGN, 'missing')
+      ).toBeUndefined();
+      expect(useNPCStore.getState().getNPCsForCampaign(CAMPAIGN)).toEqual([]);
+    });
+  });
+
   describe('updateNPC', () => {
     it('merges updates and preserves unchanged fields', () => {
       const id = useNPCStore.getState().createNPC(CAMPAIGN, {

--- a/src/store/npcStore.ts
+++ b/src/store/npcStore.ts
@@ -27,6 +27,20 @@ function generateId(): string {
   );
 }
 
+function getDuplicateName(name: string, existingNpcs: CampaignNPC[]): string {
+  const baseName = name.replace(/ \(Copy(?: \d+)?\)$/, '');
+  const existingNames = new Set(existingNpcs.map(npc => npc.name));
+  const firstCopyName = `${baseName} (Copy)`;
+
+  if (!existingNames.has(firstCopyName)) return firstCopyName;
+
+  let copyNumber = 2;
+  while (existingNames.has(`${baseName} (Copy ${copyNumber})`)) {
+    copyNumber += 1;
+  }
+  return `${baseName} (Copy ${copyNumber})`;
+}
+
 /**
  * Ids are a store invariant: any stat block entering the store is normalized,
  * and abilityUsage is pruned to live entry ids and clamped to current maxima.
@@ -66,6 +80,7 @@ interface NPCStoreState {
     campaignCode: string,
     npc: Omit<CampaignNPC, 'id' | 'campaignCode' | 'createdAt' | 'updatedAt'>
   ) => string;
+  duplicateNPC: (campaignCode: string, id: string) => string | undefined;
   updateNPC: (
     campaignCode: string,
     id: string,
@@ -220,6 +235,33 @@ export const useNPCStore = create<NPCStoreState>()(
           };
         });
         return id;
+      },
+
+      duplicateNPC: (campaignCode, id) => {
+        const existing = get().npcsByCampaign[campaignCode] ?? [];
+        const source = existing.find(npc => npc.id === id);
+        if (!source) return undefined;
+
+        const duplicateId = generateId();
+        const now = new Date().toISOString();
+        const duplicate = normalizeNpcWrite({
+          ...structuredClone(source),
+          id: duplicateId,
+          name: getDuplicateName(source.name, existing),
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        set(state => ({
+          npcsByCampaign: {
+            ...state.npcsByCampaign,
+            [campaignCode]: [
+              ...(state.npcsByCampaign[campaignCode] ?? []),
+              duplicate,
+            ],
+          },
+        }));
+        return duplicateId;
       },
 
       updateNPC: (campaignCode, id, updates) => {


### PR DESCRIPTION
## Summary
- add a duplicate action to NPC cards using the Lucide Copy icon
- clone all NPC data under a fresh identity and independent nested values
- generate collision-free names such as `Name (Copy)` and `Name (Copy 2)`
- cover duplication, naming, deep cloning, and missing-source behavior in store tests

## Validation
- `npx vitest run src/store/__tests__/npcStore.test.ts` (59 tests)
- `npx eslint src/store/npcStore.ts src/components/ui/campaign/NPCSection.tsx src/store/__tests__/npcStore.test.ts`
- `npx tsc --noEmit --pretty false`
- Prettier and `git diff --check`