### PR TITLE
feat: battle-map export (full map / player view) on core 0.59.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@3d-dice/dice-box": "^1.1.3",
         "@3d-dice/dice-ui": "^0.5.2",
         "@aws-sdk/client-s3": "^3.922.0",
-        "@fieldnotes/core": "^0.58.0",
+        "@fieldnotes/core": "^0.59.0",
         "@fieldnotes/react": "^0.9.0",
         "@fieldnotes/sync": "^0.11.0",
         "@radix-ui/react-checkbox": "^1.3.2",
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/@fieldnotes/core": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.58.0.tgz",
-      "integrity": "sha512-SO6bDGeij8PqHBezQ/NDUltXDkA5xtXHkkPhPnPnkDR8rH8yKSfI4bxoBO6KboBoR7xgF2Qd0qdy9NlO6v1KMg==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@fieldnotes/core/-/core-0.59.0.tgz",
+      "integrity": "sha512-SkG1VCMks9FLuwr+sc1P2Mkyb+1KEBgx0LDVATSZsmfbFKfQHOSkQM0I5CFn8ZAZjq5i4jXna9jxrRN/Or48mg==",
       "license": "MIT"
     },
     "node_modules/@fieldnotes/react": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@3d-dice/dice-box": "^1.1.3",
     "@3d-dice/dice-ui": "^0.5.2",
     "@aws-sdk/client-s3": "^3.922.0",
-    "@fieldnotes/core": "^0.58.0",
+    "@fieldnotes/core": "^0.59.0",
     "@fieldnotes/react": "^0.9.0",
     "@fieldnotes/sync": "^0.11.0",
     "@radix-ui/react-checkbox": "^1.3.2",

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.hooks.ts
@@ -50,6 +50,7 @@ import {
 } from '@/components/ui/campaign/location-map/measureSync';
 
 import type { TokenInfoMode } from '@/components/ui/campaign/token-overlay';
+import type { BattleMap } from '@/types/battlemap';
 
 export interface DmBattleMapCanvasProps {
   campaignCode: string;
@@ -68,6 +69,8 @@ export interface DmBattleMapCanvasProps {
   onSelectionChange?: (selectedIds: string[]) => void;
   /** Show/hide/compact state for the token decoration layer, surfaced as a toolbar toggle. */
   tokenInfoToggle: { mode: TokenInfoMode | null; onCycle: () => void };
+  /** Surfaces export-control failures (e.g. no viewport, blob export threw). */
+  onExportError: (message: string) => void;
 }
 
 const DRAWING_TYPES = new Set(['stroke', 'arrow', 'template']);
@@ -75,6 +78,8 @@ const DRAWING_TYPES = new Set(['stroke', 'arrow', 'template']);
 export interface DmBattleMapCanvasState {
   viewport: Viewport | null;
   status: BattleMapConnectionStatus;
+  /** Live store lookup — name/mapImageSize source for the export control. */
+  battleMap: BattleMap | undefined;
   tools: Tool[];
   handleReady: (vp: Viewport) => void;
   handleClearDrawings: () => void;
@@ -140,6 +145,11 @@ export function useDmBattleMapCanvas({
           selectedElementId
         ] ?? false)
       : false
+  );
+  // Same store-object reference each render unless the record actually
+  // changes — safe as a selector return without a custom equality fn.
+  const battleMap = useBattleMapStore(
+    state => state.battleMaps[campaignCode]?.[battleMapId]
   );
   // The connection is created once inside the fire-once `handleReady`
   // callback; a plain closure over `onPoke` would go stale if the prop's
@@ -422,6 +432,7 @@ export function useDmBattleMapCanvas({
   return {
     viewport,
     status,
+    battleMap,
     tools,
     handleReady,
     handleClearDrawings,

--- a/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmBattleMapCanvas.tsx
@@ -2,6 +2,8 @@
 
 import { FieldNotesCanvas, ViewportContext } from '@fieldnotes/react';
 import { BattleMapMinimap } from '@/components/ui/campaign/location-map/BattleMapMinimap';
+import { BattleMapExportControl } from '@/components/ui/campaign/location-map/BattleMapExportControl';
+import { useBattleMapStore } from '@/store/battleMapStore';
 import { DmVttToolbar } from './DmVttToolbar';
 import {
   useDmBattleMapCanvas,
@@ -18,9 +20,17 @@ export type { DmBattleMapCanvasProps };
  * init/persistence/connection wiring.
  */
 export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
-  const { children, sessionControls, tokenInfoToggle } = props;
+  const {
+    children,
+    sessionControls,
+    tokenInfoToggle,
+    campaignCode,
+    battleMapId,
+    onExportError,
+  } = props;
   const {
     viewport,
+    battleMap,
     tools,
     handleReady,
     handleClearDrawings,
@@ -61,6 +71,20 @@ export function DmBattleMapCanvas(props: DmBattleMapCanvasProps) {
               enabled: measureSharing,
               onChange: handleSetMeasureSharing,
             }}
+            exportControl={
+              <BattleMapExportControl
+                getViewport={() => viewport}
+                name={battleMap?.name ?? 'battle-map'}
+                mapImageSize={battleMap?.mapImageSize}
+                getDmOnlyElements={() =>
+                  useBattleMapStore
+                    .getState()
+                    .getBattleMap(campaignCode, battleMapId)?.dmOnlyElements ??
+                  {}
+                }
+                onError={onExportError}
+              />
+            }
           />
         )}
         {viewport && (

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.hooks.ts
@@ -171,6 +171,7 @@ export function useDmVttScreen({
     setGridMode,
     updateTokenIdentity,
     toasts,
+    addToast,
     dismissToast,
     npcDialog: {
       npc: viewingNpc?.npc ?? null,

--- a/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttScreen.tsx
@@ -68,6 +68,9 @@ export function DmVttScreen({
       tokenConfigRef={vtt.tokenConfigRef}
       onSelectionChange={vtt.onSelectionChange}
       tokenInfoToggle={{ mode: tokenInfoMode, onCycle: cycleTokenInfo }}
+      onExportError={message =>
+        vtt.addToast({ type: 'error', title: 'Export failed', message })
+      }
       sessionControls={
         <DmVttTopBar
           campaignCode={campaignCode}

--- a/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
+++ b/src/components/ui/campaign/dm-vtt/DmVttToolbar.tsx
@@ -56,6 +56,7 @@ export interface DmVttToolbarProps {
   selectedElementIsDmOnly: boolean;
   onToggleSelectedDmOnly: () => void;
   measureSharing?: MeasureSharingControl;
+  exportControl?: ReactNode;
 }
 
 const TOKEN_INFO_ICON: Record<TokenInfoMode, typeof Eye> = {
@@ -91,6 +92,7 @@ export function DmVttToolbar({
   selectedElementIsDmOnly,
   onToggleSelectedDmOnly,
   measureSharing,
+  exportControl,
 }: DmVttToolbarProps) {
   const [activeTool, setTool] = useActiveTool();
   const TokenInfoIcon = TOKEN_INFO_ICON[tokenInfoToggle.mode ?? 'compact'];
@@ -223,6 +225,7 @@ export function DmVttToolbar({
           >
             <TokenInfoIcon size={16} />
           </Button>
+          {exportControl}
         </div>
       </div>
       <div className="border-divider w-full border-t empty:hidden">

--- a/src/components/ui/campaign/location-map/BattleMapExportControl.tsx
+++ b/src/components/ui/campaign/location-map/BattleMapExportControl.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Download, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/forms/button';
+import {
+  downloadBlob,
+  exportBattleMap,
+  type ExportCapableViewport,
+} from './battleMapExport';
+
+export interface BattleMapExportControlProps {
+  getViewport: () => ExportCapableViewport | null;
+  name: string;
+  mapImageSize?: { w: number; h: number };
+  /** Provided on DM surfaces; renders the audience radio. Read live at export time. */
+  getDmOnlyElements?: () => Record<string, boolean>;
+  onError: (message: string) => void;
+  /** Test seam; defaults to exportBattleMap. */
+  exporter?: typeof exportBattleMap;
+}
+
+export function BattleMapExportControl({
+  getViewport,
+  name,
+  mapImageSize,
+  getDmOnlyElements,
+  onError,
+  exporter = exportBattleMap,
+}: BattleMapExportControlProps) {
+  const [open, setOpen] = useState(false);
+  const [audience, setAudience] = useState<'full' | 'player'>('full');
+  const [bounds, setBounds] = useState<'map' | 'view'>('map');
+  const [format, setFormat] = useState<'png' | 'jpeg'>('png');
+  const [busy, setBusy] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const handleExport = async () => {
+    const vp = getViewport();
+    if (!vp || busy) return;
+    setBusy(true);
+    try {
+      const { blob, filename } = await exporter(vp, {
+        audience: getDmOnlyElements ? audience : 'full',
+        bounds,
+        format,
+        name,
+        mapImageSize,
+        dmOnlyElements: getDmOnlyElements?.(),
+      });
+      downloadBlob(blob, filename);
+      setOpen(false);
+    } catch (error) {
+      onError(error instanceof Error ? error.message : 'Export failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const radioRow = (
+    id: string,
+    checked: boolean,
+    onChange: () => void,
+    label: string
+  ) => (
+    <label className="text-body flex min-h-[44px] items-center gap-2 text-xs">
+      <input
+        type="radio"
+        name={id}
+        checked={checked}
+        onChange={onChange}
+        disabled={busy}
+      />
+      {label}
+    </label>
+  );
+
+  return (
+    <div ref={rootRef} className="relative">
+      <Button
+        variant={open ? 'primary' : 'ghost'}
+        onClick={() => setOpen(o => !o)}
+        aria-label="Export map"
+        aria-expanded={open}
+        disabled={busy}
+        className="flex min-h-[44px] min-w-[44px] items-center justify-center gap-1.5 px-2 py-1 text-xs"
+      >
+        <Download size={16} />
+      </Button>
+
+      {open && (
+        <div className="bg-surface-raised border-divider absolute top-full right-0 z-30 mt-2 w-56 rounded-xl border p-3 shadow-xl">
+          <div className="flex flex-col gap-2">
+            {getDmOnlyElements && (
+              <div>
+                <div className="text-muted mb-1 text-[11px] font-semibold uppercase">
+                  Audience
+                </div>
+                {radioRow(
+                  'export-audience',
+                  audience === 'full',
+                  () => setAudience('full'),
+                  'Full map'
+                )}
+                {radioRow(
+                  'export-audience',
+                  audience === 'player',
+                  () => setAudience('player'),
+                  'Player view'
+                )}
+              </div>
+            )}
+
+            <div>
+              <div className="text-muted mb-1 text-[11px] font-semibold uppercase">
+                Bounds
+              </div>
+              {radioRow(
+                'export-bounds',
+                bounds === 'map',
+                () => setBounds('map'),
+                'Whole map'
+              )}
+              {radioRow(
+                'export-bounds',
+                bounds === 'view',
+                () => setBounds('view'),
+                'Current view'
+              )}
+            </div>
+
+            <div>
+              <div className="text-muted mb-1 text-[11px] font-semibold uppercase">
+                Format
+              </div>
+              {radioRow(
+                'export-format',
+                format === 'png',
+                () => setFormat('png'),
+                'PNG'
+              )}
+              {radioRow(
+                'export-format',
+                format === 'jpeg',
+                () => setFormat('jpeg'),
+                'JPEG'
+              )}
+            </div>
+
+            <Button
+              variant="primary"
+              onClick={handleExport}
+              disabled={busy}
+              aria-label="Export"
+              className="mt-1 flex min-h-[44px] w-full items-center justify-center gap-2"
+            >
+              {busy ? (
+                <Loader2 size={16} className="animate-spin" />
+              ) : (
+                <Download size={16} />
+              )}
+              Export
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/campaign/location-map/BattleMapExportControl.tsx
+++ b/src/components/ui/campaign/location-map/BattleMapExportControl.tsx
@@ -55,7 +55,11 @@ export function BattleMapExportControl({
 
   const handleExport = async () => {
     const vp = getViewport();
-    if (!vp || busy) return;
+    if (!vp) {
+      onError('Map is still loading');
+      return;
+    }
+    if (busy) return;
     setBusy(true);
     try {
       const { blob, filename } = await exporter(vp, {
@@ -110,7 +114,7 @@ export function BattleMapExportControl({
         <div className="bg-surface-raised border-divider absolute top-full right-0 z-30 mt-2 w-56 rounded-xl border p-3 shadow-xl">
           <div className="flex flex-col gap-2">
             {getDmOnlyElements && (
-              <div>
+              <div role="radiogroup" aria-label="Audience">
                 <div className="text-muted mb-1 text-[11px] font-semibold uppercase">
                   Audience
                 </div>
@@ -129,7 +133,7 @@ export function BattleMapExportControl({
               </div>
             )}
 
-            <div>
+            <div role="radiogroup" aria-label="Bounds">
               <div className="text-muted mb-1 text-[11px] font-semibold uppercase">
                 Bounds
               </div>
@@ -147,7 +151,7 @@ export function BattleMapExportControl({
               )}
             </div>
 
-            <div>
+            <div role="radiogroup" aria-label="Format">
               <div className="text-muted mb-1 text-[11px] font-semibold uppercase">
                 Format
               </div>

--- a/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.hooks.ts
@@ -156,7 +156,6 @@ export interface DmLocationEditorState {
   // Handlers
   handleReady: (vp: Viewport) => void;
   handlePickImage: () => void;
-  handleDownloadExport: () => Promise<void>;
   handleDeleteSelected: () => void;
   handleClear: () => void;
   handleSyncToPlayers: () => Promise<void>;
@@ -181,6 +180,10 @@ export interface DmLocationEditorState {
   // Shared live ruler (battlemap mode; no-ops when live sync is off)
   measureSharing: boolean;
   handleSetMeasureSharing: (enabled: boolean) => void;
+
+  // Battle-map export control
+  getViewport: () => Viewport | null;
+  getDmOnlyElements: () => Record<string, boolean>;
 }
 
 export function useDmLocationEditor(
@@ -805,43 +808,15 @@ export function useDmLocationEditor(
 
       let blob: Blob | null = null;
       try {
-        // Cap export so the largest dimension stays under 4096px
-        // to avoid massive PNGs on large maps
-        const maxDim = Math.max(
-          location.mapImageSize.w,
-          location.mapImageSize.h
-        );
-        const exportScale = maxDim > 2048 ? 1 : 2;
-        const pngBlob = await vp.exportImage({
-          scale: exportScale,
+        blob = await vp.exportImage({
+          scale: 2,
+          scaleMode: 'fit',
+          maxDimension: 4096,
           padding: 0,
+          format: 'jpeg',
+          quality: 0.85,
           filter: (el: { id: string }) => !currentDmOnly[el.id],
         });
-
-        // Convert PNG → JPEG for sync (display-only, much smaller)
-        if (pngBlob) {
-          blob = await new Promise<Blob | null>(resolve => {
-            const img = new window.Image();
-            img.onload = () => {
-              const cvs = document.createElement('canvas');
-              cvs.width = img.width;
-              cvs.height = img.height;
-              const ctx = cvs.getContext('2d');
-              if (!ctx) {
-                resolve(pngBlob);
-                return;
-              }
-              ctx.drawImage(img, 0, 0);
-              cvs.toBlob(
-                jpegBlob => resolve(jpegBlob ?? pngBlob),
-                'image/jpeg',
-                0.85
-              );
-            };
-            img.onerror = () => resolve(pngBlob);
-            img.src = URL.createObjectURL(pngBlob);
-          });
-        }
       } catch (error) {
         console.warn('Failed to export image:', error);
         // exportImage can throw on tainted canvas (cross-origin images
@@ -923,40 +898,10 @@ export function useDmLocationEditor(
     onSyncToPlayers,
   ]);
 
-  const handleDownloadExport = useCallback(async () => {
-    const vp = getVp();
-    if (!vp) return;
-    const currentDmOnly =
-      storeGetLocation(campaignCode, location.id)?.dmOnlyElements ?? {};
-    try {
-      const maxDim = Math.max(location.mapImageSize.w, location.mapImageSize.h);
-      const exportScale = maxDim > 2048 ? 1 : 2;
-      const blob = await vp.exportImage({
-        scale: exportScale,
-        padding: 0,
-        filter: (el: { id: string }) => !currentDmOnly[el.id],
-      });
-      if (!blob) {
-        console.warn('Export returned null');
-        return;
-      }
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${location.name || 'map'}-export.png`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } catch (err) {
-      console.error('Export failed:', err);
-    }
-  }, [
-    getVp,
-    campaignCode,
-    location.id,
-    location.name,
-    location.mapImageSize,
-    storeGetLocation,
-  ]);
+  const getDmOnlyElements = useCallback(
+    () => storeGetLocation(campaignCode, location.id)?.dmOnlyElements ?? {},
+    [storeGetLocation, campaignCode, location.id]
+  );
 
   const handleImageFileSelect = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -1088,7 +1033,6 @@ export function useDmLocationEditor(
     handleDeleteSelected,
     handleClear,
     handleSyncToPlayers,
-    handleDownloadExport,
     handleImageFileSelect,
     handlePickMapImage,
     handleMapImageFileSelect,
@@ -1100,5 +1044,7 @@ export function useDmLocationEditor(
     publishLayerRemove,
     measureSharing,
     handleSetMeasureSharing,
+    getViewport: getVp,
+    getDmOnlyElements,
   };
 }

--- a/src/components/ui/campaign/location-map/DmLocationEditor.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationEditor.tsx
@@ -5,14 +5,17 @@ import { FieldNotesCanvas as Canvas, ViewportContext } from '@fieldnotes/react';
 import DmLocationToolbar from './DmLocationToolbar';
 import DmLocationToolOptions from './DmLocationToolOptions';
 import DmLocationLayersPanel from './DmLocationLayersPanel';
+import { BattleMapExportControl } from './BattleMapExportControl';
 import { useDmLocationEditor } from './DmLocationEditor.hooks';
 import type { DmLocationEditorProps } from './DmLocationEditor.types';
 import { useBattleMapStore } from '@/store/battleMapStore';
+import { useToast, ToastContainer } from '@/components/ui/feedback/Toast';
 import type { BattleMap } from '@/types/battlemap';
 
 export default function DmLocationEditor(props: DmLocationEditorProps) {
   const linkEncounter = useBattleMapStore(s => s.linkEncounter);
   const unlinkEncounter = useBattleMapStore(s => s.unlinkEncounter);
+  const { toasts, addToast, dismissToast } = useToast();
 
   const {
     canvasRef,
@@ -48,7 +51,6 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
     handleDeleteSelected,
     handleClear,
     handleSyncToPlayers,
-    handleDownloadExport,
     handleImageFileSelect,
     handlePickMapImage,
     handleMapImageFileSelect,
@@ -61,6 +63,8 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
     publishLayerRemove,
     measureSharing,
     handleSetMeasureSharing,
+    getViewport,
+    getDmOnlyElements,
   } = useDmLocationEditor(props);
 
   return (
@@ -96,7 +100,6 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
             onSetGridType={handleSetGridType}
             onUpdateGridSettings={handleUpdateGridSettings}
             onSyncToPlayers={handleSyncToPlayers}
-            onDownloadExport={handleDownloadExport}
             syncing={syncing}
             hasUnsyncedChanges={hasUnsyncedChanges}
             lastSyncedAt={lastSyncedAt}
@@ -114,6 +117,17 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
             onToggleShareWithPlayers={handleToggleShareWithPlayers}
             arrangeMapsActive={arrangeMapsActive}
             onToggleArrangeMaps={handleToggleArrangeMaps}
+            exportControl={
+              <BattleMapExportControl
+                getViewport={getViewport}
+                name={props.location.name}
+                mapImageSize={props.location.mapImageSize}
+                getDmOnlyElements={getDmOnlyElements}
+                onError={message =>
+                  addToast({ type: 'error', title: 'Export failed', message })
+                }
+              />
+            }
           />
         )}
 
@@ -198,6 +212,7 @@ export default function DmLocationEditor(props: DmLocationEditorProps) {
             </div>
           )}
         </div>
+        <ToastContainer toasts={toasts} onDismiss={dismissToast} />
       </div>
     </ViewportContext.Provider>
   );

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.tsx
@@ -15,7 +15,6 @@ import {
   Trash2,
   Eraser,
   X,
-  Download,
   Loader2,
   Check,
   AlertCircle,
@@ -83,7 +82,6 @@ export default function DmLocationToolbar({
   onSetGridType,
   onUpdateGridSettings,
   onSyncToPlayers,
-  onDownloadExport,
   syncing,
   hasUnsyncedChanges,
   lastSyncedAt,
@@ -101,6 +99,7 @@ export default function DmLocationToolbar({
   onToggleShareWithPlayers,
   arrangeMapsActive,
   onToggleArrangeMaps,
+  exportControl,
 }: DmLocationToolbarProps) {
   const [activeTool, setTool] = useActiveTool();
   const { canUndo, canRedo, undo, redo } = useHistory();
@@ -328,6 +327,7 @@ export default function DmLocationToolbar({
               Open TV Display
             </Button>
           )}
+          {mode === 'battlemap' && exportControl}
           {mode === 'battlemap' && (
             <span
               className={`rounded-full px-2 py-0.5 text-xs ${
@@ -381,16 +381,7 @@ export default function DmLocationToolbar({
               Sync to Players
             </Button>
           )}
-          {mode !== 'battlemap' && (
-            <Button
-              variant="ghost"
-              onClick={onDownloadExport}
-              title="Download PNG export (debug)"
-              className="h-8 w-8 p-0"
-            >
-              <Download size={15} />
-            </Button>
-          )}
+          {mode !== 'battlemap' && exportControl}
         </div>
       </div>
     </div>

--- a/src/components/ui/campaign/location-map/DmLocationToolbar.types.ts
+++ b/src/components/ui/campaign/location-map/DmLocationToolbar.types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { EditorMode } from './DmLocationEditor.types';
 import type { BattleMapConnectionStatus } from '@/lib/battlemapSync';
 
@@ -18,7 +19,6 @@ export interface DmLocationToolbarProps {
     opacity?: number;
   }) => void;
   onSyncToPlayers: () => void;
-  onDownloadExport: () => void;
   syncing: boolean;
   /** ID of the currently selected element, or null if none */
   selectedElementId: string | null;
@@ -45,4 +45,6 @@ export interface DmLocationToolbarProps {
   arrangeMapsActive?: boolean;
   /** Toggle arrange-maps mode, which temporarily unlocks the map layer. */
   onToggleArrangeMaps?: () => void;
+  /** Battle-map export trigger + popover, rendered in both modes. */
+  exportControl?: ReactNode;
 }

--- a/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
+++ b/src/components/ui/campaign/location-map/PlayerBattleMapCanvas.tsx
@@ -39,6 +39,7 @@ import {
   type Viewport,
 } from '@fieldnotes/core';
 import { BattleMapMinimap } from './BattleMapMinimap';
+import { BattleMapExportControl } from './BattleMapExportControl';
 import { PlayerHandTool } from './PlayerHandTool';
 import {
   createManagedBattleMapConnection,
@@ -87,6 +88,8 @@ interface PlayerBattleMapCanvasProps {
   hideBackButton?: boolean;
   /** Show/hide/compact toggle for the token decoration overlay (optional — non-VTT routes render no toggle). */
   tokenInfoToggle?: { mode: TokenInfoMode | null; onCycle: () => void };
+  /** Surfaces export-control failures; the host owns the toast container. */
+  onExportError: (message: string) => void;
 }
 
 const PLAYER_TOOLS: {
@@ -121,12 +124,14 @@ export function PlayerToolbar({
   onDeleteSelected,
   tokenInfoToggle,
   characterId,
+  exportControl,
 }: {
   status: BattleMapConnectionStatus;
   hasSelection: boolean;
   onDeleteSelected: () => void;
   tokenInfoToggle?: { mode: TokenInfoMode | null; onCycle: () => void };
   characterId: string;
+  exportControl?: React.ReactNode;
 }) {
   const [activeTool, setTool] = useActiveTool();
   const TokenInfoIcon = tokenInfoToggle
@@ -159,7 +164,9 @@ export function PlayerToolbar({
           );
         })}
       </div>
-      {(hasSelection || (tokenInfoToggle && TokenInfoIcon)) && (
+      {(hasSelection ||
+        (tokenInfoToggle && TokenInfoIcon) ||
+        exportControl) && (
         <div className="flex items-center gap-1">
           {hasSelection && (
             <Button
@@ -183,6 +190,7 @@ export function PlayerToolbar({
               <TokenInfoIcon size={16} />
             </Button>
           )}
+          {exportControl}
         </div>
       )}
       <span
@@ -215,6 +223,7 @@ export function PlayerBattleMapCanvas({
   spellTemplateConfigRef,
   hideBackButton = false,
   tokenInfoToggle,
+  onExportError,
 }: PlayerBattleMapCanvasProps) {
   const [viewport, setViewport] = useState<Viewport | null>(null);
   const [status, setStatus] = useState<BattleMapConnectionStatus>('connecting');
@@ -392,6 +401,13 @@ export function PlayerBattleMapCanvas({
             onDeleteSelected={handleDeleteSelected}
             tokenInfoToggle={tokenInfoToggle}
             characterId={characterId}
+            exportControl={
+              <BattleMapExportControl
+                getViewport={() => viewport}
+                name="battle-map"
+                onError={onExportError}
+              />
+            }
           />
         )}
         {viewport && (

--- a/src/components/ui/campaign/location-map/__tests__/BattleMapExportControl.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/BattleMapExportControl.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import {
   render,
   screen,
@@ -31,6 +31,10 @@ function renderControl(
 }
 
 describe('BattleMapExportControl', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
   afterEach(() => cleanup());
 
   it('shows the audience radio only when getDmOnlyElements is provided', () => {

--- a/src/components/ui/campaign/location-map/__tests__/BattleMapExportControl.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/BattleMapExportControl.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import { BattleMapExportControl } from '../BattleMapExportControl';
+
+const vp = { exportImage: vi.fn(), getVisibleRect: vi.fn() };
+
+function renderControl(
+  props: Partial<Parameters<typeof BattleMapExportControl>[0]> = {}
+) {
+  const exporter = vi
+    .fn()
+    .mockResolvedValue({ blob: new Blob(['x']), filename: 'cave.png' });
+  render(
+    <BattleMapExportControl
+      getViewport={() => vp}
+      name="Cave"
+      mapImageSize={{ w: 100, h: 80 }}
+      onError={vi.fn()}
+      exporter={exporter}
+      {...props}
+    />
+  );
+  fireEvent.click(screen.getByRole('button', { name: /export map/i }));
+  return exporter;
+}
+
+describe('BattleMapExportControl', () => {
+  afterEach(() => cleanup());
+
+  it('shows the audience radio only when getDmOnlyElements is provided', () => {
+    renderControl({ getDmOnlyElements: () => ({}) });
+    expect(screen.getByText(/player view/i)).toBeInTheDocument();
+  });
+
+  it('hides the audience radio on player surfaces', () => {
+    renderControl();
+    expect(screen.queryByText(/player view/i)).not.toBeInTheDocument();
+  });
+
+  it('exports with the selected options and live dm-only map', async () => {
+    const dmOnly = { secret: true };
+    const exporter = renderControl({ getDmOnlyElements: () => dmOnly });
+    fireEvent.click(screen.getByLabelText(/player view/i));
+    fireEvent.click(screen.getByLabelText(/current view/i));
+    fireEvent.click(screen.getByLabelText(/jpeg/i));
+    fireEvent.click(screen.getByRole('button', { name: /^export$/i }));
+    await waitFor(() => expect(exporter).toHaveBeenCalledTimes(1));
+    expect(exporter).toHaveBeenCalledWith(
+      vp,
+      expect.objectContaining({
+        audience: 'player',
+        bounds: 'view',
+        format: 'jpeg',
+        name: 'Cave',
+        dmOnlyElements: dmOnly,
+      })
+    );
+  });
+
+  it('disables the export action (and radios) while an export is pending', async () => {
+    let resolveExport: (r: { blob: Blob; filename: string }) => void = () => {};
+    const exporter = vi.fn().mockImplementation(
+      () =>
+        new Promise<{ blob: Blob; filename: string }>(resolve => {
+          resolveExport = resolve;
+        })
+    );
+    render(
+      <BattleMapExportControl
+        getViewport={() => vp}
+        name="Cave"
+        onError={vi.fn()}
+        exporter={exporter}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /export map/i }));
+    const exportButton = screen.getByRole('button', { name: /^export$/i });
+    fireEvent.click(exportButton);
+    await waitFor(() => expect(exportButton).toBeDisabled());
+    expect(screen.getByLabelText(/jpeg/i)).toBeDisabled();
+    expect(screen.getByRole('button', { name: /export map/i })).toBeDisabled();
+    // A second click while pending must not start another export.
+    fireEvent.click(exportButton);
+    expect(exporter).toHaveBeenCalledTimes(1);
+    resolveExport({ blob: new Blob(['x']), filename: 'cave-full.png' });
+    await waitFor(() => expect(exporter).toHaveBeenCalledTimes(1));
+  });
+
+  it('surfaces export failures through onError', async () => {
+    const onError = vi.fn();
+    const exporter = vi.fn().mockRejectedValue(new Error('boom'));
+    render(
+      <BattleMapExportControl
+        getViewport={() => vp}
+        name="Cave"
+        onError={onError}
+        exporter={exporter}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /export map/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^export$/i }));
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('boom'));
+  });
+});

--- a/src/components/ui/campaign/location-map/__tests__/DmLocationToolbar.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/DmLocationToolbar.test.tsx
@@ -55,7 +55,6 @@ const baseProps: DmLocationToolbarProps = {
   onSetGridType: vi.fn(),
   onUpdateGridSettings: vi.fn(),
   onSyncToPlayers: vi.fn(),
-  onDownloadExport: vi.fn(),
   syncing: false,
   hasUnsyncedChanges: false,
   lastSyncedAt: null,

--- a/src/components/ui/campaign/location-map/__tests__/PlayerToolbar.test.tsx
+++ b/src/components/ui/campaign/location-map/__tests__/PlayerToolbar.test.tsx
@@ -93,4 +93,17 @@ describe('PlayerToolbar', () => {
     const btn = screen.getByTitle('Place token');
     expect(btn.className).not.toContain('animate-pulse');
   });
+
+  it('renders the export control passed via the exportControl prop', () => {
+    render(
+      <PlayerToolbar
+        status="live"
+        hasSelection={false}
+        onDeleteSelected={vi.fn()}
+        characterId="char-1"
+        exportControl={<button aria-label="Export map">Export</button>}
+      />
+    );
+    expect(screen.getByLabelText('Export map')).toBeInTheDocument();
+  });
 });

--- a/src/components/ui/campaign/location-map/__tests__/battleMapExport.integration.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/battleMapExport.integration.test.ts
@@ -13,7 +13,7 @@ function vpOver(store: ElementStore): ExportCapableViewport {
 }
 
 /** jsdom has no canvas: stub getContext/toBlob, capture created canvas sizes. */
-function stubCanvas(): { widths: () => number[] } {
+function stubCanvas(): { widths: () => number[]; heights: () => number[] } {
   const origCreate = document.createElement.bind(document);
   const created: HTMLCanvasElement[] = [];
   vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
@@ -60,7 +60,10 @@ function stubCanvas(): { widths: () => number[] } {
     }
     return el;
   });
-  return { widths: () => created.map(c => c.width) };
+  return {
+    widths: () => created.map(c => c.width),
+    heights: () => created.map(c => c.height),
+  };
 }
 
 afterEach(() => vi.restoreAllMocks());
@@ -89,6 +92,7 @@ describe('battle-map export against the real SDK pipeline', () => {
       name: 't',
     });
     const fullWidth = Math.max(...fullStub.widths());
+    const fullHeight = Math.max(...fullStub.heights());
     vi.restoreAllMocks();
 
     const playerStub = stubCanvas();
@@ -100,11 +104,14 @@ describe('battle-map export against the real SDK pipeline', () => {
       dmOnlyElements: { [secret.id]: true },
     });
     const playerWidth = Math.max(...playerStub.widths());
+    const playerHeight = Math.max(...playerStub.heights());
 
     expect(full.filename).toBe('t-full.png');
     expect(player.filename).toBe('t-player-view.png');
     expect(fullWidth).toBe(480); // (0..240) content bounds × scale 2
+    expect(fullHeight).toBe(480); // (0..240) content bounds × scale 2
     expect(playerWidth).toBe(80); // (0..40) × scale 2 — secret note excluded
+    expect(playerHeight).toBe(80); // (0..40) × scale 2 — secret note excluded
     expect(fullWidth).toBeGreaterThan(playerWidth);
   });
 });

--- a/src/components/ui/campaign/location-map/__tests__/battleMapExport.integration.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/battleMapExport.integration.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ElementStore, createNote, exportImage } from '@fieldnotes/core';
+import {
+  exportBattleMap,
+  type ExportCapableViewport,
+} from '../battleMapExport';
+
+function vpOver(store: ElementStore): ExportCapableViewport {
+  return {
+    exportImage: options => exportImage(store, options),
+    getVisibleRect: () => ({ x: 0, y: 0, w: 50, h: 50 }),
+  };
+}
+
+/** jsdom has no canvas: stub getContext/toBlob, capture created canvas sizes. */
+function stubCanvas(): { widths: () => number[] } {
+  const origCreate = document.createElement.bind(document);
+  const created: HTMLCanvasElement[] = [];
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    const el = origCreate(tag);
+    if (tag === 'canvas') {
+      const canvas = el as HTMLCanvasElement;
+      created.push(canvas);
+      vi.spyOn(canvas, 'getContext').mockReturnValue({
+        save: vi.fn(),
+        restore: vi.fn(),
+        scale: vi.fn(),
+        translate: vi.fn(),
+        fillRect: vi.fn(),
+        fill: vi.fn(),
+        stroke: vi.fn(),
+        beginPath: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        closePath: vi.fn(),
+        arc: vi.fn(),
+        arcTo: vi.fn(),
+        ellipse: vi.fn(),
+        quadraticCurveTo: vi.fn(),
+        bezierCurveTo: vi.fn(),
+        drawImage: vi.fn(),
+        setTransform: vi.fn(),
+        setLineDash: vi.fn(),
+        roundRect: vi.fn(),
+        fillText: vi.fn(),
+        measureText: vi.fn().mockReturnValue({ width: 40 }),
+        fillStyle: '',
+        strokeStyle: '',
+        lineWidth: 0,
+        globalAlpha: 1,
+        font: '',
+        textBaseline: '',
+        textAlign: '',
+        lineCap: '',
+        lineJoin: '',
+      } as unknown as CanvasRenderingContext2D);
+      vi.spyOn(canvas, 'toBlob').mockImplementation((cb, type) => {
+        cb(new Blob(['fake'], { type: type ?? 'image/png' }));
+      });
+    }
+    return el;
+  });
+  return { widths: () => created.map(c => c.width) };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('battle-map export against the real SDK pipeline', () => {
+  it('player-view export omits a dm-only element that full export includes', async () => {
+    const store = new ElementStore();
+    const visible = createNote({
+      position: { x: 0, y: 0 },
+      size: { w: 40, h: 40 },
+    });
+    const secret = createNote({
+      position: { x: 200, y: 200 },
+      size: { w: 40, h: 40 },
+    });
+    store.add(visible);
+    store.add(secret);
+
+    // No region (no mapImageSize) → real SDK content bounds: the dm-only note at
+    // (200,200) stretches the full export; filtering it must shrink the player export.
+    const fullStub = stubCanvas();
+    const full = await exportBattleMap(vpOver(store), {
+      audience: 'full',
+      bounds: 'map',
+      format: 'png',
+      name: 't',
+    });
+    const fullWidth = Math.max(...fullStub.widths());
+    vi.restoreAllMocks();
+
+    const playerStub = stubCanvas();
+    const player = await exportBattleMap(vpOver(store), {
+      audience: 'player',
+      bounds: 'map',
+      format: 'png',
+      name: 't',
+      dmOnlyElements: { [secret.id]: true },
+    });
+    const playerWidth = Math.max(...playerStub.widths());
+
+    expect(full.filename).toBe('t-full.png');
+    expect(player.filename).toBe('t-player-view.png');
+    expect(fullWidth).toBe(480); // (0..240) content bounds × scale 2
+    expect(playerWidth).toBe(80); // (0..40) × scale 2 — secret note excluded
+    expect(fullWidth).toBeGreaterThan(playerWidth);
+  });
+});

--- a/src/components/ui/campaign/location-map/__tests__/battleMapExport.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/battleMapExport.test.ts
@@ -116,4 +116,31 @@ describe('exportBattleMap', () => {
       })
     ).rejects.toThrow('no image');
   });
+
+  it('omits region when mapImageSize width is zero', async () => {
+    const vp = fakeVp();
+    await exportBattleMap(vp, {
+      audience: 'full',
+      bounds: 'map',
+      format: 'png',
+      name: 'Cave',
+      mapImageSize: { w: 0, h: 100 },
+    });
+    const options = vp.exportImage.mock.calls[0][0];
+    expect(options.region).toBeUndefined();
+  });
+
+  it('defines a filter that returns true for any id when dmOnlyElements is omitted for player audience', async () => {
+    const vp = fakeVp();
+    await exportBattleMap(vp, {
+      audience: 'player',
+      bounds: 'map',
+      format: 'png',
+      name: 'Cave',
+      mapImageSize: { w: 100, h: 100 },
+    });
+    const filter = vp.exportImage.mock.calls[0][0].filter;
+    expect(filter).toBeDefined();
+    expect(filter({ id: 'anything' })).toBe(true);
+  });
 });

--- a/src/components/ui/campaign/location-map/__tests__/battleMapExport.test.ts
+++ b/src/components/ui/campaign/location-map/__tests__/battleMapExport.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { exportBattleMap } from '../battleMapExport';
+import type { ExportCapableViewport } from '../battleMapExport';
+
+function fakeVp(blob: Blob | null = new Blob(['x'], { type: 'image/png' })) {
+  return {
+    exportImage: vi.fn().mockResolvedValue(blob),
+    getVisibleRect: vi.fn().mockReturnValue({ x: 5, y: 6, w: 70, h: 80 }),
+  } satisfies ExportCapableViewport;
+}
+
+describe('exportBattleMap', () => {
+  it('exports the whole map as a region from mapImageSize', async () => {
+    const vp = fakeVp();
+    await exportBattleMap(vp, {
+      audience: 'full',
+      bounds: 'map',
+      format: 'png',
+      name: 'Cave',
+      mapImageSize: { w: 1200, h: 900 },
+    });
+    expect(vp.exportImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: { x: 0, y: 0, w: 1200, h: 900 },
+        scale: 2,
+        scaleMode: 'fit',
+        format: 'png',
+      })
+    );
+    const options = vp.exportImage.mock.calls[0][0];
+    expect(options.filter).toBeUndefined();
+    expect(options.quality).toBeUndefined();
+  });
+
+  it('exports the current view via getVisibleRect', async () => {
+    const vp = fakeVp();
+    await exportBattleMap(vp, {
+      audience: 'full',
+      bounds: 'view',
+      format: 'png',
+      name: 'Cave',
+    });
+    expect(vp.exportImage).toHaveBeenCalledWith(
+      expect.objectContaining({ region: { x: 5, y: 6, w: 70, h: 80 } })
+    );
+  });
+
+  it('falls back to content bounds without mapImageSize', async () => {
+    const vp = fakeVp();
+    await exportBattleMap(vp, {
+      audience: 'full',
+      bounds: 'map',
+      format: 'png',
+      name: 'Cave',
+    });
+    expect(vp.exportImage.mock.calls[0][0].region).toBeUndefined();
+  });
+
+  it('filters dm-only elements for the player-view audience', async () => {
+    const vp = fakeVp();
+    await exportBattleMap(vp, {
+      audience: 'player',
+      bounds: 'map',
+      format: 'png',
+      name: 'Cave',
+      mapImageSize: { w: 100, h: 100 },
+      dmOnlyElements: { secret: true, revealed: false },
+    });
+    const filter = vp.exportImage.mock.calls[0][0].filter;
+    expect(filter).toBeDefined();
+    expect(filter({ id: 'secret' })).toBe(false);
+    expect(filter({ id: 'revealed' })).toBe(true);
+    expect(filter({ id: 'other' })).toBe(true);
+  });
+
+  it('plumbs jpeg quality and builds the filename', async () => {
+    const vp = fakeVp(new Blob(['x'], { type: 'image/jpeg' }));
+    const { filename } = await exportBattleMap(vp, {
+      audience: 'player',
+      bounds: 'view',
+      format: 'jpeg',
+      name: 'Goblin Cave!',
+    });
+    expect(vp.exportImage).toHaveBeenCalledWith(
+      expect.objectContaining({ format: 'jpeg', quality: 0.85 })
+    );
+    expect(filename).toBe('goblin-cave-player-view.jpg');
+  });
+
+  it('labels a full-audience current-view export "view" and a whole-map export "full"', async () => {
+    const view = await exportBattleMap(fakeVp(), {
+      audience: 'full',
+      bounds: 'view',
+      format: 'png',
+      name: 'Cave',
+    });
+    expect(view.filename).toBe('cave-view.png');
+    const full = await exportBattleMap(fakeVp(), {
+      audience: 'full',
+      bounds: 'map',
+      format: 'png',
+      name: 'Cave',
+      mapImageSize: { w: 100, h: 100 },
+    });
+    expect(full.filename).toBe('cave-full.png');
+  });
+
+  it('throws when the export yields no blob', async () => {
+    const vp = fakeVp(null);
+    await expect(
+      exportBattleMap(vp, {
+        audience: 'full',
+        bounds: 'map',
+        format: 'png',
+        name: 'Cave',
+      })
+    ).rejects.toThrow('no image');
+  });
+});

--- a/src/components/ui/campaign/location-map/battleMapExport.ts
+++ b/src/components/ui/campaign/location-map/battleMapExport.ts
@@ -1,0 +1,84 @@
+import type { ExportImageOptions } from '@fieldnotes/core';
+
+export interface BattleMapExportRequest {
+  audience: 'full' | 'player';
+  bounds: 'map' | 'view';
+  format: 'png' | 'jpeg';
+  /** Map/location display name; becomes the sanitized filename base. */
+  name: string;
+  mapImageSize?: { w: number; h: number };
+  /** DM surfaces only; player surface omits it (store already relay-filtered). */
+  dmOnlyElements?: Record<string, boolean>;
+}
+
+export interface BattleMapExportResult {
+  blob: Blob;
+  filename: string;
+}
+
+export interface ExportCapableViewport {
+  exportImage(options: ExportImageOptions): Promise<Blob | null>;
+  getVisibleRect(): { x: number; y: number; w: number; h: number };
+}
+
+const JPEG_QUALITY = 0.85;
+
+function sanitizeName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'battle-map';
+}
+
+/**
+ * One export path for every surface. The player-view audience filter is a
+ * courtesy preview for the DM — the real privacy boundary stays relay-side
+ * canRead (player stores never receive DM-only bytes).
+ */
+export async function exportBattleMap(
+  vp: ExportCapableViewport,
+  req: BattleMapExportRequest
+): Promise<BattleMapExportResult> {
+  const region =
+    req.bounds === 'view'
+      ? vp.getVisibleRect()
+      : req.mapImageSize && req.mapImageSize.w > 0 && req.mapImageSize.h > 0
+        ? { x: 0, y: 0, w: req.mapImageSize.w, h: req.mapImageSize.h }
+        : undefined;
+  const dmOnly = req.audience === 'player' ? (req.dmOnlyElements ?? {}) : null;
+
+  const options: ExportImageOptions = {
+    scale: 2,
+    scaleMode: 'fit',
+    padding: 0,
+    format: req.format,
+  };
+  if (req.format === 'jpeg') options.quality = JPEG_QUALITY;
+  if (region) options.region = region;
+  if (dmOnly) options.filter = el => !dmOnly[el.id];
+
+  const blob = await vp.exportImage(options);
+  if (!blob) throw new Error('Export produced no image');
+
+  // Spec contract: <name>-<full|player-view|view>.<ext>. Precedence: the
+  // player audience labels the file 'player-view' regardless of bounds;
+  // otherwise current-view bounds label it 'view'; otherwise 'full'.
+  const variant =
+    req.audience === 'player'
+      ? 'player-view'
+      : req.bounds === 'view'
+        ? 'view'
+        : 'full';
+  const ext = req.format === 'jpeg' ? 'jpg' : 'png';
+  return { blob, filename: `${sanitizeName(req.name)}-${variant}.${ext}` };
+}
+
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/components/ui/campaign/player-vtt/PlayerVttScreen.tsx
+++ b/src/components/ui/campaign/player-vtt/PlayerVttScreen.tsx
@@ -101,6 +101,9 @@ export function PlayerVttScreen({
       onPoke={handlePoke}
       spellTemplateConfigRef={spellTemplateConfigRef}
       tokenInfoToggle={{ mode: tokenInfoMode, onCycle: cycleTokenInfo }}
+      onExportError={message =>
+        addToast({ type: 'error', title: 'Export failed', message })
+      }
     >
       <TokenDecorationLayer decorations={decorations} mode={tokenInfoMode} />
       <SpellPlacementController


### PR DESCRIPTION
## Summary

Adopts published `@fieldnotes/core@0.59.0` (IrakliDevelop/fieldnotes#146) for battle-map export: DM exports full maps or a player-view preview; players export their permitted view. Relay untouched.

- **`location-map/battleMapExport.ts`** — one export path for every surface: bounds `'map'` (region from `mapImageSize` at world origin) or `'view'` (`getVisibleRect()`), content-bounds fallback without `mapImageSize`; audience `'player'` filters `dmOnlyElements` ids; always `scale: 2` + `scaleMode: 'fit'`; PNG or JPEG (0.85); filenames `<name>-<full|player-view|view>.<png|jpg>`. The player-view filter is a DM-side courtesy preview — the security boundary remains relay `canRead` (player stores never hold DM-only bytes).
- **`BattleMapExportControl.tsx`** — shared download-button + popover (audience radio on DM surfaces only, bounds + format radios, busy state disables the entire control, ≥44px targets, `role="radiogroup"` labels).
- **Surfaces**: DM VTT (control in `DmBattleMapCanvas`, `exportControl` slot in `DmVttToolbar`, errors via `DmVttScreen` toasts); DM location editor both modes (new local toast container — editor had no error surface); player canvas (fixed `battle-map` filename + content-bounds fallback — map name/`mapImageSize` never reach player devices, approved spec deviation). Display page: none by design.
- **Superseded code removed**: debug "Download PNG export" button + `onDownloadExport`/`handleDownloadExport`; the sync-preview PNG→JPEG canvas re-encode replaced by one SDK call (`fit`, `maxDimension: 4096`, jpeg 0.85, same dmOnly filter; S3 upload + JSON fallback untouched).

## Behavior note

Sync-to-players preview images are now hard-capped at 4096px via `scaleMode: 'fit'`: maps with max dimension 2049–4096 gain resolution vs the old `scale: 1` heuristic; maps above 4096 (previously exported uncapped) now shrink to the cap. Bounded and intended.

## Verification

- Full unit suite: 3679 passed / 1 skipped (256 files) — new: `battleMapExport.test.ts` (9 incl. region/filter/filename precedence + guard branches), `BattleMapExportControl.test.tsx` (5 incl. deferred-promise busy-state full-disable), `battleMapExport.integration.test.ts` (real SDK pipeline, canvas seam stub only, mutation-verified filter discrimination, 480×480 vs 80×80), `PlayerToolbar.test.tsx` export-control assertion.
- `tsc --noEmit` clean; eslint 0 errors; relay directory untouched; lockfile resolves published 0.59.0.
- Manual desktop/touch pass on the live app NOT yet done (delegated implementation) — recorded as outstanding in the roadmap handoff alongside the carried-over device passes for laser/ping/measure/minimap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)