### PR TITLE
feat(dm): add reusable custom magic item library

### DIFF
--- a/src/app/dm/campaign/[code]/page.tsx
+++ b/src/app/dm/campaign/[code]/page.tsx
@@ -55,7 +55,7 @@ import {
   SendItemTarget,
 } from '@/components/ui/campaign/SendItemDialog';
 import type { ItemTransfer } from '@/types/sharedState';
-import type { InventoryItem } from '@/types/character';
+import type { InventoryItem, MagicItem } from '@/types/character';
 import type { NPCInventoryItem } from '@/types/encounter';
 
 function npcItemToInventoryItem(npcItem: NPCInventoryItem): InventoryItem {
@@ -220,6 +220,45 @@ export default function CampaignViewPage() {
       }
     },
     [code, dmId, npcSendingNpcName, addToast]
+  );
+
+  const handleGiveLibraryMagicItem = useCallback(
+    async (item: MagicItem, target: SendItemTarget) => {
+      const transfer: ItemTransfer = {
+        id: `transfer-${crypto.randomUUID()}`,
+        item,
+        itemKind: 'magic',
+        fromPlayerName: 'DM',
+        fromCharacterName: 'Magic Item Library',
+        fromType: 'dm',
+        sentAt: new Date().toISOString(),
+      };
+      try {
+        const response = await fetch(`/api/campaign/${code}/shared`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            feature: 'item_transfer',
+            data: { transfer, playerId: target.playerId },
+            dmId,
+          }),
+        });
+        if (!response.ok) throw new Error('Failed to give magic item');
+        addToast({
+          type: 'success',
+          title: 'Magic Item Given',
+          message: `${item.name} sent to ${target.characterName}. The library copy was kept.`,
+        });
+      } catch (error) {
+        console.error('Failed to give magic item:', error);
+        addToast({
+          type: 'error',
+          title: 'Magic Item Not Sent',
+          message: `Could not send ${item.name} to ${target.characterName}.`,
+        });
+      }
+    },
+    [addToast, code, dmId]
   );
 
   const handleRemovePlayer = useCallback(async () => {
@@ -709,6 +748,8 @@ export default function CampaignViewPage() {
         {!loading && !error && (
           <NPCSection
             campaignCode={code}
+            players={npcSendTargets}
+            onGiveMagicItemToPlayer={handleGiveLibraryMagicItem}
             onSendItemToPlayer={(item, npcName) => {
               setNpcSendingItem(item);
               setNpcSendingNpcName(npcName);

--- a/src/app/player/characters/[characterId]/page.tsx
+++ b/src/app/player/characters/[characterId]/page.tsx
@@ -49,6 +49,7 @@ import {
   Spell,
   SpellSlots,
   InventoryItem,
+  MagicItem,
 } from '@/types/character';
 import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { NavigationContext } from '@/contexts/NavigationContext';
@@ -234,6 +235,7 @@ export default function CharacterSheet() {
     levelUpAnimationLevel,
     clearLevelUpAnimation,
     addInventoryItem,
+    addMagicItem,
     deleteInventoryItem,
   } = useCharacterStore();
 
@@ -377,17 +379,33 @@ export default function CharacterSheet() {
       if (processedTransferIdsRef.current.has(transfer.id)) continue;
       processedTransferIdsRef.current.add(transfer.id);
 
+      if (transfer.itemKind === 'magic') {
+        const {
+          id: _id,
+          createdAt: _createdAt,
+          updatedAt: _updatedAt,
+          ...item
+        } = transfer.item as MagicItem;
+        void _id;
+        void _createdAt;
+        void _updatedAt;
+        addMagicItem({ ...item, isAttuned: false, isEquipped: false });
+        added = true;
+        continue;
+      }
+
+      const inventoryItem = transfer.item as InventoryItem;
       addInventoryItem({
-        name: transfer.item.name,
-        category: transfer.item.category || 'misc',
-        quantity: transfer.item.quantity,
-        description: transfer.item.description,
-        weight: transfer.item.weight,
-        value: transfer.item.value,
-        rarity: transfer.item.rarity,
-        type: transfer.item.type,
-        location: transfer.item.location || 'Backpack',
-        tags: transfer.item.tags || [],
+        name: inventoryItem.name,
+        category: inventoryItem.category || 'misc',
+        quantity: inventoryItem.quantity,
+        description: inventoryItem.description,
+        weight: inventoryItem.weight,
+        value: inventoryItem.value,
+        rarity: inventoryItem.rarity,
+        type: inventoryItem.type,
+        location: inventoryItem.location || 'Backpack',
+        tags: inventoryItem.tags || [],
       });
       added = true;
     }
@@ -395,7 +413,12 @@ export default function CharacterSheet() {
     if (added) {
       acknowledgeTransfers();
     }
-  }, [sharedState?.transfers, addInventoryItem, acknowledgeTransfers]);
+  }, [
+    sharedState?.transfers,
+    addInventoryItem,
+    addMagicItem,
+    acknowledgeTransfers,
+  ]);
 
   // Latch DM effects into local state for the notification toast before
   // acknowledgment clears them from shared state.

--- a/src/components/ui/campaign/ItemTransferNotification.tsx
+++ b/src/components/ui/campaign/ItemTransferNotification.tsx
@@ -47,7 +47,9 @@ export function ItemTransferNotification({
         const fromLabel =
           transfer.fromType === 'npc'
             ? `${transfer.fromCharacterName} (NPC)`
-            : transfer.fromCharacterName;
+            : transfer.fromType === 'dm'
+              ? 'DM Magic Item Library'
+              : transfer.fromCharacterName;
 
         return (
           <div
@@ -69,7 +71,8 @@ export function ItemTransferNotification({
                   </p>
                   <p className="mt-1 text-base font-bold text-white">
                     {transfer.item.name}
-                    {transfer.item.quantity > 1 &&
+                    {'quantity' in transfer.item &&
+                      transfer.item.quantity > 1 &&
                       ` (x${transfer.item.quantity})`}
                   </p>
                   <p className="mt-1 text-sm text-amber-200">

--- a/src/components/ui/campaign/MagicItemLibrary/AllItemsAutocomplete.tsx
+++ b/src/components/ui/campaign/MagicItemLibrary/AllItemsAutocomplete.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+import { Input } from '@/components/ui/forms/input';
+import { Badge } from '@/components/ui/layout/badge';
+import type { ProcessedItem, ProcessedMagicItem } from '@/types/items';
+
+export type CompendiumItem =
+  | { kind: 'magic'; item: ProcessedMagicItem }
+  | { kind: 'mundane'; item: ProcessedItem };
+
+export function AllItemsAutocomplete({
+  mundaneItems,
+  magicItems,
+  loading,
+  onSelect,
+}: {
+  mundaneItems: ProcessedItem[];
+  magicItems: ProcessedMagicItem[];
+  loading: boolean;
+  onSelect: (selection: CompendiumItem) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const results = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return [];
+    const all: CompendiumItem[] = [
+      ...magicItems.map(item => ({ kind: 'magic' as const, item })),
+      ...mundaneItems.map(item => ({ kind: 'mundane' as const, item })),
+    ];
+    return all
+      .filter(({ item }) =>
+        [item.name, item.category, item.rarity, item.source]
+          .join(' ')
+          .toLowerCase()
+          .includes(needle)
+      )
+      .sort((a, b) => {
+        const aName = a.item.name.toLowerCase();
+        const bName = b.item.name.toLowerCase();
+        return (
+          Number(bName.startsWith(needle)) - Number(aName.startsWith(needle)) ||
+          aName.localeCompare(bName)
+        );
+      })
+      .slice(0, 40);
+  }, [magicItems, mundaneItems, query]);
+
+  return (
+    <div className="relative space-y-2">
+      <Input
+        label="Start from any compendium item"
+        value={query}
+        onChange={event => setQuery(event.target.value)}
+        placeholder={
+          loading
+            ? 'Loading item compendium…'
+            : 'Search weapons, armor, gear, or magic items…'
+        }
+        leftIcon={<Search size={16} />}
+        disabled={loading}
+      />
+      {query && (
+        <div className="border-divider bg-surface-raised absolute z-50 max-h-72 w-full overflow-y-auto rounded-lg border shadow-lg">
+          {results.length === 0 ? (
+            <p className="text-muted p-4 text-sm">No matching items.</p>
+          ) : (
+            results.map(result => (
+              <button
+                type="button"
+                key={`${result.kind}-${result.item.id}`}
+                onClick={() => {
+                  onSelect(result);
+                  setQuery('');
+                }}
+                className="border-divider hover:bg-surface-secondary flex w-full items-center justify-between gap-3 border-b px-3 py-2 text-left last:border-b-0"
+              >
+                <div className="min-w-0">
+                  <p className="text-heading truncate text-sm font-medium">
+                    {result.item.name}
+                  </p>
+                  <p className="text-muted text-xs">
+                    {result.item.category} · {result.item.source}
+                  </p>
+                </div>
+                <Badge
+                  variant={result.kind === 'magic' ? 'primary' : 'neutral'}
+                  size="sm"
+                >
+                  {result.kind === 'magic' ? result.item.rarity : 'Mundane'}
+                </Badge>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+      <p className="text-muted text-xs">
+        Selecting an item fills the form; every field remains editable.
+      </p>
+    </div>
+  );
+}

--- a/src/components/ui/campaign/MagicItemLibrary/MagicItemLibraryDialog.tsx
+++ b/src/components/ui/campaign/MagicItemLibrary/MagicItemLibraryDialog.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/feedback/dialog';
+import { Input } from '@/components/ui/forms/input';
+import {
+  MagicItemForm,
+  type MagicItemFormData,
+} from '@/components/ui/game/equipment/MagicItemForm';
+import { useItemsData } from '@/hooks/useItemsData';
+import { useMagicItemsData } from '@/hooks/useMagicItemsData';
+import { convertProcessedMagicItemToFormData } from '@/utils/magicItemConversion';
+import type { MagicItem } from '@/types/character';
+import type { CustomMagicItem } from '@/types/magicItemLibrary';
+import {
+  AllItemsAutocomplete,
+  type CompendiumItem,
+} from './AllItemsAutocomplete';
+
+const EMPTY_FORM: MagicItemFormData = {
+  name: '',
+  category: 'wondrous',
+  rarity: 'common',
+  description: '',
+  properties: [],
+  requiresAttunement: false,
+  isAttuned: false,
+  isEquipped: false,
+  charges: [],
+};
+
+function makeIds(
+  form: MagicItemFormData
+): Omit<MagicItem, 'id' | 'createdAt' | 'updatedAt'> {
+  return {
+    ...form,
+    charges: form.charges
+      ?.filter(charge => charge.name.trim())
+      .map(charge => ({
+        ...charge,
+        id: charge.id ?? `charge-${crypto.randomUUID()}`,
+      })),
+    chargePool: form.chargePool
+      ? {
+          ...form.chargePool,
+          abilities: form.chargePool.abilities.map(ability => ({
+            ...ability,
+            id: ability.id ?? `ability-${crypto.randomUUID()}`,
+          })),
+        }
+      : undefined,
+  };
+}
+
+export function MagicItemLibraryDialog({
+  open,
+  onOpenChange,
+  item,
+  onSave,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  item: CustomMagicItem | null;
+  onSave: (
+    data: Omit<
+      CustomMagicItem,
+      'id' | 'campaignCode' | 'createdAt' | 'updatedAt'
+    >
+  ) => void;
+}) {
+  const [form, setForm] = useState<MagicItemFormData>(EMPTY_FORM);
+  const [tagsText, setTagsText] = useState('');
+  const [group, setGroup] = useState('');
+  const [sourceItemId, setSourceItemId] = useState<string | undefined>();
+  const mundane = useItemsData();
+  const magic = useMagicItemsData();
+
+  useEffect(() => {
+    if (!open) return;
+    setForm(
+      item
+        ? {
+            name: item.name,
+            category: item.category,
+            rarity: item.rarity,
+            description: item.description,
+            properties: item.properties,
+            requiresAttunement: item.requiresAttunement,
+            isAttuned: false,
+            isEquipped: false,
+            charges: item.charges,
+            chargePool: item.chargePool,
+            bonusSpellAttack: item.bonusSpellAttack,
+            bonusSpellSaveDc: item.bonusSpellSaveDc,
+          }
+        : EMPTY_FORM
+    );
+    setTagsText(item?.tags.join(', ') ?? '');
+    setGroup(item?.group ?? '');
+    setSourceItemId(item?.sourceItemId);
+  }, [item, open]);
+
+  const handleCompendiumSelect = (selection: CompendiumItem) => {
+    setSourceItemId(selection.item.id);
+    if (selection.kind === 'magic') {
+      setForm({
+        ...EMPTY_FORM,
+        ...convertProcessedMagicItemToFormData(selection.item),
+      });
+      return;
+    }
+    const category =
+      selection.item.rawType === 'R'
+        ? 'ring'
+        : selection.item.rawType === 'P'
+          ? 'potion'
+          : selection.item.category.toLowerCase().includes('armor')
+            ? 'armor'
+            : 'other';
+    setForm({
+      ...EMPTY_FORM,
+      name: selection.item.name,
+      category,
+      description: selection.item.description,
+      properties: selection.item.properties ?? [],
+    });
+    setTagsText(selection.item.tags.join(', '));
+  };
+
+  const handleSubmit = () => {
+    const tags = [
+      ...new Set(
+        tagsText
+          .split(',')
+          .map(tag => tag.trim())
+          .filter(Boolean)
+      ),
+    ];
+    onSave({
+      ...makeIds(form),
+      tags,
+      group: group.trim() || undefined,
+      sourceItemId,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[92vh] max-w-4xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {item ? 'Edit Custom Magic Item' : 'Create Custom Magic Item'}
+          </DialogTitle>
+        </DialogHeader>
+        <DialogBody className="space-y-5">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Input
+              label="Group (optional)"
+              value={group}
+              onChange={event => setGroup(event.target.value)}
+              placeholder="e.g., Feywild rewards"
+            />
+            <Input
+              label="Tags (comma separated)"
+              value={tagsText}
+              onChange={event => setTagsText(event.target.value)}
+              placeholder="quest, utility, level 5"
+            />
+          </div>
+          <MagicItemForm
+            formData={form}
+            setFormData={setForm}
+            onSubmit={handleSubmit}
+            onCancel={() => onOpenChange(false)}
+            isEditing={!!item}
+            autocompleteSlot={
+              <AllItemsAutocomplete
+                mundaneItems={mundane.items}
+                magicItems={magic.items}
+                loading={mundane.loading || magic.loading}
+                onSelect={handleCompendiumSelect}
+              />
+            }
+          />
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/campaign/MagicItemLibrary/MagicItemLibrarySection.tsx
+++ b/src/components/ui/campaign/MagicItemLibrary/MagicItemLibrarySection.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  Copy,
+  Edit3,
+  Gift,
+  Plus,
+  Search,
+  Sparkles,
+  Trash2,
+  UserRound,
+} from 'lucide-react';
+import { Button } from '@/components/ui/forms/button';
+import { Input } from '@/components/ui/forms/input';
+import { SelectField, SelectItem } from '@/components/ui/forms/select';
+import { Badge } from '@/components/ui/layout/badge';
+import { Card, CardContent } from '@/components/ui/layout/card';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/feedback/dialog';
+import { ConfirmationModal } from '@/components/ui/feedback/ConfirmationModal';
+import { useMagicItemLibraryStore } from '@/store/magicItemLibraryStore';
+import { useNPCStore } from '@/store/npcStore';
+import type { MagicItem } from '@/types/character';
+import type { CustomMagicItem } from '@/types/magicItemLibrary';
+import type { SendItemTarget } from '../SendItemDialog';
+import { MagicItemLibraryDialog } from './MagicItemLibraryDialog';
+
+export function MagicItemLibrarySection({
+  campaignCode,
+  players,
+  onGiveToPlayer,
+}: {
+  campaignCode: string;
+  players: SendItemTarget[];
+  onGiveToPlayer: (item: MagicItem, target: SendItemTarget) => Promise<void>;
+}) {
+  const items = useMagicItemLibraryStore(
+    state => state.itemsByCampaign[campaignCode] ?? []
+  );
+  const { createItem, updateItem, deleteItem, duplicateItem } =
+    useMagicItemLibraryStore();
+  const npcs = useNPCStore(state => state.npcsByCampaign[campaignCode] ?? []);
+  const updateNPC = useNPCStore(state => state.updateNPC);
+  const [query, setQuery] = useState('');
+  const [tag, setTag] = useState('all');
+  const [editing, setEditing] = useState<CustomMagicItem | null>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [giving, setGiving] = useState<CustomMagicItem | null>(null);
+  const [recipient, setRecipient] = useState('');
+  const [deleting, setDeleting] = useState<CustomMagicItem | null>(null);
+  const [isGiving, setIsGiving] = useState(false);
+
+  const tags = useMemo(
+    () => [...new Set(items.flatMap(item => item.tags))].sort(),
+    [items]
+  );
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return items.filter(
+      item =>
+        (tag === 'all' || item.tags.includes(tag)) &&
+        (!needle ||
+          [item.name, item.group, item.rarity, item.category, ...item.tags]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase()
+            .includes(needle))
+    );
+  }, [items, query, tag]);
+
+  const handleSave = (
+    data: Omit<
+      CustomMagicItem,
+      'id' | 'campaignCode' | 'createdAt' | 'updatedAt'
+    >
+  ) => {
+    if (editing) updateItem(campaignCode, editing.id, data);
+    else createItem(campaignCode, data);
+    setEditorOpen(false);
+    setEditing(null);
+  };
+
+  const handleGive = async () => {
+    if (!giving || !recipient) return;
+    const {
+      campaignCode: _campaignCode,
+      tags: _tags,
+      group: _group,
+      sourceItemId: _source,
+      ...magicItem
+    } = giving;
+    void _campaignCode;
+    void _tags;
+    void _group;
+    void _source;
+    setIsGiving(true);
+    if (recipient.startsWith('npc:')) {
+      const npc = npcs.find(entry => entry.id === recipient.slice(4));
+      if (npc) {
+        updateNPC(campaignCode, npc.id, {
+          inventory: [
+            ...(npc.inventory ?? []),
+            {
+              id: `npc-item-${crypto.randomUUID()}`,
+              name: giving.name,
+              quantity: 1,
+              description: giving.description,
+              type: giving.category,
+              category: 'magic item',
+              rarity: giving.rarity,
+              magicItem,
+            },
+          ],
+        });
+      }
+    } else {
+      const player = players.find(
+        entry => entry.playerId === recipient.slice(7)
+      );
+      if (player) await onGiveToPlayer(magicItem, player);
+    }
+    setIsGiving(false);
+    setGiving(null);
+    setRecipient('');
+  };
+
+  return (
+    <section
+      className="border-divider mt-8 border-t pt-6"
+      aria-labelledby="magic-item-library-heading"
+    >
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3
+            id="magic-item-library-heading"
+            className="text-heading flex items-center gap-2 text-lg font-semibold"
+          >
+            <Sparkles size={20} className="text-accent-purple-text" /> Magic
+            Item Library ({items.length})
+          </h3>
+          <p className="text-muted text-sm">
+            Reusable campaign templates stay here after you give out a copy.
+          </p>
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          leftIcon={<Plus size={16} />}
+          onClick={() => {
+            setEditing(null);
+            setEditorOpen(true);
+          }}
+        >
+          Create Magic Item
+        </Button>
+      </div>
+
+      {items.length > 0 && (
+        <div className="mb-4 grid gap-3 sm:grid-cols-[1fr_200px]">
+          <Input
+            value={query}
+            onChange={event => setQuery(event.target.value)}
+            placeholder="Search name, group, rarity, or tag…"
+            leftIcon={<Search size={15} />}
+            clearable
+            onClear={() => setQuery('')}
+          />
+          <SelectField value={tag} onValueChange={setTag}>
+            <SelectItem value="all">All tags</SelectItem>
+            {tags.map(value => (
+              <SelectItem key={value} value={value}>
+                {value}
+              </SelectItem>
+            ))}
+          </SelectField>
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <div className="border-divider bg-surface-secondary rounded-lg border-2 border-dashed p-8 text-center">
+          <Sparkles size={36} className="text-faint mx-auto mb-2" />
+          <p className="text-muted text-sm">
+            No custom magic items yet. Start from any compendium item or a blank
+            form.
+          </p>
+        </div>
+      ) : filtered.length === 0 ? (
+        <p className="text-muted py-8 text-center text-sm">
+          No items match these filters.
+        </p>
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {filtered.map(item => (
+            <Card key={item.id}>
+              <CardContent className="space-y-3 p-4">
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <h4 className="text-heading font-semibold">{item.name}</h4>
+                    <p className="text-muted text-xs">
+                      {item.group || 'Ungrouped'}
+                    </p>
+                  </div>
+                  <Badge variant="primary" size="sm">
+                    {item.rarity}
+                  </Badge>
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {item.tags.map(value => (
+                    <Badge key={value} variant="neutral" size="sm">
+                      {value}
+                    </Badge>
+                  ))}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  <Button
+                    variant="secondary"
+                    size="xs"
+                    leftIcon={<Gift size={13} />}
+                    onClick={() => setGiving(item)}
+                  >
+                    Give copy
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    aria-label={`Edit ${item.name}`}
+                    onClick={() => {
+                      setEditing(item);
+                      setEditorOpen(true);
+                    }}
+                  >
+                    <Edit3 size={14} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    aria-label={`Duplicate ${item.name}`}
+                    onClick={() => duplicateItem(campaignCode, item.id)}
+                  >
+                    <Copy size={14} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    aria-label={`Delete ${item.name}`}
+                    onClick={() => setDeleting(item)}
+                  >
+                    <Trash2 size={14} />
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <MagicItemLibraryDialog
+        open={editorOpen}
+        onOpenChange={open => {
+          setEditorOpen(open);
+          if (!open) setEditing(null);
+        }}
+        item={editing}
+        onSave={handleSave}
+      />
+      <Dialog
+        open={!!giving}
+        onOpenChange={open => {
+          if (!open) setGiving(null);
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Give {giving?.name}</DialogTitle>
+          </DialogHeader>
+          <DialogBody className="space-y-3">
+            <p className="text-muted text-sm">
+              Choose a player or NPC. The library template will remain
+              unchanged.
+            </p>
+            <SelectField value={recipient} onValueChange={setRecipient}>
+              {players.map(player => (
+                <SelectItem
+                  key={`player:${player.playerId}`}
+                  value={`player:${player.playerId}`}
+                >
+                  {player.characterName} (player)
+                </SelectItem>
+              ))}
+              {npcs.map(npc => (
+                <SelectItem key={`npc:${npc.id}`} value={`npc:${npc.id}`}>
+                  {npc.name} (NPC)
+                </SelectItem>
+              ))}
+            </SelectField>
+          </DialogBody>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setGiving(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              leftIcon={<UserRound size={14} />}
+              disabled={!recipient}
+              loading={isGiving}
+              onClick={handleGive}
+            >
+              Give copy
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <ConfirmationModal
+        isOpen={!!deleting}
+        onClose={() => setDeleting(null)}
+        onConfirm={() => {
+          if (deleting) deleteItem(campaignCode, deleting.id);
+        }}
+        title="Delete magic item template?"
+        message={`Delete ${deleting?.name ?? 'this item'} from the DM library? Copies already given to players or NPCs will not be affected.`}
+        confirmText="Delete template"
+      />
+    </section>
+  );
+}

--- a/src/components/ui/campaign/NPCSection.tsx
+++ b/src/components/ui/campaign/NPCSection.tsx
@@ -28,15 +28,25 @@ import { CampaignNPC, NPCInventoryItem } from '@/types/encounter';
 import { parseAcBonus } from '@/utils/calculations';
 import { NPCFormDialog } from './NPCFormDialog';
 import { NPCDetailDialog } from './NPCDetailDialog';
+import { MagicItemLibrarySection } from './MagicItemLibrary/MagicItemLibrarySection';
+import type { SendItemTarget } from './SendItemDialog';
+import type { MagicItem } from '@/types/character';
 
 interface NPCSectionProps {
   campaignCode: string;
   onSendItemToPlayer?: (item: NPCInventoryItem, npcName: string) => void;
+  players?: SendItemTarget[];
+  onGiveMagicItemToPlayer?: (
+    item: MagicItem,
+    target: SendItemTarget
+  ) => Promise<void>;
 }
 
 export function NPCSection({
   campaignCode,
   onSendItemToPlayer,
+  players = [],
+  onGiveMagicItemToPlayer,
 }: NPCSectionProps) {
   const {
     getNPCsForCampaign,
@@ -440,6 +450,14 @@ export function NPCSection({
         onUpdateInventory={handleUpdateInventory}
         onSendItemToPlayer={onSendItemToPlayer}
       />
+
+      {npcSectionOpen && onGiveMagicItemToPlayer && (
+        <MagicItemLibrarySection
+          campaignCode={campaignCode}
+          players={players}
+          onGiveToPlayer={onGiveMagicItemToPlayer}
+        />
+      )}
     </div>
   );
 }

--- a/src/store/__tests__/magicItemLibraryStore.test.ts
+++ b/src/store/__tests__/magicItemLibraryStore.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useMagicItemLibraryStore } from '@/store/magicItemLibraryStore';
+
+const ITEM = {
+  name: 'Lantern of Returning',
+  category: 'wondrous' as const,
+  rarity: 'rare' as const,
+  description: 'Always points toward home.',
+  properties: ['Sheds bright light'],
+  requiresAttunement: true,
+  isAttuned: false,
+  tags: ['travel', 'quest'],
+  group: 'Feywild',
+};
+
+describe('magicItemLibraryStore', () => {
+  beforeEach(() => {
+    useMagicItemLibraryStore.setState({ itemsByCampaign: {} });
+  });
+
+  it('keeps reusable items isolated by campaign', () => {
+    useMagicItemLibraryStore.getState().createItem('AAA111', ITEM);
+    expect(useMagicItemLibraryStore.getState().getItems('AAA111')).toHaveLength(
+      1
+    );
+    expect(useMagicItemLibraryStore.getState().getItems('BBB222')).toEqual([]);
+  });
+
+  it('updates, duplicates, and deletes templates without mutating the source copy', () => {
+    const store = useMagicItemLibraryStore.getState();
+    const id = store.createItem('AAA111', ITEM);
+    store.updateItem('AAA111', id, { rarity: 'legendary' });
+    store.duplicateItem('AAA111', id);
+
+    const copies = useMagicItemLibraryStore.getState().getItems('AAA111');
+    expect(copies).toHaveLength(2);
+    expect(copies[0].rarity).toBe('legendary');
+    expect(copies[1].name).toBe('Lantern of Returning (Copy)');
+    expect(copies[1].id).not.toBe(id);
+
+    useMagicItemLibraryStore.getState().deleteItem('AAA111', id);
+    expect(useMagicItemLibraryStore.getState().getItems('AAA111')).toHaveLength(
+      1
+    );
+  });
+});

--- a/src/store/magicItemLibraryStore.ts
+++ b/src/store/magicItemLibraryStore.ts
@@ -1,0 +1,109 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+import { createSafeStorage } from '@/lib/safeStorage';
+import type { CustomMagicItem } from '@/types/magicItemLibrary';
+
+interface MagicItemLibraryState {
+  itemsByCampaign: Record<string, CustomMagicItem[]>;
+  getItems: (campaignCode: string) => CustomMagicItem[];
+  createItem: (
+    campaignCode: string,
+    item: Omit<
+      CustomMagicItem,
+      'id' | 'campaignCode' | 'createdAt' | 'updatedAt'
+    >
+  ) => string;
+  updateItem: (
+    campaignCode: string,
+    id: string,
+    updates: Partial<CustomMagicItem>
+  ) => void;
+  deleteItem: (campaignCode: string, id: string) => void;
+  duplicateItem: (campaignCode: string, id: string) => void;
+}
+
+const makeId = () =>
+  `magic-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
+export const useMagicItemLibraryStore = create<MagicItemLibraryState>()(
+  persist(
+    (set, get) => ({
+      itemsByCampaign: {},
+      getItems: campaignCode => get().itemsByCampaign[campaignCode] ?? [],
+      createItem: (campaignCode, data) => {
+        const id = makeId();
+        const now = new Date().toISOString();
+        const item: CustomMagicItem = {
+          ...data,
+          id,
+          campaignCode,
+          createdAt: now,
+          updatedAt: now,
+        };
+        set(state => ({
+          itemsByCampaign: {
+            ...state.itemsByCampaign,
+            [campaignCode]: [
+              ...(state.itemsByCampaign[campaignCode] ?? []),
+              item,
+            ],
+          },
+        }));
+        return id;
+      },
+      updateItem: (campaignCode, id, updates) =>
+        set(state => ({
+          itemsByCampaign: {
+            ...state.itemsByCampaign,
+            [campaignCode]: (state.itemsByCampaign[campaignCode] ?? []).map(
+              item =>
+                item.id === id
+                  ? {
+                      ...item,
+                      ...updates,
+                      id,
+                      campaignCode,
+                      updatedAt: new Date().toISOString(),
+                    }
+                  : item
+            ),
+          },
+        })),
+      deleteItem: (campaignCode, id) =>
+        set(state => ({
+          itemsByCampaign: {
+            ...state.itemsByCampaign,
+            [campaignCode]: (state.itemsByCampaign[campaignCode] ?? []).filter(
+              item => item.id !== id
+            ),
+          },
+        })),
+      duplicateItem: (campaignCode, id) => {
+        const source = get()
+          .getItems(campaignCode)
+          .find(item => item.id === id);
+        if (!source) return;
+        const {
+          id: _id,
+          campaignCode: _campaign,
+          createdAt: _created,
+          updatedAt: _updated,
+          ...copy
+        } = structuredClone(source);
+        void _id;
+        void _campaign;
+        void _created;
+        void _updated;
+        get().createItem(campaignCode, {
+          ...copy,
+          name: `${source.name} (Copy)`,
+        });
+      },
+    }),
+    {
+      name: 'rollkeeper-dm-magic-item-library',
+      storage: createJSONStorage(() => createSafeStorage()),
+      version: 1,
+    }
+  )
+);

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -301,6 +301,8 @@ export interface NPCInventoryItem {
   weight?: number; // per item in lbs
   value?: number; // per item in copper pieces
   rarity?: string; // common, uncommon, rare, very rare, legendary, artifact
+  /** Full reusable definition when this row came from the DM magic item library. */
+  magicItem?: import('./character').MagicItem;
 }
 
 export interface CampaignNPC {

--- a/src/types/magicItemLibrary.ts
+++ b/src/types/magicItemLibrary.ts
@@ -1,0 +1,8 @@
+import type { MagicItem } from './character';
+
+export interface CustomMagicItem extends MagicItem {
+  campaignCode: string;
+  tags: string[];
+  group?: string;
+  sourceItemId?: string;
+}

--- a/src/types/sharedState.ts
+++ b/src/types/sharedState.ts
@@ -1,5 +1,5 @@
 import type { CalendarConfig, WeatherType } from './calendar';
-import type { InventoryItem } from './character';
+import type { InventoryItem, MagicItem } from './character';
 import type {
   ChessPiece,
   EnemyConditionsDisplay,
@@ -45,10 +45,11 @@ export interface DmEffect {
 // Item transfer queued for a player (auto-merges on next poll)
 export interface ItemTransfer {
   id: string;
-  item: InventoryItem;
+  item: InventoryItem | MagicItem;
+  itemKind?: 'inventory' | 'magic';
   fromPlayerName: string;
   fromCharacterName: string;
-  fromType: 'player' | 'npc';
+  fromType: 'player' | 'npc' | 'dm';
   sentAt: string; // ISO timestamp
 }
 


### PR DESCRIPTION
## Summary
- add a campaign-scoped DM magic item library beneath the NPC section
- seed custom items from both mundane and magic item compendiums, while keeping every field editable
- support tags, groups, search, filtering, duplication, charges, attunement, and spell bonuses
- give reusable copies to players as true magic items or to NPC inventories without removing the library template
- extend transfer notifications and player ingestion for magic-item transfers

## Verification
- npm run type-check
- npm test (270 files, 3,773 passed, 1 skipped)
- npm run build
- ESLint on all touched files
