### PR TITLE
fix(dm): stabilize and separate magic item library

### DIFF
--- a/src/components/ui/campaign/MagicItemLibrary/MagicItemLibrarySection.tsx
+++ b/src/components/ui/campaign/MagicItemLibrary/MagicItemLibrarySection.tsx
@@ -9,7 +9,6 @@ import {
   Gift,
   Plus,
   Search,
-  Sparkles,
   Trash2,
   UserRound,
 } from 'lucide-react';
@@ -23,6 +22,7 @@ import {
   SelectSeparator,
 } from '@/components/ui/forms/select';
 import { Badge } from '@/components/ui/layout/badge';
+import { AppIcon } from '@/components/ui/icons';
 import { Card, CardContent } from '@/components/ui/layout/card';
 import {
   Dialog,
@@ -187,8 +187,12 @@ export function MagicItemLibrarySection({
               id="magic-item-library-heading"
               className="text-heading flex items-center gap-2 text-lg font-semibold"
             >
-              <Sparkles size={20} className="text-accent-purple-text" /> Magic
-              Item Library ({items.length})
+              <AppIcon
+                name="magicItem"
+                size={20}
+                className="text-accent-purple-text"
+              />{' '}
+              Magic Item Library ({items.length})
             </h3>
             <p className="text-muted text-sm">
               Reusable campaign templates stay here after you give out a copy.
@@ -233,7 +237,11 @@ export function MagicItemLibrarySection({
 
           {items.length === 0 ? (
             <div className="border-divider bg-surface-secondary rounded-lg border-2 border-dashed p-8 text-center">
-              <Sparkles size={36} className="text-faint mx-auto mb-2" />
+              <AppIcon
+                name="magicItem"
+                size={36}
+                className="text-faint mx-auto mb-2"
+              />
               <p className="text-muted text-sm">
                 No custom magic items yet. Start from any compendium item or a
                 blank form.

--- a/src/components/ui/campaign/MagicItemLibrary/MagicItemLibrarySection.tsx
+++ b/src/components/ui/campaign/MagicItemLibrary/MagicItemLibrarySection.tsx
@@ -28,9 +28,13 @@ import { ConfirmationModal } from '@/components/ui/feedback/ConfirmationModal';
 import { useMagicItemLibraryStore } from '@/store/magicItemLibraryStore';
 import { useNPCStore } from '@/store/npcStore';
 import type { MagicItem } from '@/types/character';
+import type { CampaignNPC } from '@/types/encounter';
 import type { CustomMagicItem } from '@/types/magicItemLibrary';
 import type { SendItemTarget } from '../SendItemDialog';
 import { MagicItemLibraryDialog } from './MagicItemLibraryDialog';
+
+const EMPTY_MAGIC_ITEMS: CustomMagicItem[] = [];
+const EMPTY_NPCS: CampaignNPC[] = [];
 
 export function MagicItemLibrarySection({
   campaignCode,
@@ -42,11 +46,13 @@ export function MagicItemLibrarySection({
   onGiveToPlayer: (item: MagicItem, target: SendItemTarget) => Promise<void>;
 }) {
   const items = useMagicItemLibraryStore(
-    state => state.itemsByCampaign[campaignCode] ?? []
+    state => state.itemsByCampaign[campaignCode] ?? EMPTY_MAGIC_ITEMS
   );
   const { createItem, updateItem, deleteItem, duplicateItem } =
     useMagicItemLibraryStore();
-  const npcs = useNPCStore(state => state.npcsByCampaign[campaignCode] ?? []);
+  const npcs = useNPCStore(
+    state => state.npcsByCampaign[campaignCode] ?? EMPTY_NPCS
+  );
   const updateNPC = useNPCStore(state => state.updateNPC);
   const [query, setQuery] = useState('');
   const [tag, setTag] = useState('all');

--- a/src/components/ui/campaign/MagicItemLibrary/MagicItemLibrarySection.tsx
+++ b/src/components/ui/campaign/MagicItemLibrary/MagicItemLibrarySection.tsx
@@ -15,13 +15,20 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
-import { SelectField, SelectItem } from '@/components/ui/forms/select';
+import {
+  SelectField,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+} from '@/components/ui/forms/select';
 import { Badge } from '@/components/ui/layout/badge';
 import { Card, CardContent } from '@/components/ui/layout/card';
 import {
   Dialog,
   DialogBody,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -326,24 +333,31 @@ export function MagicItemLibrarySection({
             <DialogTitle>Give {giving?.name}</DialogTitle>
           </DialogHeader>
           <DialogBody className="space-y-3">
-            <p className="text-muted text-sm">
+            <DialogDescription className="text-muted text-sm">
               Choose a player or NPC. The library template will remain
               unchanged.
-            </p>
+            </DialogDescription>
             <SelectField value={recipient} onValueChange={setRecipient}>
-              {players.map(player => (
-                <SelectItem
-                  key={`player:${player.playerId}`}
-                  value={`player:${player.playerId}`}
-                >
-                  {player.characterName} (player)
-                </SelectItem>
-              ))}
-              {npcs.map(npc => (
-                <SelectItem key={`npc:${npc.id}`} value={`npc:${npc.id}`}>
-                  {npc.name} (NPC)
-                </SelectItem>
-              ))}
+              <SelectGroup>
+                <SelectLabel>Players</SelectLabel>
+                {players.map(player => (
+                  <SelectItem
+                    key={`player:${player.playerId}`}
+                    value={`player:${player.playerId}`}
+                  >
+                    {player.characterName}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+              {players.length > 0 && npcs.length > 0 && <SelectSeparator />}
+              <SelectGroup>
+                <SelectLabel>NPCs</SelectLabel>
+                {npcs.map(npc => (
+                  <SelectItem key={`npc:${npc.id}`} value={`npc:${npc.id}`}>
+                    {npc.name}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
             </SelectField>
           </DialogBody>
           <DialogFooter>

--- a/src/components/ui/campaign/MagicItemLibrary/MagicItemLibrarySection.tsx
+++ b/src/components/ui/campaign/MagicItemLibrary/MagicItemLibrarySection.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from 'react';
 import {
+  ChevronDown,
+  ChevronRight,
   Copy,
   Edit3,
   Gift,
@@ -26,6 +28,7 @@ import {
 } from '@/components/ui/feedback/dialog';
 import { ConfirmationModal } from '@/components/ui/feedback/ConfirmationModal';
 import { useMagicItemLibraryStore } from '@/store/magicItemLibraryStore';
+import { useDmStore } from '@/store/dmStore';
 import { useNPCStore } from '@/store/npcStore';
 import type { MagicItem } from '@/types/character';
 import type { CampaignNPC } from '@/types/encounter';
@@ -54,6 +57,12 @@ export function MagicItemLibrarySection({
     state => state.npcsByCampaign[campaignCode] ?? EMPTY_NPCS
   );
   const updateNPC = useNPCStore(state => state.updateNPC);
+  const campaign = useDmStore(state =>
+    state.campaigns.find(entry => entry.code === campaignCode)
+  );
+  const setDmDashboardUi = useDmStore(state => state.setDmDashboardUi);
+  const sectionOpen =
+    campaign?.dmDashboardUi?.magicItemLibrarySectionOpen ?? true;
   const [query, setQuery] = useState('');
   const [tag, setTag] = useState('all');
   const [editing, setEditing] = useState<CustomMagicItem | null>(null);
@@ -143,17 +152,41 @@ export function MagicItemLibrarySection({
       aria-labelledby="magic-item-library-heading"
     >
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h3
-            id="magic-item-library-heading"
-            className="text-heading flex items-center gap-2 text-lg font-semibold"
+        <div className="flex min-w-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={() =>
+              setDmDashboardUi(campaignCode, {
+                magicItemLibrarySectionOpen: !sectionOpen,
+              })
+            }
+            className="text-muted hover:text-body hover:bg-surface-secondary shrink-0 rounded-md p-1 transition-colors"
+            aria-expanded={sectionOpen}
+            aria-controls="dm-campaign-magic-item-library-section"
+            title={
+              sectionOpen
+                ? 'Collapse magic item library'
+                : 'Expand magic item library'
+            }
           >
-            <Sparkles size={20} className="text-accent-purple-text" /> Magic
-            Item Library ({items.length})
-          </h3>
-          <p className="text-muted text-sm">
-            Reusable campaign templates stay here after you give out a copy.
-          </p>
+            {sectionOpen ? (
+              <ChevronDown size={20} />
+            ) : (
+              <ChevronRight size={20} />
+            )}
+          </button>
+          <div>
+            <h3
+              id="magic-item-library-heading"
+              className="text-heading flex items-center gap-2 text-lg font-semibold"
+            >
+              <Sparkles size={20} className="text-accent-purple-text" /> Magic
+              Item Library ({items.length})
+            </h3>
+            <p className="text-muted text-sm">
+              Reusable campaign templates stay here after you give out a copy.
+            </p>
+          </div>
         </div>
         <Button
           variant="primary"
@@ -168,102 +201,108 @@ export function MagicItemLibrarySection({
         </Button>
       </div>
 
-      {items.length > 0 && (
-        <div className="mb-4 grid gap-3 sm:grid-cols-[1fr_200px]">
-          <Input
-            value={query}
-            onChange={event => setQuery(event.target.value)}
-            placeholder="Search name, group, rarity, or tag…"
-            leftIcon={<Search size={15} />}
-            clearable
-            onClear={() => setQuery('')}
-          />
-          <SelectField value={tag} onValueChange={setTag}>
-            <SelectItem value="all">All tags</SelectItem>
-            {tags.map(value => (
-              <SelectItem key={value} value={value}>
-                {value}
-              </SelectItem>
-            ))}
-          </SelectField>
-        </div>
-      )}
+      {sectionOpen && (
+        <div id="dm-campaign-magic-item-library-section">
+          {items.length > 0 && (
+            <div className="mb-4 grid gap-3 sm:grid-cols-[1fr_200px]">
+              <Input
+                value={query}
+                onChange={event => setQuery(event.target.value)}
+                placeholder="Search name, group, rarity, or tag…"
+                leftIcon={<Search size={15} />}
+                clearable
+                onClear={() => setQuery('')}
+              />
+              <SelectField value={tag} onValueChange={setTag}>
+                <SelectItem value="all">All tags</SelectItem>
+                {tags.map(value => (
+                  <SelectItem key={value} value={value}>
+                    {value}
+                  </SelectItem>
+                ))}
+              </SelectField>
+            </div>
+          )}
 
-      {items.length === 0 ? (
-        <div className="border-divider bg-surface-secondary rounded-lg border-2 border-dashed p-8 text-center">
-          <Sparkles size={36} className="text-faint mx-auto mb-2" />
-          <p className="text-muted text-sm">
-            No custom magic items yet. Start from any compendium item or a blank
-            form.
-          </p>
-        </div>
-      ) : filtered.length === 0 ? (
-        <p className="text-muted py-8 text-center text-sm">
-          No items match these filters.
-        </p>
-      ) : (
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {filtered.map(item => (
-            <Card key={item.id}>
-              <CardContent className="space-y-3 p-4">
-                <div className="flex items-start justify-between gap-2">
-                  <div>
-                    <h4 className="text-heading font-semibold">{item.name}</h4>
-                    <p className="text-muted text-xs">
-                      {item.group || 'Ungrouped'}
-                    </p>
-                  </div>
-                  <Badge variant="primary" size="sm">
-                    {item.rarity}
-                  </Badge>
-                </div>
-                <div className="flex flex-wrap gap-1">
-                  {item.tags.map(value => (
-                    <Badge key={value} variant="neutral" size="sm">
-                      {value}
-                    </Badge>
-                  ))}
-                </div>
-                <div className="flex flex-wrap gap-1">
-                  <Button
-                    variant="secondary"
-                    size="xs"
-                    leftIcon={<Gift size={13} />}
-                    onClick={() => setGiving(item)}
-                  >
-                    Give copy
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    aria-label={`Edit ${item.name}`}
-                    onClick={() => {
-                      setEditing(item);
-                      setEditorOpen(true);
-                    }}
-                  >
-                    <Edit3 size={14} />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    aria-label={`Duplicate ${item.name}`}
-                    onClick={() => duplicateItem(campaignCode, item.id)}
-                  >
-                    <Copy size={14} />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    aria-label={`Delete ${item.name}`}
-                    onClick={() => setDeleting(item)}
-                  >
-                    <Trash2 size={14} />
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
+          {items.length === 0 ? (
+            <div className="border-divider bg-surface-secondary rounded-lg border-2 border-dashed p-8 text-center">
+              <Sparkles size={36} className="text-faint mx-auto mb-2" />
+              <p className="text-muted text-sm">
+                No custom magic items yet. Start from any compendium item or a
+                blank form.
+              </p>
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-muted py-8 text-center text-sm">
+              No items match these filters.
+            </p>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {filtered.map(item => (
+                <Card key={item.id}>
+                  <CardContent className="space-y-3 p-4">
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <h4 className="text-heading font-semibold">
+                          {item.name}
+                        </h4>
+                        <p className="text-muted text-xs">
+                          {item.group || 'Ungrouped'}
+                        </p>
+                      </div>
+                      <Badge variant="primary" size="sm">
+                        {item.rarity}
+                      </Badge>
+                    </div>
+                    <div className="flex flex-wrap gap-1">
+                      {item.tags.map(value => (
+                        <Badge key={value} variant="neutral" size="sm">
+                          {value}
+                        </Badge>
+                      ))}
+                    </div>
+                    <div className="flex flex-wrap gap-1">
+                      <Button
+                        variant="secondary"
+                        size="xs"
+                        leftIcon={<Gift size={13} />}
+                        onClick={() => setGiving(item)}
+                      >
+                        Give copy
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        aria-label={`Edit ${item.name}`}
+                        onClick={() => {
+                          setEditing(item);
+                          setEditorOpen(true);
+                        }}
+                      >
+                        <Edit3 size={14} />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        aria-label={`Duplicate ${item.name}`}
+                        onClick={() => duplicateItem(campaignCode, item.id)}
+                      >
+                        <Copy size={14} />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        aria-label={`Delete ${item.name}`}
+                        onClick={() => setDeleting(item)}
+                      >
+                        <Trash2 size={14} />
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/ui/campaign/MagicItemLibrary/__tests__/MagicItemLibrarySection.test.tsx
+++ b/src/components/ui/campaign/MagicItemLibrary/__tests__/MagicItemLibrarySection.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMagicItemLibraryStore } from '@/store/magicItemLibraryStore';
+import { useNPCStore } from '@/store/npcStore';
+import { MagicItemLibrarySection } from '../MagicItemLibrarySection';
+
+vi.mock('../MagicItemLibraryDialog', () => ({
+  MagicItemLibraryDialog: () => null,
+}));
+
+describe('MagicItemLibrarySection', () => {
+  beforeEach(() => {
+    useMagicItemLibraryStore.setState({ itemsByCampaign: {} });
+    useNPCStore.setState({ npcsByCampaign: {} });
+  });
+
+  it('renders an empty campaign without an external-store snapshot loop', () => {
+    render(
+      <MagicItemLibrarySection
+        campaignCode="empty-campaign"
+        players={[]}
+        onGiveToPlayer={async () => {}}
+      />
+    );
+
+    expect(screen.getByText('Magic Item Library (0)')).toBeInTheDocument();
+    expect(screen.getByText(/No custom magic items yet/)).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/campaign/MagicItemLibrary/__tests__/MagicItemLibrarySection.test.tsx
+++ b/src/components/ui/campaign/MagicItemLibrary/__tests__/MagicItemLibrarySection.test.tsx
@@ -65,4 +65,67 @@ describe('MagicItemLibrarySection', () => {
         ?.magicItemLibrarySectionOpen
     ).toBe(false);
   });
+
+  it('groups give recipients into players and NPCs', async () => {
+    const now = '2026-08-08T00:00:00.000Z';
+    useMagicItemLibraryStore.setState({
+      itemsByCampaign: {
+        'empty-campaign': [
+          {
+            id: 'healing-potion',
+            campaignCode: 'empty-campaign',
+            name: 'Potion of Healing',
+            category: 'potion',
+            rarity: 'common',
+            description: 'Restores hit points.',
+            properties: [],
+            requiresAttunement: false,
+            isAttuned: false,
+            tags: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+      },
+    });
+    useNPCStore.setState({
+      npcsByCampaign: {
+        'empty-campaign': [
+          {
+            id: 'npc-1',
+            campaignCode: 'empty-campaign',
+            name: 'Sildar',
+            armorClass: '16',
+            maxHp: 27,
+            speed: '30 ft.',
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+      },
+    });
+    const user = userEvent.setup();
+    render(
+      <MagicItemLibrarySection
+        campaignCode="empty-campaign"
+        players={[
+          {
+            playerId: 'player-1',
+            playerName: 'Alice',
+            characterId: 'character-1',
+            characterName: 'Aria',
+          },
+        ]}
+        onGiveToPlayer={async () => {}}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Give copy' }));
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByText('Players')).toBeInTheDocument();
+    expect(screen.getByText('Aria')).toBeInTheDocument();
+    expect(screen.getByText('NPCs')).toBeInTheDocument();
+    expect(screen.getByText('Sildar')).toBeInTheDocument();
+  });
 });

--- a/src/components/ui/campaign/MagicItemLibrary/__tests__/MagicItemLibrarySection.test.tsx
+++ b/src/components/ui/campaign/MagicItemLibrary/__tests__/MagicItemLibrarySection.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDmStore } from '@/store/dmStore';
 import { useMagicItemLibraryStore } from '@/store/magicItemLibraryStore';
 import { useNPCStore } from '@/store/npcStore';
 import { MagicItemLibrarySection } from '../MagicItemLibrarySection';
@@ -9,9 +11,20 @@ vi.mock('../MagicItemLibraryDialog', () => ({
 }));
 
 describe('MagicItemLibrarySection', () => {
+  afterEach(cleanup);
+
   beforeEach(() => {
     useMagicItemLibraryStore.setState({ itemsByCampaign: {} });
     useNPCStore.setState({ npcsByCampaign: {} });
+    useDmStore.setState({
+      campaigns: [
+        {
+          code: 'empty-campaign',
+          name: 'Empty campaign',
+          createdAt: '2026-08-08T00:00:00.000Z',
+        },
+      ],
+    });
   });
 
   it('renders an empty campaign without an external-store snapshot loop', () => {
@@ -25,5 +38,31 @@ describe('MagicItemLibrarySection', () => {
 
     expect(screen.getByText('Magic Item Library (0)')).toBeInTheDocument();
     expect(screen.getByText(/No custom magic items yet/)).toBeInTheDocument();
+  });
+
+  it('collapses independently while keeping creation available', async () => {
+    const user = userEvent.setup();
+    render(
+      <MagicItemLibrarySection
+        campaignCode="empty-campaign"
+        players={[]}
+        onGiveToPlayer={async () => {}}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'Collapse magic item library' })
+    );
+
+    expect(
+      screen.queryByText(/No custom magic items yet/)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Create Magic Item' })
+    ).toBeInTheDocument();
+    expect(
+      useDmStore.getState().getCampaign('empty-campaign')?.dmDashboardUi
+        ?.magicItemLibrarySectionOpen
+    ).toBe(false);
   });
 });

--- a/src/components/ui/campaign/NPCSection.tsx
+++ b/src/components/ui/campaign/NPCSection.tsx
@@ -451,7 +451,7 @@ export function NPCSection({
         onSendItemToPlayer={onSendItemToPlayer}
       />
 
-      {npcSectionOpen && onGiveMagicItemToPlayer && (
+      {onGiveMagicItemToPlayer && (
         <MagicItemLibrarySection
           campaignCode={campaignCode}
           players={players}

--- a/src/store/dmStore.ts
+++ b/src/store/dmStore.ts
@@ -25,13 +25,14 @@ interface DmStoreState {
     code: string,
     playerCharacterId: string
   ) => string | undefined;
-  /** Merge-persist DM dashboard section open/close (Players, NPCs on campaign page). */
+  /** Merge-persist DM dashboard section state on the campaign page. */
   setDmDashboardUi: (
     code: string,
     partial: Partial<{
       playersSectionOpen: boolean;
       houseRulesSectionOpen: boolean;
       npcSectionOpen: boolean;
+      magicItemLibrarySectionOpen: boolean;
       npcCollapsedGroupNames: string[];
       npcInlineSpellSlots: boolean;
       npcSeparateSpellSlotTracker: boolean;

--- a/src/types/campaign.ts
+++ b/src/types/campaign.ts
@@ -29,12 +29,13 @@ export interface CampaignInfo {
   bannerUrl?: string; // S3 URL for campaign banner image
   /** House rule: allow players to stack more than one Heroic Inspiration. Default false. */
   stackableInspiration?: boolean;
-  /** DM campaign page: collapsible Players / NPCs sections (persisted in localStorage). */
+  /** DM campaign page: collapsible dashboard sections (persisted in localStorage). */
   dmDashboardUi?: {
     playersSectionOpen?: boolean;
     /** House Rules card on the DM campaign page. Default collapsed. */
     houseRulesSectionOpen?: boolean;
     npcSectionOpen?: boolean;
+    magicItemLibrarySectionOpen?: boolean;
     /** Group headers under NPC section (when NPCs use groups); names of collapsed groups. */
     npcCollapsedGroupNames?: string[];
     /** Show slot pips inline inside each spell level header in NPC spell tab. */


### PR DESCRIPTION
## Summary
- fix the React 19/Zustand maximum-update-depth loop by using stable empty-array selector fallbacks
- make Magic Item Library an independent persisted collapsible section instead of coupling it to the NPC collapse state
- keep Create Magic Item available while the library is collapsed
- group give-copy recipients into labeled Players and NPCs categories
- connect the give dialog description to its accessible dialog contract

## Root cause
The selectors returned a newly allocated empty array when a campaign had no library items or NPCs. React's external-store snapshot comparison therefore observed a different snapshot on every render and repeated updates until hitting the maximum depth.

## Verification
- focused MagicItemLibrarySection tests: 3 passed
- full unit suite during initial hotfix verification: 3,774 passed, 1 skipped
- pnpm type-check
- git diff --check