### PR TITLE
Add configurable calendar week start

### DIFF
--- a/src/components/ui/calendar/CalendarGrid.tsx
+++ b/src/components/ui/calendar/CalendarGrid.tsx
@@ -190,6 +190,14 @@ export function CalendarGrid({
   showMoonPhases = true,
 }: CalendarGridProps) {
   const grid = getMonthGrid(browseYear, browseMonth, config);
+  const weekStartsOn =
+    (((config.weekStartsOn ?? 0) % config.weekDays.length) +
+      config.weekDays.length) %
+    config.weekDays.length;
+  const displayedWeekDays = config.weekDays.map(
+    (_, index) =>
+      config.weekDays[(index + weekStartsOn) % config.weekDays.length]
+  );
   const isCurrentMonth =
     currentDate.year === browseYear && currentDate.month === browseMonth;
 
@@ -258,9 +266,9 @@ export function CalendarGrid({
         <table className="w-full border-collapse">
           <thead>
             <tr>
-              {config.weekDays.map(wd => (
+              {displayedWeekDays.map((wd, index) => (
                 <th
-                  key={wd.name}
+                  key={`${wd.name}-${index}`}
                   className="text-muted border-divider border-b px-1 py-2 text-center text-xs font-medium"
                 >
                   <span className="hidden sm:inline">{wd.name}</span>

--- a/src/components/ui/calendar/CalendarSettingsPanel.tsx
+++ b/src/components/ui/calendar/CalendarSettingsPanel.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/components/ui/forms/button';
 import { Input } from '@/components/ui/forms/input';
 import { NumberInput } from '@/components/ui/forms/NumberInput';
+import { SelectField, SelectItem } from '@/components/ui/forms/select';
 import type { CalendarConfig } from '@/types/calendar';
 
 interface CalendarSettingsPanelProps {
@@ -23,6 +24,10 @@ export function CalendarSettingsPanel({
   onSave,
 }: CalendarSettingsPanelProps) {
   const [draft, setDraft] = useState<CalendarConfig>(config);
+  const visibleWeekStart =
+    (((draft.weekStartsOn ?? 0) % draft.weekDays.length) +
+      draft.weekDays.length) %
+    draft.weekDays.length;
 
   const update = <K extends keyof CalendarConfig>(
     key: K,
@@ -473,13 +478,28 @@ export function CalendarSettingsPanel({
             helperText="The year number shown at time zero"
           />
           <NumberInput
-            label="First Day of Week"
+            label="Year Starts On"
             min={0}
             max={draft.weekDays.length - 1}
             value={draft.yearStartWeekdayOffset}
             onChange={v => update('yearStartWeekdayOffset', v ?? 0)}
-            helperText={`0 = ${draft.weekDays[0]?.name ?? 'first day'}`}
+            helperText={`Weekday index for the first date (0 = ${draft.weekDays[0]?.name ?? 'first day'})`}
           />
+          <SelectField
+            label="Week Starts On"
+            value={String(visibleWeekStart)}
+            onValueChange={value => update('weekStartsOn', Number(value))}
+            helperText="The first column in month view"
+          >
+            {draft.weekDays.map((weekday, index) => (
+              <SelectItem
+                key={`${weekday.name}-${index}`}
+                value={String(index)}
+              >
+                {weekday.name}
+              </SelectItem>
+            ))}
+          </SelectField>
           <NumberInput
             label="Long Rest (hours)"
             min={1}

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -58,6 +58,7 @@ export interface CalendarConfig {
   eras: Era[];
   yearOffset: number; // added to raw year for display
   yearStartWeekdayOffset: number; // which weekday index year 0 day 0 falls on
+  weekStartsOn?: number; // weekday index shown in the first column (defaults to 0)
   mechanics: MechanicsConfig;
 }
 

--- a/src/utils/__tests__/calendarCalculations.test.ts
+++ b/src/utils/__tests__/calendarCalculations.test.ts
@@ -19,6 +19,7 @@ import {
 } from '@/utils/calendarCalculations';
 import {
   createDefaultCalendar,
+  createBarovianCalendar,
   createHarptosCalendar,
   createGreyhawkCalendar,
 } from '@/utils/calendarPresets';
@@ -285,6 +286,26 @@ describe('getAllMoonPhases', () => {
 // ── Grid ────────────────────────────────────────────────────────
 
 describe('getMonthGrid', () => {
+  it('shows the default calendar Monday-first', () => {
+    const grid = getMonthGrid(1, 0, defaultConfig);
+    expect(defaultConfig.weekStartsOn).toBe(1);
+    expect(grid[0][6]).toBe(0);
+  });
+
+  it('keeps the Barovian calendar Sunday-first', () => {
+    const barovia = createBarovianCalendar();
+    const grid = getMonthGrid(1, 0, barovia);
+    expect(barovia.weekStartsOn).toBe(0);
+    expect(grid[0][0]).toBe(0);
+  });
+
+  it('uses the configured first visible weekday without changing dates', () => {
+    const sundayFirst = { ...defaultConfig, weekStartsOn: 0 };
+    const mondayFirst = { ...defaultConfig, weekStartsOn: 1 };
+    expect(getMonthGrid(1, 0, sundayFirst)[0][0]).toBe(0);
+    expect(getMonthGrid(1, 0, mondayFirst)[0][6]).toBe(0);
+  });
+
   it('returns correct number of days for a 30-day month', () => {
     const grid = getMonthGrid(1, 0, defaultConfig);
     const actualDays = grid.flat().filter(d => d !== null);
@@ -325,7 +346,7 @@ describe('getMonthGrid', () => {
 
   it('pads first week with nulls when month starts mid-week', () => {
     // Use a config where month 1 starts on a non-zero weekday
-    const grid = getMonthGrid(1, 1, defaultConfig);
+    const grid = getMonthGrid(1, 1, { ...defaultConfig, weekStartsOn: 0 });
     const firstWeek = grid[0];
     // Month 0 has 30 days, day 30 with 7-day week: 30 % 7 = 2 → month 1 starts on weekday 2
     const leadingNulls = firstWeek.filter(d => d === null).length;

--- a/src/utils/calendarCalculations.ts
+++ b/src/utils/calendarCalculations.ts
@@ -310,12 +310,20 @@ export function getMonthGrid(
       config.weekDays.length * 1000) %
     config.weekDays.length;
 
+  // The weekday index is calendar data; weekStartsOn only changes how the
+  // columns are presented. Older saved calendars remain first-day-first.
+  const weekStartsOn = config.weekStartsOn ?? 0;
+  const leadingEmptyDays =
+    (((startWeekday - weekStartsOn) % config.weekDays.length) +
+      config.weekDays.length) %
+    config.weekDays.length;
+
   const daysInMonth = config.months[monthIndex].days;
   const weeks: (number | null)[][] = [];
   let currentWeek: (number | null)[] = [];
 
   // Fill leading nulls
-  for (let i = 0; i < startWeekday; i++) {
+  for (let i = 0; i < leadingEmptyDays; i++) {
     currentWeek.push(null);
   }
 

--- a/src/utils/calendarPresets.ts
+++ b/src/utils/calendarPresets.ts
@@ -64,6 +64,7 @@ export function createDefaultCalendar(): CalendarConfig {
     eras: [{ name: 'Common Era', abbreviation: 'CE', startYear: 1 }],
     yearOffset: 1,
     yearStartWeekdayOffset: 0,
+    weekStartsOn: 1,
     mechanics: {
       hoursPerLongRest: 8,
       minutesPerShortRest: 60,
@@ -146,6 +147,7 @@ export function createHarptosCalendar(): CalendarConfig {
     eras: [{ name: 'Dalereckoning', abbreviation: 'DR', startYear: 1 }],
     yearOffset: 1490,
     yearStartWeekdayOffset: 0,
+    weekStartsOn: 0,
     mechanics: {
       hoursPerLongRest: 8,
       minutesPerShortRest: 60,
@@ -227,6 +229,7 @@ export function createGreyhawkCalendar(): CalendarConfig {
     eras: [{ name: 'Common Year', abbreviation: 'CY', startYear: 1 }],
     yearOffset: 591,
     yearStartWeekdayOffset: 0,
+    weekStartsOn: 0,
     mechanics: {
       hoursPerLongRest: 8,
       minutesPerShortRest: 60,
@@ -309,6 +312,7 @@ export function createBarovianCalendar(): CalendarConfig {
     eras: [{ name: 'AC', abbreviation: 'AC', startYear: 1 }], // homebrew era
     yearOffset: 1,
     yearStartWeekdayOffset: 0,
+    weekStartsOn: 0,
     mechanics: {
       hoursPerLongRest: 8,
       minutesPerShortRest: 60,


### PR DESCRIPTION
## Summary
- add a DM-selectable first weekday for calendar month views
- default the standard calendar to Monday while preserving Sunday-first Barovia
- clarify the existing year-start weekday setting
- keep older saved calendars backward compatible

## Validation
- `npm run type-check`
- `npm test` (3,779 passed, 1 skipped)
- `npx eslint src` (0 errors; existing warnings only)
- Prettier and diff checks on changed files