### PR TITLE
Let DMs export player character backups

### DIFF
--- a/src/components/ui/campaign/PlayerDetailDialog/index.tsx
+++ b/src/components/ui/campaign/PlayerDetailDialog/index.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { MessageSquare, Package, ScrollText, Wand2 } from 'lucide-react';
+import {
+  Download,
+  MessageSquare,
+  Package,
+  ScrollText,
+  Wand2,
+} from 'lucide-react';
 import { Button } from '@/components/ui/forms/button';
 import {
   Dialog,
@@ -16,6 +22,7 @@ import { InventoryTab } from './InventoryTab';
 import { SpellsTab, characterHasSpellsToShow } from './SpellsTab';
 import { ensureArray } from './shared';
 import { CampaignPlayerData } from '@/types/campaign';
+import { exportCharacterStateToFile } from '@/utils/fileOperations';
 
 type DetailTab = 'overview' | 'spells' | 'inventory';
 
@@ -101,16 +108,27 @@ export function PlayerDetailDialog({
               {char.race || 'Unknown'} · {char.alignment || 'Unaligned'} ·
               Player: {player.playerName}
             </p>
-            {onSendMessage && (
+            <div className="flex shrink-0 items-center gap-1">
               <Button
                 variant="ghost"
                 size="sm"
-                leftIcon={<MessageSquare size={14} />}
-                onClick={onSendMessage}
+                leftIcon={<Download size={14} />}
+                onClick={() => exportCharacterStateToFile(char)}
+                title="Download a player-compatible character backup"
               >
-                Message
+                Export JSON
               </Button>
-            )}
+              {onSendMessage && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  leftIcon={<MessageSquare size={14} />}
+                  onClick={onSendMessage}
+                >
+                  Message
+                </Button>
+              )}
+            </div>
           </div>
         </DialogHeader>
 

--- a/src/utils/__tests__/fileOperations.test.ts
+++ b/src/utils/__tests__/fileOperations.test.ts
@@ -20,7 +20,7 @@ describe('exportCharacterStateToFile', () => {
     exportCharacterStateToFile(character);
 
     expect(click).toHaveBeenCalledOnce();
-    const link = click.mock.instances[0];
+    const link = click.mock.instances[0] as HTMLAnchorElement;
     expect(link.download).toBe('recovered_hero_2026-08-09.json');
 
     const encodedJson = link.href.split(',')[1];

--- a/src/utils/__tests__/fileOperations.test.ts
+++ b/src/utils/__tests__/fileOperations.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeCharacter } from './test-utils';
+import { exportCharacterStateToFile } from '../fileOperations';
+
+describe('exportCharacterStateToFile', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('downloads a player-compatible character export', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-09T12:00:00.000Z'));
+
+    const character = makeCharacter({ name: 'Recovered Hero' });
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+
+    exportCharacterStateToFile(character);
+
+    expect(click).toHaveBeenCalledOnce();
+    const link = click.mock.instances[0];
+    expect(link.download).toBe('recovered_hero_2026-08-09.json');
+
+    const encodedJson = link.href.split(',')[1];
+    const exported = JSON.parse(decodeURIComponent(encodedJson));
+    expect(exported).toEqual({
+      version: '1.0.0',
+      exportDate: '2026-08-09T12:00:00.000Z',
+      character,
+    });
+  });
+});

--- a/src/utils/fileOperations.ts
+++ b/src/utils/fileOperations.ts
@@ -1,5 +1,6 @@
-import { CharacterExport } from '@/types/character';
+import { CharacterExport, CharacterState } from '@/types/character';
 import type { PlayerCharacter } from '@/store/playerStore';
+import { APP_VERSION } from '@/utils/constants';
 
 /** A full-roster backup bundle (every character in one file). */
 export interface CharacterBackup {
@@ -69,6 +70,19 @@ export const exportCharacterToFile = (exportData: CharacterExport): void => {
   document.body.appendChild(linkElement);
   linkElement.click();
   document.body.removeChild(linkElement);
+};
+
+/**
+ * Export a character snapshot received from campaign sync. This deliberately
+ * uses the same wrapper as the player-side export so the downloaded file can
+ * be imported without any recovery-specific conversion.
+ */
+export const exportCharacterStateToFile = (character: CharacterState): void => {
+  exportCharacterToFile({
+    version: APP_VERSION,
+    exportDate: new Date().toISOString(),
+    character,
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary
- add an Export JSON action to the DM player detail dialog
- export the latest campaign-synced character snapshot in the existing player-compatible format
- cover filename and export payload compatibility with a unit test

## Validation
- npm run type-check
- ESLint on changed files
- npm test -- --run src/utils/__tests__/fileOperations.test.ts
- pre-commit lint-staged hooks